### PR TITLE
Implement argo rollouts kubectl plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
     docker:
       # CircleCI Go images available at: https://hub.docker.com/r/circleci/golang/
       - image: circleci/golang:1.13.1
+    resource_class: large
     environment:
       TEST_RESULTS: /tmp/test-results
     steps:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,25 @@
   version = "v0.33.1"
 
 [[projects]]
+  branch = "master"
+  digest = "1:6978a38432a017763a148afbc7ce6491734b54292af7d3e969d84d2e9dd242e2"
+  name = "github.com/Azure/go-ansiterm"
+  packages = [
+    ".",
+    "winterm",
+  ]
+  pruneopts = ""
+  revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
+
+[[projects]]
+  digest = "1:63e57618d792cccb87ad7cb8a0602e6205732beb3b01b0ea858fc4a5fd3ce8f1"
+  name = "github.com/MakeNowJust/heredoc"
+  packages = ["."]
+  pruneopts = ""
+  revision = "efb6ca8de9d5385c3963279701760e37637cf238"
+  version = "v2.0.1"
+
+[[projects]]
   digest = "1:8e47871087b94913898333f37af26732faaab30cdb41571136cf7aec9921dae7"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
@@ -88,6 +107,27 @@
   revision = "aa985ba8897a426e5db31b36cd8cca83cf85cead"
 
 [[projects]]
