### PR TITLE
Update dependencies for istio/client-go

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  digest = "1:dd029f90457e0bc0fc4a549a241327bdcac1f2a36692041a19ef02aec4c36103"
+  digest = "1:6187184f69efd82ef48558d39555a76a396fd0e72bca361ba4b7af292b485eab"
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
   pruneopts = ""
-  revision = "74b12019e2aa53ec27882158f59192d7cd6d1998"
-  version = "v0.33.1"
+  revision = "d1ee711ee996fa74abaffbdb572963f368f215a9"
+  version = "v0.49.0"
 
 [[projects]]
   branch = "master"
@@ -29,12 +29,12 @@
   version = "v2.0.1"
 
 [[projects]]
-  digest = "1:8e47871087b94913898333f37af26732faaab30cdb41571136cf7aec9921dae7"
+  digest = "1:c0952fb3cf9506cff577b4edf4458889570dcbd2902a7b90a1fd96bfbb97ccd8"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
   pruneopts = ""
-  revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
-  version = "v1.1.0"
+  revision = "44968752391892e1b0d0b821ee79e9a85fa13049"
+  version = "v1.1.1"
 
 [[projects]]
   branch = "master"
@@ -72,12 +72,12 @@
   version = "v2.1.2"
 
 [[projects]]
-  branch = "master"
-  digest = "1:c0bec5f9b98d0bc872ff5e834fac186b807b656683bd29cb82fb207a1513fabb"
+  digest = "1:ac2a05be7167c495fe8aaf8aaf62ecf81e78d2180ecb04e16778dc6c185c96a5"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
   pruneopts = ""
-  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+  revision = "37c8de3658fcb183f997c4e13e8337516ab753e6"
+  version = "v1.0.1"
 
 [[projects]]
   digest = "1:a6ee710e45210bafe11f2f28963571be2ac8809f9a7b675a6d2c02302a1ce1a9"
@@ -96,15 +96,15 @@
   version = "v1.1.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:7942de144228c1b62eaba44ec5153a29d25cd016e8fb23cb9533c77f6111b397"
+  digest = "1:c05f1899f086e3b4613d94d9e6f7ba6f4b6587498a1aa6037c5c294b22f5a743"
   name = "github.com/docker/distribution"
   packages = [
     "digestset",
     "reference",
   ]
   pruneopts = ""
-  revision = "aa985ba8897a426e5db31b36cd8cca83cf85cead"
+  revision = "2461543d988979529609e8cb6fca9ca190dc48da"
+  version = "v2.7.1"
 
 [[projects]]
   digest = "1:50a4629dd29d90473be834b7d6c502f310a269f06f31c069a8c6e2b4274a14b3"
@@ -128,15 +128,15 @@
   revision = "6480d4af844c189cf5dd913db24ddd339d3a4f85"
 
 [[projects]]
-  digest = "1:8a34d7a37b8f07239487752e14a5faafcbbc718fc385ad429a2c4ac6f27a207f"
+  digest = "1:03a98f5067540d81c4a163b21279c4ce5f158b78e9409921110635d2d7cb603d"
   name = "github.com/emicklei/go-restful"
   packages = [
     ".",
     "log",
   ]
   pruneopts = ""
-  revision = "3eb9738c1697594ea6e71a7156a9bb32ed216cf0"
-  version = "v2.8.0"
+  revision = "99f05a26a0a1c71e664ebe6a76d29b2c80333056"
+  version = "v2.11.1"
 
 [[projects]]
   digest = "1:dcefbadf4534c5ecac8573698fba6e6e601157bfa8f96aafe29df31ae582ef2a"
@@ -163,58 +163,58 @@
   revision = "25d852aebe32c875e9c044af3eef9c7dc6bc777f"
 
 [[projects]]
-  digest = "1:c8052dcf3ec378a9a6bc4f00ecc10d6d5eb3cc1f8faaf6b2f70f047e8881d446"
+  digest = "1:47688961daa2895c860642608d671822b7b53fed1e3e3e2d46506f01dcddaae3"
   name = "github.com/go-openapi/jsonpointer"
   packages = ["."]
   pruneopts = ""
-  revision = "ef5f0afec364d3b9396b7b77b43dbe26bf1f8004"
-  version = "v0.18.0"
+  revision = "ed123515f087412cd7ef02e49b0b0a5e6a79a360"
+  version = "v0.19.3"
 
 [[projects]]
-  digest = "1:1824e5330b35b2a2418d06aa55629cc59ad454b72e338aa125ba8ff98f16298b"
+  digest = "1:69c513ad15614075cbb474bc636fbb901aa3e9273a6da3d583df76fa62ec83d3"
   name = "github.com/go-openapi/jsonreference"
   packages = ["."]
   pruneopts = ""
-  revision = "8483a886a90412cd6858df4ea3483dce9c8e35a3"
-  version = "v0.18.0"
+  revision = "82f31475a8f7a12bc26962f6e26ceade8ea6f66a"
+  version = "v0.19.3"
 
 [[projects]]
-  digest = "1:54af405aae840f810418f3d25211012af1c4bfd56d07d3de6482a7a3b762528a"
+  digest = "1:4b44076c920b8d25526a6c492b886e79a41a09164021a614aae8f6aeb42721bd"
   name = "github.com/go-openapi/spec"
   packages = ["."]
   pruneopts = ""
-  revision = "5b6cdde3200976e3ecceb2868706ee39b6aff3e4"
-  version = "v0.18.0"
+  revision = "8557d72e4f077c2dbe1e48df09e596b6fb9b7991"
+  version = "v0.19.4"
 
 [[projects]]
-  digest = "1:417789264f7cc44cbb3431ac997473e085018b01bdd98df57e6039981428aca4"
+  digest = "1:fb1a3f651afb10230982d116bef8cb05dff148c5d3243c8ed79ef78d51f1ebe7"
   name = "github.com/go-openapi/swag"
   packages = ["."]
   pruneopts = ""
-  revision = "1d29f06aebd59ccdf11ae04aa0334ded96e2d909"
-  version = "v0.18.0"
+  revision = "c3d0f7896d589f3babb99eea24bbc7de98108e72"
+  version = "v0.19.5"
 
 [[projects]]
-  digest = "1:6e73003ecd35f4487a5e88270d3ca0a81bc80dc88053ac7e4dcfec5fba30d918"
+  digest = "1:d69d2ba23955582a64e367ff2b0808cdbd048458c178cea48f11ab8c40bd7aea"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
     "sortkeys",
   ]
   pruneopts = ""
-  revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
-  version = "v1.1.1"
+  revision = "5628607bb4c51c3157aacc3a50f0ab707582b805"
+  version = "v1.3.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:aa2251148505e561bfa8cd6b69a319b37761da57b0b25529c4af08389559e3b9"
+  digest = "1:156e8134a4ab3efcbcbc6e3dd5069bfb70ed8cbb1cdd7db557bd9035c363f335"
   name = "github.com/golang/groupcache"
   packages = ["lru"]
   pruneopts = ""
-  revision = "c65c006176ff7ff98bb916961c7abbc6b0afc0aa"
+  revision = "611e8accdfc92c4187d399e95ce826046d4c8d73"
 
 [[projects]]
-  digest = "1:3dd078fda7500c341bc26cfbc6c6a34614f295a2457149fc1045cab767cbcf18"
+  digest = "1:b852d2b62be24e445fcdbad9ce3015b44c207815d631230dfce3f14e7803f5bf"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -224,8 +224,8 @@
     "ptypes/timestamp",
   ]
   pruneopts = ""
-  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
-  version = "v1.2.0"
+  revision = "6c65a5562fc06764971b7c5d05c76c75e84bdbf7"
+  version = "v1.3.2"
 
 [[projects]]
   digest = "1:1e5b1e14524ed08301977b7b8e10c719ed853cbf3f24ecb66fae783a46f207a6"
@@ -250,23 +250,23 @@
   version = "v0.3.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:754f77e9c839b24778a4b64422236d38515301d2baeb63113aa3edc42e6af692"
+  digest = "1:8d4a577a9643f713c25a32151c0f26af7228b4b97a219b5ddb7fd38d16f6e673"
   name = "github.com/google/gofuzz"
   packages = ["."]
   pruneopts = ""
-  revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
+  revision = "f140a6486e521aad38f5917de355cbf147cc0496"
+  version = "v1.0.0"
 
 [[projects]]
-  digest = "1:a25a2c5ae694b01713fb6cd03c3b1ac1ccc1902b9f0a922680a88ec254f968e1"
+  digest = "1:ad92aa49f34cbc3546063c7eb2cabb55ee2278b72842eda80e2a20a8a06a8d73"
   name = "github.com/google/uuid"
   packages = ["."]
   pruneopts = ""
-  revision = "9b3b1e0f5f99ae461456d768e7d301a7acdaa2d8"
-  version = "v1.1.0"
+  revision = "0cd6bf5da1e1c83f8b45653022c74f71af0538a4"
+  version = "v1.1.1"
 
 [[projects]]
