### PR TITLE
feat: Add stableService field

### DIFF
--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -114,6 +114,9 @@ type CanaryStrategy struct {
 	// CanaryService holds the name of a service which selects pods with canary version and don't select any pods with stable version.
 	// +optional
 	CanaryService string `json:"canaryService,omitempty"`
+	// StableService holds the name of a service which selects pods with stable version and don't select any pods with canary version.
+	// +optional
+	StableService string `json:"stableService,omitempty"`
 	// Steps define the order of phases to execute the canary deployment
 	// +optional
 	Steps []CanaryStep `json:"steps,omitempty"`

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -52,7 +52,7 @@ func (c *RolloutController) rolloutCanary(rollout *v1alpha1.Rollout, rsList []*a
 		return err
 	}
 
-	if err := c.reconcileCanaryService(roCtx); err != nil {
+	if err := c.reconcileStableAndCanaryService(roCtx); err != nil {
 		return err
 	}
 

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -1164,7 +1164,7 @@ func TestComputeHashChangeTolerationCanary(t *testing.T) {
 	// this should only update observedGeneration and nothing else
 	// NOTE: This test will fail on every k8s library upgrade.
 	// To fix it, update expectedPatch to match the new hash.
-	expectedPatch := `{"status":{"observedGeneration":"866857855d"}}`
+	expectedPatch := `{"status":{"observedGeneration":"66c6f797f8"}}`
 	patch := f.getPatchedRollout(patchIndex)
 	assert.Equal(t, expectedPatch, patch)
 }

--- a/rollout/service.go
+++ b/rollout/service.go
@@ -117,17 +117,34 @@ func (c *RolloutController) getPreviewAndActiveServices(r *v1alpha1.Rollout) (*c
 	return previewSvc, activeSvc, nil
 }
 
-func (c *RolloutController) reconcileCanaryService(roCtx *canaryContext) error {
+func (c *RolloutController) reconcileStableAndCanaryService(roCtx *canaryContext) error {
 	r := roCtx.Rollout()
 	newRS := roCtx.NewRS()
-	if r.Spec.Strategy.Canary == nil || r.Spec.Strategy.Canary.CanaryService == "" {
+	stableRS := roCtx.StableRS()
+	if r.Spec.Strategy.Canary == nil {
 		return nil
 	}
+	if r.Spec.Strategy.Canary.StableService != "" && stableRS != nil {
+		svc, err := c.getReferencedService(r, r.Spec.Strategy.Canary.StableService)
+		if err != nil {
+			return err
+		}
 
-	svc, err := c.getReferencedService(r, r.Spec.Strategy.Canary.CanaryService)
-	if err != nil {
-		return err
+		err = c.switchServiceSelector(svc, stableRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey], r)
+		if err != nil {
+			return err
+		}
 	}
+	if r.Spec.Strategy.Canary.CanaryService != "" && newRS != nil {
+		svc, err := c.getReferencedService(r, r.Spec.Strategy.Canary.CanaryService)
+		if err != nil {
+			return err
+		}
 
-	return c.switchServiceSelector(svc, newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey], r)
+		err = c.switchServiceSelector(svc, newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey], r)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Add `.spec.strategy.canary.stableSvc` field so users can specify a service that will be modified to only serve traffic to the stable ReplicaSet.