### PR TITLE
Fix regression where canary would not progress past a pause step

### DIFF
--- a/analysis/controller_test.go
+++ b/analysis/controller_test.go
@@ -157,7 +157,8 @@ func (f *fixture) runController(analysisRunName string, startInformers bool, exp
 	actions := filterInformerActions(f.client.Actions())
 	for i, action := range actions {
 		if len(f.actions) < i+1 {
-			f.t.Errorf("%d unexpected actions: %+v", len(actions)-len(f.actions), actions[i:])
+			actionsBytes, _ := json.Marshal(actions[i:])
+			f.t.Errorf("%d unexpected actions: %+v", len(actions)-len(f.actions), string(actionsBytes))
 			break
 		}
 

--- a/experiments/controller_test.go
+++ b/experiments/controller_test.go
@@ -362,7 +362,8 @@ func (f *fixture) runController(experimentName string, startInformers bool, expe
 	actions := filterInformerActions(f.client.Actions())
 	for i, action := range actions {
 		if len(f.actions) < i+1 {
-			f.t.Errorf("%d unexpected actions: %+v", len(actions)-len(f.actions), actions[i:])
+			actionsBytes, _ := json.Marshal(actions[i:])
+			f.t.Errorf("%d unexpected actions: %+v", len(actions)-len(f.actions), string(actionsBytes))
 			break
 		}
 
@@ -377,7 +378,8 @@ func (f *fixture) runController(experimentName string, startInformers bool, expe
 	k8sActions := filterInformerActions(f.kubeclient.Actions())
 	for i, action := range k8sActions {
 		if len(f.kubeactions) < i+1 {
-			f.t.Errorf("%d unexpected actions: %+v", len(k8sActions)-len(f.kubeactions), k8sActions[i:])
+			actionsBytes, _ := json.Marshal(k8sActions[i:])
+			f.t.Errorf("%d unexpected actions: %+v", len(k8sActions)-len(f.kubeactions), string(actionsBytes))
 			break
 		}
 

--- a/metricproviders/job/job.go
+++ b/metricproviders/job/job.go
@@ -19,7 +19,7 @@ const (
 	// JobNameKey is the measurement's metadata key holding the job name associated with the measurement
 	JobNameKey = "job-name"
 	// AnalysisRunLabelKey is the job's label key where we label the name of the AnalysisRun associated to it
-	AnalysisRunLabelKey = "analysisruns.argoproj.io/name"
+	AnalysisRunLabelKey = "analysisrun.argoproj.io/name"
 )
 
 var (

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -465,7 +465,8 @@ func (f *fixture) runController(rolloutName string, startInformers bool, expectE
 	actions := filterInformerActions(f.client.Actions())
 	for i, action := range actions {
 		if len(f.actions) < i+1 {
-			f.t.Errorf("%d unexpected actions: %+v", len(actions)-len(f.actions), actions[i:])
+			actionsBytes, _ := json.Marshal(actions[i:])
+			f.t.Errorf("%d unexpected actions: %+v", len(actions)-len(f.actions), string(actionsBytes))
 			break
 		}
 
@@ -480,7 +481,8 @@ func (f *fixture) runController(rolloutName string, startInformers bool, expectE
 	k8sActions := filterInformerActions(f.kubeclient.Actions())
 	for i, action := range k8sActions {
 		if len(f.kubeactions) < i+1 {
-			f.t.Errorf("%d unexpected actions: %+v", len(k8sActions)-len(f.kubeactions), k8sActions[i:])
+			actionsBytes, _ := json.Marshal(k8sActions[i:])
+			f.t.Errorf("%d unexpected actions: %+v", len(k8sActions)-len(f.kubeactions), string(actionsBytes))
 			break
 		}
 

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -208,7 +208,7 @@ func (c *RolloutController) getNewReplicaSet(rollout *v1alpha1.Rollout, rsList, 
 // syncReplicasOnly is responsible for reconciling rollouts on scaling events.
 func (c *RolloutController) syncReplicasOnly(r *v1alpha1.Rollout, rsList []*appsv1.ReplicaSet, isScaling bool) error {
 	logCtx := logutil.WithRollout(r)
-	logCtx.Info("Reconciling scaling event")
+	logCtx.Infof("Syncing replicas only (paused: %v, isScaling: %v)", r.Spec.Paused, isScaling)
 	newRS, oldRSs, err := c.getAllReplicaSetsAndSyncRevision(r, rsList, false)
 	if err != nil {
 		return err


### PR DESCRIPTION
If a rollout was paused, it would go into syncReplicasOnly() which would call syncRolloutStatusCanary() which had no code path to unpause it ever, even after the specified duration. This change will allow it to progress to the next step after the pause duration by advancing the current step index.

Note that this change allows metadata to be updated (e.g. advancing of currentStepIndex, marking the rollout complete, etc...). This should be safe to do since we never touch replicasets weights (aside from whatever happens from scaling events).