### PR TITLE
Rename autoPromoteActiveServiceDelaySeconds to autoPromotionSeconds

### DIFF
--- a/controller/bluegreen.go
+++ b/controller/bluegreen.go
@@ -130,7 +130,7 @@ func (c *Controller) reconcileBlueGreenPause(activeSvc *corev1.Service, rollout 
 		return false
 	}
 	pauseStartTime := rollout.Status.PauseStartTime
-	autoPromoteActiveServiceDelaySeconds := rollout.Spec.Strategy.BlueGreenStrategy.AutoPromoteActiveServiceDelaySeconds
+	autoPromoteActiveServiceDelaySeconds := rollout.Spec.Strategy.BlueGreenStrategy.AutoPromotionSeconds
 	if autoPromoteActiveServiceDelaySeconds != nil && pauseStartTime != nil {
 		c.checkEnqueueRolloutDuringWait(rollout, *pauseStartTime, *autoPromoteActiveServiceDelaySeconds)
 	}

--- a/controller/bluegreen_test.go
+++ b/controller/bluegreen_test.go
@@ -205,7 +205,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 
 		r1 := newBlueGreenRollout("foo", 1, nil, "active", "preview")
 		r2 := bumpVersion(r1)
-		r2.Spec.Strategy.BlueGreenStrategy.AutoPromoteActiveServiceDelaySeconds = pointer.Int32Ptr(10)
+		r2.Spec.Strategy.BlueGreenStrategy.AutoPromotionSeconds = pointer.Int32Ptr(10)
 
 		rs1 := newReplicaSetWithStatus(r1, "foo-895c6c4f9", 1, 1)
 		rs2 := newReplicaSetWithStatus(r2, "foo-5f79b78d7f", 1, 1)
@@ -239,7 +239,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 
 		r1 := newBlueGreenRollout("foo", 1, nil, "active", "preview")
 		r2 := bumpVersion(r1)
-		r2.Spec.Strategy.BlueGreenStrategy.AutoPromoteActiveServiceDelaySeconds = pointer.Int32Ptr(10)
+		r2.Spec.Strategy.BlueGreenStrategy.AutoPromotionSeconds = pointer.Int32Ptr(10)
 
 		rs1 := newReplicaSetWithStatus(r1, "foo-895c6c4f9", 1, 1)
 		rs2 := newReplicaSetWithStatus(r2, "foo-5f79b78d7f", 1, 1)

