### PR TITLE
Fix controller crash caused by glog attempting to write to /tmp

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,6 @@
+####################################################################################################
+# argo-rollouts-dev
+####################################################################################################
+FROM scratch
+COPY dist/rollouts-controller-linux-amd64 /bin/rollouts-controller
+ENTRYPOINT [ "/bin/rollouts-controller" ]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -595,8 +595,8 @@
   revision = "e8a638592964bfb3aaacb66d283c483097d1c0a7"
 
 [[projects]]
-  branch = "master"
-  digest = "1:3166a472475f9904e42f93565fca74f7f20d9a5f3bc1b0ac321aedc5a211e796"
+  branch = "release-1.12"
+  digest = "1:9c7ee6fe7b8b621df5a7604e9a1f752b566ae451b2cf010c9c075e5e5ff81f56"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -648,7 +648,7 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = ""
-  revision = "1b0702fe2927f82126da9c2ecf567f14676f6072"
+  revision = "01f179d85dbce0f2e0e4351a92394b38694b7cae"
 
 [[projects]]
   branch = "release-1.12"
@@ -667,7 +667,7 @@
 
 [[projects]]
   branch = "release-9.0"
-  digest = "1:303a14c5b87098d9ebf2773aba2ebc9b3f4808ba4e6d7c547b0fed4e624d9e30"
+  digest = "1:b1a32e8c431a032029c57bd211aa8b7e7de4fd7e142d4805be654da286f5efe4"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -842,7 +842,7 @@
     "util/workqueue",
   ]
   pruneopts = ""
-  revision = "02f343fb27038ed2f570c9ecb2484fb11f2a59a9"
+  revision = "b6aa6aafe32b0767f075245e5d391381c5449c8a"
 
 [[projects]]
   branch = "release-1.12"
@@ -878,12 +878,12 @@
   revision = "fd15ee9cc2f77baa4f31e59e6acbf21146455073"
 
 [[projects]]
-  digest = "1:4f5eb833037cc0ba0bf8fe9cae6be9df62c19dd1c869415275c708daa8ccfda5"
+  digest = "1:32e54cfe25c8eea758b1e0d3aec033ba652d0557cb79ee62d1ba239f5f694c0e"
   name = "k8s.io/klog"
   packages = ["."]
   pruneopts = ""
-  revision = "a5bc97fbc634d635061f3146511332c7e313a55a"
-  version = "v0.1.0"
+  revision = "89e63fd5117f8c20208186ef85f096703a280c20"
+  version = "v0.3.1"
 
 [[projects]]
   branch = "master"
@@ -953,14 +953,6 @@
   packages = ["pointer"]
   pruneopts = ""
   revision = "0d26856f57b32ec3398579285e5c8a2bfe8c5243"
-
-[[projects]]
-  digest = "1:321081b4a44256715f2b68411d8eda9a17f17ebfe6f0cc61d2cc52d11c08acfa"
-  name = "sigs.k8s.io/yaml"
-  packages = ["."]
-  pruneopts = ""
-  revision = "fd68e9863619f6ec2fdd8625fe1f02e7c877e480"
-  version = "v1.1.0"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,3 +27,7 @@ required = [
 [[override]]
   name = "k8s.io/apiserver"
   branch = "release-1.12"
+
+[[override]]
+  name = "k8s.io/apimachinery"
+  branch = "release-1.12"

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ GIT_TAG=$(shell if [ -z "`git status --porcelain`" ]; then git describe --exact-
 GIT_TREE_STATE=$(shell if [ -z "`git status --porcelain`" ]; then echo "clean" ; else echo "dirty"; fi)
 TEST_CMD=$(shell [ "`which gotestsum`" != "" ] && echo gotestsum -- || echo go test)
 
+# build development images
+DEV_IMAGE=false
+
 override LDFLAGS += \
   -X ${PACKAGE}.version=${VERSION} \
   -X ${PACKAGE}.buildDate=${BUILD_DATE} \
@@ -59,7 +62,12 @@ builder-image:
 
 .PHONY: image
 image:
+ifeq ($(DEV_IMAGE), true)
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/rollouts-controller-linux-amd64 ./cmd/rollouts-controller
+	docker build -t $(IMAGE_PREFIX)argo-rollouts:$(IMAGE_TAG) -f Dockerfile.dev .
+else
 	docker build -t $(IMAGE_PREFIX)argo-rollouts:$(IMAGE_TAG)  .
+endif
 	@if [ "$(DOCKER_PUSH)" = "true" ] ; then docker push $(IMAGE_PREFIX)argo-rollouts:$(IMAGE_TAG) ; fi
 
 .PHONY: lint

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
@@ -106,7 +105,7 @@ func NewController(
 	utilruntime.Must(rolloutscheme.AddToScheme(scheme.Scheme))
 	log.Info("Creating event broadcaster")
 	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(glog.Infof)
+	eventBroadcaster.StartLogging(log.Infof)
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeclientset.CoreV1().Events("")})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerAgentName})
 	replicaSetControl := controller.RealRSControl{


### PR DESCRIPTION
Resolves: https://github.com/argoproj/argo-rollouts/issues/85

We were using a `k8s.io/apimachinery` version which somehow was using glog where it did not honor the `logtostderr` flag in glog. This caused the controller to log to `/tmp` in certain cases, which crashed the controller since /tmp does not exist in scratch containers.

This change also allows a dev version of the controller image, for much faster docker builds:

```
make image DEV_IMAGE=true
```