### PR TITLE
Add metric knob for maxInconclusive

### DIFF
--- a/manifests/crds/analysis-run-crd.yaml
+++ b/manifests/crds/analysis-run-crd.yaml
@@ -42,6 +42,9 @@ spec:
                       maxFailures:
                         format: int32
                         type: integer
+                      maxInconclusive:
+                        format: int32
+                        type: integer
                       name:
                         type: string
                       provider:

--- a/manifests/crds/analysis-template-crd.yaml
+++ b/manifests/crds/analysis-template-crd.yaml
@@ -40,6 +40,9 @@ spec:
                   maxFailures:
                     format: int32
                     type: integer
+                  maxInconclusive:
+                    format: int32
+                    type: integer
                   name:
                     type: string
                   provider:

--- a/pkg/apis/rollouts/v1alpha1/analysis_types.go
+++ b/pkg/apis/rollouts/v1alpha1/analysis_types.go
@@ -52,8 +52,11 @@ type Metric struct {
 	// either condition, the measurement is considered Inconclusive
 	FailureCondition string `json:"failureCondition,omitempty"`
 	// MaxFailures is the maximum number of times the measurement is allowed to fail, before the
-	// entire metric is considered failed (default: 0)
+	// entire metric is considered Failed (default: 0)
 	MaxFailures int32 `json:"maxFailures,omitempty"`
+	// MaxInconclusive is the maximum number of times the measurement is allowed to measure
+	// Inconclusive, before the entire metric is considered Inconclusive (default: 0)
+	MaxInconclusive int32 `json:"maxInconclusive,omitempty"`
 	// MaxConsecutiveErrors is the maximum number of times the measurement is allowed to error in
 	// succession, before the metric is considered error (default: 4)
 	MaxConsecutiveErrors *int32 `json:"maxConsecutiveErrors,omitempty"`
@@ -85,10 +88,10 @@ type AnalysisProvider struct {
 	Prometheus *PrometheusMetric `json:"prometheus,omitempty"`
 }
 
-// AnalysisStatus is the overall status of the AnalysisRun, MetricResults, or Measurement
+// AnalysisStatus is the overall status of an AnalysisRun, MetricResult, or Measurement
 type AnalysisStatus string
 
-// AnalysisStatus is the overall status of the AnalysisRun, MetricResults
+// Possible AnalysisStatus values
 const (
 	AnalysisStatusPending      AnalysisStatus = "Pending"
 	AnalysisStatusRunning      AnalysisStatus = "Running"

--- a/pkg/apis/rollouts/v1alpha1/openapi_generated.go
+++ b/pkg/apis/rollouts/v1alpha1/openapi_generated.go
@@ -254,7 +254,7 @@ func schema_pkg_apis_rollouts_v1alpha1_AnalysisRunStatus(ref common.ReferenceCal
 					},
 					"metricResults": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Metrics contains the metrics collected during the run",
+							Description: "MetricResults contains the metrics collected during the run",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -976,7 +976,14 @@ func schema_pkg_apis_rollouts_v1alpha1_Metric(ref common.ReferenceCallback) comm
 					},
 					"maxFailures": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MaxFailures is the maximum number of times the measurement is allowed to fail, before the entire metric is considered failed (default: 0)",
+							Description: "MaxFailures is the maximum number of times the measurement is allowed to fail, before the entire metric is considered Failed (default: 0)",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"maxInconclusive": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MaxInconclusive is the maximum number of times the measurement is allowed to measure Inconclusive, before the entire metric is considered Inconclusive (default: 0)",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},

--- a/utils/analysis/analysis.go
+++ b/utils/analysis/analysis.go
@@ -38,6 +38,9 @@ func ValidateMetric(metric v1alpha1.Metric) error {
 	if metric.MaxFailures < 0 {
 		return fmt.Errorf("maxFailures must be >= 0")
 	}
+	if metric.MaxInconclusive < 0 {
+		return fmt.Errorf("maxInconclusive must be >= 0")
+	}
 	if metric.MaxConsecutiveErrors != nil && *metric.MaxConsecutiveErrors < 0 {
 		return fmt.Errorf("maxConsecutiveErrors must be >= 0")
 	}
@@ -88,10 +91,12 @@ func IsTerminating(run *v1alpha1.AnalysisRun) bool {
 	if run.Spec.Terminate {
 		return true
 	}
-	for _, res := range run.Status.MetricResults {
-		switch res.Status {
-		case v1alpha1.AnalysisStatusFailed, v1alpha1.AnalysisStatusError, v1alpha1.AnalysisStatusInconclusive:
-			return true
+	if run.Status != nil {
+		for _, res := range run.Status.MetricResults {
+			switch res.Status {
+			case v1alpha1.AnalysisStatusFailed, v1alpha1.AnalysisStatusError, v1alpha1.AnalysisStatusInconclusive:
+				return true
+			}
 		}
 	}
 	return false

--- a/utils/analysis/analysis_test.go
+++ b/utils/analysis/analysis_test.go
@@ -151,7 +151,7 @@ func TestIsWorst(t *testing.T) {
 	assert.False(t, IsWorse(v1alpha1.AnalysisStatusFailed, v1alpha1.AnalysisStatusFailed))
 }
 
-func TestIsFailing(t *testing.T) {
+func TestIsFastFailTerminating(t *testing.T) {
 	run := &v1alpha1.AnalysisRun{
 		Status: &v1alpha1.AnalysisRunStatus{
 			Status: v1alpha1.AnalysisStatusRunning,
@@ -168,13 +168,16 @@ func TestIsFailing(t *testing.T) {
 		},
 	}
 	successRate := run.Status.MetricResults[1]
-	assert.False(t, IsFailing(run))
+	assert.False(t, IsTerminating(run))
 	successRate.Status = v1alpha1.AnalysisStatusError
 	run.Status.MetricResults[1] = successRate
-	assert.True(t, IsFailing(run))
+	assert.True(t, IsTerminating(run))
 	successRate.Status = v1alpha1.AnalysisStatusFailed
 	run.Status.MetricResults[1] = successRate
-	assert.True(t, IsFailing(run))
+	assert.True(t, IsTerminating(run))
+	successRate.Status = v1alpha1.AnalysisStatusInconclusive
+	run.Status.MetricResults[1] = successRate
+	assert.True(t, IsTerminating(run))
 }
 
 func TestGetResult(t *testing.T) {


### PR DESCRIPTION
This adds a metric field `maxInconclusive`, which allows user to specify a maximum number of times a metric is allowed to measure Inconclusive, before making the entire metric Inconclusive.