### PR TITLE
Add +kubebuilder:printcolumn annotations to the Rollout type

### DIFF
--- a/manifests/crds/rollout-crd.yaml
+++ b/manifests/crds/rollout-crd.yaml
@@ -3,6 +3,25 @@ kind: CustomResourceDefinition
 metadata:
   name: rollouts.argoproj.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.replicas
+    description: Number of desired pods
+    name: Desired
+    type: integer
+  - JSONPath: .status.replicas
+    description: Total number of non-terminated pods targeted by this rollout
+    name: Current
+    type: integer
+  - JSONPath: .status.updatedReplicas
+    description: Total number of non-terminated pods targeted by this rollout that
+      have the desired template spec
+    name: Up-to-date
+    type: integer
+  - JSONPath: .status.availableReplicas
+    description: Total number of available pods (ready for at least minReadySeconds)
+      targeted by this rollout
+    name: Available
+    type: integer
   group: argoproj.io
   names:
     kind: Rollout

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -2067,9 +2067,6 @@ spec:
             availableAt:
               format: date-time
               type: string
-            collisionCount:
-              format: int32
-              type: integer
             conditions:
               items:
                 properties:
@@ -2106,6 +2103,9 @@ spec:
                   availableReplicas:
                     format: int32
                     type: integer
+                  collisionCount:
+                    format: int32
+                    type: integer
                   name:
                     type: string
                   readyReplicas:
@@ -2139,6 +2139,25 @@ kind: CustomResourceDefinition
 metadata:
   name: rollouts.argoproj.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.replicas
+    description: Number of desired pods
+    name: Desired
+    type: integer
+  - JSONPath: .status.replicas
+    description: Total number of non-terminated pods targeted by this rollout
+    name: Current
+    type: integer
+  - JSONPath: .status.updatedReplicas
+    description: Total number of non-terminated pods targeted by this rollout that
+      have the desired template spec
+    name: Up-to-date
+    type: integer
+  - JSONPath: .status.availableReplicas
+    description: Total number of available pods (ready for at least minReadySeconds)
+      targeted by this rollout
+    name: Available
+    type: integer
   group: argoproj.io
   names:
     kind: Rollout

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2067,9 +2067,6 @@ spec:
             availableAt:
               format: date-time
               type: string
-            collisionCount:
-              format: int32
-              type: integer
             conditions:
               items:
                 properties:
@@ -2106,6 +2103,9 @@ spec:
                   availableReplicas:
                     format: int32
                     type: integer
+                  collisionCount:
+                    format: int32
+                    type: integer
                   name:
                     type: string
                   readyReplicas:
@@ -2139,6 +2139,25 @@ kind: CustomResourceDefinition
 metadata:
   name: rollouts.argoproj.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.replicas
+    description: Number of desired pods
+    name: Desired
+    type: integer
+  - JSONPath: .status.replicas
+    description: Total number of non-terminated pods targeted by this rollout
+    name: Current
+    type: integer
+  - JSONPath: .status.updatedReplicas
+    description: Total number of non-terminated pods targeted by this rollout that
+      have the desired template spec
+    name: Up-to-date
+    type: integer
+  - JSONPath: .status.availableReplicas
+    description: Total number of available pods (ready for at least minReadySeconds)
+      targeted by this rollout
+    name: Available
+    type: integer
   group: argoproj.io
   names:
     kind: Rollout

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -11,6 +11,10 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:path=rollouts,shortName=ro
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.HPAReplicas,selectorpath=.status.selector
+// +kubebuilder:printcolumn:name="Desired",type="integer",JSONPath=".spec.replicas",description="Number of desired pods"
+// +kubebuilder:printcolumn:name="Current",type="integer",JSONPath=".status.replicas",description="Total number of non-terminated pods targeted by this rollout"
+// +kubebuilder:printcolumn:name="Up-to-date",type="integer",JSONPath=".status.updatedReplicas",description="Total number of non-terminated pods targeted by this rollout that have the desired template spec"
+// +kubebuilder:printcolumn:name="Available",type="integer",JSONPath=".status.availableReplicas",description="Total number of available pods (ready for at least minReadySeconds) targeted by this rollout"
 
 // Rollout is a specification for a Rollout resource
 type Rollout struct {


### PR DESCRIPTION
+kubebuilder:printcolumn annotations are used to generate the additionalPrinterColumns field of a CRD to define the set of columns used in server-side printing.

The columns added are the same as those of deployment, i.e. desired, current, up-to-date and available.

Resolves https://github.com/argoproj/argo-rollouts/issues/27.