### PR TITLE
fix: omitted revisionHistoryLimit was not defaulting to 10

### DIFF
--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -369,9 +369,7 @@ func (c *RolloutController) calculateBaseStatus(roCtx rolloutContext) v1alpha1.R
 func (c *RolloutController) cleanupRollouts(oldRSs []*appsv1.ReplicaSet, roCtx rolloutContext) error {
 	rollout := roCtx.Rollout()
 	logCtx := roCtx.Log()
-	if !conditions.HasRevisionHistoryLimit(rollout) {
-		return nil
-	}
+	revHistoryLimit := defaults.GetRevisionHistoryLimitOrDefault(rollout)
 
 	// Avoid deleting replica set with deletion timestamp set
 	aliveFilter := func(rs *appsv1.ReplicaSet) bool {
@@ -379,7 +377,7 @@ func (c *RolloutController) cleanupRollouts(oldRSs []*appsv1.ReplicaSet, roCtx r
 	}
 	cleanableRSes := controller.FilterReplicaSets(oldRSs, aliveFilter)
 
-	diff := int32(len(cleanableRSes)) - *rollout.Spec.RevisionHistoryLimit
+	diff := int32(len(cleanableRSes)) - revHistoryLimit
 	if diff <= 0 {
 		return nil
 	}


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/329

Also the unit test was not verifying that the correct number of deletes were happening, only that when a delete did happen, it was to an expected replicaset.