### PR TITLE
Fix Infinite loop with PreviewReplicaCount set

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       # CircleCI Go images available at: https://hub.docker.com/r/circleci/golang/
       - image: circleci/golang:1.13.1
-    resource_class: large
+    resource_class: xlarge
     environment:
       TEST_RESULTS: /tmp/test-results
     steps:

--- a/rollout/replicaset.go
+++ b/rollout/replicaset.go
@@ -77,18 +77,6 @@ func (c *RolloutController) reconcileNewReplicaSet(roCtx rolloutContext) (bool, 
 	}
 	roCtx.Log().Infof("Reconciling new ReplicaSet '%s'", newRS.Name)
 	allRSs := roCtx.AllRSs()
-	if rollout.Spec.Strategy.BlueGreen != nil {
-		rolloutReplicas := defaults.GetReplicasOrDefault(rollout.Spec.Replicas)
-		if *(newRS.Spec.Replicas) == rolloutReplicas {
-			// Scaling not required.
-			return false, nil
-		}
-		if *(newRS.Spec.Replicas) > rolloutReplicas {
-			// Scale down.
-			scaled, _, err := c.scaleReplicaSetAndRecordEvent(newRS, rolloutReplicas, rollout)
-			return scaled, err
-		}
-	}
 	newReplicasCount, err := replicasetutil.NewRSNewReplicas(rollout, allRSs, newRS)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Solves https://github.com/argoproj/argo-rollouts/issues/301 by removing the scaling preview ReplicaSet section in the`scaleBlueGreen` method. That section would scale up the preview ReplicaSet to the `.spec.Replicas` count without taking the rollout pause status into account (https://github.com/argoproj/argo-rollouts/compare/fix-infinite-loop?expand=1#diff-cfad87918ee0d3175ebd8e47f5efd159L309 vs https://github.com/argoproj/argo-rollouts/blob/master/utils/replicaset/replicaset.go#L89). The rollout should only scale to the `.spec.Replicas` count when the rollout is paused and the ScaleUpPreviewCheckPoint is set to true.

The `scaleBlueGreen` method also scales the new ReplicaSet. Since the new ReplicaSet is the same as the preview ReplicaSet, the controller scales it to the `.spec.strategy.bluegreen.previewReplicaCount` count (as the rollout is still paused). These two updates on the same ReplicaSet cause an infinite loop as they fight over the `.spec.Replica` value.

We did not hit this bug earlier since this code only happened while the scaling. With v0.6, the controller leverages that code path whenever the rollout is paused.

In addition, I added some tests to confirm the behavior of when to set the ScaleUpPreviewCheckPoint value.