### PR TITLE
Use deterministic names for experiments and analysis

### DIFF
--- a/examples/rollout-analysis-step.yaml
+++ b/examples/rollout-analysis-step.yaml
@@ -1,0 +1,59 @@
+# This example demonstrates a Rollout which starts and finishes analysis at a specific canary step
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: rollout-analysis-step
+spec:
+  replicas: 4
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: rollout-analysis-step
+  template:
+    metadata:
+      labels:
+        app: rollout-analysis-step
+    spec:
+      containers:
+      - name: rollouts-demo
+        image: argoproj/rollouts-demo:blue
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+  strategy:
+    canary:
+      steps:
+      - setWeight: 25
+      # An AnalysisTemplate is referenced at the second step, which starts an AnalysisRun after
+      # the setWeight step. The rolllout will not progress to the following step until the
+      # AnalysisRun is complete. A failure/error of the analysis will cause the rollout's update to
+      # abort, and set the canary weight to zero.
+      - analysis:
+          name: random-fail
+          templateName: random-fail
+
+---
+# This AnalysisTemplate will run a Kubernetes Job every 5 seconds, with a 50% chance of failure.
+# When the number of accumulated failures exceeds maxFailures, it will cause the analysis run to
+# fail, and subsequently cause the rollout to abort.
+kind: AnalysisTemplate
+apiVersion: argoproj.io/v1alpha1
+metadata:
+  name: random-fail
+spec:
+  metrics:
+  - name: random-fail
+    interval: 5
+    maxFailures: 1
+    provider:
+      job:
+        spec:
+          template:
+            spec:
+              containers:
+              - name: sleep
+                image: alpine:3.8
+                command: [sh, -c]
+                args: [FLIP=$(($(($RANDOM%10))%2)) && exit $FLIP]
+              restartPolicy: Never
+          backoffLimit: 0

--- a/examples/rollout-background-analysis.yaml
+++ b/examples/rollout-background-analysis.yaml
@@ -2,18 +2,17 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
-  name: rollout-with-analysis
+  name: rollout-background-analysis
 spec:
   replicas: 4
-  minReadySeconds: 10
-  revisionHistoryLimit: 3
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
-      app: rollout-with-analysis
+      app: rollout-background-analysis
   template:
     metadata:
       labels:
-        app: rollout-with-analysis
+        app: rollout-background-analysis
     spec:
       containers:
       - name: rollouts-demo
@@ -24,18 +23,19 @@ spec:
   strategy:
     canary:
       # An AnalysisTemplate is referenced here, which starts an AnalysisRun as soon as the update
-      # begins, and terminates the run when the update completes. A failure/error of the analysis
+      # begins. The run is terminated when the update completes. A failure/error of the analysis
       # will cause the rollout's update to abort, and set the canary weight to zero.
       analysis:
         name: random-fail
         templateName: random-fail
       steps:
-      - setWeight: 50
+      - setWeight: 25
       - pause: {}
 
 ---
-# This AnalysisTemplate will run a Kubernetes Job every 10 seconds, with a 50% chance of failure.
-# When the number of accumulated failures exceeds maxFailures, it will cause the rollout to abort.
+# This AnalysisTemplate will run a Kubernetes Job every 5 seconds, with a 50% chance of failure.
+# When the number of accumulated failures exceeds maxFailures, it will cause the analysis run to
+# fail, and subsequently cause the rollout to abort.
 kind: AnalysisTemplate
 apiVersion: argoproj.io/v1alpha1
 metadata:
@@ -43,8 +43,8 @@ metadata:
 spec:
   metrics:
   - name: random-fail
-    interval: 10
-    maxFailures: 2
+    interval: 5
+    maxFailures: 1
     provider:
       job:
         spec:

--- a/examples/rollout-baseline-vs-canary.yaml
+++ b/examples/rollout-baseline-vs-canary.yaml
@@ -7,9 +7,8 @@ kind: Rollout
 metadata:
   name: rollout-baseline-vs-canary
 spec:
-  replicas: 5
-  minReadySeconds: 10
-  revisionHistoryLimit: 3
+  replicas: 3
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: rollout-baseline-vs-canary

--- a/examples/rollout-bluegreen.yaml
+++ b/examples/rollout-bluegreen.yaml
@@ -5,9 +5,8 @@ kind: Rollout
 metadata:
   name: rollout-bluegreen
 spec:
-  replicas: 1
-  minReadySeconds: 10
-  revisionHistoryLimit: 3
+  replicas: 2
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: rollout-bluegreen

--- a/examples/rollout-canary-preview.yaml
+++ b/examples/rollout-canary-preview.yaml
@@ -6,9 +6,8 @@ kind: Rollout
 metadata:
   name: rollout-canary-preview
 spec:
-  replicas: 5
-  minReadySeconds: 10
-  revisionHistoryLimit: 3
+  replicas: 3
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: rollout-canary-production

--- a/examples/rollout-canary.yaml
+++ b/examples/rollout-canary.yaml
@@ -7,8 +7,7 @@ metadata:
   name: rollout-canary
 spec:
   replicas: 5
-  minReadySeconds: 10
-  revisionHistoryLimit: 3
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: rollout-canary