+  digest = "1:50a4629dd29d90473be834b7d6c502f310a269f06f31c069a8c6e2b4274a14b3"
+  name = "github.com/docker/docker"
+  packages = [
+    "pkg/term",
+    "pkg/term/windows",
+  ]
+  pruneopts = ""
+  revision = "be7ac8be2ae072032a4005e8f232be3fc57e4127"
+
+[[projects]]
+  branch = "master"
+  digest = "1:d6c13a378213e3de60445e49084b8a0a9ce582776dfc77927775dbeb3ff72a35"
+  name = "github.com/docker/spdystream"
+  packages = [
+    ".",
+    "spdy",
+  ]
+  pruneopts = ""
+  revision = "6480d4af844c189cf5dd913db24ddd339d3a4f85"
+
+[[projects]]
   digest = "1:8a34d7a37b8f07239487752e14a5faafcbbc718fc385ad429a2c4ac6f27a207f"
   name = "github.com/emicklei/go-restful"
   packages = [
@@ -105,6 +145,14 @@
   pruneopts = ""
   revision = "afac545df32f2287a079e2dfb7ba2745a643747e"
   version = "v3.0.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:549f95037fea25e00a5341ac6a169a5b3e5306be107f45260440107b779b74f9"
+  name = "github.com/exponent-io/jsonpath"
+  packages = ["."]
+  pruneopts = ""
+  revision = "d6023ce2651d8eafb5c75bb0c7167536102ec9f5"
 
 [[projects]]
   digest = "1:b13707423743d41665fd23f0c36b2f37bb49c30e94adb813319c44188a51ba22"
@@ -180,6 +228,14 @@
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:1e5b1e14524ed08301977b7b8e10c719ed853cbf3f24ecb66fae783a46f207a6"
+  name = "github.com/google/btree"
+  packages = ["."]
+  pruneopts = ""
+  revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:9fcb267c272bc5054564b392e3ff7e65e35400fd9914afb1d169f92b95e7dbc9"
   name = "github.com/google/go-cmp"
   packages = [
@@ -220,6 +276,17 @@
   pruneopts = ""
   revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
   version = "v0.2.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:e1fd67b5695fb12f54f979606c5d650a5aa72ef242f8e71072bfd4f7b5a141a0"
+  name = "github.com/gregjones/httpcache"
+  packages = [
+    ".",
+    "diskcache",
+  ]
+  pruneopts = ""
+  revision = "901d90724c7919163f472a9812253fb26761123d"
 
 [[projects]]
   digest = "1:3313a63031ae281e5f6fd7b0bbca733dfa04d2429df86519e3b4d4c016ccb836"
@@ -285,6 +352,14 @@
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:713b341855f1480e4baca1e7c5434e1d266441340685ecbde32d59bdc065fb3f"
+  name = "github.com/mitchellh/go-wordwrap"
+  packages = ["."]
+  pruneopts = ""
+  revision = "9e67c67572bc5dd02aef930e2b0ae3c02a4b5a5c"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:0c0ff2a89c1bb0d01887e1dac043ad7efbf3ec77482ef058ac423d13497e16fd"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
@@ -307,6 +382,22 @@
   pruneopts = ""
   revision = "279bed98673dd5bef374d3b6e4b09e2af76183bf"
   version = "v1.0.0-rc1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:5f0faa008e8ff4221b55a1a5057c8b02cb2fd68da6a65c9e31c82b72cbc836d0"
+  name = "github.com/petar/GoLLRB"
+  packages = ["llrb"]
+  pruneopts = ""
+  revision = "33fb24c13b99c46c93183c291836c573ac382536"
+
+[[projects]]
+  digest = "1:4709c61d984ef9ba99b037b047546d8a576ae984fb49486e48d99658aa750cd5"
+  name = "github.com/peterbourgon/diskv"
+  packages = ["."]
+  pruneopts = ""
+  revision = "0be1b92a6df0e4f5cb0a5d15fb7f643d0ad93ce6"
+  version = "v3.0.0"
 
 [[projects]]
   digest = "1:1d7e1867c49a6dd9856598ef7c3123604ea3daabf5b83f303ff457bcbc410b1d"
@@ -373,6 +464,14 @@
   revision = "55ae3d9d557340b5bc24cd8aa5f6fa2c2ab31352"
 
 [[projects]]
+  digest = "1:2761e287c811d0948d47d0252b82281eca3801eb3c9d5f9530956643d5b9f430"
+  name = "github.com/russross/blackfriday"
+  packages = ["."]
+  pruneopts = ""
+  revision = "05f3235734ad95d0016f6a23902f06461fcf567a"
+  version = "v1.5.2"
+
+[[projects]]
   digest = "1:9a3c631555e0351fdc4e696577bb63afd90c399d782a8462dba9d100d7021db3"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
@@ -381,12 +480,12 @@
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:a1403cc8a94b8d7956ee5e9694badef0e7b051af289caad1cf668331e3ffa4f6"
+  digest = "1:0c63b3c7ad6d825a898f28cb854252a3b29d37700c68a117a977263f5ec94efe"
   name = "github.com/spf13/cobra"
   packages = ["."]
   pruneopts = ""
-  revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
-  version = "v0.0.3"
+  revision = "f2b07da1e2c38d5f12845a4f607e2e1018cbb1f5"
+  version = "v0.0.5"
 
 [[projects]]
   digest = "1:cbaf13cdbfef0e4734ed8a7504f57fe893d471d62a35b982bf6fb3f036449a66"
@@ -490,12 +589,18 @@
   packages = [
     "collate",
     "collate/build",
+    "encoding",
+    "encoding/internal",
+    "encoding/internal/identifier",
+    "encoding/unicode",
     "internal/colltab",
     "internal/gen",
     "internal/tag",
     "internal/triegen",
     "internal/ucd",
+    "internal/utf8internal",
     "language",
+    "runes",
     "secure/bidirule",
     "transform",
     "unicode/bidi",
@@ -582,6 +687,8 @@
   digest = "1:5e5cfbab57ea5444c1eb295a39fdc403f097f5ace592c829db7b3e0e3ea66903"
   name = "k8s.io/api"
   packages = [
+    "admission/v1",
+    "admission/v1beta1",
     "admissionregistration/v1",
     "admissionregistration/v1beta1",
     "apps/v1",
@@ -605,6 +712,7 @@
     "discovery/v1alpha1",
     "events/v1beta1",
     "extensions/v1beta1",
+    "imagepolicy/v1alpha1",
     "networking/v1",
     "networking/v1beta1",
     "node/v1alpha1",
@@ -644,11 +752,13 @@
     "pkg/api/equality",
     "pkg/api/errors",
     "pkg/api/meta",
+    "pkg/api/meta/testrestmapper",
     "pkg/api/resource",
     "pkg/api/validation",
     "pkg/apis/meta/internalversion",
     "pkg/apis/meta/v1",
     "pkg/apis/meta/v1/unstructured",
+    "pkg/apis/meta/v1/unstructured/unstructuredscheme",
     "pkg/apis/meta/v1/validation",
     "pkg/apis/meta/v1beta1",
     "pkg/conversion",
@@ -670,12 +780,15 @@
     "pkg/util/diff",
     "pkg/util/errors",
     "pkg/util/framer",
+    "pkg/util/httpstream",
+    "pkg/util/httpstream/spdy",
     "pkg/util/intstr",
     "pkg/util/json",
     "pkg/util/mergepatch",
     "pkg/util/naming",
     "pkg/util/net",
     "pkg/util/rand",
+    "pkg/util/remotecommand",
     "pkg/util/runtime",
     "pkg/util/sets",
     "pkg/util/strategicpatch",
@@ -688,6 +801,7 @@
     "pkg/version",
     "pkg/watch",
     "third_party/forked/golang/json",
+    "third_party/forked/golang/netutil",
     "third_party/forked/golang/reflect",
   ]
   pruneopts = ""
@@ -709,12 +823,36 @@
   revision = "3fdfe2c6555525ae54a58d22cd7f014a25ce749d"
 
 [[projects]]
+  branch = "release-1.16"
+  digest = "1:b46a88b317c3187b6fa7c5351eca48b35aad182eee371168677747430ff955bb"
+  name = "k8s.io/cli-runtime"
+  packages = [
+    "pkg/genericclioptions",
+    "pkg/kustomize",
+    "pkg/kustomize/k8sdeps",
+    "pkg/kustomize/k8sdeps/configmapandsecret",
+    "pkg/kustomize/k8sdeps/kunstruct",
+    "pkg/kustomize/k8sdeps/kv",
+    "pkg/kustomize/k8sdeps/transformer",
+    "pkg/kustomize/k8sdeps/transformer/hash",
+    "pkg/kustomize/k8sdeps/transformer/patch",
+    "pkg/kustomize/k8sdeps/validator",
+    "pkg/printers",
+    "pkg/resource",
+  ]
+  pruneopts = ""
+  revision = "6bff60de437070d7e8644b7a930837d5de512240"
+
+[[projects]]
   branch = "release-13.0"
   digest = "1:9e7a28fb6a57b9eb2e7730a2d152a5618a0e913415a13bca76607e799d39fd85"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
+    "discovery/cached/disk",
     "discovery/fake",
+    "dynamic",
+    "dynamic/fake",
     "informers",
     "informers/admissionregistration",
     "informers/admissionregistration/v1",
@@ -893,7 +1031,17 @@
     "plugin/pkg/client/auth/gcp",
     "plugin/pkg/client/auth/oidc",
     "rest",
+    "rest/fake",
     "rest/watch",
+    "restmapper",
+    "scale",
+    "scale/scheme",
+    "scale/scheme/appsint",
+    "scale/scheme/appsv1beta1",
+    "scale/scheme/appsv1beta2",
+    "scale/scheme/autoscalingv1",
+    "scale/scheme/extensionsint",
+    "scale/scheme/extensionsv1beta1",
     "testing",
     "third_party/forked/golang/template",
     "tools/auth",
@@ -907,10 +1055,13 @@
     "tools/record",
     "tools/record/util",
     "tools/reference",
+    "tools/remotecommand",
     "tools/watch",
     "transport",
+    "transport/spdy",
     "util/cert",
     "util/connrotation",
+    "util/exec",
     "util/flowcontrol",
     "util/homedir",
     "util/jsonpath",
@@ -997,10 +1148,32 @@
     "pkg/generators",
     "pkg/generators/rules",
     "pkg/util/proto",
+    "pkg/util/proto/testing",
+    "pkg/util/proto/validation",
     "pkg/util/sets",
   ]
   pruneopts = ""
   revision = "0317810137be915b9cf888946c6e115c1bfac693"
+
+[[projects]]
+  branch = "release-1.16"
+  digest = "1:687af22932f9b53ff2e6755b2eefe160f076d522794abb980f0ddb187bcefacd"
+  name = "k8s.io/kubectl"
+  packages = [
+    "pkg/cmd/testing",
+    "pkg/cmd/util",
+    "pkg/scheme",
+    "pkg/util/interrupt",
+    "pkg/util/openapi",
+    "pkg/util/openapi/testing",
+    "pkg/util/openapi/validation",
+    "pkg/util/templates",
+    "pkg/util/term",
+    "pkg/validation",
+    "pkg/version",
+  ]
+  pruneopts = ""
+  revision = "14647fd13a8b4cffc5a8f327b0018e037f72e4e8"
 
 [[projects]]
   branch = "release-1.16"
@@ -1061,6 +1234,37 @@
   revision = "69764acb6e8e900b7c05296c5d3c9c19545475f9"
 
 [[projects]]
+  digest = "1:0b2daace3dcced8712072529b621360cf520f3c2ead92d755f35a0ec8dca2714"
+  name = "sigs.k8s.io/kustomize"
+  packages = [
+    "pkg/commands/build",
+    "pkg/constants",
+    "pkg/expansion",
+    "pkg/factory",
+    "pkg/fs",
+    "pkg/git",
+    "pkg/gvk",
+    "pkg/ifc",
+    "pkg/ifc/transformer",
+    "pkg/image",
+    "pkg/internal/error",
+    "pkg/loader",
+    "pkg/patch",
+    "pkg/patch/transformer",
+    "pkg/resid",
+    "pkg/resmap",
+    "pkg/resource",
+    "pkg/target",
+    "pkg/transformers",
+    "pkg/transformers/config",
+    "pkg/transformers/config/defaultconfig",
+    "pkg/types",
+  ]
+  pruneopts = ""
+  revision = "a6f65144121d1955266b0cd836ce954c04122dc8"
+  version = "v2.0.3"
+
+[[projects]]
   digest = "1:321081b4a44256715f2b68411d8eda9a17f17ebfe6f0cc61d2cc52d11c08acfa"
   name = "sigs.k8s.io/yaml"
   packages = ["."]
@@ -1111,6 +1315,7 @@
     "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/apiserver/pkg/storage/names",
+    "k8s.io/cli-runtime/pkg/genericclioptions",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/discovery/fake",
     "k8s.io/client-go/informers",
@@ -1137,6 +1342,7 @@
     "k8s.io/klog",
     "k8s.io/kube-openapi/cmd/openapi-gen",
     "k8s.io/kube-openapi/pkg/common",
+    "k8s.io/kubectl/pkg/cmd/testing",
     "k8s.io/kubernetes/cmd/kubeadm/app/util",
     "k8s.io/kubernetes/pkg/apis/core/v1",
     "k8s.io/kubernetes/pkg/controller",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -34,5 +34,24 @@ required = [
   branch = "release-1.16"
 
 [[constraint]]
+  name = "k8s.io/cli-runtime"
+  branch = "release-1.16"
+
+[[constraint]]
+  name = "k8s.io/kubectl"
+  branch = "release-1.16"
+
+[[constraint]]
   name = "github.com/bouk/monkey"
   version = "1.0.0"
+
+# vendor/k8s.io/kubectl/pkg/util/term/resize.go:30:23: undefined: term.GetFdInfo
+[[override]]
+  name = "github.com/docker/docker"
+  revision = "be7ac8be2ae072032a4005e8f232be3fc57e4127"
+
+# vendor/k8s.io/kubectl/pkg/util/templates/markdown.go:66:11: undefined: blackfriday.LIST_ITEM_BEGINNING_OF_LIST
+[[override]]
+  name = "github.com/russross/blackfriday"
+  version = "v1.5.2"
+

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PACKAGE=github.com/argoproj/argo-rollouts
 CURRENT_DIR=$(shell pwd)
 DIST_DIR=${CURRENT_DIR}/dist
+PLUGIN_CLI_NAME?=kubectl-argo-rollouts
 
 VERSION=$(shell cat ${CURRENT_DIR}/VERSION)
 BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
@@ -12,10 +13,10 @@ GIT_TREE_STATE=$(shell if [ -z "`git status --porcelain`" ]; then echo "clean" ;
 DEV_IMAGE=false
 
 override LDFLAGS += \
-  -X ${PACKAGE}.version=${VERSION} \
-  -X ${PACKAGE}.buildDate=${BUILD_DATE} \
-  -X ${PACKAGE}.gitCommit=${GIT_COMMIT} \
-  -X ${PACKAGE}.gitTreeState=${GIT_TREE_STATE}
+  -X ${PACKAGE}/utils/version.version=${VERSION} \
+  -X ${PACKAGE}/utils/version.buildDate=${BUILD_DATE} \
+  -X ${PACKAGE}/utils/version.gitCommit=${GIT_COMMIT} \
+  -X ${PACKAGE}/utils/version.gitTreeState=${GIT_TREE_STATE}
 
 # docker image publishing options
 DOCKER_PUSH=false
@@ -53,6 +54,10 @@ codegen: mocks
 .PHONY: controller
 controller: clean-debug
 	CGO_ENABLED=0 go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/rollouts-controller ./cmd/rollouts-controller
+
+.PHONY: plugin
+plugin:
+	CGO_ENABLED=0 go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${PLUGIN_CLI_NAME} ./cmd/kubectl-argo-rollouts
 
 .PHONY: builder-image
 builder-image:

--- a/cmd/kubectl-argo-rollouts/main.go
+++ b/cmd/kubectl-argo-rollouts/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"os"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+	"k8s.io/klog"
+
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd"
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options"
+)
+
+func main() {
+	klog.InitFlags(nil)
+	streams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
+	o := options.NewArgoRolloutsOptions(streams)
+	root := cmd.NewCmdArgoRollouts(o)
+	if err := root.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/manifests/crds/analysis-run-crd.yaml
+++ b/manifests/crds/analysis-run-crd.yaml
@@ -2577,7 +2577,6 @@ spec:
                         value:
                           type: string
                       required:
-                      - message
                       - status
                       type: object
                     type: array

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -705,15 +705,6 @@ spec:
                                                       type: integer
                                                   type: object
                                                 resources:
-                                                  properties:
-                                                    limits:
-                                                      additionalProperties:
-                                                        type: string
-                                                      type: object
-                                                    requests:
-                                                      additionalProperties:
-                                                        type: string
-                                                      type: object
                                                   type: object
                                                 securityContext:
                                                   properties:
@@ -755,6 +746,78 @@ spec:
                                                         user:
                                                           type: string
                                                       type: object
+                                                    windowsOptions:
+                                                      properties:
+                                                        gmsaCredentialSpec:
+                                                          type: string
+                                                        gmsaCredentialSpecName:
+                                                          type: string
+                                                        runAsUserName:
+                                                          type: string
+                                                      type: object
+                                                  type: object
+                                                startupProbe:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    failureThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    initialDelaySeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    periodSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    successThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    timeoutSeconds:
+                                                      format: int32
+                                                      type: integer
                                                   type: object
                                                 stdin:
                                                   type: boolean
@@ -828,6 +891,509 @@ spec:
                                             type: string
                                           enableServiceLinks:
                                             type: boolean
+                                          ephemeralContainers:
+                                            items:
+                                              properties:
+                                                args:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                env:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                      valueFrom:
+                                                        properties:
+                                                          configMapKeyRef:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              name:
+                                                                type: string
+                                                              optional:
+                                                                type: boolean
+                                                            required:
+                                                            - key
+                                                            type: object
+                                                          fieldRef:
+                                                            properties:
+                                                              apiVersion:
+                                                                type: string
+                                                              fieldPath:
+                                                                type: string
+                                                            required:
+                                                            - fieldPath
+                                                            type: object
+                                                          resourceFieldRef:
+                                                            properties:
+                                                              containerName:
+                                                                type: string
+                                                              divisor:
+                                                                type: string
+                                                              resource:
+                                                                type: string
+                                                            required:
+                                                            - resource
+                                                            type: object
+                                                          secretKeyRef:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              name:
+                                                                type: string
+                                                              optional:
+                                                                type: boolean
+                                                            required:
+                                                            - key
+                                                            type: object
+                                                        type: object
+                                                    required:
+                                                    - name
+                                                    type: object
+                                                  type: array
+                                                envFrom:
+                                                  items:
+                                                    properties:
+                                                      configMapRef:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        type: object
+                                                      prefix:
+                                                        type: string
+                                                      secretRef:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        type: object
+                                                    type: object
+                                                  type: array
+                                                image:
+                                                  type: string
+                                                imagePullPolicy:
+                                                  type: string
+                                                lifecycle:
+                                                  properties:
+                                                    postStart:
+                                                      properties:
+                                                        exec:
+                                                          properties:
+                                                            command:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          type: object
+                                                        httpGet:
+                                                          properties:
+                                                            host:
+                                                              type: string
+                                                            httpHeaders:
+                                                              items:
+                                                                properties:
+                                                                  name:
+                                                                    type: string
+                                                                  value:
+                                                                    type: string
+                                                                required:
+                                                                - name
+                                                                - value
+                                                                type: object
+                                                              type: array
+                                                            path:
+                                                              type: string
+                                                            port:
+                                                              anyOf:
+                                                              - type: string
+                                                              - type: integer
+                                                            scheme:
+                                                              type: string
+                                                          required:
+                                                          - port
+                                                          type: object
+                                                        tcpSocket:
+                                                          properties:
+                                                            host:
+                                                              type: string
+                                                            port:
+                                                              anyOf:
+                                                              - type: string
+                                                              - type: integer
+                                                          required:
+                                                          - port
+                                                          type: object
+                                                      type: object
+                                                    preStop:
+                                                      properties:
+                                                        exec:
+                                                          properties:
+                                                            command:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          type: object
+                                                        httpGet:
+                                                          properties:
+                                                            host:
+                                                              type: string
+                                                            httpHeaders:
+                                                              items:
+                                                                properties:
+                                                                  name:
+                                                                    type: string
+                                                                  value:
+                                                                    type: string
+                                                                required:
+                                                                - name
+                                                                - value
+                                                                type: object
+                                                              type: array
+                                                            path:
+                                                              type: string
+                                                            port:
+                                                              anyOf:
+                                                              - type: string
+                                                              - type: integer
+                                                            scheme:
+                                                              type: string
+                                                          required:
+                                                          - port
+                                                          type: object
+                                                        tcpSocket:
+                                                          properties:
+                                                            host:
+                                                              type: string
+                                                            port:
+                                                              anyOf:
+                                                              - type: string
+                                                              - type: integer
+                                                          required:
+                                                          - port
+                                                          type: object
+                                                      type: object
+                                                  type: object
+                                                livenessProbe:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    failureThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    initialDelaySeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    periodSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    successThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    timeoutSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                  type: object
+                                                name:
+                                                  type: string
+                                                ports:
+                                                  items:
+                                                    properties:
+                                                      containerPort:
+                                                        format: int32
+                                                        type: integer
+                                                      hostIP:
+                                                        type: string
+                                                      hostPort:
+                                                        format: int32
+                                                        type: integer
+                                                      name:
+                                                        type: string
+                                                      protocol:
+                                                        type: string
+                                                    required:
+                                                    - containerPort
+                                                    type: object
+                                                  type: array
+                                                readinessProbe:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    failureThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    initialDelaySeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    periodSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    successThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    timeoutSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                  type: object
+                                                resources:
+                                                  type: object
+                                                securityContext:
+                                                  properties:
+                                                    allowPrivilegeEscalation:
+                                                      type: boolean
+                                                    capabilities:
+                                                      properties:
+                                                        add:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        drop:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    privileged:
+                                                      type: boolean
+                                                    procMount:
+                                                      type: string
+                                                    readOnlyRootFilesystem:
+                                                      type: boolean
+                                                    runAsGroup:
+                                                      format: int64
+                                                      type: integer
+                                                    runAsNonRoot:
+                                                      type: boolean
+                                                    runAsUser:
+                                                      format: int64
+                                                      type: integer
+                                                    seLinuxOptions:
+                                                      properties:
+                                                        level:
+                                                          type: string
+                                                        role:
+                                                          type: string
+                                                        type:
+                                                          type: string
+                                                        user:
+                                                          type: string
+                                                      type: object
+                                                    windowsOptions:
+                                                      properties:
+                                                        gmsaCredentialSpec:
+                                                          type: string
+                                                        gmsaCredentialSpecName:
+                                                          type: string
+                                                        runAsUserName:
+                                                          type: string
+                                                      type: object
+                                                  type: object
+                                                startupProbe:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    failureThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    initialDelaySeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    periodSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    successThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    timeoutSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                  type: object
+                                                stdin:
+                                                  type: boolean
+                                                stdinOnce:
+                                                  type: boolean
+                                                targetContainerName:
+                                                  type: string
+                                                terminationMessagePath:
+                                                  type: string
+                                                terminationMessagePolicy:
+                                                  type: string
+                                                tty:
+                                                  type: boolean
+                                                volumeDevices:
+                                                  items:
+                                                    properties:
+                                                      devicePath:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                    required:
+                                                    - devicePath
+                                                    - name
+                                                    type: object
+                                                  type: array
+                                                volumeMounts:
+                                                  items:
+                                                    properties:
+                                                      mountPath:
+                                                        type: string
+                                                      mountPropagation:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      readOnly:
+                                                        type: boolean
+                                                      subPath:
+                                                        type: string
+                                                      subPathExpr:
+                                                        type: string
+                                                    required:
+                                                    - mountPath
+                                                    - name
+                                                    type: object
+                                                  type: array
+                                                workingDir:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
                                           hostAliases:
                                             items:
                                               properties:
@@ -1193,15 +1759,6 @@ spec:
                                                       type: integer
                                                   type: object
                                                 resources:
-                                                  properties:
-                                                    limits:
-                                                      additionalProperties:
-                                                        type: string
-                                                      type: object
-                                                    requests:
-                                                      additionalProperties:
-                                                        type: string
-                                                      type: object
                                                   type: object
                                                 securityContext:
                                                   properties:
@@ -1243,6 +1800,78 @@ spec:
                                                         user:
                                                           type: string
                                                       type: object
+                                                    windowsOptions:
+                                                      properties:
+                                                        gmsaCredentialSpec:
+                                                          type: string
+                                                        gmsaCredentialSpecName:
+                                                          type: string
+                                                        runAsUserName:
+                                                          type: string
+                                                      type: object
+                                                  type: object
+                                                startupProbe:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    failureThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    initialDelaySeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    periodSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    successThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    timeoutSeconds:
+                                                      format: int32
+                                                      type: integer
                                                   type: object
                                                 stdin:
                                                   type: boolean
@@ -1298,6 +1927,12 @@ spec:
                                             additionalProperties:
                                               type: string
                                             type: object
+                                          overhead:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          preemptionPolicy:
+                                            type: string
                                           priority:
                                             format: int32
                                             type: integer
@@ -1359,6 +1994,15 @@ spec:
                                                   - value
                                                   type: object
                                                 type: array
+                                              windowsOptions:
+                                                properties:
+                                                  gmsaCredentialSpec:
+                                                    type: string
+                                                  gmsaCredentialSpecName:
+                                                    type: string
+                                                  runAsUserName:
+                                                    type: string
+                                                type: object
                                             type: object
                                           serviceAccount:
                                             type: string
@@ -1385,6 +2029,45 @@ spec:
                                                   type: integer
                                                 value:
                                                   type: string
+                                              type: object
+                                            type: array
+                                          topologySpreadConstraints:
+                                            items:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                maxSkew:
+                                                  format: int32
+                                                  type: integer
+                                                topologyKey:
+                                                  type: string
+                                                whenUnsatisfiable:
+                                                  type: string
+                                              required:
+                                              - maxSkew
+                                              - topologyKey
+                                              - whenUnsatisfiable
                                               type: object
                                             type: array
                                           volumes:
@@ -1895,7 +2578,6 @@ spec:
                         value:
                           type: string
                       required:
-                      - message
                       - status
                       type: object
                     type: array
@@ -2631,15 +3313,6 @@ spec:
                                                   type: integer
                                               type: object
                                             resources:
-                                              properties:
-                                                limits:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                                requests:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
                                               type: object
                                             securityContext:
                                               properties:
@@ -2681,6 +3354,78 @@ spec:
                                                     user:
                                                       type: string
                                                   type: object
+                                                windowsOptions:
+                                                  properties:
+                                                    gmsaCredentialSpec:
+                                                      type: string
+                                                    gmsaCredentialSpecName:
+                                                      type: string
+                                                    runAsUserName:
+                                                      type: string
+                                                  type: object
+                                              type: object
+                                            startupProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
                                               type: object
                                             stdin:
                                               type: boolean
@@ -2754,6 +3499,509 @@ spec:
                                         type: string
                                       enableServiceLinks:
                                         type: boolean
+                                      ephemeralContainers:
+                                        items:
+                                          properties:
+                                            args:
+                                              items:
+                                                type: string
+                                              type: array
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                  valueFrom:
+                                                    properties:
+                                                      configMapKeyRef:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        required:
+                                                        - key
+                                                        type: object
+                                                      fieldRef:
+                                                        properties:
+                                                          apiVersion:
+                                                            type: string
+                                                          fieldPath:
+                                                            type: string
+                                                        required:
+                                                        - fieldPath
+                                                        type: object
+                                                      resourceFieldRef:
+                                                        properties:
+                                                          containerName:
+                                                            type: string
+                                                          divisor:
+                                                            type: string
+                                                          resource:
+                                                            type: string
+                                                        required:
+                                                        - resource
+                                                        type: object
+                                                      secretKeyRef:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        required:
+                                                        - key
+                                                        type: object
+                                                    type: object
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                            envFrom:
+                                              items:
+                                                properties:
+                                                  configMapRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                  prefix:
+                                                    type: string
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            image:
+                                              type: string
+                                            imagePullPolicy:
+                                              type: string
+                                            lifecycle:
+                                              properties:
+                                                postStart:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                  type: object
+                                                preStop:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                  type: object
+                                              type: object
+                                            livenessProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            name:
+                                              type: string
+                                            ports:
+                                              items:
+                                                properties:
+                                                  containerPort:
+                                                    format: int32
+                                                    type: integer
+                                                  hostIP:
+                                                    type: string
+                                                  hostPort:
+                                                    format: int32
+                                                    type: integer
+                                                  name:
+                                                    type: string
+                                                  protocol:
+                                                    type: string
+                                                required:
+                                                - containerPort
+                                                type: object
+                                              type: array
+                                            readinessProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            resources:
+                                              type: object
+                                            securityContext:
+                                              properties:
+                                                allowPrivilegeEscalation:
+                                                  type: boolean
+                                                capabilities:
+                                                  properties:
+                                                    add:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    drop:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                privileged:
+                                                  type: boolean
+                                                procMount:
+                                                  type: string
+                                                readOnlyRootFilesystem:
+                                                  type: boolean
+                                                runAsGroup:
+                                                  format: int64
+                                                  type: integer
+                                                runAsNonRoot:
+                                                  type: boolean
+                                                runAsUser:
+                                                  format: int64
+                                                  type: integer
+                                                seLinuxOptions:
+                                                  properties:
+                                                    level:
+                                                      type: string
+                                                    role:
+                                                      type: string
+                                                    type:
+                                                      type: string
+                                                    user:
+                                                      type: string
+                                                  type: object
+                                                windowsOptions:
+                                                  properties:
+                                                    gmsaCredentialSpec:
+                                                      type: string
+                                                    gmsaCredentialSpecName:
+                                                      type: string
+                                                    runAsUserName:
+                                                      type: string
+                                                  type: object
+                                              type: object
+                                            startupProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            stdin:
+                                              type: boolean
+                                            stdinOnce:
+                                              type: boolean
+                                            targetContainerName:
+                                              type: string
+                                            terminationMessagePath:
+                                              type: string
+                                            terminationMessagePolicy:
+                                              type: string
+                                            tty:
+                                              type: boolean
+                                            volumeDevices:
+                                              items:
+                                                properties:
+                                                  devicePath:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - devicePath
+                                                - name
+                                                type: object
+                                              type: array
+                                            volumeMounts:
+                                              items:
+                                                properties:
+                                                  mountPath:
+                                                    type: string
+                                                  mountPropagation:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  subPath:
+                                                    type: string
+                                                  subPathExpr:
+                                                    type: string
+                                                required:
+                                                - mountPath
+                                                - name
+                                                type: object
+                                              type: array
+                                            workingDir:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
                                       hostAliases:
                                         items:
                                           properties:
@@ -3119,15 +4367,6 @@ spec:
                                                   type: integer
                                               type: object
                                             resources:
-                                              properties:
-                                                limits:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                                requests:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
                                               type: object
                                             securityContext:
                                               properties:
@@ -3169,6 +4408,78 @@ spec:
                                                     user:
                                                       type: string
                                                   type: object
+                                                windowsOptions:
+                                                  properties:
+                                                    gmsaCredentialSpec:
+                                                      type: string
+                                                    gmsaCredentialSpecName:
+                                                      type: string
+                                                    runAsUserName:
+                                                      type: string
+                                                  type: object
+                                              type: object
+                                            startupProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
                                               type: object
                                             stdin:
                                               type: boolean
@@ -3224,6 +4535,12 @@ spec:
                                         additionalProperties:
                                           type: string
                                         type: object
+                                      overhead:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      preemptionPolicy:
+                                        type: string
                                       priority:
                                         format: int32
                                         type: integer
@@ -3285,6 +4602,15 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              runAsUserName:
+                                                type: string
+                                            type: object
                                         type: object
                                       serviceAccount:
                                         type: string
@@ -3311,6 +4637,45 @@ spec:
                                               type: integer
                                             value:
                                               type: string
+                                          type: object
+                                        type: array
+                                      topologySpreadConstraints:
+                                        items:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                            maxSkew:
+                                              format: int32
+                                              type: integer
+                                            topologyKey:
+                                              type: string
+                                            whenUnsatisfiable:
+                                              type: string
+                                          required:
+                                          - maxSkew
+                                          - topologyKey
+                                          - whenUnsatisfiable
                                           type: object
                                         type: array
                                       volumes:
@@ -4442,15 +5807,6 @@ spec:
                                       type: integer
                                   type: object
                                 resources:
-                                  properties:
-                                    limits:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                    requests:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
                                   type: object
                                 securityContext:
                                   properties:
@@ -4492,6 +5848,78 @@ spec:
                                         user:
                                           type: string
                                       type: object
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                      required:
+                                      - port
+                                      type: object
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
                                   type: object
                                 stdin:
                                   type: boolean
@@ -4565,6 +5993,509 @@ spec:
                             type: string
                           enableServiceLinks:
                             type: boolean
+                          ephemeralContainers:
+                            items:
+                              properties:
+                                args:
+                                  items:
+                                    type: string
+                                  type: array
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                                env:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          configMapKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                type: string
+                                              resource:
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                envFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      prefix:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                    type: object
+                                  type: array
+                                image:
+                                  type: string
+                                imagePullPolicy:
+                                  type: string
+                                lifecycle:
+                                  properties:
+                                    postStart:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    preStop:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                  type: object
+                                livenessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                      required:
+                                      - port
+                                      type: object
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                name:
+                                  type: string
+                                ports:
+                                  items:
+                                    properties:
+                                      containerPort:
+                                        format: int32
+                                        type: integer
+                                      hostIP:
+                                        type: string
+                                      hostPort:
+                                        format: int32
+                                        type: integer
+                                      name:
+                                        type: string
+                                      protocol:
+                                        type: string
+                                    required:
+                                    - containerPort
+                                    type: object
+                                  type: array
+                                readinessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                      required:
+                                      - port
+                                      type: object
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                resources:
+                                  type: object
+                                securityContext:
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      type: boolean
+                                    capabilities:
+                                      properties:
+                                        add:
+                                          items:
+                                            type: string
+                                          type: array
+                                        drop:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    privileged:
+                                      type: boolean
+                                    procMount:
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      type: boolean
+                                    runAsGroup:
+                                      format: int64
+                                      type: integer
+                                    runAsNonRoot:
+                                      type: boolean
+                                    runAsUser:
+                                      format: int64
+                                      type: integer
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: string
+                                        role:
+                                          type: string
+                                        type:
+                                          type: string
+                                        user:
+                                          type: string
+                                      type: object
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                      required:
+                                      - port
+                                      type: object
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                stdin:
+                                  type: boolean
+                                stdinOnce:
+                                  type: boolean
+                                targetContainerName:
+                                  type: string
+                                terminationMessagePath:
+                                  type: string
+                                terminationMessagePolicy:
+                                  type: string
+                                tty:
+                                  type: boolean
+                                volumeDevices:
+                                  items:
+                                    properties:
+                                      devicePath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    required:
+                                    - devicePath
+                                    - name
+                                    type: object
+                                  type: array
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      mountPropagation:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      subPath:
+                                        type: string
+                                      subPathExpr:
+                                        type: string
+                                    required:
+                                    - mountPath
+                                    - name
+                                    type: object
+                                  type: array
+                                workingDir:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
                           hostAliases:
                             items:
                               properties:
@@ -4930,15 +6861,6 @@ spec:
                                       type: integer
                                   type: object
                                 resources:
-                                  properties:
-                                    limits:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                    requests:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
                                   type: object
                                 securityContext:
                                   properties:
@@ -4980,6 +6902,78 @@ spec:
                                         user:
                                           type: string
                                       type: object
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                      required:
+                                      - port
+                                      type: object
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
                                   type: object
                                 stdin:
                                   type: boolean
@@ -5035,6 +7029,12 @@ spec:
                             additionalProperties:
                               type: string
                             type: object
+                          overhead:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          preemptionPolicy:
+                            type: string
                           priority:
                             format: int32
                             type: integer
@@ -5096,6 +7096,15 @@ spec:
                                   - value
                                   type: object
                                 type: array
+                              windowsOptions:
+                                properties:
+                                  gmsaCredentialSpec:
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    type: string
+                                  runAsUserName:
+                                    type: string
+                                type: object
                             type: object
                           serviceAccount:
                             type: string
@@ -5122,6 +7131,45 @@ spec:
                                   type: integer
                                 value:
                                   type: string
+                              type: object
+                            type: array
+                          topologySpreadConstraints:
+                            items:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                maxSkew:
+                                  format: int32
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                              required:
+                              - maxSkew
+                              - topologyKey
+                              - whenUnsatisfiable
                               type: object
                             type: array
                           volumes:
@@ -6455,7 +8503,6 @@ spec:
                                 type: integer
                             type: object
                           resources:
-                            properties: {}
                             type: object
                           securityContext:
                             properties:
@@ -6497,6 +8544,78 @@ spec:
                                   user:
                                     type: string
                                 type: object
+                              windowsOptions:
+                                properties:
+                                  gmsaCredentialSpec:
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    type: string
+                                  runAsUserName:
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                  scheme:
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
                             type: object
                           stdin:
                             type: boolean
@@ -6570,6 +8689,509 @@ spec:
                       type: string
                     enableServiceLinks:
                       type: boolean
+                    ephemeralContainers:
+                      items:
+                        properties:
+                          args:
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    configMapKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        fieldPath:
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      properties:
+                                        containerName:
+                                          type: string
+                                        divisor:
+                                          type: string
+                                        resource:
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          envFrom:
+                            items:
+                              properties:
+                                configMapRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            type: string
+                          imagePullPolicy:
+                            type: string
+                          lifecycle:
+                            properties:
+                              postStart:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: string
+                                        - type: integer
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: string
+                                        - type: integer
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: string
+                                        - type: integer
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: string
+                                        - type: integer
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                  scheme:
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            type: string
+                          ports:
+                            items:
+                              properties:
+                                containerPort:
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  type: string
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                                name:
+                                  type: string
+                                protocol:
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                          readinessProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                  scheme:
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            type: object
+                          securityContext:
+                            properties:
+                              allowPrivilegeEscalation:
+                                type: boolean
+                              capabilities:
+                                properties:
+                                  add:
+                                    items:
+                                      type: string
+                                    type: array
+                                  drop:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                type: boolean
+                              procMount:
+                                type: string
+                              readOnlyRootFilesystem:
+                                type: boolean
+                              runAsGroup:
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                type: boolean
+                              runAsUser:
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                properties:
+                                  level:
+                                    type: string
+                                  role:
+                                    type: string
+                                  type:
+                                    type: string
+                                  user:
+                                    type: string
+                                type: object
+                              windowsOptions:
+                                properties:
+                                  gmsaCredentialSpec:
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    type: string
+                                  runAsUserName:
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                  scheme:
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            type: boolean
+                          stdinOnce:
+                            type: boolean
+                          targetContainerName:
+                            type: string
+                          terminationMessagePath:
+                            type: string
+                          terminationMessagePolicy:
+                            type: string
+                          tty:
+                            type: boolean
+                          volumeDevices:
+                            items:
+                              properties:
+                                devicePath:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                          volumeMounts:
+                            items:
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          workingDir:
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
                     hostAliases:
                       items:
                         properties:
@@ -6935,15 +9557,6 @@ spec:
                                 type: integer
                             type: object
                           resources:
-                            properties:
-                              limits:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              requests:
-                                additionalProperties:
-                                  type: string
-                                type: object
                             type: object
                           securityContext:
                             properties:
@@ -6985,6 +9598,78 @@ spec:
                                   user:
                                     type: string
                                 type: object
+                              windowsOptions:
+                                properties:
+                                  gmsaCredentialSpec:
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    type: string
+                                  runAsUserName:
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                  scheme:
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
                             type: object
                           stdin:
                             type: boolean
@@ -7040,6 +9725,12 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                    overhead:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    preemptionPolicy:
+                      type: string
                     priority:
                       format: int32
                       type: integer
@@ -7101,6 +9792,15 @@ spec:
                             - value
                             type: object
                           type: array
+                        windowsOptions:
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
+                              type: string
+                          type: object
                       type: object
                     serviceAccount:
                       type: string
@@ -7127,6 +9827,45 @@ spec:
                             type: integer
                           value:
                             type: string
+                        type: object
+                      type: array
+                    topologySpreadConstraints:
+                      items:
+                        properties:
+                          labelSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          maxSkew:
+                            format: int32
+                            type: integer
+                          topologyKey:
+                            type: string
+                          whenUnsatisfiable:
+                            type: string
+                        required:
+                        - maxSkew
+                        - topologyKey
+                        - whenUnsatisfiable
                         type: object
                       type: array
                     volumes:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -705,15 +705,6 @@ spec:
                                                       type: integer
                                                   type: object
                                                 resources:
-                                                  properties:
-                                                    limits:
-                                                      additionalProperties:
-                                                        type: string
-                                                      type: object
-                                                    requests:
-                                                      additionalProperties:
-                                                        type: string
-                                                      type: object
                                                   type: object
                                                 securityContext:
                                                   properties:
@@ -755,6 +746,78 @@ spec:
                                                         user:
                                                           type: string
                                                       type: object
+                                                    windowsOptions:
+                                                      properties:
+                                                        gmsaCredentialSpec:
+                                                          type: string
+                                                        gmsaCredentialSpecName:
+                                                          type: string
+                                                        runAsUserName:
+                                                          type: string
+                                                      type: object
+                                                  type: object
+                                                startupProbe:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    failureThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    initialDelaySeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    periodSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    successThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    timeoutSeconds:
+                                                      format: int32
+                                                      type: integer
                                                   type: object
                                                 stdin:
                                                   type: boolean
@@ -828,6 +891,509 @@ spec:
                                             type: string
                                           enableServiceLinks:
                                             type: boolean
+                                          ephemeralContainers:
+                                            items:
+                                              properties:
+                                                args:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                env:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                      valueFrom:
+                                                        properties:
+                                                          configMapKeyRef:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              name:
+                                                                type: string
+                                                              optional:
+                                                                type: boolean
+                                                            required:
+                                                            - key
+                                                            type: object
+                                                          fieldRef:
+                                                            properties:
+                                                              apiVersion:
+                                                                type: string
+                                                              fieldPath:
+                                                                type: string
+                                                            required:
+                                                            - fieldPath
+                                                            type: object
+                                                          resourceFieldRef:
+                                                            properties:
+                                                              containerName:
+                                                                type: string
+                                                              divisor:
+                                                                type: string
+                                                              resource:
+                                                                type: string
+                                                            required:
+                                                            - resource
+                                                            type: object
+                                                          secretKeyRef:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              name:
+                                                                type: string
+                                                              optional:
+                                                                type: boolean
+                                                            required:
+                                                            - key
+                                                            type: object
+                                                        type: object
+                                                    required:
+                                                    - name
+                                                    type: object
+                                                  type: array
+                                                envFrom:
+                                                  items:
+                                                    properties:
+                                                      configMapRef:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        type: object
+                                                      prefix:
+                                                        type: string
+                                                      secretRef:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        type: object
+                                                    type: object
+                                                  type: array
+                                                image:
+                                                  type: string
+                                                imagePullPolicy:
+                                                  type: string
+                                                lifecycle:
+                                                  properties:
+                                                    postStart:
+                                                      properties:
+                                                        exec:
+                                                          properties:
+                                                            command:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          type: object
+                                                        httpGet:
+                                                          properties:
+                                                            host:
+                                                              type: string
+                                                            httpHeaders:
+                                                              items:
+                                                                properties:
+                                                                  name:
+                                                                    type: string
+                                                                  value:
+                                                                    type: string
+                                                                required:
+                                                                - name
+                                                                - value
+                                                                type: object
+                                                              type: array
+                                                            path:
+                                                              type: string
+                                                            port:
+                                                              anyOf:
+                                                              - type: string
+                                                              - type: integer
+                                                            scheme:
+                                                              type: string
+                                                          required:
+                                                          - port
+                                                          type: object
+                                                        tcpSocket:
+                                                          properties:
+                                                            host:
+                                                              type: string
+                                                            port:
+                                                              anyOf:
+                                                              - type: string
+                                                              - type: integer
+                                                          required:
+                                                          - port
+                                                          type: object
+                                                      type: object
+                                                    preStop:
+                                                      properties:
+                                                        exec:
+                                                          properties:
+                                                            command:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          type: object
+                                                        httpGet:
+                                                          properties:
+                                                            host:
+                                                              type: string
+                                                            httpHeaders:
+                                                              items:
+                                                                properties:
+                                                                  name:
+                                                                    type: string
+                                                                  value:
+                                                                    type: string
+                                                                required:
+                                                                - name
+                                                                - value
+                                                                type: object
+                                                              type: array
+                                                            path:
+                                                              type: string
+                                                            port:
+                                                              anyOf:
+                                                              - type: string
+                                                              - type: integer
+                                                            scheme:
+                                                              type: string
+                                                          required:
+                                                          - port
+                                                          type: object
+                                                        tcpSocket:
+                                                          properties:
+                                                            host:
+                                                              type: string
+                                                            port:
+                                                              anyOf:
+                                                              - type: string
+                                                              - type: integer
+                                                          required:
+                                                          - port
+                                                          type: object
+                                                      type: object
+                                                  type: object
+                                                livenessProbe:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    failureThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    initialDelaySeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    periodSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    successThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    timeoutSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                  type: object
+                                                name:
+                                                  type: string
+                                                ports:
+                                                  items:
+                                                    properties:
+                                                      containerPort:
+                                                        format: int32
+                                                        type: integer
+                                                      hostIP:
+                                                        type: string
+                                                      hostPort:
+                                                        format: int32
+                                                        type: integer
+                                                      name:
+                                                        type: string
+                                                      protocol:
+                                                        type: string
+                                                    required:
+                                                    - containerPort
+                                                    type: object
+                                                  type: array
+                                                readinessProbe:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    failureThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    initialDelaySeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    periodSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    successThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    timeoutSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                  type: object
+                                                resources:
+                                                  type: object
+                                                securityContext:
+                                                  properties:
+                                                    allowPrivilegeEscalation:
+                                                      type: boolean
+                                                    capabilities:
+                                                      properties:
+                                                        add:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        drop:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    privileged:
+                                                      type: boolean
+                                                    procMount:
+                                                      type: string
+                                                    readOnlyRootFilesystem:
+                                                      type: boolean
+                                                    runAsGroup:
+                                                      format: int64
+                                                      type: integer
+                                                    runAsNonRoot:
+                                                      type: boolean
+                                                    runAsUser:
+                                                      format: int64
+                                                      type: integer
+                                                    seLinuxOptions:
+                                                      properties:
+                                                        level:
+                                                          type: string
+                                                        role:
+                                                          type: string
+                                                        type:
+                                                          type: string
+                                                        user:
+                                                          type: string
+                                                      type: object
+                                                    windowsOptions:
+                                                      properties:
+                                                        gmsaCredentialSpec:
+                                                          type: string
+                                                        gmsaCredentialSpecName:
+                                                          type: string
+                                                        runAsUserName:
+                                                          type: string
+                                                      type: object
+                                                  type: object
+                                                startupProbe:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    failureThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    initialDelaySeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    periodSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    successThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    timeoutSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                  type: object
+                                                stdin:
+                                                  type: boolean
+                                                stdinOnce:
+                                                  type: boolean
+                                                targetContainerName:
+                                                  type: string
+                                                terminationMessagePath:
+                                                  type: string
+                                                terminationMessagePolicy:
+                                                  type: string
+                                                tty:
+                                                  type: boolean
+                                                volumeDevices:
+                                                  items:
+                                                    properties:
+                                                      devicePath:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                    required:
+                                                    - devicePath
+                                                    - name
+                                                    type: object
+                                                  type: array
+                                                volumeMounts:
+                                                  items:
+                                                    properties:
+                                                      mountPath:
+                                                        type: string
+                                                      mountPropagation:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      readOnly:
+                                                        type: boolean
+                                                      subPath:
+                                                        type: string
+                                                      subPathExpr:
+                                                        type: string
+                                                    required:
+                                                    - mountPath
+                                                    - name
+                                                    type: object
+                                                  type: array
+                                                workingDir:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
                                           hostAliases:
                                             items:
                                               properties:
@@ -1193,15 +1759,6 @@ spec:
                                                       type: integer
                                                   type: object
                                                 resources:
-                                                  properties:
-                                                    limits:
-                                                      additionalProperties:
-                                                        type: string
-                                                      type: object
-                                                    requests:
-                                                      additionalProperties:
-                                                        type: string
-                                                      type: object
                                                   type: object
                                                 securityContext:
                                                   properties:
@@ -1243,6 +1800,78 @@ spec:
                                                         user:
                                                           type: string
                                                       type: object
+                                                    windowsOptions:
+                                                      properties:
+                                                        gmsaCredentialSpec:
+                                                          type: string
+                                                        gmsaCredentialSpecName:
+                                                          type: string
+                                                        runAsUserName:
+                                                          type: string
+                                                      type: object
+                                                  type: object
+                                                startupProbe:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    failureThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    initialDelaySeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    periodSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    successThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    timeoutSeconds:
+                                                      format: int32
+                                                      type: integer
                                                   type: object
                                                 stdin:
                                                   type: boolean
@@ -1298,6 +1927,12 @@ spec:
                                             additionalProperties:
                                               type: string
                                             type: object
+                                          overhead:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          preemptionPolicy:
+                                            type: string
                                           priority:
                                             format: int32
                                             type: integer
@@ -1359,6 +1994,15 @@ spec:
                                                   - value
                                                   type: object
                                                 type: array
+                                              windowsOptions:
+                                                properties:
+                                                  gmsaCredentialSpec:
+                                                    type: string
+                                                  gmsaCredentialSpecName:
+                                                    type: string
+                                                  runAsUserName:
+                                                    type: string
+                                                type: object
                                             type: object
                                           serviceAccount:
                                             type: string
@@ -1385,6 +2029,45 @@ spec:
                                                   type: integer
                                                 value:
                                                   type: string
+                                              type: object
+                                            type: array
+                                          topologySpreadConstraints:
+                                            items:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                maxSkew:
+                                                  format: int32
+                                                  type: integer
+                                                topologyKey:
+                                                  type: string
+                                                whenUnsatisfiable:
+                                                  type: string
+                                              required:
+                                              - maxSkew
+                                              - topologyKey
+                                              - whenUnsatisfiable
                                               type: object
                                             type: array
                                           volumes:
@@ -1895,7 +2578,6 @@ spec:
                         value:
                           type: string
                       required:
-                      - message
                       - status
                       type: object
                     type: array
@@ -2631,15 +3313,6 @@ spec:
                                                   type: integer
                                               type: object
                                             resources:
-                                              properties:
-                                                limits:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                                requests:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
                                               type: object
                                             securityContext:
                                               properties:
@@ -2681,6 +3354,78 @@ spec:
                                                     user:
                                                       type: string
                                                   type: object
+                                                windowsOptions:
+                                                  properties:
+                                                    gmsaCredentialSpec:
+                                                      type: string
+                                                    gmsaCredentialSpecName:
+                                                      type: string
+                                                    runAsUserName:
+                                                      type: string
+                                                  type: object
+                                              type: object
+                                            startupProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
                                               type: object
                                             stdin:
                                               type: boolean
@@ -2754,6 +3499,509 @@ spec:
                                         type: string
                                       enableServiceLinks:
                                         type: boolean
+                                      ephemeralContainers:
+                                        items:
+                                          properties:
+                                            args:
+                                              items:
+                                                type: string
+                                              type: array
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                  valueFrom:
+                                                    properties:
+                                                      configMapKeyRef:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        required:
+                                                        - key
+                                                        type: object
+                                                      fieldRef:
+                                                        properties:
+                                                          apiVersion:
+                                                            type: string
+                                                          fieldPath:
+                                                            type: string
+                                                        required:
+                                                        - fieldPath
+                                                        type: object
+                                                      resourceFieldRef:
+                                                        properties:
+                                                          containerName:
+                                                            type: string
+                                                          divisor:
+                                                            type: string
+                                                          resource:
+                                                            type: string
+                                                        required:
+                                                        - resource
+                                                        type: object
+                                                      secretKeyRef:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        required:
+                                                        - key
+                                                        type: object
+                                                    type: object
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                            envFrom:
+                                              items:
+                                                properties:
+                                                  configMapRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                  prefix:
+                                                    type: string
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            image:
+                                              type: string
+                                            imagePullPolicy:
+                                              type: string
+                                            lifecycle:
+                                              properties:
+                                                postStart:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                  type: object
+                                                preStop:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                  type: object
+                                              type: object
+                                            livenessProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            name:
+                                              type: string
+                                            ports:
+                                              items:
+                                                properties:
+                                                  containerPort:
+                                                    format: int32
+                                                    type: integer
+                                                  hostIP:
+                                                    type: string
+                                                  hostPort:
+                                                    format: int32
+                                                    type: integer
+                                                  name:
+                                                    type: string
+                                                  protocol:
+                                                    type: string
+                                                required:
+                                                - containerPort
+                                                type: object
+                                              type: array
+                                            readinessProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            resources:
+                                              type: object
+                                            securityContext:
+                                              properties:
+                                                allowPrivilegeEscalation:
+                                                  type: boolean
+                                                capabilities:
+                                                  properties:
+                                                    add:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    drop:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                privileged:
+                                                  type: boolean
+                                                procMount:
+                                                  type: string
+                                                readOnlyRootFilesystem:
+                                                  type: boolean
+                                                runAsGroup:
+                                                  format: int64
+                                                  type: integer
+                                                runAsNonRoot:
+                                                  type: boolean
+                                                runAsUser:
+                                                  format: int64
+                                                  type: integer
+                                                seLinuxOptions:
+                                                  properties:
+                                                    level:
+                                                      type: string
+                                                    role:
+                                                      type: string
+                                                    type:
+                                                      type: string
+                                                    user:
+                                                      type: string
+                                                  type: object
+                                                windowsOptions:
+                                                  properties:
+                                                    gmsaCredentialSpec:
+                                                      type: string
+                                                    gmsaCredentialSpecName:
+                                                      type: string
+                                                    runAsUserName:
+                                                      type: string
+                                                  type: object
+                                              type: object
+                                            startupProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            stdin:
+                                              type: boolean
+                                            stdinOnce:
+                                              type: boolean
+                                            targetContainerName:
+                                              type: string
+                                            terminationMessagePath:
+                                              type: string
+                                            terminationMessagePolicy:
+                                              type: string
+                                            tty:
+                                              type: boolean
+                                            volumeDevices:
+                                              items:
+                                                properties:
+                                                  devicePath:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - devicePath
+                                                - name
+                                                type: object
+                                              type: array
+                                            volumeMounts:
+                                              items:
+                                                properties:
+                                                  mountPath:
+                                                    type: string
+                                                  mountPropagation:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  subPath:
+                                                    type: string
+                                                  subPathExpr:
+                                                    type: string
+                                                required:
+                                                - mountPath
+                                                - name
+                                                type: object
+                                              type: array
+                                            workingDir:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
                                       hostAliases:
                                         items:
                                           properties:
@@ -3119,15 +4367,6 @@ spec:
                                                   type: integer
                                               type: object
                                             resources:
-                                              properties:
-                                                limits:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                                requests:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
                                               type: object
                                             securityContext:
                                               properties:
@@ -3169,6 +4408,78 @@ spec:
                                                     user:
                                                       type: string
                                                   type: object
+                                                windowsOptions:
+                                                  properties:
+                                                    gmsaCredentialSpec:
+                                                      type: string
+                                                    gmsaCredentialSpecName:
+                                                      type: string
+                                                    runAsUserName:
+                                                      type: string
+                                                  type: object
+                                              type: object
+                                            startupProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
                                               type: object
                                             stdin:
                                               type: boolean
@@ -3224,6 +4535,12 @@ spec:
                                         additionalProperties:
                                           type: string
                                         type: object
+                                      overhead:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      preemptionPolicy:
+                                        type: string
                                       priority:
                                         format: int32
                                         type: integer
@@ -3285,6 +4602,15 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              runAsUserName:
+                                                type: string
+                                            type: object
                                         type: object
                                       serviceAccount:
                                         type: string
@@ -3311,6 +4637,45 @@ spec:
                                               type: integer
                                             value:
                                               type: string
+                                          type: object
+                                        type: array
+                                      topologySpreadConstraints:
+                                        items:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                            maxSkew:
+                                              format: int32
+                                              type: integer
+                                            topologyKey:
+                                              type: string
+                                            whenUnsatisfiable:
+                                              type: string
+                                          required:
+                                          - maxSkew
+                                          - topologyKey
+                                          - whenUnsatisfiable
                                           type: object
                                         type: array
                                       volumes:
@@ -4442,15 +5807,6 @@ spec:
                                       type: integer
                                   type: object
                                 resources:
-                                  properties:
-                                    limits:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                    requests:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
                                   type: object
                                 securityContext:
                                   properties:
@@ -4492,6 +5848,78 @@ spec:
                                         user:
                                           type: string
                                       type: object
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                      required:
+                                      - port
+                                      type: object
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
                                   type: object
                                 stdin:
                                   type: boolean
@@ -4565,6 +5993,509 @@ spec:
                             type: string
                           enableServiceLinks:
                             type: boolean
+                          ephemeralContainers:
+                            items:
+                              properties:
+                                args:
+                                  items:
+                                    type: string
+                                  type: array
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                                env:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          configMapKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                type: string
+                                              resource:
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                envFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      prefix:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                    type: object
+                                  type: array
+                                image:
+                                  type: string
+                                imagePullPolicy:
+                                  type: string
+                                lifecycle:
+                                  properties:
+                                    postStart:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    preStop:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                  type: object
+                                livenessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                      required:
+                                      - port
+                                      type: object
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                name:
+                                  type: string
+                                ports:
+                                  items:
+                                    properties:
+                                      containerPort:
+                                        format: int32
+                                        type: integer
+                                      hostIP:
+                                        type: string
+                                      hostPort:
+                                        format: int32
+                                        type: integer
+                                      name:
+                                        type: string
+                                      protocol:
+                                        type: string
+                                    required:
+                                    - containerPort
+                                    type: object
+                                  type: array
+                                readinessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                      required:
+                                      - port
+                                      type: object
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                resources:
+                                  type: object
+                                securityContext:
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      type: boolean
+                                    capabilities:
+                                      properties:
+                                        add:
+                                          items:
+                                            type: string
+                                          type: array
+                                        drop:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    privileged:
+                                      type: boolean
+                                    procMount:
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      type: boolean
+                                    runAsGroup:
+                                      format: int64
+                                      type: integer
+                                    runAsNonRoot:
+                                      type: boolean
+                                    runAsUser:
+                                      format: int64
+                                      type: integer
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: string
+                                        role:
+                                          type: string
+                                        type:
+                                          type: string
+                                        user:
+                                          type: string
+                                      type: object
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                      required:
+                                      - port
+                                      type: object
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                stdin:
+                                  type: boolean
+                                stdinOnce:
+                                  type: boolean
+                                targetContainerName:
+                                  type: string
+                                terminationMessagePath:
+                                  type: string
+                                terminationMessagePolicy:
+                                  type: string
+                                tty:
+                                  type: boolean
+                                volumeDevices:
+                                  items:
+                                    properties:
+                                      devicePath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    required:
+                                    - devicePath
+                                    - name
+                                    type: object
+                                  type: array
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      mountPropagation:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      subPath:
+                                        type: string
+                                      subPathExpr:
+                                        type: string
+                                    required:
+                                    - mountPath
+                                    - name
+                                    type: object
+                                  type: array
+                                workingDir:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
                           hostAliases:
                             items:
                               properties:
@@ -4930,15 +6861,6 @@ spec:
                                       type: integer
                                   type: object
                                 resources:
-                                  properties:
-                                    limits:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                    requests:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
                                   type: object
                                 securityContext:
                                   properties:
@@ -4980,6 +6902,78 @@ spec:
                                         user:
                                           type: string
                                       type: object
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                      required:
+                                      - port
+                                      type: object
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
                                   type: object
                                 stdin:
                                   type: boolean
@@ -5035,6 +7029,12 @@ spec:
                             additionalProperties:
                               type: string
                             type: object
+                          overhead:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          preemptionPolicy:
+                            type: string
                           priority:
                             format: int32
                             type: integer
@@ -5096,6 +7096,15 @@ spec:
                                   - value
                                   type: object
                                 type: array
+                              windowsOptions:
+                                properties:
+                                  gmsaCredentialSpec:
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    type: string
+                                  runAsUserName:
+                                    type: string
+                                type: object
                             type: object
                           serviceAccount:
                             type: string
@@ -5122,6 +7131,45 @@ spec:
                                   type: integer
                                 value:
                                   type: string
+                              type: object
+                            type: array
+                          topologySpreadConstraints:
+                            items:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                maxSkew:
+                                  format: int32
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                              required:
+                              - maxSkew
+                              - topologyKey
+                              - whenUnsatisfiable
                               type: object
                             type: array
                           volumes:
@@ -6455,7 +8503,6 @@ spec:
                                 type: integer
                             type: object
                           resources:
-                            properties: {}
                             type: object
                           securityContext:
                             properties:
@@ -6497,6 +8544,78 @@ spec:
                                   user:
                                     type: string
                                 type: object
+                              windowsOptions:
+                                properties:
+                                  gmsaCredentialSpec:
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    type: string
+                                  runAsUserName:
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                  scheme:
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
                             type: object
                           stdin:
                             type: boolean
@@ -6570,6 +8689,509 @@ spec:
                       type: string
                     enableServiceLinks:
                       type: boolean
+                    ephemeralContainers:
+                      items:
+                        properties:
+                          args:
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    configMapKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        fieldPath:
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      properties:
+                                        containerName:
+                                          type: string
+                                        divisor:
+                                          type: string
+                                        resource:
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          envFrom:
+                            items:
+                              properties:
+                                configMapRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            type: string
+                          imagePullPolicy:
+                            type: string
+                          lifecycle:
+                            properties:
+                              postStart:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: string
+                                        - type: integer
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: string
+                                        - type: integer
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: string
+                                        - type: integer
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: string
+                                        - type: integer
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                  scheme:
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            type: string
+                          ports:
+                            items:
+                              properties:
+                                containerPort:
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  type: string
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                                name:
+                                  type: string
+                                protocol:
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                          readinessProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                  scheme:
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            type: object
+                          securityContext:
+                            properties:
+                              allowPrivilegeEscalation:
+                                type: boolean
+                              capabilities:
+                                properties:
+                                  add:
+                                    items:
+                                      type: string
+                                    type: array
+                                  drop:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                type: boolean
+                              procMount:
+                                type: string
+                              readOnlyRootFilesystem:
+                                type: boolean
+                              runAsGroup:
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                type: boolean
+                              runAsUser:
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                properties:
+                                  level:
+                                    type: string
+                                  role:
+                                    type: string
+                                  type:
+                                    type: string
+                                  user:
+                                    type: string
+                                type: object
+                              windowsOptions:
+                                properties:
+                                  gmsaCredentialSpec:
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    type: string
+                                  runAsUserName:
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                  scheme:
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            type: boolean
+                          stdinOnce:
+                            type: boolean
+                          targetContainerName:
+                            type: string
+                          terminationMessagePath:
+                            type: string
+                          terminationMessagePolicy:
+                            type: string
+                          tty:
+                            type: boolean
+                          volumeDevices:
+                            items:
+                              properties:
+                                devicePath:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                          volumeMounts:
+                            items:
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          workingDir:
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
                     hostAliases:
                       items:
                         properties:
@@ -6935,15 +9557,6 @@ spec:
                                 type: integer
                             type: object
                           resources:
-                            properties:
-                              limits:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              requests:
-                                additionalProperties:
-                                  type: string
-                                type: object
                             type: object
                           securityContext:
                             properties:
@@ -6985,6 +9598,78 @@ spec:
                                   user:
                                     type: string
                                 type: object
+                              windowsOptions:
+                                properties:
+                                  gmsaCredentialSpec:
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    type: string
+                                  runAsUserName:
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                  scheme:
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
                             type: object
                           stdin:
                             type: boolean
@@ -7040,6 +9725,12 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                    overhead:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    preemptionPolicy:
+                      type: string
                     priority:
                       format: int32
                       type: integer
@@ -7101,6 +9792,15 @@ spec:
                             - value
                             type: object
                           type: array
+                        windowsOptions:
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
+                              type: string
+                          type: object
                       type: object
                     serviceAccount:
                       type: string
@@ -7127,6 +9827,45 @@ spec:
                             type: integer
                           value:
                             type: string
+                        type: object
+                      type: array
+                    topologySpreadConstraints:
+                      items:
+                        properties:
+                          labelSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          maxSkew:
+                            format: int32
+                            type: integer
+                          topologyKey:
+                            type: string
+                          whenUnsatisfiable:
+                            type: string
+                        required:
+                        - maxSkew
+                        - topologyKey
+                        - whenUnsatisfiable
                         type: object
                       type: array
                     volumes:

--- a/pkg/apis/rollouts/v1alpha1/analysis_types.go
+++ b/pkg/apis/rollouts/v1alpha1/analysis_types.go
@@ -207,7 +207,7 @@ type Measurement struct {
 	// Status is the status of this single measurement
 	Status AnalysisStatus `json:"status"`
 	// Message contains a message describing current condition (e.g. error messages)
-	Message string `json:"message"`
+	Message string `json:"message,omitempty"`
 	// StartedAt is the timestamp in which this measurement started to be measured
 	StartedAt *metav1.Time `json:"startedAt,omitempty"`
 	// FinishedAt is the timestamp in which this measurement completed and value was collected

--- a/pkg/apis/rollouts/v1alpha1/openapi_generated.go
+++ b/pkg/apis/rollouts/v1alpha1/openapi_generated.go
@@ -1022,7 +1022,7 @@ func schema_pkg_apis_rollouts_v1alpha1_Measurement(ref common.ReferenceCallback)
 						},
 					},
 				},
-				Required: []string{"status", "message"},
+				Required: []string{"status"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/kubectl-argo-rollouts/cmd/cmd.go
+++ b/pkg/kubectl-argo-rollouts/cmd/cmd.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/pause"
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/resume"
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/version"
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options"
+)
+
+const (
+	example = `
+  # Pause the guestbook rollout
+  %[1]s pause guestbook
+
+  # Resume the guestbook rollout
+  %[1]s resume guestbook
+`
+)
+
+func NewCmdArgoRollouts(o *options.ArgoRolloutsOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "kubectl-argo-rollouts COMMAND",
+		Short:             "Manage argo rollouts",
+		Example:           o.Example(example),
+		SilenceUsage:      true,
+		PersistentPreRunE: o.PersistentPreRunE,
+		RunE: func(c *cobra.Command, args []string) error {
+			return o.UsageErr(c)
+		},
+	}
+	cmd.AddCommand(pause.NewCmdPause(o))
+	cmd.AddCommand(resume.NewCmdResume(o))
+	cmd.AddCommand(version.NewCmdVersion(o))
+	return cmd
+}

--- a/pkg/kubectl-argo-rollouts/cmd/cmd_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/cmd_test.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	options "github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options/fake"
+)
+
+func TestCmdArgoRolloutsCmdUsage(t *testing.T) {
+	_, o := options.NewFakeArgoRolloutsOptions()
+	cmd := NewCmdArgoRollouts(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	err := cmd.Execute()
+	assert.Error(t, err)
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "Usage:")
+	assert.Contains(t, stderr, "kubectl-argo-rollouts COMMAND")
+}

