### PR TITLE
ClusterRole missing patch privileges on replicasets

### DIFF
--- a/manifests/base/argo-rollouts-role.yaml
+++ b/manifests/base/argo-rollouts-role.yaml
@@ -8,36 +8,37 @@ metadata:
     app.kubernetes.io/part-of: argo-rollouts
 rules:
 - apiGroups:
-  - argoproj.io
-  resources:
-  - rollouts
-  - experiments
-  verbs:
-  - watch
-  - get
-  - list
-  - update
-  - patch
-- apiGroups:
   - apps
   resources:
   - replicasets
   verbs:
+  - watch
   - get
   - list
   - create
   - update
+  - patch
   - delete
-  - watch
 - apiGroups:
   - ""
   resources:
   - services
   verbs:
+  - watch
   - get
   - list
   - patch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  - experiments
+  verbs:
+  - get
+  - list
+  - update
   - watch
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/manifests/cluster-install/argo-rollouts-clusterrole.yaml
+++ b/manifests/cluster-install/argo-rollouts-clusterrole.yaml
@@ -17,6 +17,7 @@ rules:
   - list
   - create
   - update
+  - patch
   - delete
 - apiGroups:
   - ""

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -4363,36 +4363,37 @@ metadata:
   name: argo-rollouts-role
 rules:
 - apiGroups:
-  - argoproj.io
-  resources:
-  - rollouts
-  - experiments
-  verbs:
-  - watch
-  - get
-  - list
-  - update
-  - patch
-- apiGroups:
   - apps
   resources:
   - replicasets
   verbs:
+  - watch
   - get
   - list
   - create
   - update
+  - patch
   - delete
-  - watch
 - apiGroups:
   - ""
   resources:
   - services
   verbs:
+  - watch
   - get
   - list
   - patch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  - experiments
+  verbs:
+  - get
+  - list
+  - update
   - watch
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -2373,6 +2373,9 @@ spec:
                       type: integer
                     previewService:
                       type: string
+                    scaleDownDelayRevisionLimit:
+                      format: int32
+                      type: integer
                     scaleDownDelaySeconds:
                       format: int32
                       type: integer
@@ -4488,6 +4491,7 @@ rules:
   - list
   - create
   - update
+  - patch
   - delete
 - apiGroups:
   - ""

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -4363,36 +4363,37 @@ metadata:
   name: argo-rollouts-role
 rules:
 - apiGroups:
-  - argoproj.io
-  resources:
-  - rollouts
-  - experiments
-  verbs:
-  - watch
-  - get
-  - list
-  - update
-  - patch
-- apiGroups:
   - apps
   resources:
   - replicasets
   verbs:
+  - watch
   - get
   - list
   - create
   - update
+  - patch
   - delete
-  - watch
 - apiGroups:
   - ""
   resources:
   - services
   verbs:
+  - watch
   - get
   - list
   - patch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  - experiments
+  verbs:
+  - get
+  - list
+  - update
   - watch
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2373,6 +2373,9 @@ spec:
                       type: integer
                     previewService:
                       type: string
+                    scaleDownDelayRevisionLimit:
+                      format: int32
+                      type: integer
                     scaleDownDelaySeconds:
                       format: int32
                       type: integer


### PR DESCRIPTION
Controller was hitting the following error:

```
E0910 23:45:08.441072       1 controller.go:287] [replicasets.apps "istio-rollout-67fb48cc58" is forbidden: User "system:serviceaccount:argo-rollouts:argo-rollouts" cannot patch resource "replicasets" in API group "apps" in the namespace "istio-rollout", replicasets.apps "istio-rollout-7bffb4d96b" is forbidden: Use
r "system:serviceaccount:argo-rollouts:argo-rollouts" cannot patch resource "replicasets" in API group "apps" in the namespace "istio-rollout"]
```