### PR TITLE
Bluegreen: allow preview service/replica sets to be replaced and fix sg fault in syncReplicasOnly

### DIFF
--- a/rollout/bluegreen.go
+++ b/rollout/bluegreen.go
@@ -144,6 +144,10 @@ func (c *RolloutController) reconcileBlueGreenPause(activeSvc, previewSvc *corev
 	}
 
 	newRS := roCtx.NewRS()
+	if newRS == nil {
+		return false
+	}
+
 	newRSPodHash := newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
 	if _, ok := activeSvc.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey]; !ok {
@@ -223,6 +227,14 @@ func (c *RolloutController) syncRolloutStatusBlueGreen(previewSvc *corev1.Servic
 	oldRSs := roCtx.OlderRSs()
 	allRSs := roCtx.AllRSs()
 	newStatus := c.calculateBaseStatus(roCtx)
+
+	if replicasetutil.CheckPodSpecChange(r, newRS) {
+		roCtx.PauseContext().ClearPauseConditions()
+		roCtx.PauseContext().RemoveAbort()
+		newStatus = c.calculateRolloutConditions(roCtx, newStatus)
+		return c.persistRolloutStatus(roCtx, &newStatus)
+	}
+
 	newStatus.AvailableReplicas = replicasetutil.GetAvailableReplicaCountForReplicaSets([]*appsv1.ReplicaSet{newRS})
 	previewSelector, ok := serviceutil.GetRolloutSelectorLabel(previewSvc)
 	if !ok {
@@ -233,6 +245,7 @@ func (c *RolloutController) syncRolloutStatusBlueGreen(previewSvc *corev1.Servic
 	if !ok {
 		activeSelector = ""
 	}
+
 	newStatus.BlueGreen.ActiveSelector = activeSelector
 	if newStatus.BlueGreen.ActiveSelector != r.Status.BlueGreen.ActiveSelector {
 		previousActiveRS, _ := replicasetutil.GetReplicaSetByTemplateHash(oldRSs, r.Status.BlueGreen.ActiveSelector)

--- a/rollout/bluegreen.go
+++ b/rollout/bluegreen.go
@@ -232,9 +232,6 @@ func (c *RolloutController) syncRolloutStatusBlueGreen(previewSvc *corev1.Servic
 		roCtx.PauseContext().ClearPauseConditions()
 		roCtx.PauseContext().RemoveAbort()
 		newStatus = c.calculateRolloutConditions(roCtx, newStatus)
-		if err := c.persistRolloutStatus(roCtx, &newStatus); err != nil {
-			return err
-		}
 	}
 
 	newStatus.AvailableReplicas = replicasetutil.GetAvailableReplicaCountForReplicaSets([]*appsv1.ReplicaSet{newRS})

--- a/rollout/bluegreen.go
+++ b/rollout/bluegreen.go
@@ -231,7 +231,6 @@ func (c *RolloutController) syncRolloutStatusBlueGreen(previewSvc *corev1.Servic
 	if replicasetutil.CheckPodSpecChange(r, newRS) {
 		roCtx.PauseContext().ClearPauseConditions()
 		roCtx.PauseContext().RemoveAbort()
-		newStatus = c.calculateRolloutConditions(roCtx, newStatus)
 	}
 
 	newStatus.AvailableReplicas = replicasetutil.GetAvailableReplicaCountForReplicaSets([]*appsv1.ReplicaSet{newRS})

--- a/rollout/bluegreen.go
+++ b/rollout/bluegreen.go
@@ -232,7 +232,9 @@ func (c *RolloutController) syncRolloutStatusBlueGreen(previewSvc *corev1.Servic
 		roCtx.PauseContext().ClearPauseConditions()
 		roCtx.PauseContext().RemoveAbort()
 		newStatus = c.calculateRolloutConditions(roCtx, newStatus)
-		return c.persistRolloutStatus(roCtx, &newStatus)
+		if err := c.persistRolloutStatus(roCtx, &newStatus); err != nil {
+			return err
+		}
 	}
 
 	newStatus.AvailableReplicas = replicasetutil.GetAvailableReplicaCountForReplicaSets([]*appsv1.ReplicaSet{newRS})

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -1049,8 +1049,6 @@ requests:
 
 		_ = f.expectUpdateRolloutAction(r)
 		f.expectPatchRolloutAction(r)
-		f.expectPatchRolloutAction(r)
-
 		rs := newReplicaSet(r, 1)
 		rsIdx := f.expectCreateReplicaSetAction(rs)
 		f.run(getKey(r, t))

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -1049,6 +1049,8 @@ requests:
 
 		_ = f.expectUpdateRolloutAction(r)
 		f.expectPatchRolloutAction(r)
+		f.expectPatchRolloutAction(r)
+
 		rs := newReplicaSet(r, 1)
 		rsIdx := f.expectCreateReplicaSetAction(rs)
 		f.run(getKey(r, t))

--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -271,7 +271,7 @@ func checkStepHashChange(rollout *v1alpha1.Rollout) bool {
 
 // checkPodSpecChange indicates if the rollout spec has changed indicating that the rollout needs to reset the
 // currentStepIndex to zero. If there is no previous pod spec to compare to the function defaults to false
-func checkPodSpecChange(rollout *v1alpha1.Rollout, newRS *appsv1.ReplicaSet) bool {
+func CheckPodSpecChange(rollout *v1alpha1.Rollout, newRS *appsv1.ReplicaSet) bool {
 	if rollout.Status.CurrentPodHash == "" {
 		return false
 	}
@@ -292,7 +292,7 @@ func PodTemplateOrStepsChanged(rollout *v1alpha1.Rollout, newRS *appsv1.ReplicaS
 	if checkStepHashChange(rollout) {
 		return true
 	}
-	if checkPodSpecChange(rollout, newRS) {
+	if CheckPodSpecChange(rollout, newRS) {
 		return true
 	}
 	return false

--- a/utils/replicaset/replicaset_test.go
+++ b/utils/replicaset/replicaset_test.go
@@ -622,12 +622,12 @@ func TestMaxUnavailable(t *testing.T) {
 func TestCheckPodSpecChange(t *testing.T) {
 	ro := generateRollout("ngnix")
 	rs := generateRS(ro)
-	assert.False(t, checkPodSpecChange(&ro, &rs))
+	assert.False(t, CheckPodSpecChange(&ro, &rs))
 	ro.Status.CurrentPodHash = controller.ComputeHash(&ro.Spec.Template, ro.Status.CollisionCount)
-	assert.False(t, checkPodSpecChange(&ro, &rs))
+	assert.False(t, CheckPodSpecChange(&ro, &rs))
 
 	ro.Status.CurrentPodHash = "different-hash"
-	assert.True(t, checkPodSpecChange(&ro, &rs))
+	assert.True(t, CheckPodSpecChange(&ro, &rs))
 }
 
 func TestCheckStepHashChange(t *testing.T) {


### PR DESCRIPTION
## tl;dr

- solves https://github.com/argoproj/argo-rollouts/issues/311 .
- allow users to replace preview service's replica sets under Bluegreen type rollouts without prior abortion 

## motivation

In the course of bug fixing, I found that it is impossible for users to update preview service/replica with the new replica set of different template when the current preview service is not empt (i.e., rollout resource is paused). As of now, to achieve the replacement, users must set `status.abort` prior to try new templates.

To make matters worse, argo-rollouts controller would be panic if we do so (this is the same reason as https://github.com/argoproj/argo-rollouts/issues/311).