--- a/pkg/kubectl-argo-rollouts/cmd/cmd_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/cmd_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 func TestCmdArgoRolloutsCmdUsage(t *testing.T) {
-	_, o := options.NewFakeArgoRolloutsOptions()
+	tf, o := options.NewFakeArgoRolloutsOptions()
+	defer tf.Cleanup()
 	cmd := NewCmdArgoRollouts(o)
 	cmd.PersistentPreRunE = o.PersistentPreRunE
 	err := cmd.Execute()

--- a/pkg/kubectl-argo-rollouts/cmd/pause/pause.go
+++ b/pkg/kubectl-argo-rollouts/cmd/pause/pause.go
@@ -1,0 +1,44 @@
+package pause
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	types "k8s.io/apimachinery/pkg/types"
+
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options"
+)
+
+const (
+	example = `
+  # Pause a rollout
+  %[1]s pause guestbook
+`
+)
+
+// NewCmdPause returns a new instance of an `rollouts pause` command
+func NewCmdPause(o *options.ArgoRolloutsOptions) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:          "pause ROLLOUT",
+		Short:        "Pause a rollout",
+		Example:      o.Example(example),
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return o.UsageErr(c)
+			}
+			ns := o.Namespace()
+			rolloutIf := o.RolloutsClientset().ArgoprojV1alpha1().Rollouts(ns)
+			for _, name := range args {
+				ro, err := rolloutIf.Patch(name, types.MergePatchType, []byte(`{"spec":{"paused":true}}`))
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(o.Out, "rollout '%s' paused\n", ro.Name)
+			}
+			return nil
+		},
+	}
+	o.AddKubectlFlags(cmd)
+	return cmd
+}