-  digest = "1:16b2837c8b3cf045fa2cdc82af0cf78b19582701394484ae76b2c3bc3c99ad73"
+  digest = "1:728f28282e0edc47e2d8f41c9ec1956ad645ad6b15e6376ab31e2c3b094fc38f"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
@@ -274,8 +274,8 @@
     "extensions",
   ]
   pruneopts = ""
-  revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
-  version = "v0.2.0"
+  revision = "ab0dd09aa10e2952b28e12ecd35681b20463ebab"
+  version = "v0.3.1"
 
 [[projects]]
   branch = "master"
@@ -289,23 +289,23 @@
   revision = "901d90724c7919163f472a9812253fb26761123d"
 
 [[projects]]
-  digest = "1:3313a63031ae281e5f6fd7b0bbca733dfa04d2429df86519e3b4d4c016ccb836"
+  digest = "1:7f6f07500a0b7d3766b00fa466040b97f2f5b5f3eef2ecabfe516e703b05119a"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
     "simplelru",
   ]
   pruneopts = ""
-  revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
-  version = "v0.5.0"
+  revision = "7f827b33c0f158ec5dfbba01bb0b14a4541fd81d"
+  version = "v0.5.3"
 
 [[projects]]
-  digest = "1:7ab38c15bd21e056e3115c8b526d201eaf74e0308da9370997c6b3c187115d36"
+  digest = "1:6906c992632a66c125bd44e68a7abc354d9eda683e451b5c2d9b1614d15d4f18"
   name = "github.com/imdario/mergo"
   packages = ["."]
   pruneopts = ""
-  revision = "9f23e2d6bd2a77f959b2bf6acdbefd708a83a4a4"
-  version = "v0.3.6"
+  revision = "1afb36080aec31e0d1528973ebe6721b191b0369"
+  version = "v0.3.8"
 
 [[projects]]
   digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
@@ -316,12 +316,12 @@
   version = "v1.0"
 
 [[projects]]
-  digest = "1:b79fc583e4dc7055ed86742e22164ac41bf8c0940722dbcb600f1a3ace1a8cb5"
+  digest = "1:64bdeae058b988b2b198326b1ca6155497e904e697348d838add8a6e4c25842e"
   name = "github.com/json-iterator/go"
   packages = ["."]
   pruneopts = ""
-  revision = "1624edc4454b8682399def8740d46db5e4362ba4"
-  version = "v1.1.5"
+  revision = "03217c3e97663914aec3faafde50d081f197a0a2"
+  version = "v1.1.8"
 
 [[projects]]
   branch = "master"
@@ -335,12 +335,20 @@
   revision = "720a0952cc2ac777afc295d9861263e2a4cf96a1"
 
 [[projects]]
-  digest = "1:6a874e3ddfb9db2b42bd8c85b6875407c702fa868eed20634ff489bc896ccfd3"
+  digest = "1:0f51cee70b0d254dbc93c22666ea2abf211af81c1701a96d04e2284b408621db"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
   pruneopts = ""
-  revision = "5c8c8bd35d3832f5d134ae1e1e375b69a4d25242"
-  version = "v1.0.1"
+  revision = "f55edac94c9bbba5d6182a4be46d86a2c9b5b50e"
+  version = "v1.0.2"
+
+[[projects]]
+  branch = "master"
+  digest = "1:93018a4331df9925058905133cb997aec8f54d5303f4536a23e49b5648632d06"
+  name = "github.com/liggitt/tabwriter"
+  packages = ["."]
+  pruneopts = ""
+  revision = "89fcab3d43de07060e4fd4c1547430ed57e87f24"
 
 [[projects]]
   digest = "1:b60ba8f16c4bd2c27ddab8c95f045d1275df450b28d0d95513a9e70c8ae9910c"
@@ -351,8 +359,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:212bebc561f4f654a653225868b2a97353cd5e160dc0b0bbc7232b06608474ec"
+  digest = "1:263db331ad7732d9d1e45003031dd3d6295c0c4be232f99596dde34fa51e3df9"
   name = "github.com/mailru/easyjson"
   packages = [
     "buffer",
@@ -360,7 +367,8 @@
     "jwriter",
   ]
   pruneopts = ""
-  revision = "60711f1a8329503b04e1c88535f419d0bb440bff"
+  revision = "1b2b06f5f209fea48ff5922d8bfb2b9ed5d8f00b"
+  version = "v0.7.0"
 
 [[projects]]
   digest = "1:9b58ad18b38cf0d44b1d006fce319e45f200eafa406fe7f65fe0d0194b9f7a9f"
@@ -451,7 +459,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:6f218995d6a74636cfcab45ce03005371e682b4b9bee0e5eb0ccfd83ef85364f"
+  digest = "1:6bea0cda3fc62855d5312163e7d259fb97e31692d93c08cfffbeb2d00df0f13c"
   name = "github.com/prometheus/client_golang"
   packages = [
     "api",
@@ -461,19 +469,19 @@
     "prometheus/promhttp",
   ]
   pruneopts = ""
-  revision = "505eaef017263e299324067d40ca2c48f6a2cf50"
-  version = "v0.9.2"
+  revision = "170205fb58decfd011f1550d4cfb737230d7ae4f"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:cd67319ee7536399990c4b00fae07c3413035a53193c644549a676091507cadc"
+  digest = "1:0a565f69553dd41b3de790fde3532e9237142f2637899e20cd3e7396f0c4f2f7"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
   pruneopts = ""
-  revision = "fd36f4220a901265f90734c3183c5f0c91daa0b8"
+  revision = "14fe0d1b01d4d5fc031dd4bec1823bd3ebbe8016"
 
 [[projects]]
-  digest = "1:96af18a3819d2ff7d6aa07e6e50955b11e477dbc8b890324c67462b84adca56b"
+  digest = "1:8904acfa3ef080005c1fc0670ed0471739d1e211be5638cfa6af536b701942ae"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
@@ -481,22 +489,20 @@
     "model",
   ]
   pruneopts = ""
-  revision = "cfeb6f9992ffa54aaa4f2170ade4067ee478b250"
-  version = "v0.2.0"
+  revision = "287d3e634a1e550c9e463dd7e5a75a422c614505"
+  version = "v0.7.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:5dff64a37ab1e65130c24f01d5fbda61226b73cc61b6f0c8af24373509a89b73"
+  digest = "1:4c64aa254bc24990bc0216de9dd955ff83f061e9baac7ed2ffc293442ab7514a"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
+    "internal/fs",
     "internal/util",
-    "iostats",
-    "nfs",
-    "xfs",
   ]
   pruneopts = ""
-  revision = "55ae3d9d557340b5bc24cd8aa5f6fa2c2ab31352"
+  revision = "6d489fc7f1d9cd890a250f3ea3431b1744b9623f"
+  version = "v0.0.8"
 
 [[projects]]
   digest = "1:2761e287c811d0948d47d0252b82281eca3801eb3c9d5f9530956643d5b9f430"
@@ -507,12 +513,12 @@
   version = "v1.5.2"
 
 [[projects]]
-  digest = "1:9a3c631555e0351fdc4e696577bb63afd90c399d782a8462dba9d100d7021db3"
+  digest = "1:1a405cddcf3368445051fb70ab465ae99da56ad7be8d8ca7fc52159d1c2d873c"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = ""
-  revision = "e1e72e9de974bd926e5c56f83753fba2df402ce5"
-  version = "v1.3.0"
+  revision = "839c75faf7f98a33d445d181f3018b5c3409a45e"
+  version = "v1.4.2"
 
 [[projects]]
   digest = "1:0c63b3c7ad6d825a898f28cb854252a3b29d37700c68a117a977263f5ec94efe"
@@ -523,12 +529,12 @@
   version = "v0.0.5"
 
 [[projects]]
-  digest = "1:cbaf13cdbfef0e4734ed8a7504f57fe893d471d62a35b982bf6fb3f036449a66"
+  digest = "1:688428eeb1ca80d92599eb3254bdf91b51d7e232fead3a73844c1f201a281e51"
   name = "github.com/spf13/pflag"
   packages = ["."]
   pruneopts = ""
-  revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
-  version = "v1.0.3"
+  revision = "2e9d26c8c37aae03e3f9d4e90b7116f5accb7cab"
+  version = "v1.0.5"
 
 [[projects]]
   digest = "1:711eebe744c0151a9d09af2315f0bb729b2ec7637ef4c410fa90a18ef74b65b6"
@@ -539,15 +545,15 @@
   version = "v0.1.1"
 
 [[projects]]
-  digest = "1:c587772fb8ad29ad4db67575dad25ba17a51f072ff18a22b4f0257a4d9c24f75"
+  digest = "1:f7b541897bcde05a04a044c342ddc7425aab7e331f37b47fbb486cd16324b48e"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
     "mock",
   ]
   pruneopts = ""
