### PR TITLE
Annotate instead of label experiment names in replicasets

### DIFF
--- a/experiments/controller_test.go
+++ b/experiments/controller_test.go
@@ -233,7 +233,7 @@ func templateToRS(ex *v1alpha1.Experiment, template v1alpha1.TemplateSpec, avail
 			Name:            fmt.Sprintf("%s-%s-%s", ex.Name, template.Name, podHash),
 			UID:             uuid.NewUUID(),
 			Namespace:       metav1.NamespaceDefault,
-			Labels:          newReplicaSetLabels(ex.Name, template.Name),
+			Annotations:     newReplicaSetAnnotations(ex.Name, template.Name),
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(ex, controllerKind)},
 		},
 		Spec: appsv1.ReplicaSetSpec{

--- a/rollout/experiment.go
+++ b/rollout/experiment.go
@@ -220,8 +220,10 @@ func (c *RolloutController) createExperimentWithCollisionHandling(roCtx *canaryC
 			return nil, err
 		}
 		existingEqual := experimentutil.IsSemanticallyEqual(newEx.Spec, existingEx.Spec)
-		roCtx.log.Infof("Encountered collision of existing experiment %s (status: %s, equal: %v)", existingEx.Name, existingEx.Status.Status, existingEqual)
-		if !existingEx.Status.Status.Completed() && existingEqual {
+		controllerRef := metav1.GetControllerOf(existingEx)
+		controllerUIDEqual := controllerRef != nil && controllerRef.UID == roCtx.Rollout().UID
+		roCtx.log.Infof("Encountered collision of existing experiment %s (status: %s, equal: %v, controllerUIDEqual: %v)", existingEx.Name, existingEx.Status.Status, existingEqual, controllerUIDEqual)
+		if !existingEx.Status.Status.Completed() && existingEqual && controllerUIDEqual {
 			// If we get here, the existing experiment has been determined to be our experiment and
 			// we likely reconciled the rollout with a stale cache (quite common).
 			return existingEx, nil


### PR DESCRIPTION
This annotates replicasets with the experiment name and template name, instead of labeling them. Labels are subject to 63 character limits. 

To associate replicasets to templates, the new logic is to list all replicaset in the namespace, then filter out only the ones with the same owner UID, and then associate by the annotations.