### PR TITLE
Introduce 'kubectl argo rollouts create' command

### DIFF
--- a/experiments/experiment.go
+++ b/experiments/experiment.go
@@ -458,23 +458,13 @@ func (ec *experimentContext) newAnalysisRun(analysis v1alpha1.ExperimentAnalysis
 	if err != nil {
 		return nil, err
 	}
-
-	newArgs, err := analysisutil.MergeArgs(args, template.Spec.Args)
+	name := fmt.Sprintf("%s-%s", ec.ex.Name, analysis.Name)
+	run, err := analysisutil.NewAnalysisRunFromTemplate(template, args, name, "", ec.ex.Namespace)
 	if err != nil {
 		return nil, err
 	}
-	ar := v1alpha1.AnalysisRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            fmt.Sprintf("%s-%s", ec.ex.Name, analysis.Name),
-			Namespace:       ec.ex.Namespace,
-			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(ec.ex, controllerKind)},
-		},
-		Spec: v1alpha1.AnalysisRunSpec{
-			Metrics: template.Spec.Metrics,
-			Args:    newArgs,
-		},
-	}
-	return &ar, nil
+	run.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(ec.ex, controllerKind)}
+	return run, nil
 }
 
 // verifyAnalysisTemplate verifies an AnalysisTemplate. For now, it simply means that it exists

