### PR TITLE
Don't validate scaleDownDelay > progressingDeadline

### DIFF
--- a/utils/conditions/conditions.go
+++ b/utils/conditions/conditions.go
@@ -39,8 +39,6 @@ const (
 	InvalidMaxSurgeMaxUnavailable = "MaxSurge and MaxUnavailable both can not be zero"
 	// InvalidStepMessage indicates that a step must have either setWeight or pause set
 	InvalidStepMessage = "Step must have either setWeight or pause set"
-	// ScaleDownDelayLongerThanDeadlineMessage indicates the ScaleDownDelaySeconds is longer than ProgressDeadlineSeconds
-	ScaleDownDelayLongerThanDeadlineMessage = "ScaleDownDelaySeconds cannot be longer than ProgressDeadlineSeconds"
 	// MinReadyLongerThanDeadlineMessage indicates the MinReadySeconds is longer than ProgressDeadlineSeconds
 	MinReadyLongerThanDeadlineMessage = "MinReadySeconds cannot be longer than ProgressDeadlineSeconds"
 	// InvalidStrategyMessage indiciates that multiple strategies can not be listed
@@ -299,10 +297,6 @@ func VerifyRolloutSpec(rollout *v1alpha1.Rollout, prevCond *v1alpha1.RolloutCond
 	}
 
 	if rollout.Spec.Strategy.BlueGreenStrategy != nil {
-		if defaults.GetScaleDownDelaySecondsOrDefault(rollout) > defaults.GetProgressDeadlineSecondsOrDefault(rollout) {
-			return newInvalidSpecRolloutCondition(prevCond, InvalidSpecReason, ScaleDownDelayLongerThanDeadlineMessage)
-		}
-
 		if rollout.Spec.Strategy.BlueGreenStrategy.ActiveService == "" {
 			message := fmt.Sprintf(MissingFieldMessage, ".Spec.Strategy.BlueGreenStrategy.ActiveService")
 			return newInvalidSpecRolloutCondition(prevCond, InvalidSpecReason, message)

--- a/utils/conditions/rollouts_test.go
+++ b/utils/conditions/rollouts_test.go
@@ -250,13 +250,6 @@ func TestVerifyRolloutSpecBlueGreen(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf(MissingFieldMessage, ".Spec.Strategy.BlueGreenStrategy.ActiveService"), noActiveSvcCond.Message)
 	assert.Equal(t, InvalidSpecReason, noActiveSvcCond.Reason)
 
-	scaleDownDelayLongerThanProgressDeadline := validRollout.DeepCopy()
-	scaleDownDelayLongerThanProgressDeadline.Spec.Strategy.BlueGreenStrategy.ScaleDownDelaySeconds = pointer.Int32Ptr(1000)
-	scaleDownDelayLongerThanProgressDeadlineCond := VerifyRolloutSpec(scaleDownDelayLongerThanProgressDeadline, nil)
-	assert.NotNil(t, scaleDownDelayLongerThanProgressDeadlineCond)
-	assert.Equal(t, InvalidSpecReason, scaleDownDelayLongerThanProgressDeadlineCond.Reason)
-	assert.Equal(t, ScaleDownDelayLongerThanDeadlineMessage, scaleDownDelayLongerThanProgressDeadlineCond.Message)
-
 	sameSvcs := validRollout.DeepCopy()
 	sameSvcs.Spec.Strategy.BlueGreenStrategy.ActiveService = "preview"
 	sameSvcsCond := VerifyRolloutSpec(sameSvcs, nil)


### PR DESCRIPTION
Since the scaleDownDelay is attached to individual RS and a rollout can be complete without the old RS scaling down, the progressDeadlineSeconds is now independent of the scaleDownDelaySeconds