### PR TITLE
Simplify experiment replicaset names. Surface experiment images to CLI

### DIFF
--- a/experiments/replicaset_test.go
+++ b/experiments/replicaset_test.go
@@ -136,7 +136,7 @@ func TestNameCollisionWithEquivalentPodTemplateAndControllerUID(t *testing.T) {
 	e.Status.Phase = v1alpha1.AnalysisPhasePending
 
 	rs := templateToRS(e, templates[0], 0)
-	rs.ObjectMeta.Annotations[ExperimentTemplateNameAnnotationKey] = "something-different" // change this to something different
+	rs.ObjectMeta.Annotations[v1alpha1.ExperimentTemplateNameAnnotationKey] = "something-different" // change this to something different
 
 	f := newFixture(t, e, rs)
 	defer f.Close()

--- a/pkg/apis/rollouts/v1alpha1/experiment_types.go
+++ b/pkg/apis/rollouts/v1alpha1/experiment_types.go
@@ -5,6 +5,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// Annotations that are labeled into the ReplicaSets that are part of an experiment
+const (
+	ExperimentNameAnnotationKey         = "experiment.argoproj.io/name"
+	ExperimentTemplateNameAnnotationKey = "experiment.argoproj.io/template-name"
+)
+
 // Experiment is a specification for an Experiment resource
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/kubectl-argo-rollouts/info/info.go
+++ b/pkg/kubectl-argo-rollouts/info/info.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/duration"
 
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/annotations"
 )
 
@@ -62,4 +63,11 @@ func parseRevision(annots map[string]string) int {
 		}
 	}
 	return 0
+}
+
+func parseExperimentTemplateName(annots map[string]string) string {
+	if annots != nil {
+		return annots[v1alpha1.ExperimentTemplateNameAnnotationKey]
+	}
+	return ""
 }

--- a/pkg/kubectl-argo-rollouts/info/replicaset_info.go
+++ b/pkg/kubectl-argo-rollouts/info/replicaset_info.go
@@ -21,6 +21,7 @@ type ReplicaSetInfo struct {
 	Preview   bool
 	Replicas  int32
 	Available int32
+	Template  string
 	Images    []string
 	Pods      []PodInfo
 }
@@ -45,6 +46,7 @@ func getReplicaSetInfo(ownerUID types.UID, ro *v1alpha1.Rollout, allReplicaSets 
 		}
 		rsInfo.Icon = replicaSetIcon(rsInfo.Status)
 		rsInfo.Revision = parseRevision(rs.ObjectMeta.Annotations)
+		rsInfo.Template = parseExperimentTemplateName(rs.ObjectMeta.Annotations)
 
 		if ro != nil {
 			if ro.Spec.Strategy.Canary != nil && rs.Labels != nil {

--- a/pkg/kubectl-argo-rollouts/info/rollout_info.go
+++ b/pkg/kubectl-argo-rollouts/info/rollout_info.go
@@ -106,10 +106,6 @@ func RolloutStatusString(ro *v1alpha1.Rollout) string {
 		// more replicas need to be updated
 		return "Progressing"
 	}
-	if ro.Status.Replicas > ro.Status.UpdatedReplicas {
-		// old replicas are pending termination
-		return "Progressing"
-	}
 	if ro.Status.AvailableReplicas < ro.Status.UpdatedReplicas {
 		// updated replicas are still becoming available
 		return "Progressing"
@@ -121,6 +117,10 @@ func RolloutStatusString(ro *v1alpha1.Rollout) string {
 		// service cutover pending
 		return "Progressing"
 	} else if ro.Spec.Strategy.Canary != nil {
+		if ro.Status.Replicas > ro.Status.UpdatedReplicas {
+			// old replicas are pending termination
+			return "Progressing"
+		}
 		if ro.Status.Canary.StableRS != "" && ro.Status.Canary.StableRS == ro.Status.CurrentPodHash {
 			return "Healthy"
 		}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12677113/68352762-577ec980-00bc-11ea-81e8-67e7227eb8f8.png)

1. Removes the pod template hash from replicasets created from experiments
2. Surface any running images of experiments to the CLI