--- a/examples/rollout-experiment-step.yaml
+++ b/examples/rollout-experiment-step.yaml
@@ -1,0 +1,66 @@
+# This example demonstrates a Rollout which begins an an experiment at a specified step.
+# The rollout willl not proceed to the next step until the experiment is completed and successful.
+# In this example, the experiment itself starts its own AnalysisRun which is tied to the experiment.
+# This is useful for when analysis should be done only during the experimentation phase, but not
+# during the regular update of the rollout.
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: rollout-experiment-step
+spec:
+  replicas: 4
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: rollout-experiment-step
+  template:
+    metadata:
+      labels:
+        app: rollout-experiment-step
+    spec:
+      containers:
+      - name: rollouts-demo
+        image: argoproj/rollouts-demo:blue
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+  strategy:
+    canary:
+      steps:
+      - setWeight: 25
+      # The second step is the experiment which starts a single canary pod
+      - experiment:
+          templates:
+          - name: canary
+            specRef: canary
+          # This experiment performs its own analysis by referencing one or more AnalysisTemplates
+          # here. The success or failure of these runs will progress or abort the rollout respectively.
+          analyses:
+          - name: random-fail
+            templateName: random-fail
+
+---
+# This AnalysisTemplate will run a Kubernetes Job every 5 seconds, with a 50% chance of failure.
+# When the number of accumulated failures exceeds maxFailures, it will cause the analysis run to
+# fail, and subsequently cause the rollout to abort.
+kind: AnalysisTemplate
+apiVersion: argoproj.io/v1alpha1
+metadata:
+  name: random-fail
+spec:
+  metrics:
+  - name: random-fail
+    interval: 5
+    maxFailures: 1
+    provider:
+      job:
+        spec:
+          template:
+            spec:
+              containers:
+              - name: sleep
+                image: alpine:3.8
+                command: [sh, -c]
+                args: [FLIP=$(($(($RANDOM%10))%2)) && exit $FLIP]
+              restartPolicy: Never
+          backoffLimit: 0

--- a/examples/rollout-rolling-update.yaml
+++ b/examples/rollout-rolling-update.yaml
@@ -5,8 +5,7 @@ metadata:
   name: rollout-rollingupdate
 spec:
   replicas: 5
-  minReadySeconds: 10
-  revisionHistoryLimit: 3
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: rollout-rollingupdate