-  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
-  version = "v1.2.2"
+  revision = "221dbe5ed46703ee255b1da0dec05086f5035f62"
+  version = "v1.4.0"
 
 [[projects]]
   digest = "1:857a9ecd5cb13379ecc8f798f6e6b6b574c98b9355657d91e068275f1120aaf7"
@@ -558,16 +564,16 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:1ad3ae8a5edf223abb8435e16ccc0696ce886c6f889e100809122e931e7423b2"
+  digest = "1:c8b536f08002f0916e288eb66b7d961e3a854542f50532255a7c737edd22987a"
   name = "github.com/valyala/fasttemplate"
   packages = ["."]
   pruneopts = ""
-  revision = "8b5e4e491ab636663841c42ea3c5a9adebabaf36"
-  version = "v1.0.1"
+  revision = "8fcc7a99b5795b7c3e95172237cf93282fc339a9"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:f7be435e0ca22e2cd62b2d2542081a231685837170a87a3662abb7cdf9f3f1cd"
+  digest = "1:294e6b6b426e0c2c956addcf17151a25906eb56f8d3f75b6103e6e450ed13182"
   name = "golang.org/x/crypto"
   packages = [
     "ed25519",
@@ -576,11 +582,11 @@
     "ssh/terminal",
   ]
   pruneopts = ""
-  revision = "3d3f9f413869b949e48070b5bc593aa22cc2b8f2"
+  revision = "b544559bb6d1b5c62fba4af5e843ff542174f079"
 
 [[projects]]
   branch = "master"
-  digest = "1:4ac199b027ed34460ec4e0a92c882156f561e78cd046fef095e50f867462435a"
+  digest = "1:f58e146d19d1af39792c0b599b24b13de51f75b073ba52c1aa658fe535be9120"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -591,11 +597,11 @@
     "idna",
   ]
   pruneopts = ""
-  revision = "adae6a3d119ae4890b46832a2e88a95adc62b8e7"
+  revision = "ef20fe5d793301b553005db740f730d87993f778"
 
 [[projects]]
   branch = "master"
-  digest = "1:51d339a1d79f5c617fba14414aefb7dfd184b8ba0ddbb9f95251430b67c8aab8"
+  digest = "1:5dea728c174ca00e8f11af6006d614f0a093e72e713b0687a0107faa87fe1219"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
@@ -605,21 +611,21 @@
     "jwt",
   ]
   pruneopts = ""
-  revision = "f42d05182288abf10faef86d16c0d07b8d40ea2d"
+  revision = "5d9234df094ce600ff541158d1491aa10d078a47"
 
 [[projects]]
   branch = "master"
-  digest = "1:bae7ec6144727bacb0f06565215267a39134f63a4955114d03961ca9061a1e97"
+  digest = "1:6530ff3e6639af9bab7d2cf1e141c348e63af92058fa64d0660a6e8817d41640"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = ""
-  revision = "93218def8b18e66adbdab3eca8ec334700329f1f"
+  revision = "6d18c012aee9febd81bbf9806760c8c4480e870d"
 
 [[projects]]
-  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
+  digest = "1:740b51a55815493a8d0f2b1e0d0ae48fe48953bf7eaf3fcc4198823bf67768c0"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -630,6 +636,8 @@
     "encoding/unicode",
     "internal/colltab",
     "internal/gen",
+    "internal/language",
+    "internal/language/compact",
     "internal/tag",
     "internal/triegen",
     "internal/ucd",
@@ -645,32 +653,41 @@
     "width",
   ]
   pruneopts = ""
-  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
-  version = "v0.3.0"
+  revision = "342b2e1fbaa52c93f31447ad2c6abc048c63e475"
+  version = "v0.3.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:14cb1d4240bcbbf1386ae763957e04e2765ec4e4ce7bb2769d05fa6faccd774e"
+  digest = "1:c43c206d0f8927031df6fc877cf58502af5ff875b76b4ceb6b617b676f7731f7"
   name = "golang.org/x/time"
   packages = ["rate"]
   pruneopts = ""
-  revision = "85acf8d2951cb2a3bde7632f9ff273ef0379bcbd"
+  revision = "555d28b269f0569763d25dbe1a237ae74c6bcc82"
 
 [[projects]]
   branch = "master"
-  digest = "1:882f3bb4a5ee4ce6f76c9c5833dd5ccb3282269949cd9f1c0d9212b45cb298c9"
+  digest = "1:a9341f466e54cd77c62428c523e7fc68764ae94a637d7ec3f50b91f8be6d6c52"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
+    "go/gcexportdata",
+    "go/internal/gcimporter",
+    "go/internal/packagesdriver",
+    "go/packages",
+    "go/types/typeutil",
     "imports",
     "internal/fastwalk",
     "internal/gopathwalk",
+    "internal/imports",
+    "internal/module",
+    "internal/semver",
+    "internal/span",
   ]
   pruneopts = ""
-  revision = "2ddaf7f79a0937ffa9072ede7b696fd084abfe86"
+  revision = "6e064ea0cf2dcfaca8da2da9f42da458bab38756"
 
 [[projects]]
-  digest = "1:77d3cff3a451d50be4b52db9c7766c0d8570ba47593f0c9dc72173adb208e788"
+  digest = "1:c4404231035fad619a12f82ae3f0f8f9edc1cc7f34e7edad7a28ccac5336cc96"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -685,8 +702,8 @@
     "urlfetch",
   ]
   pruneopts = ""
-  revision = "4a4468ece617fc8205e99368fa2200e9d1fad421"
-  version = "v1.3.0"
+  revision = "971852bfffca25b069c31162ae8f247a3dba083b"
+  version = "v1.6.5"
 
 [[projects]]
   digest = "1:75fb3fcfc73a8c723efde7777b40e8e8ff9babf30d8c56160d01beffea8a95a6"
@@ -697,7 +714,7 @@
   version = "v0.9.1"
 
 [[projects]]
-  digest = "1:ddc5fa8f9159bea7d1ce58143e6d8fd8054018f7bc3709940aa7f7bc92855ed9"
+  digest = "1:ba3a06e718d7af979eb34dbb0f6bcb29754ceee7fdb4f257542652a74c67fb2d"
   name = "gopkg.in/square/go-jose.v2"
   packages = [
     ".",
@@ -706,20 +723,20 @@
     "jwt",
   ]
   pruneopts = ""
-  revision = "ef984e69dd356202fd4e4910d4d9c24468bdf0b8"
-  version = "v2.1.9"
+  revision = "8fd82ff1d52a5162ff23c0a48e2c64a1fa4a3f8f"
+  version = "v2.4.0"
 
 [[projects]]
-  digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
+  digest = "1:5a53f6ef09fb1ac261a97f8a72e8837ff53cbaa969022a6679da210e4cbe9b0f"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = ""
-  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
-  version = "v2.2.1"
+  revision = "1f64d6156d11335c3f22d9330b0ad14fc1e789ce"
+  version = "v2.2.7"
 
 [[projects]]
-  branch = "release-1.16"
-  digest = "1:5e5cfbab57ea5444c1eb295a39fdc403f097f5ace592c829db7b3e0e3ea66903"
+  branch = "release-1.17"
+  digest = "1:56e60433de6cd760ef423329df7ee112fe5020198dc8efb1858be27de59626ef"
   name = "k8s.io/api"
   packages = [
     "admission/v1",
@@ -745,8 +762,10 @@
     "coordination/v1beta1",
     "core/v1",
     "discovery/v1alpha1",
+    "discovery/v1beta1",
     "events/v1beta1",
     "extensions/v1beta1",
+    "flowcontrol/v1alpha1",
     "imagepolicy/v1alpha1",
     "networking/v1",
     "networking/v1beta1",
@@ -765,11 +784,11 @@
     "storage/v1beta1",
   ]
   pruneopts = ""
-  revision = "195af9ec35214c6d98662c5791364285bf2e2cf2"
+  revision = "4ed536977f46736ee9334e6e29097551f17e8211"
 
 [[projects]]
-  branch = "release-1.16"
-  digest = "1:ea9d3d1bec3c3ecdfef0e0f92dc1c99468e9a13fedfb7f1bc297ae6c88968619"
+  branch = "release-1.17"
+  digest = "1:f49350d53ae2982ec596f0d4936e12750fb7329891a9eba38db7e441539b4eb7"
   name = "k8s.io/apiextensions-apiserver"
   packages = [
     "pkg/apis/apiextensions",
@@ -777,11 +796,11 @@
     "pkg/features",
   ]
   pruneopts = ""
-  revision = "59c675dd9926a891c040ac814ecea8dba8598c63"
+  revision = "a52f1408cb2530e556fdff6b872021b4947dada7"
 
 [[projects]]
