### PR TITLE
Fixed a markdown

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -115,6 +115,6 @@ kubectl -n argo-rollouts apply -f manifests/install.yaml
 If you need to run the mkdocs server, you will need to do the following:
 
 * Follow the instruction guide to install [mkDocs](https://www.mkdocs.org/#installation)
-* Install the `material` theme with the (following guide](https://squidfunk.github.io/mkdocs-material/#quick-start)
+* Install the `material` theme with the [following guide](https://squidfunk.github.io/mkdocs-material/#quick-start)
 
 Afterwards, you can run `mkdocs serve` and access your documentation at [http://127.0.0.1:8000/](http://127.0.0.1:8000/)


### PR DESCRIPTION
`following guide` should be a link.