### PR TITLE
Rename prometheus.server to address to better reflect API client interface

### DIFF
--- a/docs/features/analysis.md
+++ b/docs/features/analysis.md
@@ -76,7 +76,7 @@ spec:
     successCondition: result >= 0.95
     maxFailures: 3
     prometheus:
-      server: http://prometheus.example.com:9090
+      address: http://prometheus.example.com:9090
       query: |
         sum(irate(
           istio_requests_total{reporter="source",destination_service=~"{{inputs.service-name}}",response_code!~"5.*"}[5m]
@@ -131,7 +131,7 @@ spec:
   - name: success-rate
     successCondition: result >= 0.95
     prometheus:
-      server: http://prometheus.example.com:9090
+      address: http://prometheus.example.com:9090
       query: |
         sum(irate(
           istio_requests_total{reporter="source",destination_service=~"{{inputs.service-name}}",response_code!~"5.*"}[5m]
@@ -151,7 +151,7 @@ Multiple measurements can be performed over a longer duration period, by specify
     interval: 60
     count: 5
     prometheus:
-      server: http://prometheus.example.com:9090
+      address: http://prometheus.example.com:9090
       query: ...
 ```
 
@@ -168,7 +168,7 @@ every 5 minutes, causing the analysis run to fail if 10 or more errors were enco
     failureCondition: result >= 10
     maxFailures: 3
     prometheus:
-      server: http://prometheus.example.com:9090
+      address: http://prometheus.example.com:9090
       query: |
         sum(irate(
           istio_requests_total{reporter="source",destination_service=~"{{inputs.service-name}}",response_code~"5.*"}[5m]
@@ -186,7 +186,7 @@ could become `Inconclusive`, is when a metric defines no success or failure cond
   metrics:
   - name: my-query
     prometheus:
-      server: http://prometheus.example.com:9090
+      address: http://prometheus.example.com:9090
       query: ...
 ```
 
@@ -199,7 +199,7 @@ specified, but the measurement value did not meet either condition.
     successCondition: result >= 0.90
     failureCondition: result < 0.50
     prometheus:
-      server: http://prometheus.example.com:9090
+      address: http://prometheus.example.com:9090
       query: ...
 ```
 

--- a/manifests/crds/analysis-run-crd.yaml
+++ b/manifests/crds/analysis-run-crd.yaml
@@ -2498,9 +2498,9 @@ spec:
                             type: object
                           prometheus:
                             properties:
-                              query:
+                              address:
                                 type: string
-                              server:
+                              query:
                                 type: string
                             type: object
                         type: object

--- a/manifests/crds/analysis-template-crd.yaml
+++ b/manifests/crds/analysis-template-crd.yaml
@@ -2496,9 +2496,9 @@ spec:
                         type: object
                       prometheus:
                         properties:
-                          query:
+                          address:
                             type: string
-                          server:
+                          query:
                             type: string
                         type: object
                     type: object

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -2499,9 +2499,9 @@ spec:
                             type: object
                           prometheus:
                             properties:
-                              query:
+                              address:
                                 type: string
-                              server:
+                              query:
                                 type: string
                             type: object
                         type: object
@@ -5107,9 +5107,9 @@ spec:
                         type: object
                       prometheus:
                         properties:
-                          query:
+                          address:
                             type: string
-                          server:
+                          query:
                             type: string
                         type: object
                     type: object

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2499,9 +2499,9 @@ spec:
                             type: object
                           prometheus:
                             properties:
-                              query:
+                              address:
                                 type: string
-                              server:
+                              query:
                                 type: string
                             type: object
                         type: object
@@ -5107,9 +5107,9 @@ spec:
                         type: object
                       prometheus:
                         properties:
-                          query:
+                          address:
                             type: string
-                          server:
+                          query:
                             type: string
                         type: object
                     type: object

--- a/metricproviders/prometheus/prometheus.go
+++ b/metricproviders/prometheus/prometheus.go
@@ -142,7 +142,7 @@ func NewPrometheusProvider(api v1.API, logCtx log.Entry) *Provider {
 // NewPrometheusAPI generates a prometheus API from the metric configuration
 func NewPrometheusAPI(metric v1alpha1.Metric) (v1.API, error) {
 	client, err := api.NewClient(api.Config{
-		Address: metric.Provider.Prometheus.Server,
+		Address: metric.Provider.Prometheus.Address,
 	})
 	if err != nil {
 		return nil, err

--- a/metricproviders/prometheus/prometheus_test.go
+++ b/metricproviders/prometheus/prometheus_test.go
@@ -287,14 +287,14 @@ func TestNewPrometheusAPI(t *testing.T) {
 	metric := v1alpha1.Metric{
 		Provider: v1alpha1.MetricProvider{
 			Prometheus: &v1alpha1.PrometheusMetric{
-				Server: ":invalid::url",
+				Address: ":invalid::url",
 			},
 		},
 	}
 	_, err := NewPrometheusAPI(metric)
 	assert.NotNil(t, err)
 
-	metric.Provider.Prometheus.Server = "https://www.example.com"
+	metric.Provider.Prometheus.Address = "https://www.example.com"
 	_, err = NewPrometheusAPI(metric)
 	assert.Nil(t, err)
 }

--- a/pkg/apis/rollouts/v1alpha1/analysis_types.go
+++ b/pkg/apis/rollouts/v1alpha1/analysis_types.go
@@ -115,8 +115,8 @@ func (as AnalysisStatus) Completed() bool {
 
 // PrometheusMetric defines the prometheus query to perform canary analysis
 type PrometheusMetric struct {
-	// Server is the address and port of the prometheus server
-	Server string `json:"server,omitempty"`
+	// Address is the HTTP address and port of the prometheus server
+	Address string `json:"address,omitempty"`
 	// Query is a raw prometheus query to perform
 	Query string `json:"query,omitempty"`
 }

--- a/pkg/apis/rollouts/v1alpha1/openapi_generated.go
+++ b/pkg/apis/rollouts/v1alpha1/openapi_generated.go
@@ -1285,9 +1285,9 @@ func schema_pkg_apis_rollouts_v1alpha1_PrometheusMetric(ref common.ReferenceCall
 			SchemaProps: spec.SchemaProps{
 				Description: "PrometheusMetric defines the prometheus query to perform canary analysis",
 				Properties: map[string]spec.Schema{
-					"server": {
+					"address": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Server is the address and port of the prometheus server",
+							Description: "Address is the HTTP address and port of the prometheus server",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/test/e2e/expectedfailures/analysis-run-prometheus-bad-server.yaml
+++ b/test/e2e/expectedfailures/analysis-run-prometheus-bad-server.yaml
@@ -8,4 +8,4 @@ spec:
     - name: success-rate
       provider:
         prometheus:
-          server: http://prometheus-operator-prometheus.prometheus-operator:9090
+          address: http://prometheus-operator-prometheus.prometheus-operator:9090


### PR DESCRIPTION
This is a simple field rename from prometheus.server to prometheus.address, as this is the same terminology that the Prometheus API client uses.