-  branch = "release-1.16"
-  digest = "1:8ac118b8194fbc5d845ca59c3e3ca2e179ffe49a3f4db9093cd636f423f32f2d"
+  branch = "release-1.17"
+  digest = "1:ebe6841dab09284a758103248a80009c7512074ed8bede2ef5b25d42cd90ba80"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -791,6 +810,7 @@
     "pkg/api/resource",
     "pkg/api/validation",
     "pkg/apis/meta/internalversion",
+    "pkg/apis/meta/internalversion/scheme",
     "pkg/apis/meta/v1",
     "pkg/apis/meta/v1/unstructured",
     "pkg/apis/meta/v1/unstructured/unstructuredscheme",
@@ -841,11 +861,11 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = ""
-  revision = "a2eda9f80ab8a454a81bdde16d62a1afe5f931c0"
+  revision = "79c2a76c473a20cdc4ce59cae4b72529b5d9d16b"
 
 [[projects]]
-  branch = "release-1.16"
-  digest = "1:e077a9d0f91972dd98d17b570a7d2f9dc45bf1104a9fd836ca727f193e4c617c"
+  branch = "release-1.17"
+  digest = "1:0e551a2cb3e79f93d644e88dbaad469b4b1540054e0c30cb7432b7e6f1c013e9"
   name = "k8s.io/apiserver"
   packages = [
     "pkg/authentication/authenticator",
@@ -856,11 +876,11 @@
     "pkg/util/feature",
   ]
   pruneopts = ""
-  revision = "3fdfe2c6555525ae54a58d22cd7f014a25ce749d"
+  revision = "5a28f8b2ad8e9028a7bfb77c3fb149a8f3fb71bb"
 
 [[projects]]
-  branch = "release-1.16"
-  digest = "1:b46a88b317c3187b6fa7c5351eca48b35aad182eee371168677747430ff955bb"
+  branch = "release-1.17"
+  digest = "1:8fbb3cdb703a9c3ab0da305ae057dc2929233769e41a2f1a01a46f61a720a751"
   name = "k8s.io/cli-runtime"
   packages = [
     "pkg/genericclioptions",
@@ -877,11 +897,11 @@
     "pkg/resource",
   ]
   pruneopts = ""
-  revision = "6bff60de437070d7e8644b7a930837d5de512240"
+  revision = "0b9013f67e6cd086bccd6773f4a4d03b567212d9"
 
 [[projects]]
-  branch = "release-13.0"
-  digest = "1:9e7a28fb6a57b9eb2e7730a2d152a5618a0e913415a13bca76607e799d39fd85"
+  branch = "release-14.0"
+  digest = "1:3757a99a03f5907565e068354433cdb00b5ad5c0cd7468c575c39b0248dd562e"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -916,10 +936,13 @@
     "informers/core/v1",
     "informers/discovery",
     "informers/discovery/v1alpha1",
+    "informers/discovery/v1beta1",
     "informers/events",
     "informers/events/v1beta1",
     "informers/extensions",
     "informers/extensions/v1beta1",
+    "informers/flowcontrol",
+    "informers/flowcontrol/v1alpha1",
     "informers/internalinterfaces",
     "informers/networking",
     "informers/networking/v1",
@@ -988,10 +1011,14 @@
     "kubernetes/typed/core/v1/fake",
     "kubernetes/typed/discovery/v1alpha1",
     "kubernetes/typed/discovery/v1alpha1/fake",
+    "kubernetes/typed/discovery/v1beta1",
+    "kubernetes/typed/discovery/v1beta1/fake",
     "kubernetes/typed/events/v1beta1",
     "kubernetes/typed/events/v1beta1/fake",
     "kubernetes/typed/extensions/v1beta1",
     "kubernetes/typed/extensions/v1beta1/fake",
+    "kubernetes/typed/flowcontrol/v1alpha1",
+    "kubernetes/typed/flowcontrol/v1alpha1/fake",
     "kubernetes/typed/networking/v1",
     "kubernetes/typed/networking/v1/fake",
     "kubernetes/typed/networking/v1beta1",
@@ -1039,8 +1066,10 @@
     "listers/coordination/v1beta1",
     "listers/core/v1",
     "listers/discovery/v1alpha1",
+    "listers/discovery/v1beta1",
     "listers/events/v1beta1",
     "listers/extensions/v1beta1",
+    "listers/flowcontrol/v1alpha1",
     "listers/networking/v1",
     "listers/networking/v1beta1",
     "listers/node/v1alpha1",
@@ -1106,11 +1135,11 @@
     "util/workqueue",
   ]
   pruneopts = ""
-  revision = "f06fe3961ca9f09ba2f23c3c83decd95186d71c2"
+  revision = "3a262fe58afa1b373d52d77e9f44e09355de0c82"
 
 [[projects]]
   branch = "master"
-  digest = "1:2929909e6a506832aa3924522331d43aab91d17c85399802bd960e428cef5d6d"
+  digest = "1:00b6bba6e1264189d3ad10486b82f16f5954ef031b1160e594b93fed62bd413d"
   name = "k8s.io/cluster-bootstrap"
   packages = [
     "token/api",
@@ -1118,11 +1147,11 @@
     "util/secrets",
   ]
   pruneopts = ""
-  revision = "f632ced2d31d86dd39523c0625e3b52642d5289f"
+  revision = "9cd964a09fe2d3597f2f7071b10d8c9beaeffc06"
 
 [[projects]]
-  branch = "release-1.16"
-  digest = "1:254da4cb69b3776686b730a206e081e6f8898bb64760619d1895c25c407e718f"
+  branch = "release-1.17"
+  digest = "1:ca606588d89081ab930c37f9f6754c94e919fe24f8c80f92550bcde9b80b8438"
   name = "k8s.io/code-generator"
   packages = [
     "cmd/client-gen",
@@ -1137,22 +1166,24 @@
     "pkg/util",
   ]
   pruneopts = ""
-  revision = "8e001e5d18949be7e823ccb9cfe9b60026e7bda0"
+  revision = "e95606b614f049ef6087115cb340d8d5805b8da7"
 
 [[projects]]
   branch = "master"
-  digest = "1:727faf154ba5437cba7957d087b3e9f330f6ee0e15f91e2eba4dbba491bb53ff"
+  digest = "1:b7b8ac6452811e1a2d7bc1a80336c2c51eb228c5c65574bf6d84eed3b7e0c8ff"
   name = "k8s.io/component-base"
   packages = [
     "config",
+    "config/v1alpha1",
     "featuregate",
+    "version",
   ]
   pruneopts = ""
-  revision = "4062e14deebed23a9af22e52b675e89cb753b99e"
+  revision = "9e57f2cf1edade764d8307c4f3d4073e204d46de"
 
 [[projects]]
   branch = "master"
-  digest = "1:0cc7d194e005097afad585545a3049ac7b5d1e3a1bfa86aa6bf6f2fb0e0a5063"
+  digest = "1:c75b39778d0f13a692738ff3029c0a211f8be840bbdfb912dc47544d45c188ac"
   name = "k8s.io/gengo"
   packages = [
     "args",
@@ -1163,19 +1194,19 @@
     "types",
   ]
   pruneopts = ""
-  revision = "fd15ee9cc2f77baa4f31e59e6acbf21146455073"
+  revision = "e74f70b9b27e1167f8aba52265fe03a6805efdcd"
 
 [[projects]]
-  digest = "1:32e54cfe25c8eea758b1e0d3aec033ba652d0557cb79ee62d1ba239f5f694c0e"
+  digest = "1:7ce71844fcaaabcbe09a392902edb5790ddca3a7070ae8d20830dc6dbe2751af"
   name = "k8s.io/klog"
   packages = ["."]
   pruneopts = ""
-  revision = "89e63fd5117f8c20208186ef85f096703a280c20"
-  version = "v0.3.1"
+  revision = "2ca9ad30301bf30a8a6e0fa2110db6b8df699a91"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:e5d4ca90c0f3862515c98454bb37d4d340f4ceeca60ac3e0a5cb5857360aed7c"
+  digest = "1:16a343bd9d820ae320de4d1eaa8acc7a214aac4b38fb21d03255d3a457d861df"
   name = "k8s.io/kube-openapi"
   packages = [
     "cmd/openapi-gen",
@@ -1189,11 +1220,19 @@
     "pkg/util/sets",
   ]
   pruneopts = ""
-  revision = "0317810137be915b9cf888946c6e115c1bfac693"
+  revision = "30be4d16710ac61bce31eb28a01054596fe6a9f1"
 
 [[projects]]
-  branch = "release-1.16"
-  digest = "1:687af22932f9b53ff2e6755b2eefe160f076d522794abb980f0ddb187bcefacd"
+  branch = "master"
+  digest = "1:08747027bb8eb57fc7694289abdb1cc0e57cadc413ba4e1f3b8483dd53171b90"
+  name = "k8s.io/kube-proxy"
+  packages = ["config/v1alpha1"]
+  pruneopts = ""
+  revision = "f5c1e18580248d7240c9a3bf1c4a3c424126f1f4"
+
+[[projects]]
+  branch = "release-1.17"
+  digest = "1:caf7117fae0618d93a517db3a3058ebeedfdea5ff6b4937c5164bc993c4df5a0"
   name = "k8s.io/kubectl"
   packages = [
     "pkg/cmd/testing",
@@ -1206,20 +1245,26 @@
     "pkg/util/templates",
     "pkg/util/term",
     "pkg/validation",
-    "pkg/version",
   ]
   pruneopts = ""
