### PR TITLE
Pause and abort a rollout upon inconclusive and failed experiment

### DIFF
--- a/manifests/crds/rollout-crd.yaml
+++ b/manifests/crds/rollout-crd.yaml
@@ -2705,8 +2705,6 @@ spec:
                   type: string
                 currentStepAnalysisRun:
                   type: string
-                experimentFailed:
-                  type: boolean
                 stableRS:
                   type: string
               type: object

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -10432,8 +10432,6 @@ spec:
                   type: string
                 currentStepAnalysisRun:
                   type: string
-                experimentFailed:
-                  type: boolean
                 stableRS:
                   type: string
               type: object

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -10432,8 +10432,6 @@ spec:
                   type: string
                 currentStepAnalysisRun:
                   type: string
-                experimentFailed:
-                  type: boolean
                 stableRS:
                   type: string
               type: object

--- a/pkg/apis/rollouts/v1alpha1/openapi_generated.go
+++ b/pkg/apis/rollouts/v1alpha1/openapi_generated.go
@@ -581,13 +581,6 @@ func schema_pkg_apis_rollouts_v1alpha1_CanaryStatus(ref common.ReferenceCallback
 							Format:      "",
 						},
 					},
-					"experimentFailed": {
-						SchemaProps: spec.SchemaProps{
-							Description: "ExperimentFailed indicates the most recent executed experiment in the canary steps failed",
-							Type:        []string{"boolean"},
-							Format:      "",
-						},
-					},
 					"currentStepAnalysisRun": {
 						SchemaProps: spec.SchemaProps{
 							Description: "CurrentStepAnalysisRun indicates the analysisRun for the current step index",

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -369,9 +369,6 @@ type CanaryStatus struct {
 	// StableRS indicates the last replicaset that walked through all the canary steps or was the only replicaset
 	// +optional
 	StableRS string `json:"stableRS,omitempty"`
-	// ExperimentFailed indicates the most recent executed experiment in the canary steps failed
-	// +optional
-	ExperimentFailed bool `json:"experimentFailed,omitempty"`
 	// CurrentStepAnalysisRun indicates the analysisRun for the current step index
 	CurrentStepAnalysisRun string `json:"currentStepAnalysisRun,omitempty"`
 	// CurrentBackgroundAnalysisRun indicates the analysisRun for the Background step

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -269,6 +269,8 @@ type PauseReason string
 const (
 	// PauseReasonInconclusiveAnalysis pauses rollout when rollout has an inconclusive analysis run
 	PauseReasonInconclusiveAnalysis PauseReason = "InconclusiveAnalysisRun"
+	// PauseReasonInconclusiveExperiment pauses rollout when rollout has an inconclusive experiment
+	PauseReasonInconclusiveExperiment PauseReason = "InconclusiveExperiment"
 	// PauseReasonCanaryPauseStep pause rollout for canary pause step
 	PauseReasonCanaryPauseStep PauseReason = "CanaryPauseStep"
 	// PauseReasonBlueGreenPause pause rollout before promoting rollout

--- a/pkg/kubectl-argo-rollouts/info/experiment_info.go
+++ b/pkg/kubectl-argo-rollouts/info/experiment_info.go
@@ -43,6 +43,7 @@ func getExperimentInfo(
 		expInfo.Icon = analysisIcon(exp.Status.Status)
 		expInfo.Revision = parseRevision(exp.ObjectMeta.Annotations)
 		expInfo.ReplicaSets = getReplicaSetInfo(exp.UID, nil, allReplicaSets, allPods)
+		expInfo.AnalysisRuns = getAnalysisRunInfo(exp.UID, allAnalysisRuns)
 
 		expInfos = append(expInfos, expInfo)
 	}

--- a/rollout/analysis.go
+++ b/rollout/analysis.go
@@ -104,9 +104,6 @@ func (c *RolloutController) reconcileBackgroundAnalysisRun(roCtx *canaryContext)
 	currentAr := analysisutil.FilterAnalysisRunsByName(currentArs, rollout.Status.Canary.CurrentBackgroundAnalysisRun)
 	if rollout.Spec.Strategy.Canary.Analysis == nil {
 		err := c.cancelAnalysisRuns(roCtx, []*v1alpha1.AnalysisRun{currentAr})
-		if err != nil {
-			return nil, err
-		}
 		return nil, err
 	}
 

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -347,7 +347,8 @@ func (c *RolloutController) syncRolloutStatusCanary(roCtx *canaryContext) error 
 
 	if currExp != nil {
 		newStatus.Canary.CurrentExperiment = currExp.Name
-		if currExp.Status.Status.Completed() && currExp.Status.Status != v1alpha1.AnalysisStatusSuccessful {
+		switch currExp.Status.Status {
+		case v1alpha1.AnalysisStatusFailed, v1alpha1.AnalysisStatusError:
 			newStatus.Canary.ExperimentFailed = true
 		}
 	}

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -347,10 +347,6 @@ func (c *RolloutController) syncRolloutStatusCanary(roCtx *canaryContext) error 
 
 	if currExp != nil {
 		newStatus.Canary.CurrentExperiment = currExp.Name
-		switch currExp.Status.Status {
-		case v1alpha1.AnalysisStatusFailed, v1alpha1.AnalysisStatusError:
-			newStatus.Canary.ExperimentFailed = true
-		}
 	}
 
 	newStatus.CurrentStepIndex = currentStepIndex


### PR DESCRIPTION
Built ontop of https://github.com/argoproj/argo-rollouts/pull/255. 

View last commit only.

Resolves https://github.com/argoproj/argo-rollouts/issues/253