### PR TITLE
Add ProgressDeadlineSeconds

### DIFF
--- a/controller/canary.go
+++ b/controller/canary.go
@@ -286,5 +286,6 @@ func (c *Controller) syncRolloutStatusCanary(olderRSs []*appsv1.ReplicaSet, newR
 	newStatus.PauseStartTime = pauseStartTime
 
 	newStatus.CurrentStepIndex = currentStepIndex
+	newStatus = c.calculateRolloutConditions(r, newStatus, allRSs, newRS)
 	return c.persistRolloutStatus(r, &newStatus, &paused)
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -293,15 +293,20 @@ func (c *Controller) syncHandler(key string) error {
 		logutil.WithRollout(r).Error("Error: Spec submitted is invalid")
 		generation := conditions.ComputeGenerationHash(r.Spec)
 		if r.Status.ObservedGeneration != generation || !reflect.DeepEqual(invalidSpecCond, prevCond) {
-			newStatus := r.Status
+			newStatus := r.Status.DeepCopy()
 			newStatus.ObservedGeneration = generation
-			conditions.SetRolloutCondition(&newStatus, *invalidSpecCond)
-			err := c.persistRolloutStatus(r, &newStatus, nil)
+			conditions.SetRolloutCondition(newStatus, *invalidSpecCond)
+			err := c.persistRolloutStatus(r, newStatus, nil)
 			if err != nil {
 				return err
 			}
 		}
 		return nil
+	}
+
+	err = c.checkPausedConditions(r)
+	if err != nil {
+		return err
 	}
 
 	// List ReplicaSets owned by this Rollout, while reconciling ControllerRef

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -13,7 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	kubeinformers "k8s.io/client-go/informers"
@@ -28,6 +27,8 @@ import (
 	informers "github.com/argoproj/argo-rollouts/pkg/client/informers/externalversions"
 	"github.com/argoproj/argo-rollouts/utils/annotations"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/equality"
 )
 
 var (
@@ -59,13 +60,11 @@ type fixture struct {
 	kubeobjects     []runtime.Object
 	objects         []runtime.Object
 	enqueuedObjects map[string]int
-	checkObjects    bool
 }
 
 func newFixture(t *testing.T) *fixture {
 	f := &fixture{}
 	f.t = t
-	f.checkObjects = false
 	f.objects = []runtime.Object{}
 	f.kubeobjects = []runtime.Object{}
 	f.enqueuedObjects = make(map[string]int)
@@ -287,7 +286,7 @@ func (f *fixture) runController(rolloutName string, startInformers bool, expectE
 		}
 
 		expectedAction := f.actions[i]
-		checkAction(expectedAction, action, f.t, f.checkObjects)
+		checkAction(expectedAction, action, f.t)
 	}
 
 	if len(f.actions) > len(actions) {
@@ -302,7 +301,7 @@ func (f *fixture) runController(rolloutName string, startInformers bool, expectE
 		}
 
 		expectedAction := f.kubeactions[i]
-		checkAction(expectedAction, action, f.t, f.checkObjects)
+		checkAction(expectedAction, action, f.t)
 	}
 
 	if len(f.kubeactions) > len(k8sActions) {
@@ -312,7 +311,7 @@ func (f *fixture) runController(rolloutName string, startInformers bool, expectE
 }
 
 // checkAction verifies that expected and actual actions are equal
-func checkAction(expected, actual core.Action, t *testing.T, checkObjects bool) {
+func checkAction(expected, actual core.Action, t *testing.T) {
 	if !(expected.Matches(actual.GetVerb(), actual.GetResource().Resource) && actual.GetSubresource() == expected.GetSubresource()) {
 		t.Errorf("Expected\n\t%#v\ngot\n\t%#v", expected, actual)
 		if patch, ok := actual.(core.PatchAction); ok {
@@ -329,38 +328,6 @@ func checkAction(expected, actual core.Action, t *testing.T, checkObjects bool) 
 	if reflect.TypeOf(actual) != reflect.TypeOf(expected) {
 		t.Errorf("Action has wrong type. Expected: %t. Got: %t", expected, actual)
 		return
-	}
-	if !checkObjects {
-		return
-	}
-	switch a := actual.(type) {
-	case core.CreateAction:
-		e, _ := expected.(core.CreateAction)
-		expObject := e.GetObject()
-		object := a.GetObject()
-
-		if !reflect.DeepEqual(expObject, object) {
-			t.Errorf("Action %s %s has wrong object\nDiff:\n %s",
-				a.GetVerb(), a.GetResource().Resource, diff.ObjectGoPrintDiff(expObject, object))
-		}
-	case core.UpdateAction:
-		e, _ := expected.(core.UpdateAction)
-		expObject := e.GetObject()
-		object := a.GetObject()
-
-		if !reflect.DeepEqual(expObject, object) {
-			t.Errorf("Action %s %s has wrong object\nDiff:\n %s",
-				a.GetVerb(), a.GetResource().Resource, diff.ObjectGoPrintDiff(expObject, object))
-		}
-	case core.PatchAction:
-		e, _ := expected.(core.PatchAction)
-		expPatch := e.GetPatch()
-		patch := a.GetPatch()
-
-		if !reflect.DeepEqual(expPatch, patch) {
-			t.Errorf("Action %s %s has wrong patch\nDiff:\n %s",
-				a.GetVerb(), a.GetResource().Resource, diff.ObjectGoPrintDiff(string(expPatch), string(patch)))
-		}
 	}
 }
 
@@ -392,47 +359,122 @@ func (f *fixture) expectGetServiceAction(s *corev1.Service) {
 	f.kubeactions = append(f.kubeactions, core.NewGetAction(serviceSchema, s.Namespace, s.Name))
 }
 
-func (f *fixture) expectPatchServiceAction(s *corev1.Service, newLabel string) {
+func (f *fixture) expectPatchServiceAction(s *corev1.Service, newLabel string) int {
 	patch := fmt.Sprintf(switchSelectorPatch, v1alpha1.DefaultRolloutUniqueLabelKey, newLabel)
 	serviceSchema := schema.GroupVersionResource{
 		Resource: "services",
 		Version:  "v1",
 	}
+	len := len(f.kubeactions)
 	f.kubeactions = append(f.kubeactions, core.NewPatchAction(serviceSchema, s.Namespace, s.Name, []byte(patch)))
+	return len
 }
 
-func (f *fixture) expectCreateReplicaSetAction(r *appsv1.ReplicaSet) {
+func (f *fixture) expectCreateReplicaSetAction(r *appsv1.ReplicaSet) int {
+	len := len(f.kubeactions)
 	f.kubeactions = append(f.kubeactions, core.NewCreateAction(schema.GroupVersionResource{Resource: "replicasets"}, r.Namespace, r))
+	return len
 }
 
-func (f *fixture) expectUpdateReplicaSetAction(r *appsv1.ReplicaSet) {
+func (f *fixture) expectUpdateReplicaSetAction(r *appsv1.ReplicaSet) int {
+	len := len(f.kubeactions)
 	f.kubeactions = append(f.kubeactions, core.NewUpdateAction(schema.GroupVersionResource{Resource: "replicasets"}, r.Namespace, r))
+	return len
 }
 
-func (f *fixture) expectGetRolloutAction(rollout *v1alpha1.Rollout) {
+func (f *fixture) expectGetRolloutAction(rollout *v1alpha1.Rollout) int {
+	len := len(f.kubeactions)
 	f.kubeactions = append(f.kubeactions, core.NewGetAction(schema.GroupVersionResource{Resource: "rollouts"}, rollout.Namespace, rollout.Name))
+	return len
 }
 
-func (f *fixture) expectUpdateRolloutAction(rollout *v1alpha1.Rollout) {
+func (f *fixture) expectUpdateRolloutAction(rollout *v1alpha1.Rollout) int {
 	action := core.NewUpdateAction(schema.GroupVersionResource{Resource: "rollouts"}, rollout.Namespace, rollout)
+	len := len(f.actions)
 	f.actions = append(f.actions, action)
+	return len
 }
 
-func (f *fixture) expectPatchRolloutAction(rollout *v1alpha1.Rollout) {
+func (f *fixture) expectPatchRolloutAction(rollout *v1alpha1.Rollout) int {
 	serviceSchema := schema.GroupVersionResource{
 		Resource: "rollouts",
 		Version:  "v1alpha1",
 	}
+	len := len(f.actions)
 	f.actions = append(f.actions, core.NewPatchAction(serviceSchema, rollout.Namespace, rollout.Name, nil))
+	return len
 }
 
-func (f *fixture) expectPatchRolloutActionWithPatch(rollout *v1alpha1.Rollout, patch string) {
+func (f *fixture) expectPatchRolloutActionWithPatch(rollout *v1alpha1.Rollout, patch string) int {
 	expectedPatch := calculatePatch(rollout, patch)
 	serviceSchema := schema.GroupVersionResource{
 		Resource: "rollouts",
 		Version:  "v1alpha1",
 	}
+	len := len(f.actions)
 	f.actions = append(f.actions, core.NewPatchAction(serviceSchema, rollout.Namespace, rollout.Name, []byte(expectedPatch)))
+	return len
+}
+
+func (f *fixture) getCreatedReplicaSet(index int) *appsv1.ReplicaSet {
+	action := filterInformerActions(f.kubeclient.Actions())[index]
+	createAction, ok := action.(core.CreateAction)
+	if !ok {
+		assert.Fail(f.t, "Expected Created action, not %s", action.GetVerb())
+	}
+	obj := createAction.GetObject()
+	rs := &appsv1.ReplicaSet{}
+	converter := runtime.NewTestUnstructuredConverter(equality.Semantic)
+	objMap, _ := converter.ToUnstructured(obj)
+	runtime.NewTestUnstructuredConverter(equality.Semantic).FromUnstructured(objMap, rs)
+	return rs
+}
+
+func (f *fixture) getUpdatedReplicaSet(index int) *appsv1.ReplicaSet {
+	action := filterInformerActions(f.kubeclient.Actions())[index]
+	updateAction, ok := action.(core.UpdateAction)
+	if !ok {
+		assert.Fail(f.t, "Expected Update action, not %s", action.GetVerb())
+	}
+	obj := updateAction.GetObject()
+	rs := &appsv1.ReplicaSet{}
+	converter := runtime.NewTestUnstructuredConverter(equality.Semantic)
+	objMap, _ := converter.ToUnstructured(obj)
+	runtime.NewTestUnstructuredConverter(equality.Semantic).FromUnstructured(objMap, rs)
+	return rs
+}
+
+func (f *fixture) verifyPatchedService(index int, newPodHash string) bool {
+	action := filterInformerActions(f.kubeclient.Actions())[index]
+	patchAction, ok := action.(core.PatchAction)
+	if !ok {
+		assert.Fail(f.t, "Expected Patch action, not %s", action.GetVerb())
+	}
+	patch := fmt.Sprintf(switchSelectorPatch, v1alpha1.DefaultRolloutUniqueLabelKey, newPodHash)
+	return string(patchAction.GetPatch()) == patch
+}
+
+func (f *fixture) getUpdatedRollout(index int) *v1alpha1.Rollout {
+	action := filterInformerActions(f.client.Actions())[index]
+	updateAction, ok := action.(core.UpdateAction)
+	if !ok {
+		assert.Fail(f.t, "Expected Update action, not %s", action.GetVerb())
+	}
+	obj := updateAction.GetObject()
+	rollout := &v1alpha1.Rollout{}
+	converter := runtime.NewTestUnstructuredConverter(equality.Semantic)
+	objMap, _ := converter.ToUnstructured(obj)
+	runtime.NewTestUnstructuredConverter(equality.Semantic).FromUnstructured(objMap, rollout)
+	return rollout
+}
+
+func (f *fixture) getPatchedRollout(index int) string {
+	action := filterInformerActions(f.client.Actions())[index]
+	patchAction, ok := action.(core.PatchAction)
+	if !ok {
+		assert.Fail(f.t, "Expected Patch action, not %s", action.GetVerb())
+	}
+	return string(patchAction.GetPatch())
 }
 
 func TestDontSyncRolloutsWithEmptyPodSelector(t *testing.T) {

--- a/manifests/crds/rollout-crd.yaml
+++ b/manifests/crds/rollout-crd.yaml
@@ -42,6 +42,15 @@ spec:
             paused:
               description: Paused pauses the rollout at its current step.
               type: boolean
+            progressDeadlineSeconds:
+              description: ProgressDeadlineSeconds The maximum time in seconds for
+                a rollout to make progress before it is considered to be failed. Argo
+                Rollouts will continue to process failed rollouts and a condition
+                with a ProgressDeadlineExceeded reason will be surfaced in the rollout
+                status. Note that progress will not be estimated during the time a
+                rollout is paused. Defaults to 600s.
+              format: int32
+              type: integer
             replicas:
               description: Number of desired pods. This is a pointer to distinguish
                 between explicit zero and not specified. Defaults to 1.

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -43,6 +43,15 @@ spec:
             paused:
               description: Paused pauses the rollout at its current step.
               type: boolean
+            progressDeadlineSeconds:
+              description: ProgressDeadlineSeconds The maximum time in seconds for
+                a rollout to make progress before it is considered to be failed. Argo
+                Rollouts will continue to process failed rollouts and a condition
+                with a ProgressDeadlineExceeded reason will be surfaced in the rollout
+                status. Note that progress will not be estimated during the time a
+                rollout is paused. Defaults to 600s.
+              format: int32
+              type: integer
             replicas:
               description: Number of desired pods. This is a pointer to distinguish
                 between explicit zero and not specified. Defaults to 1.

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -43,6 +43,15 @@ spec:
             paused:
               description: Paused pauses the rollout at its current step.
               type: boolean
+            progressDeadlineSeconds:
+              description: ProgressDeadlineSeconds The maximum time in seconds for
+                a rollout to make progress before it is considered to be failed. Argo
+                Rollouts will continue to process failed rollouts and a condition
+                with a ProgressDeadlineExceeded reason will be surfaced in the rollout
+                status. Note that progress will not be estimated during the time a
+                rollout is paused. Defaults to 600s.
+              format: int32
+              type: integer
             replicas:
               description: Number of desired pods. This is a pointer to distinguish
                 between explicit zero and not specified. Defaults to 1.

--- a/pkg/apis/rollouts/v1alpha1/openapi_generated.go
+++ b/pkg/apis/rollouts/v1alpha1/openapi_generated.go
@@ -402,6 +402,13 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutSpec(ref common.ReferenceCallback)
 							Format:      "",
 						},
 					},
+					"progressDeadlineSeconds": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ProgressDeadlineSeconds The maximum time in seconds for a rollout to make progress before it is considered to be failed. Argo Rollouts will continue to process failed rollouts and a condition with a ProgressDeadlineExceeded reason will be surfaced in the rollout status. Note that progress will not be estimated during the time a rollout is paused. Defaults to 600s.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
 				Required: []string{"selector", "template"},
 			},

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -46,6 +46,13 @@ type RolloutSpec struct {
 	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
 	// Paused pauses the rollout at its current step.
 	Paused bool `json:"paused,omitempty"`
+	// ProgressDeadlineSeconds The maximum time in seconds for a rollout to
+	// make progress before it is considered to be failed. Argo Rollouts will
+	// continue to process failed rollouts and a condition with a
+	// ProgressDeadlineExceeded reason will be surfaced in the rollout status.
+	// Note that progress will not be estimated during the time a rollout is paused.
+	// Defaults to 600s.
+	ProgressDeadlineSeconds *int32 `json:"progressDeadlineSeconds,omitempty"`
 }
 
 const (
@@ -74,7 +81,7 @@ type BlueGreenStrategy struct {
 	// +optional
 }
 
-// ReplicaBasedCanaryStrategy defines parameters for a Replica Based Canary
+// CanaryStrategy defines parameters for a Replica Based Canary
 type CanaryStrategy struct {
 	// Steps define the order of phases to execute the canary deployment
 	// +optional
@@ -121,6 +128,7 @@ type SetPreview struct{}
 // SwitchActive empty struct to indicate the SetActive step
 type SwitchActive struct{}
 
+// RolloutPause defines a pause stage for a rollout
 type RolloutPause struct {
 	// Duration the amount of time to wait before moving to the next step.
 	// +optional
@@ -205,9 +213,17 @@ const (
 	// InvalidSpec means the rollout has an invalid spec and will not progress until
 	// the spec is fixed.
 	InvalidSpec RolloutConditionType = "InvalidSpec"
-	// Available means the rollout is available, ie. the active service is pointing at a
+	// RolloutAvailable means the rollout is available, ie. the active service is pointing at a
 	// replicaset with the required replicas up and running for at least minReadySeconds.
 	RolloutAvailable RolloutConditionType = "Available"
+	// RolloutProgressing means the rollout is progressing. Progress for a rollout is
+	// considered when a new replica set is created or adopted, when pods scale
+	// up or old pods scale down, or when the services are updated. Progress is not estimated
+	// for paused rollouts.
+	RolloutProgressing RolloutConditionType = "Progressing"
+	// RolloutReplicaFailure ReplicaFailure is added in a deployment when one of its pods
+	// fails to be created or deleted.
+	RolloutReplicaFailure RolloutConditionType = "ReplicaFailure"
 )
 
 // RolloutCondition describes the state of a rollout at a certain point.

--- a/pkg/apis/rollouts/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/rollouts/v1alpha1/zz_generated.deepcopy.go
@@ -253,6 +253,11 @@ func (in *RolloutSpec) DeepCopyInto(out *RolloutSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ProgressDeadlineSeconds != nil {
+		in, out := &in.ProgressDeadlineSeconds, &out.ProgressDeadlineSeconds
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/utils/conditions/conditions.go
+++ b/utils/conditions/conditions.go
@@ -5,19 +5,21 @@ import (
 	"hash/fnv"
 	"math"
 	"reflect"
+	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/kubernetes/pkg/controller"
 	hashutil "k8s.io/kubernetes/pkg/util/hash"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
+	logutil "github.com/argoproj/argo-rollouts/utils/log"
 )
 
 const (
-	// FailedRSCreateReason is added in a rollout when it cannot create a new replica set.
-	FailedRSCreateReason = "ReplicaSetCreateError"
 	// Verify Spec constants
 
 	// InvalidSpecReason indicates that the spec is invalid
@@ -40,6 +42,68 @@ const (
 	DuplicatedServicesMessage = "This rollout uses the same service for the active and preview services, but two different services are required."
 	// Available the reason to indicate that the rollout is serving traffic from the active service
 	Available = "Available"
+
+	// Reasons and Messages for rollout Progressing Condition
+
+	// ReplicaSetUpdatedReason is added in a rollout when one of its replica sets is updated as part
+	// of the rollout process.
+	ReplicaSetUpdatedReason = "ReplicaSetUpdated"
+	// RolloutProgessingMessage is added in a rollout when one of its replica sets is updated as part
+	// of the rollout process.
+	RolloutProgressingMessage = "Rollout %q is progressing."
+	// ReplicaSetProgessingMessage is added in a rollout when one of its replica sets is updated as part
+	// of the rollout process.
+	ReplicaSetProgressingMessage = "ReplicaSet %q is progressing."
+	// FailedRSCreateReason is added in a rollout when it cannot create a new replica set.
+	FailedRSCreateReason = "ReplicaSetCreateError"
+	// FailedRSCreateMessage is added in a rollout when it cannot create a new replica set.
+	FailedRSCreateMessage = "Failed to create new replica set %q: %v"
+
+	// NewReplicaSetReason is added in a rollout when it creates a new replica set.
+	NewReplicaSetReason = "NewReplicaSetCreated"
+	//NewReplicasSetMessage is added in a rollout when it creates a new replicas \set.
+	NewReplicaSetMessage = "Created new replica set %q"
+	// FoundNewRSReason is added in a rollout when it adopts an existing replica set.
+	FoundNewRSReason = "FoundNewReplicaSet"
+	// FoundNewRSMessage is added in a rollout when it adopts an existing replica set.
+	FoundNewRSMessage = "Found new replica set %q"
+
+	// NewRSAvailableReason is added in a rollout when its newest replica set is made available
+	// ie. the number of new pods that have passed readiness checks and run for at least minReadySeconds
+	// is at least the minimum available pods that need to run for the rollout.
+	NewRSAvailableReason = "NewReplicaSetAvailable"
+
+	// TimedOutReason is added in a rollout when its newest replica set fails to show any progress
+	// within the given deadline (progressDeadlineSeconds).
+	TimedOutReason = "ProgressDeadlineExceeded"
+	// RolloutTimeOutMessage is is added in a rollout when the rollout fails to show any progress
+	// within the given deadline (progressDeadlineSeconds).
+	RolloutTimeOutMessage = "Rollout %q has timed out progressing."
+	// ReplicaSetTimeOutMessage is added in a rollout when its newest replica set fails to show any progress
+	// within the given deadline (progressDeadlineSeconds).
+	ReplicaSetTimeOutMessage = "ReplicaSet %q has timed out progressing."
+
+	// RolloutCompletedMessage is added when the rollout is completed
+	RolloutCompletedMessage = "Rollout %q has successfully progressed."
+	// ReplicaSetCompletedMessage is added when the rollout is completed
+	ReplicaSetCompletedMessage = "Rollout %q has successfully progressed."
+
+	// PausedRolloutReason is added in a rollout when it is paused. Lack of progress shouldn't be
+	// estimated once a rollout is paused.
+	PausedRolloutReason = "RolloutPaused"
+	// PausedRolloutMessage is added in a rollout when it is paused. Lack of progress shouldn't be
+	// estimated once a rollout is paused.
+	PausedRolloutMessage = "Rollout is paused"
+	// ResumedRolloutReason is added in a rollout when it is resumed. Useful for not failing accidentally
+	// rollout that paused amidst a rollout and are bounded by a deadline.
+	ResumedRolloutReason = "RolloutResumed"
+	// ResumeRolloutMessage is added in a rollout when it is resumed. Useful for not failing accidentally
+	// rollout that paused amidst a rollout and are bounded by a deadline.
+	ResumeRolloutMessage = "Rollout is resumed"
+	// ServiceNotFoundReason is added in a rollout when the service defined in the spec is not found
+	ServiceNotFoundReason = "ServiceNotFound"
+	// ServiceNotFoundMessage is added in a rollout when the service defined in the spec is not found
+	ServiceNotFoundMessage = "Service %q is not found"
 )
 
 // NewRolloutCondition creates a new rollout condition.
@@ -97,15 +161,69 @@ func filterOutCondition(conditions []v1alpha1.RolloutCondition, condType v1alpha
 	return newConditions
 }
 
+// RolloutProgressing reports progress for a rollout. Progress is estimated by comparing the
+// current with the new status of the rollout that the controller is observing. More specifically,
+// when new pods are scaled up, become ready or available, old pods are scaled down, or we modify the
+// services, then we consider the rollout is progressing.
+func RolloutProgressing(rollout *v1alpha1.Rollout, newStatus *v1alpha1.RolloutStatus) bool {
+	oldStatus := rollout.Status
+
+	strategySpecificProgress := false
+	if rollout.Spec.Strategy.BlueGreenStrategy != nil {
+		activeSelectorChange := rollout.Status.BlueGreen.ActiveSelector != newStatus.BlueGreen.ActiveSelector
+		previewSelectorChange := rollout.Status.BlueGreen.PreviewSelector != newStatus.BlueGreen.PreviewSelector
+		strategySpecificProgress = activeSelectorChange || previewSelectorChange
+	}
+
+	if rollout.Spec.Strategy.CanaryStrategy != nil {
+		stableRSChange := newStatus.Canary.StableRS != oldStatus.Canary.StableRS
+		incrementStepIndex := false
+		if newStatus.CurrentStepIndex != nil && oldStatus.CurrentStepIndex != nil {
+			incrementStepIndex = *newStatus.CurrentStepIndex != *oldStatus.CurrentStepIndex
+		}
+		stepsHashChange := newStatus.CurrentStepHash != oldStatus.CurrentStepHash
+		strategySpecificProgress = stableRSChange || incrementStepIndex || stepsHashChange
+	}
+
+	// Old replicas that need to be scaled down
+	oldStatusOldReplicas := oldStatus.Replicas - oldStatus.UpdatedReplicas
+	newStatusOldReplicas := newStatus.Replicas - newStatus.UpdatedReplicas
+
+	return (newStatus.UpdatedReplicas != oldStatus.UpdatedReplicas) ||
+		(newStatusOldReplicas < oldStatusOldReplicas) ||
+		newStatus.ReadyReplicas > rollout.Status.ReadyReplicas ||
+		newStatus.AvailableReplicas > rollout.Status.AvailableReplicas ||
+		strategySpecificProgress
+}
+
 // RolloutComplete considers a rollout to be complete once all of its desired replicas
 // are updated, available, and receiving traffic from the active service, and no old pods are running.
 func RolloutComplete(rollout *v1alpha1.Rollout, newStatus *v1alpha1.RolloutStatus) bool {
+	completedStrategy := true
+	if rollout.Spec.Strategy.BlueGreenStrategy != nil {
+		activeSelectorComplete := newStatus.BlueGreen.ActiveSelector == newStatus.CurrentPodHash
+		previewSelectorComplete := true
+		if rollout.Spec.Strategy.BlueGreenStrategy.PreviewService != "" {
+			previewSelectorComplete = newStatus.BlueGreen.PreviewSelector == ""
+		}
+		completedStrategy = activeSelectorComplete && previewSelectorComplete
+	}
+	if rollout.Spec.Strategy.CanaryStrategy != nil {
+		stepCount := len(rollout.Spec.Strategy.CanaryStrategy.Steps)
+		executedAllSteps := true
+		if stepCount > 0 && newStatus.CurrentStepIndex != nil {
+			executedAllSteps = int32(stepCount) == *newStatus.CurrentStepIndex
+		}
+		currentRSIsStable := newStatus.Canary.StableRS == controller.ComputeHash(&rollout.Spec.Template, rollout.Status.CollisionCount)
+		completedStrategy = executedAllSteps && currentRSIsStable
+	}
+
 	replicas := defaults.GetRolloutReplicasOrDefault(rollout)
 	return newStatus.UpdatedReplicas == replicas &&
 		newStatus.Replicas == replicas &&
 		newStatus.AvailableReplicas == replicas &&
-		newStatus.BlueGreen.ActiveSelector == newStatus.CurrentPodHash &&
-		newStatus.ObservedGeneration == ComputeGenerationHash(rollout.Spec)
+		rollout.Status.ObservedGeneration == ComputeGenerationHash(rollout.Spec) &&
+		completedStrategy
 }
 
 // ComputeStepHash returns a hash value calculated from the Rollout's steps. The hash will
@@ -195,4 +313,61 @@ func VerifyRolloutSpec(rollout *v1alpha1.Rollout, prevCond *v1alpha1.RolloutCond
 // HasRevisionHistoryLimit checks if the RevisionHistoryLimit field is set
 func HasRevisionHistoryLimit(r *v1alpha1.Rollout) bool {
 	return r.Spec.RevisionHistoryLimit != nil && *r.Spec.RevisionHistoryLimit != math.MaxInt32
+}
+
+// RolloutTimedOut considers a rollout to have timed out once its condition that reports progress
+// is older than progressDeadlineSeconds or a Progressing condition with a TimedOutReason reason already
+// exists.
+func RolloutTimedOut(rollout *v1alpha1.Rollout, newStatus *v1alpha1.RolloutStatus) bool {
+	// Look for the Progressing condition. If it doesn't exist, we have no base to estimate progress.
+	// If it's already set with a TimedOutReason reason, we have already timed out, no need to check
+	// again.
+	condition := GetRolloutCondition(*newStatus, v1alpha1.RolloutProgressing)
+	if condition == nil {
+		return false
+	}
+	// If the previous condition has been a successful rollout then we shouldn't try to
+	// estimate any progress. Scenario:
+	//
+	// * progressDeadlineSeconds is smaller than the difference between now and the time
+	//   the last rollout finished in the past.
+	// * the creation of a new ReplicaSet triggers a resync of the rollout prior to the
+	//   cached copy of the Rollout getting updated with the status.condition that indicates
+	//   the creation of the new ReplicaSet.
+	//
+	// The rollout will be resynced and eventually its Progressing condition will catch
+	// up with the state of the world.
+	if condition.Reason == NewRSAvailableReason {
+		return false
+	}
+	if condition.Reason == TimedOutReason {
+		return true
+	}
+
+	// Look at the difference in seconds between now and the last time we reported any
+	// progress or tried to create a replica set, or resumed a paused rollout and
+	// compare against progressDeadlineSeconds.
+	from := condition.LastUpdateTime
+	now := time.Now()
+
+	progressDeadlineSeconds := defaults.GetProgressDeadlineSecondsOrDefault(rollout)
+	delta := time.Duration(progressDeadlineSeconds) * time.Second
+	timedOut := from.Add(delta).Before(now)
+	logCtx := logutil.WithRollout(rollout)
+
+	logCtx.Infof("Timed out (%t) [last progress check: %v - now: %v]", timedOut, from, now)
+	return timedOut
+}
+
+// ReplicaSetToRolloutCondition converts a replica set condition into a rollout condition.
+// Useful for promoting replica set failure conditions into rollout.
+func ReplicaSetToRolloutCondition(cond appsv1.ReplicaSetCondition) v1alpha1.RolloutCondition {
+	return v1alpha1.RolloutCondition{
+		Type:               v1alpha1.RolloutConditionType(cond.Type),
+		Status:             cond.Status,
+		LastTransitionTime: cond.LastTransitionTime,
+		LastUpdateTime:     cond.LastTransitionTime,
+		Reason:             cond.Reason,
+		Message:            cond.Message,
+	}
 }

--- a/utils/defaults/defaults.go
+++ b/utils/defaults/defaults.go
@@ -15,6 +15,8 @@ const (
 	DefaultMaxSurge = "25"
 	// DefaultMaxUnavailable default number for the max number of unavailable pods during a rollout
 	DefaultMaxUnavailable = 0
+	// DefaultProgressDeadlineSeconds default number of seconds for the rollout to be making progress
+	DefaultProgressDeadlineSeconds = int32(600)
 )
 
 // GetRolloutReplicasOrDefault returns the specified number of replicas in a rollout or the default number
@@ -57,4 +59,11 @@ func GetStrategyType(rollout *v1alpha1.Rollout) string {
 		return "canary"
 	}
 	return "No Strategy listed"
+}
+
+func GetProgressDeadlineSecondsOrDefault(rollout *v1alpha1.Rollout) int32 {
+	if rollout.Spec.ProgressDeadlineSeconds != nil {
+		return *rollout.Spec.ProgressDeadlineSeconds
+	}
+	return DefaultProgressDeadlineSeconds
 }

--- a/utils/defaults/defaults_test.go
+++ b/utils/defaults/defaults_test.go
@@ -95,3 +95,16 @@ func TestGetStrategyType(t *testing.T) {
 	}
 	assert.Equal(t, "No Strategy listed", GetStrategyType(noStrategyRollout))
 }
+
+func TestGetProgressDeadlineSecondsOrDefault(t *testing.T) {
+	seconds := int32(2)
+	rolloutNonDefaultValue := &v1alpha1.Rollout{
+		Spec: v1alpha1.RolloutSpec{
+			ProgressDeadlineSeconds: &seconds,
+		},
+	}
+
+	assert.Equal(t, seconds, GetProgressDeadlineSecondsOrDefault(rolloutNonDefaultValue))
+	rolloutDefaultValue := &v1alpha1.Rollout{}
+	assert.Equal(t, DefaultProgressDeadlineSeconds, GetProgressDeadlineSecondsOrDefault(rolloutDefaultValue))
+}


### PR DESCRIPTION
Additionally, I simplified the testing framework to allow developers to test specific fields within the objects sent to the Kubernetes API instead of the entire object.  