-  revision = "14647fd13a8b4cffc5a8f327b0018e037f72e4e8"
+  revision = "2be0bc77e782f4bf3c3c1dd64d63c24e37a74e67"
 
 [[projects]]
-  branch = "release-1.16"
-  digest = "1:985440fa37318b73e722b1d50d75635e08e2ed76aac87e7362fadcad4a9d8fa3"
+  branch = "master"
+  digest = "1:b7190022a979a6fd5593e2a5c7c7c4d9aa53c7bd225646b5196097da7b1df4e4"
+  name = "k8s.io/kubelet"
+  packages = ["config/v1beta1"]
+  pruneopts = ""
+  revision = "1af7323de76f8169903bcd0baf047ab3ca690059"
+
+[[projects]]
+  branch = "release-1.17"
+  digest = "1:48d253b36b32f162381524a3651af65b64756cdac9250c884b20b9d78467307d"
   name = "k8s.io/kubernetes"
   packages = [
     "cmd/kubeadm/app/apis/kubeadm",
     "cmd/kubeadm/app/constants",
     "cmd/kubeadm/app/util",
-    "cmd/kubeadm/app/version",
     "pkg/api/legacyscheme",
     "pkg/api/service",
     "pkg/api/v1/pod",
@@ -1237,12 +1282,8 @@
     "pkg/controller",
     "pkg/features",
     "pkg/fieldpath",
-    "pkg/kubelet/apis/config",
     "pkg/kubelet/types",
     "pkg/master/ports",
-    "pkg/proxy/apis/config",
-    "pkg/registry/core/service/allocator",
-    "pkg/registry/core/service/ipallocator",
     "pkg/security/apparmor",
     "pkg/serviceaccount",
     "pkg/util/hash",
@@ -1252,11 +1293,11 @@
     "pkg/util/taints",
   ]
   pruneopts = ""
-  revision = "a2ff5d71deafff1d9688eb6f7533dd239980c420"
+  revision = "7041fe06b91759007a05edd1b3a1089e14e53090"
 
 [[projects]]
   branch = "master"
-  digest = "1:874afa816ece04beefd8724c8d397fdccc80c5d6d72ed8567e9af47b928887c9"
+  digest = "1:a8a2e6bbef691323b833d0eb11bb0e570e7eb9619ac76f7b11265530e1cac922"
   name = "k8s.io/utils"
   packages = [
     "buffer",
@@ -1268,7 +1309,7 @@
     "trace",
   ]
   pruneopts = ""