--- a/pkg/kubectl-argo-rollouts/cmd/pause/pause_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/pause/pause_test.go
@@ -15,7 +15,8 @@ import (
 )
 
 func TestPauseCmdUsage(t *testing.T) {
-	_, o := options.NewFakeArgoRolloutsOptions()
+	tf, o := options.NewFakeArgoRolloutsOptions()
+	defer tf.Cleanup()
 	cmd := NewCmdPause(o)
 	cmd.PersistentPreRunE = o.PersistentPreRunE
 	cmd.SetArgs([]string{})
@@ -36,7 +37,8 @@ func TestPauseCmd(t *testing.T) {
 		},
 	}
 
-	_, o := options.NewFakeArgoRolloutsOptions(&ro)
+	tf, o := options.NewFakeArgoRolloutsOptions(&ro)
+	defer tf.Cleanup()
 	fakeClient := o.RolloutsClient.(*fakeroclient.Clientset)
 	fakeClient.ReactionChain = nil
 	fakeClient.AddReactor("patch", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
@@ -62,7 +64,8 @@ func TestPauseCmd(t *testing.T) {
 }
 
 func TestPauseCmdError(t *testing.T) {
-	_, o := options.NewFakeArgoRolloutsOptions(&v1alpha1.Rollout{})
+	tf, o := options.NewFakeArgoRolloutsOptions(&v1alpha1.Rollout{})
+	defer tf.Cleanup()
 	cmd := NewCmdPause(o)
 	cmd.PersistentPreRunE = o.PersistentPreRunE
 	cmd.SetArgs([]string{"doesnotexist", "-n", "test"})

--- a/pkg/kubectl-argo-rollouts/cmd/pause/pause_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/pause/pause_test.go
@@ -1,0 +1,75 @@
+package pause
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubetesting "k8s.io/client-go/testing"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	fakeroclient "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
+	options "github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options/fake"
+)
+
+func TestPauseCmdUsage(t *testing.T) {
+	_, o := options.NewFakeArgoRolloutsOptions()
+	cmd := NewCmdPause(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	assert.Error(t, err)
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "Usage:")
+	assert.Contains(t, stderr, "pause ROLLOUT")
+}
+
+func TestPauseCmd(t *testing.T) {
+	ro := v1alpha1.Rollout{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "guestbook",
+			Namespace: "test",
+		},
+	}
+
+	_, o := options.NewFakeArgoRolloutsOptions(&ro)
+	fakeClient := o.RolloutsClient.(*fakeroclient.Clientset)
+	fakeClient.ReactionChain = nil
+	fakeClient.AddReactor("patch", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		if patchAction, ok := action.(kubetesting.PatchAction); ok {
+			if string(patchAction.GetPatch()) == `{"spec":{"paused":true}}` {
+				ro.Spec.Paused = true
+			}
+		}
+		return true, &ro, nil
+	})
+
+	cmd := NewCmdPause(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{"guestbook", "-n", "test"})
+	err := cmd.Execute()
+	assert.Nil(t, err)
+
+	assert.True(t, ro.Spec.Paused)
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Equal(t, stdout, "rollout 'guestbook' paused\n")
+	assert.Empty(t, stderr)
+}
+
+func TestPauseCmdError(t *testing.T) {
+	_, o := options.NewFakeArgoRolloutsOptions(&v1alpha1.Rollout{})
+	cmd := NewCmdPause(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{"doesnotexist", "-n", "test"})
+	err := cmd.Execute()
+	assert.Error(t, err)
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Empty(t, stdout)
+	assert.Equal(t, "Error: rollouts.argoproj.io \"doesnotexist\" not found\n", stderr)
+}