--- a/pkg/kubectl-argo-rollouts/cmd/cmd.go
+++ b/pkg/kubectl-argo-rollouts/cmd/cmd.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/abort"
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/create"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/get"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/list"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/pause"
@@ -19,7 +20,7 @@ const (
   # Pause the guestbook rollout
   %[1]s pause guestbook
 
-  # Resume the guestbook rollout
+  # Promote the guestbook rollout
   %[1]s promote guestbook
 `
 )
@@ -35,6 +36,7 @@ func NewCmdArgoRollouts(o *options.ArgoRolloutsOptions) *cobra.Command {
 			return o.UsageErr(c)
 		},
 	}
+	cmd.AddCommand(create.NewCmdCreate(o))
 	cmd.AddCommand(get.NewCmdGet(o))
 	cmd.AddCommand(list.NewCmdList(o))
 	cmd.AddCommand(pause.NewCmdPause(o))

--- a/pkg/kubectl-argo-rollouts/cmd/create/create.go
+++ b/pkg/kubectl-argo-rollouts/cmd/create/create.go
@@ -1,0 +1,279 @@
+package create
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"unicode"
+
+	"github.com/ghodss/yaml"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts"
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/get"
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options"
+	analysisutil "github.com/argoproj/argo-rollouts/utils/analysis"
+)
+
+type CreateOptions struct {
+	get.GetOptions
+	options.ArgoRolloutsOptions
+
+	Files    []string
+	From     string
+	FromFile string
+}
+
+type CreateAnalysisRunOptions struct {
+	options.ArgoRolloutsOptions
+
+	Name         string
+	GenerateName string
+	ArgFlags     []string
+	From         string
+	FromFile     string
+}
+
+// NewCmdCreate returns a new instance of an `rollouts create` command
+func NewCmdCreate(o *options.ArgoRolloutsOptions) *cobra.Command {
+	createOptions := CreateOptions{
+		ArgoRolloutsOptions: *o,
+	}
+	var cmd = &cobra.Command{
+		Use:   "create -f my-experiment.yaml",
+		Short: "Create a rollout resource",
+		Example: o.Example(`
+  # Create a resource and watch it
+  %[1]s create -f my-experiment.yaml -w
+`),
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(createOptions.Files) == 0 {
+				return o.UsageErr(c)
+			}
+			if len(createOptions.Files) > 1 && createOptions.Watch {
+				return errors.New("Cannot watch multiple resources")
+			}
+
+			var objs []runtime.Object
+			for _, f := range createOptions.Files {
+				obj, err := createOptions.createResource(f)
+				if err != nil {
+					return err
+				}
+				objs = append(objs, obj)
+			}
+			if createOptions.Watch {
+				switch obj := objs[0].(type) {
+				case *v1alpha1.Rollout:
+					getCmd := get.NewCmdGetRollout(o)
+					getCmd.SetArgs([]string{obj.Name, "--watch"})
+					return getCmd.Execute()
+				case *v1alpha1.Experiment:
+					getCmd := get.NewCmdGetExperiment(o)
+					getCmd.SetArgs([]string{obj.Name, "--watch"})
+					return getCmd.Execute()
+				default:
+					return errors.New("Can only watch resources of type Rollout or Experiment")
+				}
+			}
+			return nil
+		},
+	}
+	cmd.AddCommand(NewCmdCreateAnalysisRun(o))
+
+	o.AddKubectlFlags(cmd)
+	cmd.Flags().StringArrayVarP(&createOptions.Files, "filename", "f", []string{}, "Files to use to create the resource")
+	cmd.Flags().BoolVarP(&createOptions.Watch, "watch", "w", false, "Watch live updates to the resource after creating")
+	cmd.Flags().BoolVar(&createOptions.NoColor, "no-color", false, "Do not colorize output")
+	return cmd
+}
+
+// isJSON detects if the byte array looks like json, based on the first non-whitespace character
+func isJSON(fileBytes []byte) bool {
+	for _, b := range fileBytes {
+		if !unicode.IsSpace(rune(b)) {
+			return b == '{'
+		}
+	}
+	return false
+}
+
+func unmarshal(fileBytes []byte, obj interface{}) error {
+	if isJSON(fileBytes) {
+		decoder := json.NewDecoder(bytes.NewReader(fileBytes))
+		decoder.DisallowUnknownFields()
+		return decoder.Decode(&obj)
+	} else {
+		return yaml.UnmarshalStrict(fileBytes, &obj, yaml.DisallowUnknownFields)
+	}
+}
+
+func (c *CreateOptions) createResource(path string) (runtime.Object, error) {
+	fileBytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var un unstructured.Unstructured
+	err = unmarshal(fileBytes, &un)
+	if err != nil {
+		return nil, err
+	}
+	gvk := un.GroupVersionKind()
+	ns := c.ArgoRolloutsOptions.Namespace()
+	switch {
+	case gvk.Group == rollouts.Group && gvk.Kind == rollouts.ExperimentKind:
+		var exp v1alpha1.Experiment
+		err = unmarshal(fileBytes, &exp)
+		if err != nil {
+			return nil, err
+		}
+		obj, err := c.RolloutsClientset().ArgoprojV1alpha1().Experiments(ns).Create(&exp)
+		if err != nil {
+			return nil, err
+		}
+		fmt.Fprintf(c.Out, "%s.%s/%s created\n", rollouts.ExperimentSingular, rollouts.Group, obj.Name)
+		return obj, nil
+	case gvk.Group == rollouts.Group && gvk.Kind == rollouts.RolloutKind:
+		var ro v1alpha1.Rollout
+		err = unmarshal(fileBytes, &ro)
+		if err != nil {
+			return nil, err
+		}
+		obj, err := c.RolloutsClientset().ArgoprojV1alpha1().Rollouts(ns).Create(&ro)
+		if err != nil {
+			return nil, err
+		}
+		fmt.Fprintf(c.Out, "%s.%s/%s created\n", rollouts.RolloutSingular, rollouts.Group, obj.Name)
+		return obj, nil
+	case gvk.Group == rollouts.Group && gvk.Kind == rollouts.AnalysisTemplateKind:
+		var template v1alpha1.AnalysisTemplate
+		err = unmarshal(fileBytes, &template)
+		if err != nil {
+			return nil, err
+		}
+		obj, err := c.RolloutsClientset().ArgoprojV1alpha1().AnalysisTemplates(ns).Create(&template)
+		if err != nil {
+			return nil, err
+		}
+		fmt.Fprintf(c.Out, "%s.%s/%s created\n", rollouts.AnalysisTemplateSingular, rollouts.Group, obj.Name)
+		return obj, nil
+	case gvk.Group == rollouts.Group && gvk.Kind == rollouts.AnalysisRunKind:
+		var run v1alpha1.AnalysisRun
+		err = unmarshal(fileBytes, &run)
+		if err != nil {
+			return nil, err
+		}
+		obj, err := c.RolloutsClientset().ArgoprojV1alpha1().AnalysisRuns(ns).Create(&run)
+		if err != nil {
+			return nil, err
+		}
+		fmt.Fprintf(c.Out, "%s.%s/%s created\n", rollouts.AnalysisRunSingular, rollouts.Group, obj.Name)
+		return obj, nil
+	default:
+		return nil, fmt.Errorf("creates of %s/%s unsupported", gvk.Group, gvk.Kind)
+	}
+}
+
+// NewCmdCreateAnalysisRun returns a new instance of an `rollouts create analysisrun` command
+func NewCmdCreateAnalysisRun(o *options.ArgoRolloutsOptions) *cobra.Command {
+	createOptions := CreateAnalysisRunOptions{
+		ArgoRolloutsOptions: *o,
+	}
+	var cmd = &cobra.Command{
+		Use:   "analysisrun",
+		Short: "Create an AnalysisRun from a template",
+		Example: o.Example(`
+  # Create an AnalysisRun from a local template file
+  %[1]s create analysisrun --from-file my-analysis-template.yaml
+  # Create an AnalysisRun from a template in the cluster
+  %[1]s create analysisrun --from my-analysis-template
+`),
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			froms := 0
+			if createOptions.From != "" {
+				froms++
+			}
+			if createOptions.FromFile != "" {
+				froms++
+			}
+			if froms != 1 {
+				return fmt.Errorf("one of --from or --from-file must be specified")
+			}
+			templateArgs, err := createOptions.ParseArgs()
+			if err != nil {
+				return err
+			}
+			ns := o.Namespace()
+			var template *v1alpha1.AnalysisTemplate
+			if createOptions.From != "" {
+				template, err = createOptions.RolloutsClientset().ArgoprojV1alpha1().AnalysisTemplates(ns).Get(createOptions.From, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+			} else {
+				fileBytes, err := ioutil.ReadFile(createOptions.FromFile)
+				if err != nil {
+					return err
+				}
+				var tmpl v1alpha1.AnalysisTemplate
+				err = unmarshal(fileBytes, &tmpl)
+				if err != nil {
+					return err
+				}
+				template = &tmpl
+			}
+			var name, generateName string
+			if createOptions.Name != "" {
+				name = createOptions.Name
+			} else if createOptions.GenerateName != "" {
+				generateName = createOptions.GenerateName
+			} else {
+				generateName = template.Name + "-"
+			}
+
+			run, err := analysisutil.NewAnalysisRunFromTemplate(template, templateArgs, name, generateName, ns)
+			if err != nil {
+				return err
+			}
+			created, err := createOptions.RolloutsClientset().ArgoprojV1alpha1().AnalysisRuns(ns).Create(run)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(createOptions.Out, "analysisrun.argoproj.io/%s created\n", created.Name)
+			return nil
+		},
+	}
+	o.AddKubectlFlags(cmd)
+	cmd.Flags().StringVar(&createOptions.Name, "name", "", "Use the specified name for the run")
+	cmd.Flags().StringVar(&createOptions.GenerateName, "generate-name", "", "Use the specified generateName for the run")
+	cmd.Flags().StringArrayVarP(&createOptions.ArgFlags, "argument", "a", []string{}, "Arguments to the parameter template")
+	cmd.Flags().StringVar(&createOptions.From, "from", "", "Create an AnalysisRun from an AnalysisTemplate in the cluster")
+	cmd.Flags().StringVar(&createOptions.FromFile, "from-file", "", "Create an AnalysisRun from an AnalysisTemplate in a local file")
+	return cmd
+}
+
+func (c *CreateAnalysisRunOptions) ParseArgs() ([]v1alpha1.Argument, error) {
+	var args []v1alpha1.Argument
+	for _, argFlag := range c.ArgFlags {
+		argSplit := strings.SplitN(argFlag, "=", 2)
+		if len(argSplit) != 2 {
+			return nil, errors.New("arguments must be in the form NAME=VALUE")
+		}
+		arg := v1alpha1.Argument{
+			Name:  argSplit[0],
+			Value: pointer.StringPtr(argSplit[1]),
+		}
+		args = append(args, arg)
+	}
+	return args, nil
+}

--- a/pkg/kubectl-argo-rollouts/cmd/create/testdata/analysis-template.json
+++ b/pkg/kubectl-argo-rollouts/cmd/create/testdata/analysis-template.json
@@ -1,0 +1,47 @@
+
+{
+  "kind": "AnalysisTemplate",
+  "apiVersion": "argoproj.io/v1alpha1",
+  "metadata": {
+    "name": "pass"
+  },
+  "spec": {
+    "args": [
+      {
+        "name": "foo"
+      }
+    ],
+    "metrics": [
+      {
+        "name": "pass",
+        "interval": "5s",
+        "failureLimit": 1,
+        "provider": {
+          "job": {
+            "spec": {
+              "template": {
+                "spec": {
+                  "containers": [
+                    {
+                      "name": "sleep",
+                      "image": "alpine:3.8",
+                      "command": [
+                        "sh",
+                        "-c"
+                      ],
+                      "args": [
+                        "exit 0"
+                      ]
+                    }
+                  ],
+                  "restartPolicy": "Never"
+                }
+              },
+              "backoffLimit": 0
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/pkg/kubectl-argo-rollouts/cmd/create/testdata/analysis-template.yaml
+++ b/pkg/kubectl-argo-rollouts/cmd/create/testdata/analysis-template.yaml
@@ -1,0 +1,23 @@
+kind: AnalysisTemplate
+apiVersion: argoproj.io/v1alpha1
+metadata:
+  name: pass
+spec:
+  args:
+  - name: foo
+  metrics:
+  - name: pass
+    interval: 5s
+    failureLimit: 1
+    provider:
+      job:
+        spec:
+          template:
+            spec:
+              containers:
+              - name: sleep
+                image: alpine:3.8
+                command: [sh, -c]
+                args: [exit 0]
+              restartPolicy: Never
+          backoffLimit: 0

--- a/pkg/kubectl-argo-rollouts/cmd/get/get.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get.go
@@ -67,8 +67,8 @@ const (
 )
 
 type GetOptions struct {
-	watch   bool
-	noColor bool
+	Watch   bool
+	NoColor bool
 
 	options.ArgoRolloutsOptions
 }
@@ -110,7 +110,7 @@ func (o *GetOptions) Clear() {
 
 // colorize adds ansii color codes to the string based on well known words
 func (o *GetOptions) colorize(s string) string {
-	if o.noColor {
+	if o.NoColor {
 		return s
 	}
 	color := colorMapping[s]
@@ -119,7 +119,7 @@ func (o *GetOptions) colorize(s string) string {
 
 // colorizeStatus adds ansii color codes to the string based on supplied status string
 func (o *GetOptions) colorizeStatus(s string, status string) string {
-	if o.noColor {
+	if o.NoColor {
 		return s
 	}
 	color := colorMapping[status]
@@ -134,7 +134,7 @@ func (o *GetOptions) colorizeStatus(s string, status string) string {
 // color, it provides more consistent string lengths so that tabwriter can calculate
 // widths correctly.
 func (o *GetOptions) ansiFormat(s string, codes ...int) string {
-	if o.noColor || os.Getenv("TERM") == "dumb" || len(codes) == 0 {
+	if o.NoColor || os.Getenv("TERM") == "dumb" || len(codes) == 0 {
 		return s
 	}
 	codeStrs := make([]string, len(codes))

--- a/pkg/kubectl-argo-rollouts/cmd/get/get_experiment.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get_experiment.go
@@ -43,7 +43,7 @@ func NewCmdGetExperiment(o *options.ArgoRolloutsOptions) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if !getOptions.watch {
+			if !getOptions.Watch {
 				getOptions.PrintExperiment(expInfo)
 			} else {
 				expUpdates := make(chan *info.ExperimentInfo)
@@ -58,8 +58,8 @@ func NewCmdGetExperiment(o *options.ArgoRolloutsOptions) *cobra.Command {
 		},
 	}
 	o.AddKubectlFlags(cmd)
-	cmd.Flags().BoolVarP(&getOptions.watch, "watch", "w", false, "Watch live updates to the rollout")
-	cmd.Flags().BoolVar(&getOptions.noColor, "no-color", false, "Do not colorize output")
+	cmd.Flags().BoolVarP(&getOptions.Watch, "watch", "w", false, "Watch live updates to the rollout")
+	cmd.Flags().BoolVar(&getOptions.NoColor, "no-color", false, "Do not colorize output")
 	return cmd
 }
 

--- a/pkg/kubectl-argo-rollouts/cmd/get/get_rollout.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get_rollout.go
@@ -43,7 +43,7 @@ func NewCmdGetRollout(o *options.ArgoRolloutsOptions) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if !getOptions.watch {
+			if !getOptions.Watch {
 				getOptions.PrintRollout(ri)
 			} else {
 				rolloutUpdates := make(chan *info.RolloutInfo)
@@ -58,8 +58,8 @@ func NewCmdGetRollout(o *options.ArgoRolloutsOptions) *cobra.Command {
 		},
 	}
 	o.AddKubectlFlags(cmd)
-	cmd.Flags().BoolVarP(&getOptions.watch, "watch", "w", false, "Watch live updates to the rollout")
-	cmd.Flags().BoolVar(&getOptions.noColor, "no-color", false, "Do not colorize output")
+	cmd.Flags().BoolVarP(&getOptions.Watch, "watch", "w", false, "Watch live updates to the rollout")
+	cmd.Flags().BoolVar(&getOptions.NoColor, "no-color", false, "Do not colorize output")
 	return cmd
 }
 

--- a/pkg/kubectl-argo-rollouts/cmd/get/get_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get_test.go
@@ -223,6 +223,7 @@ NAME                                                                           K
 │  │  └──⧉ rollout-experiment-analysis-6f646bf7b7-1-vcv27-canary-7699dcf5d     ReplicaSet   ✔ Healthy       7d
 │  │     └──□ rollout-experiment-analysis-6f646bf7b7-1-vcv27-canary-7699vgr24  Pod          ✔ Running       7d   ready:1/1
 │  └──α rollout-experiment-analysis-random-fail-6f646bf7b7-skqcr               AnalysisRun  ? Inconclusive  7d   ✔ 4,✖ 4,? 1,⚠ 1
+│     └──⊞ rollout-experiment-analysis-random-fail-6f646bf7b7-skqcr-rsxm69     Job          ✔ Successful    7d
 └──# revision:1
    └──⧉ rollout-experiment-analysis-f6db98dff                                  ReplicaSet   ✔ Healthy       7d   stable
       ├──□ rollout-experiment-analysis-f6db98dff-8dmnz                         Pod          ✔ Running       7d   ready:1/1

--- a/pkg/kubectl-argo-rollouts/cmd/promote/promote.go
+++ b/pkg/kubectl-argo-rollouts/cmd/promote/promote.go
@@ -44,7 +44,7 @@ func NewCmdPromote(o *options.ArgoRolloutsOptions) *cobra.Command {
 	)
 	var cmd = &cobra.Command{
 		Use:          "promote ROLLOUT",
-		Short:        "promote a rollout",
+		Short:        "Promote a rollout",
 		Example:      o.Example(example),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {

--- a/pkg/kubectl-argo-rollouts/info/analysisrun_info.go
+++ b/pkg/kubectl-argo-rollouts/info/analysisrun_info.go
@@ -49,7 +49,7 @@ func getAnalysisRunInfo(ownerUID types.UID, allAnalysisRuns []*v1alpha1.Analysis
 			arInfo.Inconclusive += mr.Inconclusive
 			arInfo.Error += mr.Error
 			lastMeasurement := analysisutil.LastMeasurement(run, mr.Name)
-			if lastMeasurement != nil && lastMeasurement.Metadata != nil && lastMeasurement.Phase != v1alpha1.AnalysisPhaseSuccessful {
+			if lastMeasurement != nil && lastMeasurement.Metadata != nil {
 				if jobName, ok := lastMeasurement.Metadata[job.JobNameKey]; ok {
 					jobInfo := JobInfo{
 						Metadata: Metadata{

--- a/pkg/kubectl-argo-rollouts/info/testdata/testdata.go
+++ b/pkg/kubectl-argo-rollouts/info/testdata/testdata.go
@@ -85,7 +85,7 @@ func discoverObjects(path string) *RolloutObjects {
 		switch typeMeta.Kind {
 		case "Rollout":
 			var ro v1alpha1.Rollout
-			err = yaml.UnmarshalStrict(yamlBytes, &ro)
+			err = yaml.UnmarshalStrict(yamlBytes, &ro, yaml.DisallowUnknownFields)
 			if err != nil {
 				panic(err)
 			}
@@ -93,7 +93,7 @@ func discoverObjects(path string) *RolloutObjects {
 			objs.Rollouts = append(objs.Rollouts, &ro)
 		case "ReplicaSet":
 			var rs appsv1.ReplicaSet
-			err = yaml.UnmarshalStrict(yamlBytes, &rs)
+			err = yaml.UnmarshalStrict(yamlBytes, &rs, yaml.DisallowUnknownFields)
 			if err != nil {
 				panic(err)
 			}
@@ -101,7 +101,7 @@ func discoverObjects(path string) *RolloutObjects {
 			objs.ReplicaSets = append(objs.ReplicaSets, &rs)
 		case "Pod":
 			var pod corev1.Pod
-			err = yaml.UnmarshalStrict(yamlBytes, &pod)
+			err = yaml.UnmarshalStrict(yamlBytes, &pod, yaml.DisallowUnknownFields)
 			if err != nil {
 				panic(err)
 			}
@@ -109,7 +109,7 @@ func discoverObjects(path string) *RolloutObjects {
 			objs.Pods = append(objs.Pods, &pod)
 		case "Experiment":
 			var exp v1alpha1.Experiment
-			err = yaml.UnmarshalStrict(yamlBytes, &exp)
+			err = yaml.UnmarshalStrict(yamlBytes, &exp, yaml.DisallowUnknownFields)
 			if err != nil {
 				panic(err)
 			}
@@ -117,7 +117,7 @@ func discoverObjects(path string) *RolloutObjects {
 			objs.Experiments = append(objs.Experiments, &exp)
 		case "AnalysisRun":
 			var run v1alpha1.AnalysisRun
-			err = yaml.UnmarshalStrict(yamlBytes, &run)
+			err = yaml.UnmarshalStrict(yamlBytes, &run, yaml.DisallowUnknownFields)
 			if err != nil {
 				panic(err)
 			}

--- a/utils/analysis/helpers.go
+++ b/utils/analysis/helpers.go
@@ -186,3 +186,22 @@ func CreateWithCollisionCounter(logCtx *log.Entry, analysisRunIf argoprojclient.
 		collisionCount++
 	}
 }
+
+func NewAnalysisRunFromTemplate(template *v1alpha1.AnalysisTemplate, args []v1alpha1.Argument, name, generateName, namespace string) (*v1alpha1.AnalysisRun, error) {
+	newArgs, err := MergeArgs(args, template.Spec.Args)
+	if err != nil {
+		return nil, err
+	}
+	ar := v1alpha1.AnalysisRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:         name,
+			GenerateName: generateName,
+			Namespace:    namespace,
+		},
+		Spec: v1alpha1.AnalysisRunSpec{
+			Metrics: template.Spec.Metrics,
+			Args:    newArgs,
+		},
+	}
+	return &ar, nil
+}

--- a/utils/analysis/helpers_test.go
+++ b/utils/analysis/helpers_test.go
@@ -388,3 +388,37 @@ func TestMergeArgs(t *testing.T) {
 		assert.Equal(t, "my-value", *args[0].Value)
 	}
 }
+
+func TestNewAnalysisRunFromTemplate(t *testing.T) {
+	template := v1alpha1.AnalysisTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: v1alpha1.AnalysisTemplateSpec{
+			Metrics: []v1alpha1.Metric{
+				{
+					Name: "success-rate",
+				},
+			},
+			Args: []v1alpha1.Argument{
+				{
+					Name: "my-arg",
+				},
+			},
+		},
+	}
+	args := []v1alpha1.Argument{
+		{
+			Name:  "my-arg",
+			Value: pointer.StringPtr("my-val"),
+		},
+	}
+	run, err := NewAnalysisRunFromTemplate(&template, args, "foo-run", "foo-run-generate-", "my-ns")
+	assert.NoError(t, err)
+	assert.Equal(t, "foo-run", run.Name)
+	assert.Equal(t, "foo-run-generate-", run.GenerateName)
+	assert.Equal(t, "my-ns", run.Namespace)
+	assert.Equal(t, "my-arg", run.Spec.Args[0].Name)
+	assert.Equal(t, "my-val", *run.Spec.Args[0].Value)
+}


### PR DESCRIPTION
1. Introduce `kubectl argo rollouts create -f file.yaml` with a `-w` watch option
2. Introduce `kubectl argo rollouts create analysisrun` with ` --from=templatename` or ` --from-file=template.yaml`
3. Made generating an AnalysisRun from a AnalysisTemplate into a helper
4. Always show the last job when displaying analysis jobs (not just the failed ones)