-  revision = "69764acb6e8e900b7c05296c5d3c9c19545475f9"
+  revision = "6ca3b61696b65b0e81f1a39b4937fc2d2994ed6a"
 
 [[projects]]
   digest = "1:0b2daace3dcced8712072529b621360cf520f3c2ead92d755f35a0ec8dca2714"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -7,39 +7,43 @@ required = [
 
 [[constraint]]
   name = "k8s.io/client-go"
-  branch = "release-13.0"
+  branch = "release-14.0"
+
+[[constraint]]
+  name = "istio.io/client-go"
+  branch = "release-1.4"
 
 [[constraint]]
   name = "k8s.io/code-generator"
-  branch = "release-1.16"
+  branch = "release-1.17"
 
 [[constraint]]
-  branch = "release-1.16"
+  branch = "release-1.17"
   name = "k8s.io/api"
 
 [[constraint]]
   name = "k8s.io/apiserver"
-  branch = "release-1.16"
+  branch = "release-1.17"
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  branch = "release-1.16"
+  branch = "release-1.17"
 
 [[constraint]]
   name = "k8s.io/kubernetes"
-  branch = "release-1.16"
+  branch = "release-1.17"
 
 [[constraint]]
   name = "k8s.io/apiextensions-apiserver"
-  branch = "release-1.16"
+  branch = "release-1.17"
 
 [[constraint]]
   name = "k8s.io/cli-runtime"
-  branch = "release-1.16"
+  branch = "release-1.17"
 
 [[constraint]]
   name = "k8s.io/kubectl"
-  branch = "release-1.16"
+  branch = "release-1.17"
 
 [[constraint]]
   name = "github.com/bouk/monkey"

--- a/metricproviders/prometheus/mock_test.go
+++ b/metricproviders/prometheus/mock_test.go
@@ -4,24 +4,30 @@ import (
 	"context"
 	"time"
 
+	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 )
 
 type mockAPI struct {
-	value model.Value
-	err   error
+	value    model.Value
+	warnings []string
+	err      error
 }
 
 // Query performs a query for the given time.
-func (m mockAPI) Query(ctx context.Context, query string, ts time.Time) (model.Value, error) {
+func (m mockAPI) Query(ctx context.Context, query string, ts time.Time) (model.Value, api.Warnings, error) {
 	if m.err != nil {
-		return nil, m.err
+		return nil, nil, m.err
 	}
-	return m.value, nil
+	return m.value, m.warnings, nil
 }
 
 // Below methods are not used but required for the interface implementation
+
+func (m mockAPI) Alerts(ctx context.Context) (v1.AlertsResult, error) {
+	return v1.AlertsResult{}, nil
+}
 
 func (m mockAPI) AlertManagers(ctx context.Context) (v1.AlertManagersResult, error) {
 	return v1.AlertManagersResult{}, nil
@@ -47,19 +53,27 @@ func (m mockAPI) Flags(ctx context.Context) (v1.FlagsResult, error) {
 	return v1.FlagsResult{}, nil
 }
 
+func (m mockAPI) LabelNames(ctx context.Context) ([]string, api.Warnings, error) {
+	return nil, nil, nil
+}
+
 // LabelValues performs a query for the values of the given label.
-func (m mockAPI) LabelValues(ctx context.Context, label string) (model.LabelValues, error) {
-	return nil, nil
+func (m mockAPI) LabelValues(ctx context.Context, label string) (model.LabelValues, api.Warnings, error) {
+	return nil, nil, nil
 }
 
 // QueryRange performs a query for the given range.
-func (m mockAPI) QueryRange(ctx context.Context, query string, r v1.Range) (model.Value, error) {
-	return nil, nil
+func (m mockAPI) QueryRange(ctx context.Context, query string, r v1.Range) (model.Value, api.Warnings, error) {
+	return nil, nil, nil
+}
+
+func (m mockAPI) Rules(ctx context.Context) (v1.RulesResult, error) {
+	return v1.RulesResult{}, nil
 }
 
 // Series finds series by label matchers.
-func (m mockAPI) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, error) {
-	return nil, nil
+func (m mockAPI) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, api.Warnings, error) {
+	return nil, nil, nil
 }
 
 // Snapshot creates a snapshot of all current data into snapshots/<datetime>-<rand>
@@ -71,4 +85,8 @@ func (m mockAPI) Snapshot(ctx context.Context, skipHead bool) (v1.SnapshotResult
 // Targets returns an overview of the current state of the Prometheus target discovery.
 func (m mockAPI) Targets(ctx context.Context) (v1.TargetsResult, error) {
 	return v1.TargetsResult{}, nil
+}
+
+func (m mockAPI) TargetsMetadata(ctx context.Context, matchTarget string, metric string, limit string) ([]v1.MetricMetadata, error) {
+	return nil, nil
 }

--- a/pkg/apis/rollouts/v1alpha1/analysis_types.go
+++ b/pkg/apis/rollouts/v1alpha1/analysis_types.go
@@ -22,15 +22,20 @@ type AnalysisTemplate struct {
 type AnalysisTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`
-	Items           []AnalysisTemplate `json:"items"`
+	// +listType=set
+	Items []AnalysisTemplate `json:"items"`
 }
 
 // AnalysisTemplateSpec is the specification for a AnalysisTemplate resource
 type AnalysisTemplateSpec struct {
 	// Metrics contains the list of metrics to query as part of an analysis run
+	// +listType=map
+	// +listMapKey=name
 	Metrics []Metric `json:"metrics"`
 	// Args are the list of arguments to the template
 	// +optional
+	// +listType=map
+	// +listMapKey=name
 	Args []Argument `json:"args,omitempty"`
 }
 
@@ -154,15 +159,20 @@ type AnalysisRun struct {
 type AnalysisRunList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`
-	Items           []AnalysisRun `json:"items"`
+	// +listType=atomic
+	Items []AnalysisRun `json:"items"`
 }
 
 // AnalysisRunSpec is the spec for a AnalysisRun resource
 type AnalysisRunSpec struct {
 	// Metrics contains the list of metrics to query as part of an analysis run
+	// +listType=map
+	// +listMapKey=name
 	Metrics []Metric `json:"metrics"`
 	// Args are the list of arguments used in this run
 	// +optional
+	// +listType=map
+	// +listMapKey=name
 	Args []Argument `json:"args,omitempty"`
 	// Terminate is used to prematurely stop the run (e.g. rollout completed and analysis is no longer desired)
 	Terminate bool `json:"terminate,omitempty"`
@@ -184,6 +194,8 @@ type AnalysisRunStatus struct {
 	// Message is a message explaining current status
 	Message string `json:"message,omitempty"`
 	// MetricResults contains the metrics collected during the run
+	// +listType=map
+	// +listMapKey=name
 	MetricResults []MetricResult `json:"metricResults,omitempty"`
 }
 
@@ -195,6 +207,7 @@ type MetricResult struct {
 	// Phase is the overall aggregate status of the metric
 	Phase AnalysisPhase `json:"phase"`
 	// Measurements holds the most recent measurements collected for the metric
+	// +listType=atomic
 	Measurements []Measurement `json:"measurements,omitempty"`
 	// Message contains a message describing current condition (e.g. error messages)
 	Message string `json:"message,omitempty"`
@@ -245,7 +258,8 @@ type KayentaMetric struct {
 	StorageAccountName       string `json:"storageAccountName"`
 
 	Threshold KayentaThreshold `json:"threshold"`
-
+	// +listType=map
+	// +listMapKey=name
 	Scopes []KayentaScope `json:"scopes"`
 }
 

--- a/pkg/apis/rollouts/v1alpha1/experiment_types.go
+++ b/pkg/apis/rollouts/v1alpha1/experiment_types.go
@@ -27,6 +27,8 @@ type Experiment struct {
 // ExperimentSpec is the spec for a Experiment resource
 type ExperimentSpec struct {
 	// Templates are a list of PodSpecs that define the ReplicaSets that should be run during an experiment.
+	// +listType=map
+	// +listMapKey=name
 	Templates []TemplateSpec `json:"templates"`
 	// Duration the amount of time for the experiment to run as a duration string (e.g. 30s, 5m, 1h).
 	// If omitted, the experiment will run indefinitely, stopped either via termination, or a failed analysis run.
@@ -42,6 +44,8 @@ type ExperimentSpec struct {
 	// Terminate is used to prematurely stop the experiment
 	Terminate bool `json:"terminate,omitempty"`
 	// Analyses references AnalysisTemplates to run during the experiment
+	// +listType=map
+	// +listMapKey=name
 	Analyses []ExperimentAnalysisTemplateRef `json:"analyses,omitempty"`
 }
 
@@ -119,6 +123,8 @@ type ExperimentStatus struct {
 	Message string `json:"message,omitempty"`
 	// TemplateStatuses holds the ReplicaSet related statuses for individual templates
 	// +optional
+	// +listType=map
+	// +listMapKey=name
 	TemplateStatuses []TemplateStatus `json:"templateStatuses,omitempty"`
 	// AvailableAt the time when all the templates become healthy and the experiment should start tracking the time to
 	// run for the duration of specificed in the spec.
@@ -126,9 +132,13 @@ type ExperimentStatus struct {
 	AvailableAt *metav1.Time `json:"availableAt,omitempty"`
 	// Conditions a list of conditions a experiment can have.
 	// +optional
+	// +listType=map
+	// +listMapKey=type
 	Conditions []ExperimentCondition `json:"conditions,omitempty"`
 	// AnalysisRuns tracks the status of AnalysisRuns associated with this Experiment
 	// +optional
+	// +listType=map
+	// +listMapKey=name
 	AnalysisRuns []ExperimentAnalysisRunStatus `json:"analysisRuns,omitempty"`
 }
 
@@ -178,7 +188,7 @@ type ExperimentCondition struct {
 type ExperimentList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`
-
+	// +listType=set
 	Items []Experiment `json:"items"`
 }
 
@@ -189,6 +199,8 @@ type ExperimentAnalysisTemplateRef struct {
 	TemplateName string `json:"templateName"`
 	// Args are the arguments that will be added to the AnalysisRuns
 	// +optional
+	// +listType=map
+	// +listMapKey=name
 	Args []Argument `json:"args,omitempty"`
 }
 

--- a/pkg/apis/rollouts/v1alpha1/openapi_generated.go
+++ b/pkg/apis/rollouts/v1alpha1/openapi_generated.go
@@ -84,6 +84,7 @@ func schema_pkg_apis_rollouts_v1alpha1_AnalysisRun(ref common.ReferenceCallback)
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "AnalysisRun is an instantiation of an AnalysisTemplate",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -128,6 +129,7 @@ func schema_pkg_apis_rollouts_v1alpha1_AnalysisRunArgument(ref common.ReferenceC
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "AnalysisRunArgument argument to add to analysisRun",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
@@ -163,6 +165,7 @@ func schema_pkg_apis_rollouts_v1alpha1_AnalysisRunList(ref common.ReferenceCallb
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "AnalysisRunList is a list of AnalysisTemplate resources",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -184,6 +187,11 @@ func schema_pkg_apis_rollouts_v1alpha1_AnalysisRunList(ref common.ReferenceCallb
 						},
 					},
 					"items": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{
@@ -209,8 +217,17 @@ func schema_pkg_apis_rollouts_v1alpha1_AnalysisRunSpec(ref common.ReferenceCallb
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "AnalysisRunSpec is the spec for a AnalysisRun resource",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"metrics": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Metrics contains the list of metrics to query as part of an analysis run",
 							Type:        []string{"array"},
@@ -224,6 +241,14 @@ func schema_pkg_apis_rollouts_v1alpha1_AnalysisRunSpec(ref common.ReferenceCallb
 						},
 					},
 					"args": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Args are the list of arguments used in this run",
 							Type:        []string{"array"},
@@ -257,6 +282,7 @@ func schema_pkg_apis_rollouts_v1alpha1_AnalysisRunStatus(ref common.ReferenceCal
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "AnalysisRunStatus is the status for a AnalysisRun resource",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"phase": {
 						SchemaProps: spec.SchemaProps{
@@ -273,6 +299,14 @@ func schema_pkg_apis_rollouts_v1alpha1_AnalysisRunStatus(ref common.ReferenceCal
 						},
 					},
 					"metricResults": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "MetricResults contains the metrics collected during the run",
 							Type:        []string{"array"},
@@ -299,6 +333,7 @@ func schema_pkg_apis_rollouts_v1alpha1_AnalysisTemplate(ref common.ReferenceCall
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "AnalysisTemplate holds the template for performing canary analysis",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -338,6 +373,7 @@ func schema_pkg_apis_rollouts_v1alpha1_AnalysisTemplateList(ref common.Reference
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "AnalysisTemplateList is a list of AnalysisTemplate resources",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -359,6 +395,11 @@ func schema_pkg_apis_rollouts_v1alpha1_AnalysisTemplateList(ref common.Reference
 						},
 					},
 					"items": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "set",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{
@@ -384,8 +425,17 @@ func schema_pkg_apis_rollouts_v1alpha1_AnalysisTemplateSpec(ref common.Reference
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "AnalysisTemplateSpec is the specification for a AnalysisTemplate resource",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"metrics": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Metrics contains the list of metrics to query as part of an analysis run",
 							Type:        []string{"array"},
@@ -399,6 +449,14 @@ func schema_pkg_apis_rollouts_v1alpha1_AnalysisTemplateSpec(ref common.Reference
 						},
 					},
 					"args": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Args are the list of arguments to the template",
 							Type:        []string{"array"},
@@ -425,6 +483,7 @@ func schema_pkg_apis_rollouts_v1alpha1_Argument(ref common.ReferenceCallback) co
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "Argument is an argument to an AnalysisRun",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
@@ -444,7 +503,6 @@ func schema_pkg_apis_rollouts_v1alpha1_Argument(ref common.ReferenceCallback) co
 				Required: []string{"name"},
 			},
 		},
-		Dependencies: []string{},
 	}
 }
 
@@ -453,6 +511,7 @@ func schema_pkg_apis_rollouts_v1alpha1_ArgumentValueFrom(ref common.ReferenceCal
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "ArgumentValueFrom defines references to fields within resources to grab for the value (i.e. Pod Template Hash)",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"podTemplateHashValue": {
 						SchemaProps: spec.SchemaProps{
@@ -464,7 +523,6 @@ func schema_pkg_apis_rollouts_v1alpha1_ArgumentValueFrom(ref common.ReferenceCal
 				},
 			},
 		},
-		Dependencies: []string{},
 	}
 }
 
@@ -473,6 +531,7 @@ func schema_pkg_apis_rollouts_v1alpha1_BlueGreenStatus(ref common.ReferenceCallb
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "BlueGreenStatus status fields that only pertain to the blueGreen rollout",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"previewSelector": {
 						SchemaProps: spec.SchemaProps{
@@ -521,6 +580,7 @@ func schema_pkg_apis_rollouts_v1alpha1_BlueGreenStrategy(ref common.ReferenceCal
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "BlueGreenStrategy defines parameters for Blue Green deployment",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"activeService": {
 						SchemaProps: spec.SchemaProps{
@@ -575,7 +635,6 @@ func schema_pkg_apis_rollouts_v1alpha1_BlueGreenStrategy(ref common.ReferenceCal
 				Required: []string{"activeService"},
 			},
 		},
-		Dependencies: []string{},
 	}
 }
 
@@ -584,6 +643,7 @@ func schema_pkg_apis_rollouts_v1alpha1_CanaryStatus(ref common.ReferenceCallback
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "CanaryStatus status fields that only pertain to the canary rollout",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"stableRS": {
 						SchemaProps: spec.SchemaProps{
@@ -616,7 +676,6 @@ func schema_pkg_apis_rollouts_v1alpha1_CanaryStatus(ref common.ReferenceCallback
 				},
 			},
 		},
-		Dependencies: []string{},
 	}
 }
 
@@ -625,6 +684,7 @@ func schema_pkg_apis_rollouts_v1alpha1_CanaryStep(ref common.ReferenceCallback) 
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "CanaryStep defines a step of a canary deployment.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"setWeight": {
 						SchemaProps: spec.SchemaProps{
@@ -664,6 +724,7 @@ func schema_pkg_apis_rollouts_v1alpha1_CanaryStrategy(ref common.ReferenceCallba
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "CanaryStrategy defines parameters for a Replica Based Canary",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"canaryService": {
 						SchemaProps: spec.SchemaProps{
@@ -673,6 +734,11 @@ func schema_pkg_apis_rollouts_v1alpha1_CanaryStrategy(ref common.ReferenceCallba
 						},
 					},
 					"steps": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Steps define the order of phases to execute the canary deployment",
 							Type:        []string{"array"},
@@ -716,6 +782,7 @@ func schema_pkg_apis_rollouts_v1alpha1_Experiment(ref common.ReferenceCallback) 
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "Experiment is a specification for an Experiment resource",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -759,6 +826,7 @@ func schema_pkg_apis_rollouts_v1alpha1_ExperimentAnalysisRunStatus(ref common.Re
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
@@ -792,7 +860,6 @@ func schema_pkg_apis_rollouts_v1alpha1_ExperimentAnalysisRunStatus(ref common.Re
 				Required: []string{"name", "analysisRun", "phase"},
 			},
 		},
-		Dependencies: []string{},
 	}
 }
 
@@ -800,6 +867,7 @@ func schema_pkg_apis_rollouts_v1alpha1_ExperimentAnalysisTemplateRef(ref common.
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
@@ -816,6 +884,14 @@ func schema_pkg_apis_rollouts_v1alpha1_ExperimentAnalysisTemplateRef(ref common.
 						},
 					},
 					"args": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Args are the arguments that will be added to the AnalysisRuns",
 							Type:        []string{"array"},
@@ -842,6 +918,7 @@ func schema_pkg_apis_rollouts_v1alpha1_ExperimentCondition(ref common.ReferenceC
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "ExperimentCondition describes the state of a experiment at a certain point.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
@@ -897,6 +974,7 @@ func schema_pkg_apis_rollouts_v1alpha1_ExperimentList(ref common.ReferenceCallba
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "ExperimentList is a list of Experiment resources",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -918,6 +996,11 @@ func schema_pkg_apis_rollouts_v1alpha1_ExperimentList(ref common.ReferenceCallba
 						},
 					},
 					"items": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "set",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{
@@ -943,8 +1026,17 @@ func schema_pkg_apis_rollouts_v1alpha1_ExperimentSpec(ref common.ReferenceCallba
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "ExperimentSpec is the spec for a Experiment resource",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"templates": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Templates are a list of PodSpecs that define the ReplicaSets that should be run during an experiment.",
 							Type:        []string{"array"},
@@ -979,6 +1071,14 @@ func schema_pkg_apis_rollouts_v1alpha1_ExperimentSpec(ref common.ReferenceCallba
 						},
 					},
 					"analyses": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Analyses references AnalysisTemplates to run during the experiment",
 							Type:        []string{"array"},
@@ -1005,6 +1105,7 @@ func schema_pkg_apis_rollouts_v1alpha1_ExperimentStatus(ref common.ReferenceCall
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "ExperimentStatus is the status for a Experiment resource",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"phase": {
 						SchemaProps: spec.SchemaProps{
@@ -1021,6 +1122,14 @@ func schema_pkg_apis_rollouts_v1alpha1_ExperimentStatus(ref common.ReferenceCall
 						},
 					},
 					"templateStatuses": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "TemplateStatuses holds the ReplicaSet related statuses for individual templates",
 							Type:        []string{"array"},
@@ -1040,6 +1149,14 @@ func schema_pkg_apis_rollouts_v1alpha1_ExperimentStatus(ref common.ReferenceCall
 						},
 					},
 					"conditions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"type",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Conditions a list of conditions a experiment can have.",
 							Type:        []string{"array"},
@@ -1053,6 +1170,14 @@ func schema_pkg_apis_rollouts_v1alpha1_ExperimentStatus(ref common.ReferenceCall
 						},
 					},
 					"analysisRuns": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "AnalysisRuns tracks the status of AnalysisRuns associated with this Experiment",
 							Type:        []string{"array"},
@@ -1078,6 +1203,7 @@ func schema_pkg_apis_rollouts_v1alpha1_JobMetric(ref common.ReferenceCallback) c
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "JobMetric defines a job to run which acts as a metric",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
@@ -1102,6 +1228,7 @@ func schema_pkg_apis_rollouts_v1alpha1_KayentaMetric(ref common.ReferenceCallbac
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
 					"address": {
 						SchemaProps: spec.SchemaProps{
@@ -1145,6 +1272,14 @@ func schema_pkg_apis_rollouts_v1alpha1_KayentaMetric(ref common.ReferenceCallbac
 						},
 					},
 					"scopes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{
@@ -1169,6 +1304,7 @@ func schema_pkg_apis_rollouts_v1alpha1_KayentaScope(ref common.ReferenceCallback
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
@@ -1199,6 +1335,7 @@ func schema_pkg_apis_rollouts_v1alpha1_KayentaThreshold(ref common.ReferenceCall
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
 					"pass": {
 						SchemaProps: spec.SchemaProps{
@@ -1216,7 +1353,6 @@ func schema_pkg_apis_rollouts_v1alpha1_KayentaThreshold(ref common.ReferenceCall
 				Required: []string{"pass", "marginal"},
 			},
 		},
-		Dependencies: []string{},
 	}
 }
 
@@ -1225,6 +1361,7 @@ func schema_pkg_apis_rollouts_v1alpha1_Measurement(ref common.ReferenceCallback)
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "Measurement is a point in time result value of a single metric, and the time it was measured",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"phase": {
 						SchemaProps: spec.SchemaProps{
@@ -1264,6 +1401,7 @@ func schema_pkg_apis_rollouts_v1alpha1_Measurement(ref common.ReferenceCallback)
 							Description: "Metadata stores additional metadata about this metric result, used by the different providers (e.g. kayenta run ID, job name)",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Type:   []string{"string"},
@@ -1293,6 +1431,7 @@ func schema_pkg_apis_rollouts_v1alpha1_Metric(ref common.ReferenceCallback) comm
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "Metric defines a metric in which to perform analysis",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
@@ -1370,6 +1509,7 @@ func schema_pkg_apis_rollouts_v1alpha1_MetricProvider(ref common.ReferenceCallba
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "MetricProvider which external system to use to verify the analysis Only one of the fields in this struct should be non-nil",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"prometheus": {
 						SchemaProps: spec.SchemaProps{
@@ -1401,6 +1541,7 @@ func schema_pkg_apis_rollouts_v1alpha1_MetricResult(ref common.ReferenceCallback
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "MetricResult contain a list of the most recent measurements for a single metric along with counters on how often the measurement",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
@@ -1417,6 +1558,11 @@ func schema_pkg_apis_rollouts_v1alpha1_MetricResult(ref common.ReferenceCallback
 						},
 					},
 					"measurements": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Measurements holds the most recent measurements collected for the metric",
 							Type:        []string{"array"},
@@ -1492,6 +1638,7 @@ func schema_pkg_apis_rollouts_v1alpha1_PauseCondition(ref common.ReferenceCallba
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "PauseCondition the reason for a pause and when it started",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"reason": {
 						SchemaProps: spec.SchemaProps{
@@ -1518,12 +1665,14 @@ func schema_pkg_apis_rollouts_v1alpha1_PodTemplateMetadata(ref common.ReferenceC
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "PodTemplateMetadata extra labels to add to the template",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"labels": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Labels Additional labels to add to the experiment",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Type:   []string{"string"},
@@ -1538,6 +1687,7 @@ func schema_pkg_apis_rollouts_v1alpha1_PodTemplateMetadata(ref common.ReferenceC
 							Description: "Annotations additional annotations to add to the experiment",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Type:   []string{"string"},
@@ -1550,7 +1700,6 @@ func schema_pkg_apis_rollouts_v1alpha1_PodTemplateMetadata(ref common.ReferenceC
 				},
 			},
 		},
-		Dependencies: []string{},
 	}
 }
 
@@ -1559,6 +1708,7 @@ func schema_pkg_apis_rollouts_v1alpha1_PrometheusMetric(ref common.ReferenceCall
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "PrometheusMetric defines the prometheus query to perform canary analysis",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"address": {
 						SchemaProps: spec.SchemaProps{
@@ -1577,7 +1727,6 @@ func schema_pkg_apis_rollouts_v1alpha1_PrometheusMetric(ref common.ReferenceCall
 				},
 			},
 		},
-		Dependencies: []string{},
 	}
 }
 
@@ -1586,6 +1735,7 @@ func schema_pkg_apis_rollouts_v1alpha1_Rollout(ref common.ReferenceCallback) com
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "Rollout is a specification for a Rollout resource",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -1630,6 +1780,7 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutAnalysisStep(ref common.ReferenceC
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "RolloutAnalysisStep defines a template that is used to create a analysisRun",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"templateName": {
 						SchemaProps: spec.SchemaProps{
@@ -1639,6 +1790,14 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutAnalysisStep(ref common.ReferenceC
 						},
 					},
 					"args": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Args the arguments that will be added to the AnalysisRuns",
 							Type:        []string{"array"},
@@ -1665,6 +1824,7 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutCondition(ref common.ReferenceCall
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "RolloutCondition describes the state of a rollout at a certain point.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
@@ -1720,8 +1880,14 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutExperimentStep(ref common.Referenc
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "RolloutExperimentStep defines a template that is used to create a experiment for a step",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"templates": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Templates what templates that should be added to the experiment. Should be non-nil",
 							Type:        []string{"array"},
@@ -1742,6 +1908,11 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutExperimentStep(ref common.Referenc
 						},
 					},
 					"analyses": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Analyses reference which analysis templates to run with the experiment",
 							Type:        []string{"array"},
@@ -1767,6 +1938,7 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutExperimentStepAnalysisTemplateRef(
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
@@ -1783,8 +1955,16 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutExperimentStepAnalysisTemplateRef(
 						},
 					},
 					"args": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Args the arguments that will be added to the AnalysisRuns",
+							Description: "Args the arguments that will be added to the",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -1809,6 +1989,7 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutExperimentTemplate(ref common.Refe
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "RolloutExperimentTemplate defines the template used to create experiments for the Rollout's experiment canary step",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
@@ -1857,6 +2038,7 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutList(ref common.ReferenceCallback)
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "RolloutList is a list of Rollout resources",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -1878,6 +2060,11 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutList(ref common.ReferenceCallback)
 						},
 					},
 					"items": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "set",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{
@@ -1903,6 +2090,7 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutPause(ref common.ReferenceCallback
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "RolloutPause defines a pause stage for a rollout",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"duration": {
 						SchemaProps: spec.SchemaProps{
@@ -1914,7 +2102,6 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutPause(ref common.ReferenceCallback
 				},
 			},
 		},
-		Dependencies: []string{},
 	}
 }
 
@@ -1923,6 +2110,7 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutSpec(ref common.ReferenceCallback)
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "RolloutSpec is the spec for a Rollout resource",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"replicas": {
 						SchemaProps: spec.SchemaProps{
@@ -1991,6 +2179,7 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutStatus(ref common.ReferenceCallbac
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "RolloutStatus is the status for a Rollout resource",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"abort": {
 						SchemaProps: spec.SchemaProps{
@@ -2000,6 +2189,14 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutStatus(ref common.ReferenceCallbac
 						},
 					},
 					"pauseConditions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"reason",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "PauseConditions indicates why the rollout is currently paused",
 							Type:        []string{"array"},
@@ -2089,6 +2286,14 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutStatus(ref common.ReferenceCallbac
 						},
 					},
 					"conditions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"type",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Conditions a list of conditions a rollout can have.",
 							Type:        []string{"array"},
@@ -2140,6 +2345,7 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutStrategy(ref common.ReferenceCallb
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "RolloutStrategy defines strategy to apply during next rollout",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"blueGreen": {
 						SchemaProps: spec.SchemaProps{
@@ -2163,6 +2369,7 @@ func schema_pkg_apis_rollouts_v1alpha1_ScopeDetail(ref common.ReferenceCallback)
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
 					"scope": {
 						SchemaProps: spec.SchemaProps{
@@ -2198,7 +2405,6 @@ func schema_pkg_apis_rollouts_v1alpha1_ScopeDetail(ref common.ReferenceCallback)
 				Required: []string{"scope", "region", "step", "start", "end"},
 			},
 		},
-		Dependencies: []string{},
 	}
 }
 
@@ -2206,6 +2412,7 @@ func schema_pkg_apis_rollouts_v1alpha1_TemplateSpec(ref common.ReferenceCallback
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
@@ -2254,6 +2461,7 @@ func schema_pkg_apis_rollouts_v1alpha1_TemplateStatus(ref common.ReferenceCallba
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "TemplateStatus is the status of a specific template of an Experiment",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -116,6 +116,7 @@ type CanaryStrategy struct {
 	CanaryService string `json:"canaryService,omitempty"`
 	// Steps define the order of phases to execute the canary deployment
 	// +optional
+	// +listType=atomic
 	Steps []CanaryStep `json:"steps,omitempty"`
 	// MaxUnavailable The maximum number of pods that can be unavailable during the update.
 	// Value can be an absolute number (ex: 5) or a percentage of total pods at the start of update (ex: 10%).
@@ -149,11 +150,13 @@ type CanaryStrategy struct {
 // RolloutExperimentStep defines a template that is used to create a experiment for a step
 type RolloutExperimentStep struct {
 	// Templates what templates that should be added to the experiment. Should be non-nil
+	// +listType=atomic
 	Templates []RolloutExperimentTemplate `json:"templates"`
 	// Duration is a duration string (e.g. 30s, 5m, 1h) that the experiment should run for
 	// +optional
 	Duration DurationString `json:"duration,omitempty"`
 	// Analyses reference which analysis templates to run with the experiment
+	// +listType=atomic
 	Analyses []RolloutExperimentStepAnalysisTemplateRef `json:"analyses,omitempty"`
 }
 
@@ -162,7 +165,9 @@ type RolloutExperimentStepAnalysisTemplateRef struct {
 	Name string `json:"name"`
 	// TemplateName reference of the AnalysisTemplate name used by the Rollout to create the run
 	TemplateName string `json:"templateName"`
-	// Args the arguments that will be added to the AnalysisRuns
+	// Args the arguments that will be added to the
+	// +listType=map
+	// +listMapKey=name
 	Args []AnalysisRunArgument `json:"args,omitempty"`
 }
 
@@ -223,6 +228,8 @@ type RolloutAnalysisStep struct {
 	// TemplateName reference of the AnalysisTemplate name used by the Rollout to create the run
 	TemplateName string `json:"templateName"`
 	// Args the arguments that will be added to the AnalysisRuns
+	// +listType=map
+	// +listMapKey=name
 	Args []AnalysisRunArgument `json:"args,omitempty"`
 }
 
@@ -295,6 +302,8 @@ type RolloutStatus struct {
 	// Abort cancel the current rollout progression
 	Abort bool `json:"abort,omitempty"`
 	// PauseConditions indicates why the rollout is currently paused
+	// +listType=map
+	// +listMapKey=reason
 	PauseConditions []PauseCondition `json:"pauseConditions,omitempty"`
 	//ControllerPause indicates the controller has paused the rollout
 	ControllerPause bool `json:"controllerPause,omitempty"`
@@ -334,6 +343,8 @@ type RolloutStatus struct {
 	ObservedGeneration string `json:"observedGeneration,omitempty"`
 	// Conditions a list of conditions a rollout can have.
 	// +optional
+	// +listType=map
+	// +listMapKey=type
 	Conditions []RolloutCondition `json:"conditions,omitempty"`
 	// Canary describes the state of the canary rollout
 	// +optional
@@ -428,5 +439,6 @@ type RolloutList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`
 
+	// +listType=set
 	Items []Rollout `json:"items"`
 }


### PR DESCRIPTION
To introduce the istio/client-go library, I needed to upgrade the K8s libraries to v1.17. As a result, I needed to:
- Change the query method on the Prometheus API interface and update the mock to match the changes in the interface
- Add the `listType` go tag to all the types.go to start preparing for server-side apply. Check out https://github.com/kubernetes/kube-openapi/issues/175 for the API violations that would occur without these tags and https://godoc.org/k8s.io/kube-openapi/pkg/idl for what tags are available.               