--- a/pkg/kubectl-argo-rollouts/cmd/resume/resume.go
+++ b/pkg/kubectl-argo-rollouts/cmd/resume/resume.go
@@ -1,0 +1,43 @@
+package resume
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	types "k8s.io/apimachinery/pkg/types"
+
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options"
+)
+
+const (
+	example = `
+  # Resume a rollout
+  %[1]s resume guestbook
+`
+)
+
+// NewCmdResume returns a new instance of an `rollouts resume` command
+func NewCmdResume(o *options.ArgoRolloutsOptions) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:          "resume ROLLOUT",
+		Short:        "Resume a rollout",
+		Example:      o.Example(example),
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return o.UsageErr(c)
+			}
+			rolloutIf := o.RolloutsClientset().ArgoprojV1alpha1().Rollouts(o.Namespace())
+			for _, name := range args {
+				ro, err := rolloutIf.Patch(name, types.MergePatchType, []byte(`{"spec":{"paused":false}}`))
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(o.Out, "rollout '%s' resumed\n", ro.Name)
+			}
+			return nil
+		},
+	}
+	o.AddKubectlFlags(cmd)
+	return cmd
+}

--- a/pkg/kubectl-argo-rollouts/cmd/resume/resume_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/resume/resume_test.go
@@ -15,7 +15,8 @@ import (
 )
 
 func TestResumeCmdUsage(t *testing.T) {
-	_, o := options.NewFakeArgoRolloutsOptions()
+	tf, o := options.NewFakeArgoRolloutsOptions()
+	defer tf.Cleanup()
 	cmd := NewCmdResume(o)
 	cmd.PersistentPreRunE = o.PersistentPreRunE
 	cmd.SetArgs([]string{})
@@ -39,7 +40,8 @@ func TestResumeCmdSuccess(t *testing.T) {
 		},
 	}
 
