### PR TITLE
Remove loud log message

### DIFF
--- a/utils/controller/controller.go
+++ b/utils/controller/controller.go
@@ -81,7 +81,6 @@ func processNextWorkItem(workqueue workqueue.RateLimitingInterface, objType stri
 		// Finally, if no error occurs we Forget this item so it does not
 		// get queued again until another change happens.
 		workqueue.Forget(obj)
-		logCtx.Info("Successfully synced")
 		return nil
 	}(obj)
 


### PR DESCRIPTION
This log message does not offer any insights into the various resources being synced and pollutes the logs with hundreds of `Successfully synced` messages. Most of these messages come from the service controller that has to process all the services in the cluster regardless if they are used by the rollout.