### PR TITLE
Scale down older RS on non-happy path

### DIFF
--- a/controller/sync.go
+++ b/controller/sync.go
@@ -458,7 +458,7 @@ func (c *Controller) calculateRolloutConditions(r *v1alpha1.Rollout, newStatus v
 		}
 	}
 
-	activeRS := replicasetutil.GetActiveReplicaSet(allRSs, newStatus.BlueGreen.ActiveSelector)
+	activeRS, _ := replicasetutil.GetActiveReplicaSet(allRSs, newStatus.BlueGreen.ActiveSelector)
 	if r.Spec.Strategy.BlueGreenStrategy != nil && activeRS != nil && annotations.IsSaturated(r, activeRS) {
 		availability := conditions.NewRolloutCondition(v1alpha1.RolloutAvailable, corev1.ConditionTrue, conditions.AvailableReason, conditions.AvailableMessage)
 		conditions.SetRolloutCondition(&newStatus, *availability)

--- a/utils/replicaset/bluegreen.go
+++ b/utils/replicaset/bluegreen.go
@@ -7,21 +7,21 @@ import (
 )
 
 // GetActiveReplicaSet finds the replicaset that is serving traffic from the active service or returns nil
-func GetActiveReplicaSet(allRS []*appsv1.ReplicaSet, activeSelector string) *appsv1.ReplicaSet {
+func GetActiveReplicaSet(allRS []*appsv1.ReplicaSet, activeSelector string) (*appsv1.ReplicaSet, []*appsv1.ReplicaSet) {
 	if activeSelector == "" {
-		return nil
+		return nil, allRS
 	}
-	for _, rs := range allRS {
+	for i, rs := range allRS {
 		if rs == nil {
 			continue
 		}
 		if podHash, ok := rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]; ok {
 			if podHash == activeSelector {
-				return rs
+				return rs, append(allRS[:i], allRS[i+1:]...)
 			}
 		}
 	}
-	return nil
+	return nil, allRS
 }
 
 func ReadyForPreview(rollout *v1alpha1.Rollout, newRS *appsv1.ReplicaSet, allRSs []*appsv1.ReplicaSet) bool {

--- a/utils/replicaset/bluegreen_test.go
+++ b/utils/replicaset/bluegreen_test.go
@@ -12,20 +12,26 @@ import (
 )
 
 func TestGetActiveReplicaSet(t *testing.T) {
-	assert.Nil(t, GetActiveReplicaSet(nil, ""))
+	activeRS, nonActiveRSs := GetActiveReplicaSet(nil, "")
+	assert.Nil(t, activeRS)
+	assert.Nil(t, nonActiveRSs)
 	rs1 := &appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: "abcd"},
 		},
 	}
-	assert.Nil(t, GetActiveReplicaSet([]*appsv1.ReplicaSet{rs1}, "1234"))
+	activeRS, nonActiveRSs = GetActiveReplicaSet([]*appsv1.ReplicaSet{rs1}, "1234")
+	assert.Nil(t, activeRS)
+	assert.Equal(t, rs1, nonActiveRSs[0])
 
 	rs2 := &appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: "1234"},
 		},
 	}
-	assert.Equal(t, rs2, GetActiveReplicaSet([]*appsv1.ReplicaSet{nil, rs1, rs2}, "1234"))
+	activeRS, nonActiveRSs = GetActiveReplicaSet([]*appsv1.ReplicaSet{nil, rs1, rs2}, "1234")
+	assert.Equal(t, rs2, activeRS)
+	assert.Len(t, nonActiveRSs, 2)
 }
 
 func TestReadyForPreview(t *testing.T) {

--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -53,7 +53,7 @@ func FindOldReplicaSets(rollout *v1alpha1.Rollout, rsList []*appsv1.ReplicaSet) 
 func NewRSNewReplicas(rollout *v1alpha1.Rollout, allRSs []*appsv1.ReplicaSet, newRS *appsv1.ReplicaSet) (int32, error) {
 	if rollout.Spec.Strategy.BlueGreenStrategy != nil {
 		if rollout.Spec.Strategy.BlueGreenStrategy.PreviewReplicaCount != nil {
-			activeRS := GetActiveReplicaSet(allRSs, rollout.Status.BlueGreen.ActiveSelector)
+			activeRS, _ := GetActiveReplicaSet(allRSs, rollout.Status.BlueGreen.ActiveSelector)
 			if activeRS == nil || activeRS.Name == newRS.Name {
 				return defaults.GetRolloutReplicasOrDefault(rollout), nil
 			}


### PR DESCRIPTION
Solves the second half of https://github.com/argoproj/argo-rollouts/issues/70 by scaling down and deleting old replicasets at any point of the rollout instead of just at the end.