-	_, o := options.NewFakeArgoRolloutsOptions(&ro)
+	tf, o := options.NewFakeArgoRolloutsOptions(&ro)
+	defer tf.Cleanup()
 	fakeClient := o.RolloutsClient.(*fakeroclient.Clientset)
 	fakeClient.ReactionChain = nil
 	fakeClient.AddReactor("patch", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
@@ -65,7 +67,8 @@ func TestResumeCmdSuccess(t *testing.T) {
 }
 
 func TestResumeCmdError(t *testing.T) {
-	_, o := options.NewFakeArgoRolloutsOptions(&v1alpha1.Rollout{})
+	tf, o := options.NewFakeArgoRolloutsOptions(&v1alpha1.Rollout{})
+	defer tf.Cleanup()
 	cmd := NewCmdResume(o)
 	cmd.PersistentPreRunE = o.PersistentPreRunE
 	cmd.SetArgs([]string{"doesnotexist", "-n", "test"})

--- a/pkg/kubectl-argo-rollouts/cmd/resume/resume_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/resume/resume_test.go
@@ -1,0 +1,78 @@
+package resume
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubetesting "k8s.io/client-go/testing"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	fakeroclient "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
+	options "github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options/fake"
+)
+
+func TestResumeCmdUsage(t *testing.T) {
+	_, o := options.NewFakeArgoRolloutsOptions()
+	cmd := NewCmdResume(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	assert.Error(t, err)
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "Usage:")
+	assert.Contains(t, stderr, "resume ROLLOUT")
+}
+
+func TestResumeCmdSuccess(t *testing.T) {
+	ro := v1alpha1.Rollout{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "guestbook",
+			Namespace: "test",
+		},
+		Spec: v1alpha1.RolloutSpec{
+			Paused: true,
+		},
+	}
+
+	_, o := options.NewFakeArgoRolloutsOptions(&ro)
+	fakeClient := o.RolloutsClient.(*fakeroclient.Clientset)
+	fakeClient.ReactionChain = nil
+	fakeClient.AddReactor("patch", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		if patchAction, ok := action.(kubetesting.PatchAction); ok {
+			if string(patchAction.GetPatch()) == `{"spec":{"paused":false}}` {
+				ro.Spec.Paused = false
+			}
+		}
+		return true, &ro, nil
+	})
+
+	cmd := NewCmdResume(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{"guestbook", "-n", "test"})
+	err := cmd.Execute()
+	assert.Nil(t, err)
+
+	assert.False(t, ro.Spec.Paused)
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Equal(t, stdout, "rollout 'guestbook' resumed\n")
+	assert.Empty(t, stderr)
+}
+
+func TestResumeCmdError(t *testing.T) {
+	_, o := options.NewFakeArgoRolloutsOptions(&v1alpha1.Rollout{})
+	cmd := NewCmdResume(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{"doesnotexist", "-n", "test"})
+	err := cmd.Execute()
+	assert.Error(t, err)
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Empty(t, stdout)
+	assert.Equal(t, "Error: rollouts.argoproj.io \"doesnotexist\" not found\n", stderr)
+}