--- a/controller/pause.go
+++ b/controller/pause.go
@@ -61,9 +61,9 @@ func calculatePauseStatus(rollout *v1alpha1.Rollout, addPause bool) (*metav1.Tim
 	}
 
 	if paused && rollout.Spec.Strategy.BlueGreenStrategy != nil {
-		if pauseStartTime != nil && rollout.Spec.Strategy.BlueGreenStrategy.AutoPromoteActiveServiceDelaySeconds != nil {
+		if pauseStartTime != nil && rollout.Spec.Strategy.BlueGreenStrategy.AutoPromotionSeconds != nil {
 			now := metav1.Now()
-			autoPromoteActiveServiceDelaySeconds := *rollout.Spec.Strategy.BlueGreenStrategy.AutoPromoteActiveServiceDelaySeconds
+			autoPromoteActiveServiceDelaySeconds := *rollout.Spec.Strategy.BlueGreenStrategy.AutoPromotionSeconds
 			switchDeadline := pauseStartTime.Add(time.Duration(autoPromoteActiveServiceDelaySeconds) * time.Second)
 			if now.After(switchDeadline) {
 				return nil, false

--- a/manifests/crds/rollout-crd.yaml
+++ b/manifests/crds/rollout-crd.yaml
@@ -57,10 +57,8 @@ spec:
               format: int32
               type: integer
             revisionHistoryLimit:
-              description: The number of old ReplicaSets to retain. This is a pointer
-                to distinguish between explicit zero and not specified. This is set
-                to the max value of int32 (i.e. 2147483647) by default, which means
-                "retaining all old ReplicaSets".
+              description: The number of old ReplicaSets to retain. If unspecified,
+                will retain 10 old ReplicaSets
               format: int32
               type: integer
             selector: {}
@@ -75,10 +73,12 @@ spec:
                       description: Name of the service that the rollout modifies as
                         the active service.
                       type: string
-                    autoPromoteActiveServiceDelaySeconds:
-                      description: AutoPromoteActiveServiceDelaySeconds add a delay
-                        before automatically promoting the ReplicaSet under the preview
-                        service to the active service.
+                    autoPromotionSeconds:
+                      description: AutoPromotionSeconds automatically promotes the
+                        current ReplicaSet to active after the specified pause delay
+                        in seconds after the ReplicaSet becomes ready. If omitted,
+                        the Rollout enters and remains in a paused state until manually
+                        resumed by resetting spec.Paused to false.
                       format: int32
                       type: integer
                     previewReplicaCount:
@@ -94,7 +94,10 @@ spec:
                       type: string
                     scaleDownDelaySeconds:
                       description: ScaleDownDelaySeconds adds a delay before scaling
-                        down the previous replicaset. See https://github.com/argoproj/argo-rollouts/issues/19#issuecomment-476329960
+                        down the previous replicaset. If omitted, the Rollout waits
+                        30 seconds before scaling down the previous ReplicaSet. A
+                        minimum of 30 seconds is recommended to ensure IP table propagation
+                        across the nodes in a cluster. See https://github.com/argoproj/argo-rollouts/issues/19#issuecomment-476329960
                         for more information
                       format: int32
                       type: integer

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -58,10 +58,8 @@ spec:
               format: int32
               type: integer
             revisionHistoryLimit:
-              description: The number of old ReplicaSets to retain. This is a pointer
-                to distinguish between explicit zero and not specified. This is set
-                to the max value of int32 (i.e. 2147483647) by default, which means
-                "retaining all old ReplicaSets".
+              description: The number of old ReplicaSets to retain. If unspecified,
+                will retain 10 old ReplicaSets
               format: int32
               type: integer
             selector: {}
@@ -76,10 +74,12 @@ spec:
                       description: Name of the service that the rollout modifies as
                         the active service.
                       type: string
-                    autoPromoteActiveServiceDelaySeconds:
-                      description: AutoPromoteActiveServiceDelaySeconds add a delay
-                        before automatically promoting the ReplicaSet under the preview
-                        service to the active service.
+                    autoPromotionSeconds:
+                      description: AutoPromotionSeconds automatically promotes the
+                        current ReplicaSet to active after the specified pause delay
+                        in seconds after the ReplicaSet becomes ready. If omitted,
+                        the Rollout enters and remains in a paused state until manually
+                        resumed by resetting spec.Paused to false.
                       format: int32
                       type: integer
                     previewReplicaCount:
@@ -95,7 +95,10 @@ spec:
                       type: string
                     scaleDownDelaySeconds:
                       description: ScaleDownDelaySeconds adds a delay before scaling
-                        down the previous replicaset. See https://github.com/argoproj/argo-rollouts/issues/19#issuecomment-476329960
+                        down the previous replicaset. If omitted, the Rollout waits
+                        30 seconds before scaling down the previous ReplicaSet. A
+                        minimum of 30 seconds is recommended to ensure IP table propagation
+                        across the nodes in a cluster. See https://github.com/argoproj/argo-rollouts/issues/19#issuecomment-476329960
                         for more information
                       format: int32
                       type: integer

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -58,10 +58,8 @@ spec:
               format: int32
               type: integer
             revisionHistoryLimit:
-              description: The number of old ReplicaSets to retain. This is a pointer
-                to distinguish between explicit zero and not specified. This is set
-                to the max value of int32 (i.e. 2147483647) by default, which means
-                "retaining all old ReplicaSets".
+              description: The number of old ReplicaSets to retain. If unspecified,
+                will retain 10 old ReplicaSets
               format: int32
               type: integer
             selector: {}
@@ -76,10 +74,12 @@ spec:
                       description: Name of the service that the rollout modifies as
                         the active service.
                       type: string
-                    autoPromoteActiveServiceDelaySeconds:
-                      description: AutoPromoteActiveServiceDelaySeconds add a delay
-                        before automatically promoting the ReplicaSet under the preview
-                        service to the active service.
+                    autoPromotionSeconds:
+                      description: AutoPromotionSeconds automatically promotes the
+                        current ReplicaSet to active after the specified pause delay
+                        in seconds after the ReplicaSet becomes ready. If omitted,
+                        the Rollout enters and remains in a paused state until manually
+                        resumed by resetting spec.Paused to false.
                       format: int32
                       type: integer
                     previewReplicaCount:
@@ -95,7 +95,10 @@ spec:
                       type: string
                     scaleDownDelaySeconds:
                       description: ScaleDownDelaySeconds adds a delay before scaling
-                        down the previous replicaset. See https://github.com/argoproj/argo-rollouts/issues/19#issuecomment-476329960
+                        down the previous replicaset. If omitted, the Rollout waits
+                        30 seconds before scaling down the previous ReplicaSet. A
+                        minimum of 30 seconds is recommended to ensure IP table propagation
+                        across the nodes in a cluster. See https://github.com/argoproj/argo-rollouts/issues/19#issuecomment-476329960
                         for more information
                       format: int32
                       type: integer

--- a/pkg/apis/rollouts/v1alpha1/openapi_generated.go
+++ b/pkg/apis/rollouts/v1alpha1/openapi_generated.go
@@ -112,16 +112,16 @@ func schema_pkg_apis_rollouts_v1alpha1_BlueGreenStrategy(ref common.ReferenceCal
 							Format:      "int32",
 						},
 					},
-					"autoPromoteActiveServiceDelaySeconds": {
+					"autoPromotionSeconds": {
 						SchemaProps: spec.SchemaProps{
-							Description: "AutoPromoteActiveServiceDelaySeconds add a delay before automatically promoting the ReplicaSet under the preview service to the active service.",
+							Description: "AutoPromotionSeconds automatically promotes the current ReplicaSet to active after the specified pause delay in seconds after the ReplicaSet becomes ready. If omitted, the Rollout enters and remains in a paused state until manually resumed by resetting spec.Paused to false.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
 					},
 					"scaleDownDelaySeconds": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ScaleDownDelaySeconds adds a delay before scaling down the previous replicaset. See https://github.com/argoproj/argo-rollouts/issues/19#issuecomment-476329960 for more information",
+							Description: "ScaleDownDelaySeconds adds a delay before scaling down the previous replicaset. If omitted, the Rollout waits 30 seconds before scaling down the previous ReplicaSet. A minimum of 30 seconds is recommended to ensure IP table propagation across the nodes in a cluster. See https://github.com/argoproj/argo-rollouts/issues/19#issuecomment-476329960 for more information",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -168,7 +168,7 @@ func schema_pkg_apis_rollouts_v1alpha1_CanaryStep(ref common.ReferenceCallback) 
 					},
 					"pause": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Pause freezes the rollout. If an empty struct is provided, it will freeze until a user sets the spec.Pause to false",
+							Description: "Pause freezes the rollout by setting spec.Paused to true. A Rollout will resume when spec.Paused is reset to false.",
 							Ref:         ref("github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.RolloutPause"),
 						},
 					},
@@ -424,7 +424,7 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutSpec(ref common.ReferenceCallback)
 					},
 					"revisionHistoryLimit": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The number of old ReplicaSets to retain. This is a pointer to distinguish between explicit zero and not specified. This is set to the max value of int32 (i.e. 2147483647) by default, which means \"retaining all old ReplicaSets\".",
+							Description: "The number of old ReplicaSets to retain. If unspecified, will retain 10 old ReplicaSets",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},

--- a/pkg/apis/rollouts/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/rollouts/v1alpha1/zz_generated.deepcopy.go
@@ -54,8 +54,8 @@ func (in *BlueGreenStrategy) DeepCopyInto(out *BlueGreenStrategy) {
 		*out = new(int32)
 		**out = **in
 	}
-	if in.AutoPromoteActiveServiceDelaySeconds != nil {
-		in, out := &in.AutoPromoteActiveServiceDelaySeconds, &out.AutoPromoteActiveServiceDelaySeconds
+	if in.AutoPromotionSeconds != nil {
+		in, out := &in.AutoPromotionSeconds, &out.AutoPromotionSeconds
 		*out = new(int32)
 		**out = **in
 	}


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/66

* Rename autoPromoteActiveServiceDelaySeconds to autoPromotionSeconds
* Improve and fix documentation for various fields