--- a/rollout/analysis.go
+++ b/rollout/analysis.go
@@ -76,7 +76,7 @@ func (c *RolloutController) reconcileAnalysisRuns(roCtx *canaryContext) error {
 	otherArs, _ = analysisutil.FilterAnalysisRuns(otherArs, func(ar *v1alpha1.AnalysisRun) bool {
 		for _, curr := range newCurrentAnalysisRuns {
 			if ar.Name == curr.Name {
-				roCtx.log.Infof("Saved %s from inadvertent termination", ar.Name)
+				roCtx.log.Infof("Rescued %s from inadvertent termination", ar.Name)
 				return false
 			}
 		}
@@ -164,7 +164,7 @@ func (c *RolloutController) createAnalysisRun(roCtx *canaryContext, rolloutAnaly
 		if err != nil {
 			return nil, err
 		}
-		existingEqual := analysisutil.IsSemanticallyEqual(ar, existingAR)
+		existingEqual := analysisutil.IsSemanticallyEqual(ar.Spec, existingAR.Spec)
 		roCtx.log.Infof("Encountered collision of existing analysisrun %s (status: %s, equal: %v)", existingAR.Name, existingAR.Status.Status, existingEqual)
 		if !existingAR.Status.Status.Completed() && existingEqual {
 			// If we get here, the existing AR has been determined to be our analysis run and we
@@ -247,7 +247,7 @@ func (c *RolloutController) getAnalysisRunFromRollout(roCtx *canaryContext, roll
 	revision := r.Annotations[annotations.RevisionAnnotation]
 	ar := v1alpha1.AnalysisRun{
 		ObjectMeta: metav1.ObjectMeta{
-			// TOOD(jessesuen): consider incorporating the step index into the name like we do for experiments
+			// TODO(jessesuen): consider incorporating the step index into the name like we do for experiments
 			Name:      fmt.Sprintf("%s-%s-%s-%s", r.Name, podHash, revision, rolloutAnalysisStep.Name),
 			Namespace: r.Namespace,
 			Labels:    labels,

--- a/rollout/analysis.go
+++ b/rollout/analysis.go
@@ -66,6 +66,22 @@ func (c *RolloutController) reconcileAnalysisRuns(roCtx *canaryContext) error {
 	if backgroundAnalysisRun != nil {
 		newCurrentAnalysisRuns = append(newCurrentAnalysisRuns, backgroundAnalysisRun)
 	}
+	roCtx.SetCurrentAnalysisRuns(newCurrentAnalysisRuns)
+
+	// Due to the possibility that we are operating on stale/inconsistent data in the informer, it's
+	// possible that otherArs includes the current analysis runs that we just created or reclaimed
+	// in newCurrentAnalysisRuns, despite the fact that our rollout status did not have those set.
+	// To prevent us from terminating the runs that we just created moments ago, rebuild otherArs
+	// to ensure it does not include the newly created runs.
+	otherArs, _ = analysisutil.FilterAnalysisRuns(otherArs, func(ar *v1alpha1.AnalysisRun) bool {
+		for _, curr := range newCurrentAnalysisRuns {
+			if ar.Name == curr.Name {
+				roCtx.log.Infof("Saved %s from inadvertent termination", ar.Name)
+				return false
+			}
+		}
+		return true
+	})
 
 	err = c.cancelAnalysisRuns(roCtx, otherArs)
 	if err != nil {
@@ -79,7 +95,6 @@ func (c *RolloutController) reconcileAnalysisRuns(roCtx *canaryContext) error {
 		return err
 	}
 
-	roCtx.SetCurrentAnalysisRuns(newCurrentAnalysisRuns)
 	return nil
 }
 
@@ -134,9 +149,31 @@ func (c *RolloutController) createAnalysisRun(roCtx *canaryContext, rolloutAnaly
 	if err != nil {
 		return nil, err
 	}
-	ar, err = c.argoprojclientset.ArgoprojV1alpha1().AnalysisRuns(ar.Namespace).Create(ar)
-	if err != nil {
-		return nil, err
+	collisionCount := 1
+	baseName := ar.Name
+	for {
+		newAR, err := c.argoprojclientset.ArgoprojV1alpha1().AnalysisRuns(ar.Namespace).Create(ar)
+		if err == nil {
+			ar = newAR
+			break
+		}
+		if !k8serrors.IsAlreadyExists(err) {
+			return nil, err
+		}
+		existingAR, err := c.argoprojclientset.ArgoprojV1alpha1().AnalysisRuns(ar.Namespace).Get(ar.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		existingEqual := analysisutil.IsSemanticallyEqual(ar, existingAR)
+		roCtx.log.Infof("Encountered collision of existing analysisrun %s (status: %s, equal: %v)", existingAR.Name, existingAR.Status.Status, existingEqual)
+		if !existingAR.Status.Status.Completed() && existingEqual {
+			// If we get here, the existing AR has been determined to be our analysis run and we
+			// likely reconciled the rollout with a stale cache (quite common).
+			ar = existingAR
+			break
+		}
+		ar.Name = fmt.Sprintf("%s.%d", baseName, collisionCount)
+		collisionCount++
 	}
 	return ar, nil
 }
@@ -154,9 +191,6 @@ func (c *RolloutController) reconcileStepBasedAnalysisRun(roCtx *canaryContext) 
 
 	if step == nil || step.Analysis == nil || index == nil {
 		err := c.cancelAnalysisRuns(roCtx, []*v1alpha1.AnalysisRun{currentAr})
-		if err != nil {
-			return nil, err
-		}
 		return nil, err
 	}
 	if currentAr == nil {
@@ -210,14 +244,15 @@ func (c *RolloutController) getAnalysisRunFromRollout(roCtx *canaryContext, roll
 		}
 		return nil, err
 	}
-
+	revision := r.Annotations[annotations.RevisionAnnotation]
 	ar := v1alpha1.AnalysisRun{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-%s-%s-", r.Name, rolloutAnalysisStep.Name, podHash),
-			Namespace:    r.Namespace,
-			Labels:       labels,
+			// TOOD(jessesuen): consider incorporating the step index into the name like we do for experiments
+			Name:      fmt.Sprintf("%s-%s-%s-%s", r.Name, podHash, revision, rolloutAnalysisStep.Name),
+			Namespace: r.Namespace,
+			Labels:    labels,
 			Annotations: map[string]string{
-				annotations.RevisionAnnotation: r.Annotations[annotations.RevisionAnnotation],
+				annotations.RevisionAnnotation: revision,
 			},
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(r, controllerKind)},
 		},

--- a/rollout/analysis_test.go
+++ b/rollout/analysis_test.go
@@ -91,9 +91,8 @@ func TestCreateBackgroundAnalysisRun(t *testing.T) {
 
 	f.run(getKey(r2, t))
 	createdAr := f.getCreatedAnalysisRun(createdIndex)
-	expectedArGeneratedName := fmt.Sprintf("%s-%s-%s-", r2.Name, at.Name, rs2PodHash)
-	expectedArName := fmt.Sprintf("%s%s", expectedArGeneratedName, MockGeneratedNameSuffix)
-	assert.Equal(t, expectedArGeneratedName, createdAr.GenerateName)
+	expectedArName := fmt.Sprintf("%s-%s-%s-%s", r2.Name, rs2PodHash, "2", at.Name)
+	assert.Equal(t, expectedArName, createdAr.Name)
 
 	patch := f.getPatchedRollout(index)
 	expectedPatch := `{
@@ -144,9 +143,8 @@ func TestCreateAnalysisRunOnAnalysisStep(t *testing.T) {
 
 	f.run(getKey(r2, t))
 	createdAr := f.getCreatedAnalysisRun(createdIndex)
-	expectedArGeneratedName := fmt.Sprintf("%s-%s-%s-", r2.Name, at.Name, rs2PodHash)
-	expectedArName := fmt.Sprintf("%s%s", expectedArGeneratedName, MockGeneratedNameSuffix)
-	assert.Equal(t, expectedArGeneratedName, createdAr.GenerateName)
+	expectedArName := fmt.Sprintf("%s-%s-%s-%s", r2.Name, rs2PodHash, "2", at.Name)
+	assert.Equal(t, expectedArName, createdAr.Name)
 
 	patch := f.getPatchedRollout(index)
 	expectedPatch := `{

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -421,36 +421,6 @@ func (f *fixture) newController(resync resyncFunc) (*RolloutController, informer
 		i.Argoproj().V1alpha1().AnalysisRuns().Informer().GetIndexer().Add(ar)
 	}
 
-	f.client.PrependReactor("create", "analysisruns", func(action core.Action) (bool, runtime.Object, error) {
-		createAction, ok := action.(core.CreateAction)
-		if !ok {
-			assert.Fail(f.t, "Expected Created action, not %s", action.GetVerb())
-		}
-		ar := &v1alpha1.AnalysisRun{}
-		converter := runtime.NewTestUnstructuredConverter(equality.Semantic)
-		objMap, _ := converter.ToUnstructured(createAction.GetObject())
-		runtime.NewTestUnstructuredConverter(equality.Semantic).FromUnstructured(objMap, ar)
-		if ar.Name == "" && ar.GenerateName != "" {
-			ar.Name = ar.GenerateName + MockGeneratedNameSuffix
-		}
-		return true, ar.DeepCopyObject(), nil
-	})
-
-	f.client.PrependReactor("create", "experiments", func(action core.Action) (bool, runtime.Object, error) {
-		createAction, ok := action.(core.CreateAction)
-		if !ok {
-			assert.Fail(f.t, "Expected Created action, not %s", action.GetVerb())
-		}
-		ex := &v1alpha1.Experiment{}
-		converter := runtime.NewTestUnstructuredConverter(equality.Semantic)
-		objMap, _ := converter.ToUnstructured(createAction.GetObject())
-		runtime.NewTestUnstructuredConverter(equality.Semantic).FromUnstructured(objMap, ex)
-		if ex.Name == "" && ex.GenerateName != "" {
-			ex.Name = ex.GenerateName + MockGeneratedNameSuffix
-		}
-		return true, ex.DeepCopyObject(), nil
-	})
-
 	return c, i, k8sI
 }
 
@@ -484,7 +454,7 @@ func (f *fixture) runController(rolloutName string, startInformers bool, expectE
 	actions := filterInformerActions(f.client.Actions())
 	for i, action := range actions {
 		if len(f.actions) < i+1 {
-			actionsBytes, _ := json.Marshal(actions[i:])
+			actionsBytes, _ := json.MarshalIndent(actions[i:], "", "  ")
 			f.t.Errorf("%d unexpected actions: %+v", len(actions)-len(f.actions), string(actionsBytes))
 			break
 		}
@@ -500,7 +470,7 @@ func (f *fixture) runController(rolloutName string, startInformers bool, expectE
 	k8sActions := filterInformerActions(f.kubeclient.Actions())
 	for i, action := range k8sActions {
 		if len(f.kubeactions) < i+1 {
-			actionsBytes, _ := json.Marshal(k8sActions[i:])
+			actionsBytes, _ := json.MarshalIndent(k8sActions[i:], "", "  ")
 			f.t.Errorf("%d unexpected actions: %+v", len(k8sActions)-len(f.kubeactions), string(actionsBytes))
 			break
 		}
@@ -625,6 +595,18 @@ func (f *fixture) expectCreateAnalysisRunAction(ar *v1alpha1.AnalysisRun) int {
 	action := core.NewCreateAction(schema.GroupVersionResource{Resource: "analysisruns"}, ar.Namespace, ar)
 	len := len(f.actions)
 	f.actions = append(f.actions, action)
+	return len
+}
+
+func (f *fixture) expectGetAnalysisRunAction(ar *v1alpha1.AnalysisRun) int {
+	len := len(f.actions)
+	f.actions = append(f.actions, core.NewGetAction(schema.GroupVersionResource{Resource: "analysisruns"}, ar.Namespace, ar.Name))
+	return len
+}
+
+func (f *fixture) expectGetExperimentAction(ex *v1alpha1.Experiment) int {
+	len := len(f.actions)
+	f.actions = append(f.actions, core.NewGetAction(schema.GroupVersionResource{Resource: "experiments"}, ex.Namespace, ex.Name))
 	return len
 }
 

--- a/rollout/experiment_test.go
+++ b/rollout/experiment_test.go
@@ -53,9 +53,112 @@ func TestRolloutCreateExperiment(t *testing.T) {
 
 	f.run(getKey(r2, t))
 	createdEx := f.getCreatedExperiment(createExIndex)
-	assert.Equal(t, createdEx.GenerateName, ex.GenerateName)
+	assert.Equal(t, createdEx.Name, ex.Name)
 	assert.Equal(t, createdEx.Spec.Analyses[0].TemplateName, at.Name)
 	assert.Equal(t, createdEx.Spec.Analyses[0].Name, "test")
+	patch := f.getPatchedRollout(patchIndex)
+	expectedPatch := `{
+		"status": {
+			"canary": {
+				"currentExperiment": "%s"
+			},
+			"conditions": %s
+		}
+	}`
+	conds := generateConditionsPatch(true, conditions.ReplicaSetUpdatedReason, r2, false)
+	assert.Equal(t, calculatePatch(r2, fmt.Sprintf(expectedPatch, ex.Name, conds)), patch)
+}
+
+func TestCreateExperimentWithCollision(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{{
+		Experiment: &v1alpha1.RolloutExperimentStep{
+			Templates: []v1alpha1.RolloutExperimentTemplate{{
+				Name:     "stable-template",
+				SpecRef:  v1alpha1.StableSpecRef,
+				Replicas: pointer.Int32Ptr(1),
+			}},
+		},
+	}}
+
+	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r2 := bumpVersion(r1)
+
+	rs1 := newReplicaSetWithStatus(r1, 1, 1)
+	rs2 := newReplicaSetWithStatus(r2, 0, 0)
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+
+	ex, _ := GetExperimentFromTemplate(r2, rs1, rs2)
+	ex.Status.Status = v1alpha1.AnalysisStatusFailed
+	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 1, 0, 1, false)
+
+	f.experimentLister = append(f.experimentLister, ex)
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2, ex)
+
+	f.expectCreateExperimentAction(ex)                  // create fails
+	f.expectGetExperimentAction(ex)                     // get existing
+	createExIndex := f.expectCreateExperimentAction(ex) // create with a new name
+	patchIndex := f.expectPatchRolloutAction(r1)
+
+	f.run(getKey(r2, t))
+	createdEx := f.getCreatedExperiment(createExIndex)
+	assert.Equal(t, ex.Name+".1", createdEx.Name)
+	patch := f.getPatchedRollout(patchIndex)
+	expectedPatch := `{
+		"status": {
+			"canary": {
+				"currentExperiment": "%s"
+			},
+			"conditions": %s
+		}
+	}`
+	conds := generateConditionsPatch(true, conditions.ReplicaSetUpdatedReason, r2, false)
+	assert.Equal(t, calculatePatch(r2, fmt.Sprintf(expectedPatch, createdEx.Name, conds)), patch)
+}
+
+func TestCreateExperimentWithCollisionAndSemanticEquality(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{{
+		Experiment: &v1alpha1.RolloutExperimentStep{
+			Templates: []v1alpha1.RolloutExperimentTemplate{{
+				Name:     "stable-template",
+				SpecRef:  v1alpha1.StableSpecRef,
+				Replicas: pointer.Int32Ptr(1),
+			}},
+		},
+	}}
+
+	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r2 := bumpVersion(r1)
+
+	rs1 := newReplicaSetWithStatus(r1, 1, 1)
+	rs2 := newReplicaSetWithStatus(r2, 0, 0)
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+
+	ex, _ := GetExperimentFromTemplate(r2, rs1, rs2)
+	ex.Status.Status = v1alpha1.AnalysisStatusRunning
+	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 1, 0, 1, false)
+
+	f.experimentLister = append(f.experimentLister, ex)
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2, ex)
+
+	createExIndex := f.expectCreateExperimentAction(ex)
+	f.expectGetExperimentAction(ex) // get existing to verify semantic equality
+	patchIndex := f.expectPatchRolloutAction(r1)
+
+	f.run(getKey(r2, t))
+	createdEx := f.getCreatedExperiment(createExIndex)
+	assert.Equal(t, ex.Name, createdEx.Name)
 	patch := f.getPatchedRollout(patchIndex)
 	expectedPatch := `{
 		"status": {
@@ -245,43 +348,6 @@ func TestRolloutExperimentFinishedIncrementStep(t *testing.T) {
 	generatedConditions := generateConditionsPatch(true, conditions.ReplicaSetUpdatedReason, rs2, false)
 
 	assert.Equal(t, calculatePatch(r2, fmt.Sprintf(expectedPatch, generatedConditions)), patch)
-}
-
-func TestRolloutDoNotCreateExperimentWithoutNewRS(t *testing.T) {
-	f := newFixture(t)
-	defer f.Close()
-
-	steps := []v1alpha1.CanaryStep{{
-		Experiment: &v1alpha1.RolloutExperimentStep{
-			Templates: []v1alpha1.RolloutExperimentTemplate{{
-				Name:     "canary-template",
-				SpecRef:  v1alpha1.CanarySpecRef,
-				Replicas: pointer.Int32Ptr(1),
-			}},
-		},
-	}}
-
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
-	r2 := bumpVersion(r1)
-
-	rs1 := newReplicaSetWithStatus(r1, 1, 1)
-	rs2 := newReplicaSetWithStatus(r2, 1, 1)
-	//ex, _ := GetExperimentFromTemplate(r2, rs1, rs2)
-
-	// f.kubeobjects = append(f.kubeobjects, rs1)
-	// f.replicaSetLister = append(f.replicaSetLister, rs1)
-	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
-
-	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 1, 1, 1, false)
-
-	f.rolloutLister = append(f.rolloutLister, r2)
-	//f.objects = append(f.objects, r2, ex)
-	f.objects = append(f.objects, r2)
-
-	f.expectCreateReplicaSetAction(rs2)
-	f.expectUpdateRolloutAction(r2)
-	f.expectPatchRolloutAction(r1)
-	f.run(getKey(r2, t))
 }
 
 func TestRolloutDoNotCreateExperimentWithoutStableRS(t *testing.T) {

--- a/rollout/experiment_test.go
+++ b/rollout/experiment_test.go
@@ -60,13 +60,13 @@ func TestRolloutCreateExperiment(t *testing.T) {
 	expectedPatch := `{
 		"status": {
 			"canary": {
-				"currentExperiment": "%s%s"
+				"currentExperiment": "%s"
 			},
 			"conditions": %s
 		}
 	}`
 	conds := generateConditionsPatch(true, conditions.ReplicaSetUpdatedReason, r2, false)
-	assert.Equal(t, calculatePatch(r2, fmt.Sprintf(expectedPatch, ex.GenerateName, MockGeneratedNameSuffix, conds)), patch)
+	assert.Equal(t, calculatePatch(r2, fmt.Sprintf(expectedPatch, ex.Name, conds)), patch)
 }
 
 func TestRolloutExperimentProcessingDoNothing(t *testing.T) {
@@ -127,7 +127,6 @@ func TestRolloutDegradedExperimentEnterDegraded(t *testing.T) {
 	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 1, 0, 1, false)
 	ex, _ := GetExperimentFromTemplate(r2, rs2, rs1)
 	ex.Status.Status = v1alpha1.AnalysisStatusFailed
-	ex.Name = fmt.Sprintf("%s%s", ex.GenerateName, MockGeneratedNameSuffix)
 	r2.Status.Canary.CurrentExperiment = ex.Name
 
 	f.rolloutLister = append(f.rolloutLister, r2)
@@ -267,17 +266,17 @@ func TestRolloutDoNotCreateExperimentWithoutNewRS(t *testing.T) {
 
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
 	rs2 := newReplicaSetWithStatus(r2, 1, 1)
-	ex, _ := GetExperimentFromTemplate(r2, rs1, rs2)
+	//ex, _ := GetExperimentFromTemplate(r2, rs1, rs2)
 
-	f.kubeobjects = append(f.kubeobjects, rs1)
-	f.replicaSetLister = append(f.replicaSetLister, rs1)
+	// f.kubeobjects = append(f.kubeobjects, rs1)
+	// f.replicaSetLister = append(f.replicaSetLister, rs1)
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
 	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 1, 1, 1, false)
 
 	f.rolloutLister = append(f.rolloutLister, r2)
-	f.experimentLister = append(f.experimentLister, ex)
-	f.objects = append(f.objects, r2, ex)
+	//f.objects = append(f.objects, r2, ex)
+	f.objects = append(f.objects, r2)
 
 	f.expectCreateReplicaSetAction(rs2)
 	f.expectUpdateRolloutAction(r2)
@@ -302,15 +301,12 @@ func TestRolloutDoNotCreateExperimentWithoutStableRS(t *testing.T) {
 	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 
-	rs1 := newReplicaSetWithStatus(r1, 1, 1)
 	rs2 := newReplicaSetWithStatus(r2, 1, 1)
-	ex, _ := GetExperimentFromTemplate(r2, rs1, rs2)
 
 	r2 = updateCanaryRolloutStatus(r2, "", 1, 1, 1, false)
 
 	f.rolloutLister = append(f.rolloutLister, r2)
-	f.experimentLister = append(f.experimentLister, ex)
-	f.objects = append(f.objects, r2, ex)
+	f.objects = append(f.objects, r2)
 
 	f.expectCreateReplicaSetAction(rs2)
 	f.expectUpdateRolloutAction(r2)

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -630,7 +630,7 @@ func (c *RolloutController) requeueStuckRollout(r *v1alpha1.Rollout, newStatus v
 	}
 	// No need to estimate progress if the rollout is complete or already timed out.
 	isPaused := len(r.Status.PauseConditions) > 0 || r.Spec.Paused
-	if conditions.RolloutComplete(r, &newStatus) || currentCond.Reason == conditions.TimedOutReason || isPaused {
+	if conditions.RolloutComplete(r, &newStatus) || currentCond.Reason == conditions.TimedOutReason || isPaused || r.Status.Abort {
 		return time.Duration(-1)
 	}
 	// If there is no sign of progress at this point then there is a high chance that the

--- a/utils/analysis/filter.go
+++ b/utils/analysis/filter.go
@@ -32,7 +32,7 @@ func GetCurrentBackgroundAnalysisRun(currentArs []*v1alpha1.AnalysisRun) *v1alph
 
 // FilterCurrentRolloutAnalysisRuns returns analysisRuns that match the analysisRuns listed in the rollout status
 func FilterCurrentRolloutAnalysisRuns(analysisRuns []*v1alpha1.AnalysisRun, r *v1alpha1.Rollout) ([]*v1alpha1.AnalysisRun, []*v1alpha1.AnalysisRun) {
-	return filterAnalysisRuns(analysisRuns, func(ar *v1alpha1.AnalysisRun) bool {
+	return FilterAnalysisRuns(analysisRuns, func(ar *v1alpha1.AnalysisRun) bool {
 		if ar.Name == r.Status.Canary.CurrentStepAnalysisRun {
 			return true
 		}
@@ -45,7 +45,7 @@ func FilterCurrentRolloutAnalysisRuns(analysisRuns []*v1alpha1.AnalysisRun, r *v
 
 // FilterAnalysisRunsByRolloutType returns a list of analysisRuns that have the rollout-type of the typeFilter
 func FilterAnalysisRunsByRolloutType(analysisRuns []*v1alpha1.AnalysisRun, typeFilter string) []*v1alpha1.AnalysisRun {
-	analysisRunsByType, _ := filterAnalysisRuns(analysisRuns, func(ar *v1alpha1.AnalysisRun) bool {
+	analysisRunsByType, _ := FilterAnalysisRuns(analysisRuns, func(ar *v1alpha1.AnalysisRun) bool {
 		analysisRunType, ok := ar.Labels[v1alpha1.RolloutTypeLabel]
 		if !ok || analysisRunType != typeFilter {
 			return false
@@ -57,7 +57,7 @@ func FilterAnalysisRunsByRolloutType(analysisRuns []*v1alpha1.AnalysisRun, typeF
 
 // FilterAnalysisRunsByName returns the analysisRuns with the name provided
 func FilterAnalysisRunsByName(analysisRuns []*v1alpha1.AnalysisRun, name string) *v1alpha1.AnalysisRun {
-	analysisRunsByName, _ := filterAnalysisRuns(analysisRuns, func(ar *v1alpha1.AnalysisRun) bool {
+	analysisRunsByName, _ := FilterAnalysisRuns(analysisRuns, func(ar *v1alpha1.AnalysisRun) bool {
 		return ar.Name == name
 	})
 	if len(analysisRunsByName) == 1 {
@@ -66,7 +66,7 @@ func FilterAnalysisRunsByName(analysisRuns []*v1alpha1.AnalysisRun, name string)
 	return nil
 }
 
-func filterAnalysisRuns(ars []*v1alpha1.AnalysisRun, cond func(ar *v1alpha1.AnalysisRun) bool) ([]*v1alpha1.AnalysisRun, []*v1alpha1.AnalysisRun) {
+func FilterAnalysisRuns(ars []*v1alpha1.AnalysisRun, cond func(ar *v1alpha1.AnalysisRun) bool) ([]*v1alpha1.AnalysisRun, []*v1alpha1.AnalysisRun) {
 	condTrue := []*v1alpha1.AnalysisRun{}
 	condFalse := []*v1alpha1.AnalysisRun{}
 	for i := range ars {

--- a/utils/analysis/helpers.go
+++ b/utils/analysis/helpers.go
@@ -1,6 +1,8 @@
 package analysis
 
 import (
+	"encoding/json"
+
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	patchtypes "k8s.io/apimachinery/pkg/types"
 
@@ -98,8 +100,21 @@ func LastMeasurement(run *v1alpha1.AnalysisRun, metricName string) *v1alpha1.Mea
 	return nil
 }
 
-// TerminateRun terminates an anlysis run
+// TerminateRun terminates an analysis run
 func TerminateRun(analysisRunIf argoprojclient.AnalysisRunInterface, name string) error {
 	_, err := analysisRunIf.Patch(name, patchtypes.MergePatchType, []byte(`{"spec":{"terminate":true}}`))
 	return err
+}
+
+// IsSemanticallyEqual checks to see if two analysis runs are semantically equal
+func IsSemanticallyEqual(left, right *v1alpha1.AnalysisRun) bool {
+	leftBytes, err := json.Marshal(left.Spec)
+	if err != nil {
+		panic(err)
+	}
+	rightBytes, err := json.Marshal(right.Spec)
+	if err != nil {
+		panic(err)
+	}
+	return string(leftBytes) == string(rightBytes)
 }

--- a/utils/analysis/helpers.go
+++ b/utils/analysis/helpers.go
@@ -107,12 +107,12 @@ func TerminateRun(analysisRunIf argoprojclient.AnalysisRunInterface, name string
 }
 
 // IsSemanticallyEqual checks to see if two analysis runs are semantically equal
-func IsSemanticallyEqual(left, right *v1alpha1.AnalysisRun) bool {
-	leftBytes, err := json.Marshal(left.Spec)
+func IsSemanticallyEqual(left, right v1alpha1.AnalysisRunSpec) bool {
+	leftBytes, err := json.Marshal(left)
 	if err != nil {
 		panic(err)
 	}
-	rightBytes, err := json.Marshal(right.Spec)
+	rightBytes, err := json.Marshal(right)
 	if err != nil {
 		panic(err)
 	}

--- a/utils/analysis/helpers_test.go
+++ b/utils/analysis/helpers_test.go
@@ -203,3 +203,19 @@ func TestTerminateRun(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, patched)
 }
+
+func TestIsSemanticallyEqual(t *testing.T) {
+	left := &v1alpha1.AnalysisRunSpec{
+		AnalysisSpec: v1alpha1.AnalysisTemplateSpec{
+			Metrics: []v1alpha1.Metric{
+				{
+					Name: "success-rate",
+				},
+			},
+		},
+	}
+	right := left.DeepCopy()
+	assert.True(t, IsSemanticallyEqual(*left, *right))
+	right.AnalysisSpec.Metrics[0].Name = "foo"
+	assert.False(t, IsSemanticallyEqual(*left, *right))
+}

--- a/utils/experiment/experiment.go
+++ b/utils/experiment/experiment.go
@@ -187,12 +187,12 @@ func Worst(left, right v1alpha1.TemplateStatusCode) v1alpha1.TemplateStatusCode 
 }
 
 // IsSemanticallyEqual checks to see if two experiments are semantically equal
-func IsSemanticallyEqual(left, right *v1alpha1.Experiment) bool {
-	leftBytes, err := json.Marshal(left.Spec)
+func IsSemanticallyEqual(left, right v1alpha1.ExperimentSpec) bool {
+	leftBytes, err := json.Marshal(left)
 	if err != nil {
 		panic(err)
 	}
-	rightBytes, err := json.Marshal(right.Spec)
+	rightBytes, err := json.Marshal(right)
 	if err != nil {
 		panic(err)
 	}

--- a/utils/experiment/experiment.go
+++ b/utils/experiment/experiment.go
@@ -1,6 +1,7 @@
 package experiment
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -90,16 +91,6 @@ func GetCollisionCountForTemplate(experiment *v1alpha1.Experiment, template v1al
 		collisionCount = templateStatus.CollisionCount
 	}
 	return collisionCount
-}
-
-// ExperimentGeneratedNameFromRollout gets the name of the experiment based on the rollout
-func ExperimentGeneratedNameFromRollout(rollout *v1alpha1.Rollout) string {
-	currentStep := int32(0)
-	if rollout.Status.CurrentStepIndex != nil {
-		currentStep = *rollout.Status.CurrentStepIndex
-	}
-	podTemplateSpecHash := controller.ComputeHash(&rollout.Spec.Template, rollout.Status.CollisionCount)
-	return fmt.Sprintf("%s-%s-%d-", rollout.Name, podTemplateSpecHash, currentStep)
 }
 
 // ReplicasetNameFromExperiment gets the replicaset name based off of the experiment and the template
@@ -193,4 +184,17 @@ func Worst(left, right v1alpha1.TemplateStatusCode) v1alpha1.TemplateStatusCode 
 		return right
 	}
 	return left
+}
+
+// IsSemanticallyEqual checks to see if two experiments are semantically equal
+func IsSemanticallyEqual(left, right *v1alpha1.Experiment) bool {
+	leftBytes, err := json.Marshal(left.Spec)
+	if err != nil {
+		panic(err)
+	}
+	rightBytes, err := json.Marshal(right.Spec)
+	if err != nil {
+		panic(err)
+	}
+	return string(leftBytes) == string(rightBytes)
 }

--- a/utils/experiment/experiment_test.go
+++ b/utils/experiment/experiment_test.go
@@ -147,29 +147,6 @@ func TestExperimentByCreationTimestamp(t *testing.T) {
 	})
 }
 
-func TestExperimentGeneratedNameFromRollout(t *testing.T) {
-	r := v1alpha1.Rollout{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "foo",
-		},
-		Spec: v1alpha1.RolloutSpec{
-			Strategy: v1alpha1.RolloutStrategy{
-				Canary: &v1alpha1.CanaryStrategy{
-					Steps: []v1alpha1.CanaryStep{{
-						Experiment: &v1alpha1.RolloutExperimentStep{},
-					}},
-				},
-			},
-		},
-	}
-	name := ExperimentGeneratedNameFromRollout(&r)
-	assert.Equal(t, "foo-6cb88c6bcf-0-", name)
-
-	r.Status.CurrentStepIndex = pointer.Int32Ptr(1)
-	name = ExperimentGeneratedNameFromRollout(&r)
-	assert.Equal(t, "foo-6cb88c6bcf-1-", name)
-}
-
 func TestIsTeriminating(t *testing.T) {
 	{
 		e := &v1alpha1.Experiment{

--- a/utils/experiment/experiment_test.go
+++ b/utils/experiment/experiment_test.go
@@ -331,3 +331,17 @@ func TestTerminate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, patched)
 }
+
+func TestIsSemanticallyEqual(t *testing.T) {
+	left := &v1alpha1.ExperimentSpec{
+		Templates: []v1alpha1.TemplateSpec{
+			{
+				Name: "canary",
+			},
+		},
+	}
+	right := left.DeepCopy()
+	assert.True(t, IsSemanticallyEqual(*left, *right))
+	right.Templates[0].Replicas = pointer.Int32Ptr(1)
+	assert.False(t, IsSemanticallyEqual(*left, *right))
+}

--- a/utils/experiment/filter_test.go
+++ b/utils/experiment/filter_test.go
@@ -18,10 +18,10 @@ func TestGetExperiments(t *testing.T) {
 			Name: "foo",
 		},
 	}
-	r.Status.Canary.CurrentExperiment = ExperimentGeneratedNameFromRollout(r)
+	r.Status.Canary.CurrentExperiment = "foo-exp"
 	ex1 := &v1alpha1.Experiment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: ExperimentGeneratedNameFromRollout(r),
+			Name: "foo-exp",
 			UID:  uuid.NewUUID(),
 		},
 	}


### PR DESCRIPTION
Experiments and analysis runs created from rollout objects will have deterministic names, preventing duplicates from being created.

Resolves https://github.com/argoproj/argo-rollouts/issues/243