--- a/pkg/kubectl-argo-rollouts/cmd/version/version.go
+++ b/pkg/kubectl-argo-rollouts/cmd/version/version.go
@@ -1,0 +1,43 @@
+package version
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options"
+	versionutils "github.com/argoproj/argo-rollouts/utils/version"
+)
+
+// NewCmdVersion returns a new instance of an `rollouts version` command
+func NewCmdVersion(o *options.ArgoRolloutsOptions) *cobra.Command {
+	var (
+		short bool
+	)
+	var cmd = &cobra.Command{
+		Use:          "version",
+		Short:        "Print version",
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			PrintVersion(o.Out, short)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&short, "short", false, "print just the version number")
+	return cmd
+}
+
+// PrintVersion prints the version to the output stream
+func PrintVersion(out io.Writer, short bool) {
+	version := versionutils.GetVersion()
+	fmt.Fprintf(out, "%s: %s\n", "kubectl-argo-rollouts", version)
+	if !short {
+		fmt.Fprintf(out, "  BuildDate: %s\n", version.BuildDate)
+		fmt.Fprintf(out, "  GitCommit: %s\n", version.GitCommit)
+		fmt.Fprintf(out, "  GitTreeState: %s\n", version.GitTreeState)
+		fmt.Fprintf(out, "  GoVersion: %s\n", version.GoVersion)
+		fmt.Fprintf(out, "  Compiler: %s\n", version.Compiler)
+		fmt.Fprintf(out, "  Platform: %s\n", version.Platform)
+	}
+}

--- a/pkg/kubectl-argo-rollouts/cmd/version/version_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/version/version_test.go
@@ -1,0 +1,33 @@
+package version
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	options "github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options/fake"
+)
+
+func TestVersionCmd(t *testing.T) {
+	_, o := options.NewFakeArgoRolloutsOptions()
+	cmd := NewCmdVersion(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{"version"})
+	err := cmd.Execute()
+	assert.NoError(t, err)
+	stdout := o.Out.(*bytes.Buffer).String()
+	assert.Contains(t, stdout, "kubectl-argo-rollouts: v99.99.99+unknown\n")
+	assert.Contains(t, stdout, "BuildDate: 1970-01-01T00:00:00Z\n")
+}
+
+func TestVersionCmdShort(t *testing.T) {
+	_, o := options.NewFakeArgoRolloutsOptions()
+	cmd := NewCmdVersion(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{"version", "--short"})
+	err := cmd.Execute()
+	assert.NoError(t, err)
+	stdout := o.Out.(*bytes.Buffer).String()
+	assert.Equal(t, "kubectl-argo-rollouts: v99.99.99+unknown\n", stdout)
+}

--- a/pkg/kubectl-argo-rollouts/cmd/version/version_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/version/version_test.go
@@ -10,10 +10,11 @@ import (
 )
 
 func TestVersionCmd(t *testing.T) {
-	_, o := options.NewFakeArgoRolloutsOptions()
+	tf, o := options.NewFakeArgoRolloutsOptions()
+	defer tf.Cleanup()
 	cmd := NewCmdVersion(o)
 	cmd.PersistentPreRunE = o.PersistentPreRunE
-	cmd.SetArgs([]string{"version"})
+	cmd.SetArgs([]string{})
 	err := cmd.Execute()
 	assert.NoError(t, err)
 	stdout := o.Out.(*bytes.Buffer).String()
@@ -22,10 +23,11 @@ func TestVersionCmd(t *testing.T) {
 }
 
 func TestVersionCmdShort(t *testing.T) {
-	_, o := options.NewFakeArgoRolloutsOptions()
+	tf, o := options.NewFakeArgoRolloutsOptions()
+	defer tf.Cleanup()
 	cmd := NewCmdVersion(o)
 	cmd.PersistentPreRunE = o.PersistentPreRunE
-	cmd.SetArgs([]string{"version", "--short"})
+	cmd.SetArgs([]string{"--short"})
 	err := cmd.Execute()
 	assert.NoError(t, err)
 	stdout := o.Out.(*bytes.Buffer).String()

--- a/pkg/kubectl-argo-rollouts/options/fake/fakeoptions.go
+++ b/pkg/kubectl-argo-rollouts/options/fake/fakeoptions.go
@@ -1,0 +1,20 @@
+package options
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+
+	fakeroclient "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options"
+)
+
+// NewFakeArgoRolloutsOptions returns a options.ArgoRolloutsOptions suitable for testing
+func NewFakeArgoRolloutsOptions(obj ...runtime.Object) (*cmdtesting.TestFactory, *options.ArgoRolloutsOptions) {
+	iostreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	tf := cmdtesting.NewTestFactory()
+	o := options.NewArgoRolloutsOptions(iostreams)
+	o.RESTClientGetter = tf
+	o.RolloutsClient = fakeroclient.NewSimpleClientset(obj...)
+	return tf, o
+}

--- a/pkg/kubectl-argo-rollouts/options/options.go
+++ b/pkg/kubectl-argo-rollouts/options/options.go
@@ -1,0 +1,117 @@
+package options
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"strconv"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/klog"
+
+	roclientset "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned"
+)
+
+const (
+	cliName = "kubectl argo rollouts"
+)
+
+// ArgoRolloutsOptions are a set of common CLI flags and convenience functions made available to
+// all commands of the kubectl-argo-rollouts plugin
+type ArgoRolloutsOptions struct {
+	CLIName          string
+	RESTClientGetter genericclioptions.RESTClientGetter
+	ConfigFlags      *genericclioptions.ConfigFlags
+	KlogLevel        int
+	LogLevel         string
+	RolloutsClient   roclientset.Interface
+
+	Log *log.Logger
+	genericclioptions.IOStreams
+}
+
+// NewArgoRolloutsOptions provides an instance of ArgoRolloutsOptions with default values
+func NewArgoRolloutsOptions(streams genericclioptions.IOStreams) *ArgoRolloutsOptions {
+	logCtx := log.New()
+	logCtx.SetOutput(streams.ErrOut)
+	klog.SetOutput(streams.ErrOut)
+	configFlags := genericclioptions.NewConfigFlags(true)
+
+	return &ArgoRolloutsOptions{
+		CLIName:          cliName,
+		RESTClientGetter: configFlags,
+		ConfigFlags:      configFlags,
+		IOStreams:        streams,
+		Log:              logCtx,
+		LogLevel:         log.InfoLevel.String(),
+	}
+}
+
+// Example returns the example string with the CLI command replaced in the example
+func (o *ArgoRolloutsOptions) Example(example string) string {
+	return strings.Trim(fmt.Sprintf(example, cliName), "\n")
+}
+
+// UsageErr is a convenience function to output usage and return an error
+func (o *ArgoRolloutsOptions) UsageErr(c *cobra.Command) error {
+	c.Usage()
+	c.SilenceErrors = true
+	return errors.New(c.UsageString())
+}
+
+// PersistentPreRunE contains common logic which will be executed for all commands
+func (o *ArgoRolloutsOptions) PersistentPreRunE(c *cobra.Command, args []string) error {
+	// NOTE: we set the output of the cobra command to stderr because the only thing that should
+	// emit to this are returned errors from command.RunE
+	c.SetOut(o.ErrOut)
+	level, err := log.ParseLevel(o.LogLevel)
+	if err != nil {
+		return err
+	}
+	o.Log.SetLevel(level)
+	if flag.Lookup("v") != nil {
+		// the '-v' flag is set by klog.Init(), which we only call in main.go
+		err := flag.Set("v", strconv.Itoa(o.KlogLevel))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// AddKubectlFlags adds kubectl related flags to the command
+func (o *ArgoRolloutsOptions) AddKubectlFlags(cmd *cobra.Command) {
+	flags := cmd.Flags()
+	o.ConfigFlags.AddFlags(flags)
+	flags.IntVarP(&o.KlogLevel, "kloglevel", "v", 0, "Log level for kubernetes client library")
+	flags.StringVar(&o.LogLevel, "loglevel", log.InfoLevel.String(), "Log level for kubectl argo rollouts")
+}
+
+// RolloutsClientset returns a Rollout client interface based on client flags
+func (o *ArgoRolloutsOptions) RolloutsClientset() roclientset.Interface {
+	if o.RolloutsClient != nil {
+		return o.RolloutsClient
+	}
+	config, err := o.RESTClientGetter.ToRESTConfig()
+	if err != nil {
+		panic(err)
+	}
+	rolloutsClient, err := roclientset.NewForConfig(config)
+	if err != nil {
+		panic(err)
+	}
+	o.RolloutsClient = rolloutsClient
+	return o.RolloutsClient
+}
+
+// Namespace returns the namespace based on client flags or kube context
+func (o *ArgoRolloutsOptions) Namespace() string {
+	namespace, _, err := o.RESTClientGetter.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		panic(err)
+	}
+	return namespace
+}

--- a/pkg/kubectl-argo-rollouts/options/options_test.go
+++ b/pkg/kubectl-argo-rollouts/options/options_test.go
@@ -14,7 +14,8 @@ import (
 )
 
 func TestExample(t *testing.T) {
-	_, o := fakeoptions.NewFakeArgoRolloutsOptions()
+	tf, o := fakeoptions.NewFakeArgoRolloutsOptions()
+	defer tf.Cleanup()
 	example := `
   # do something
   %[1]s foo
@@ -23,7 +24,8 @@ func TestExample(t *testing.T) {
 }
 
 func TestUsageErr(t *testing.T) {
-	_, o := fakeoptions.NewFakeArgoRolloutsOptions()
+	tf, o := fakeoptions.NewFakeArgoRolloutsOptions()
+	defer tf.Cleanup()
 
 	var cmd = &cobra.Command{
 		Use:               "foo SOMETHING",
@@ -42,7 +44,8 @@ func TestUsageErr(t *testing.T) {
 }
 
 func TestAddKubectlFlags(t *testing.T) {
-	_, o := fakeoptions.NewFakeArgoRolloutsOptions()
+	tf, o := fakeoptions.NewFakeArgoRolloutsOptions()
+	defer tf.Cleanup()
 
 	var cmd = &cobra.Command{
 		Use:               "foo SOMETHING",
@@ -68,6 +71,7 @@ func TestAddKubectlFlags(t *testing.T) {
 func TestRolloutsClientset(t *testing.T) {
 	iostreams, _, _, _ := genericclioptions.NewTestIOStreams()
 	tf := cmdtesting.NewTestFactory().WithNamespace("foo")
+	defer tf.Cleanup()
 	o := options.NewArgoRolloutsOptions(iostreams)
 	o.RESTClientGetter = tf
 	o.RESTClientGetter.ToRawKubeConfigLoader().Namespace()

--- a/pkg/kubectl-argo-rollouts/options/options_test.go
+++ b/pkg/kubectl-argo-rollouts/options/options_test.go
@@ -1,0 +1,90 @@
+package options_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options"
+	fakeoptions "github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options/fake"
+)
+
+func TestExample(t *testing.T) {
+	_, o := fakeoptions.NewFakeArgoRolloutsOptions()
+	example := `
+  # do something
+  %[1]s foo
+`
+	assert.Equal(t, "  # do something\n  kubectl argo rollouts foo", o.Example(example))
+}
+
+func TestUsageErr(t *testing.T) {
+	_, o := fakeoptions.NewFakeArgoRolloutsOptions()
+
+	var cmd = &cobra.Command{
+		Use:               "foo SOMETHING",
+		SilenceUsage:      true,
+		PersistentPreRunE: o.PersistentPreRunE,
+		RunE: func(c *cobra.Command, args []string) error {
+			return o.UsageErr(c)
+		},
+	}
+	err := cmd.Execute()
+	assert.Error(t, err)
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	stdout := o.Out.(*bytes.Buffer).String()
+	assert.Equal(t, "Usage:\n  foo SOMETHING [flags]\n\nFlags:\n  -h, --help   help for foo\n", stderr)
+	assert.Empty(t, stdout)
+}
+
+func TestAddKubectlFlags(t *testing.T) {
+	_, o := fakeoptions.NewFakeArgoRolloutsOptions()
+
+	var cmd = &cobra.Command{
+		Use:               "foo SOMETHING",
+		SilenceUsage:      true,
+		PersistentPreRunE: o.PersistentPreRunE,
+		RunE: func(c *cobra.Command, args []string) error {
+			o.Log.Debug("hello world")
+			return nil
+		},
+	}
+	o.AddKubectlFlags(cmd)
+
+	cmd.SetArgs([]string{"-v", "9", "--loglevel", "debug"})
+	err := cmd.Execute()
+	assert.NoError(t, err)
+
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	stdout := o.Out.(*bytes.Buffer).String()
+	assert.Contains(t, stderr, "hello world")
+	assert.Empty(t, stdout)
+}
+
+func TestRolloutsClientset(t *testing.T) {
+	iostreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	tf := cmdtesting.NewTestFactory().WithNamespace("foo")
+	o := options.NewArgoRolloutsOptions(iostreams)
+	o.RESTClientGetter = tf
+	o.RESTClientGetter.ToRawKubeConfigLoader().Namespace()
+	//o.ConfigFlags = tf
+
+	var cmd = &cobra.Command{
+		Use:               "foo SOMETHING",
+		SilenceUsage:      true,
+		PersistentPreRunE: o.PersistentPreRunE,
+		RunE: func(c *cobra.Command, args []string) error {
+			assert.Equal(t, "foo", o.Namespace())
+			_ = o.RolloutsClientset()
+			return nil
+		},
+	}
+	o.AddKubectlFlags(cmd)
+
+	err := cmd.Execute()
+	assert.NoError(t, err)
+}

--- a/utils/version/version.go
+++ b/utils/version/version.go
@@ -1,0 +1,65 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// Version information set by link flags during build. We fall back to these sane
+// default values when we build outside the Makefile context (e.g. go run, go build, or go test).
+var (
+	version      = "99.99.99"             // value from VERSION file
+	buildDate    = "1970-01-01T00:00:00Z" // output from `date -u +'%Y-%m-%dT%H:%M:%SZ'`
+	gitCommit    = ""                     // output from `git rev-parse HEAD`
+	gitTag       = ""                     // output from `git describe --exact-match --tags HEAD` (if clean tree state)
+	gitTreeState = ""                     // determined from `git status --porcelain`. either 'clean' or 'dirty'
+)
+
+// Version contains Argo version information
+type Version struct {
+	Version      string
+	BuildDate    string
+	GitCommit    string
+	GitTag       string
+	GitTreeState string
+	GoVersion    string
+	Compiler     string
+	Platform     string
+}
+
+func (v Version) String() string {
+	return v.Version
+}
+
+// GetVersion returns the version information
+func GetVersion() Version {
+	var versionStr string
+
+	if gitCommit != "" && gitTag != "" && gitTreeState == "clean" {
+		// if we have a clean tree state and the current commit is tagged,
+		// this is an official release.
+		versionStr = gitTag
+	} else {
+		// otherwise formulate a version string based on as much metadata
+		// information we have available.
+		versionStr = "v" + version
+		if len(gitCommit) >= 7 {
+			versionStr += "+" + gitCommit[0:7]
+			if gitTreeState != "clean" {
+				versionStr += ".dirty"
+			}
+		} else {
+			versionStr += "+unknown"
+		}
+	}
+	return Version{
+		Version:      versionStr,
+		BuildDate:    buildDate,
+		GitCommit:    gitCommit,
+		GitTag:       gitTag,
+		GitTreeState: gitTreeState,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
See below for examples:

```bash
$ kubectl argo rollouts version
kubectl-argo-rollouts: v0.5.0+71cfcca
  BuildDate: 2019-10-11T09:33:48Z
  GitCommit: 71cfcca753186304cfc39bc602d77358e7ad12ab
  GitTreeState: clean
  GoVersion: go1.13.1
  Compiler: gc
  Platform: darwin/amd64

$ kubectl argo rollouts resume canary-demo -n default
rollout 'canary-demo' resumed

$ kubectl argo rollouts pause canary-demo -n default
rollout 'canary-demo' paused

$ kubectl argo rollouts -v=6 resume doesnt-exist
I1011 02:36:12.660302   81169 loader.go:375] Config loaded from file:  /Users/jsuen/.kube/config
I1011 02:36:13.135455   81169 round_trippers.go:443] PATCH https://35.235.69.198/apis/argoproj.io/v1alpha1/namespaces/argo/rollouts/doesnt-exist 404 Not Found in 474 milliseconds
Error: rollouts.argoproj.io "doesnt-exist" not found