### PR TITLE
feat: Support instance ids for rollout controller segregation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1344,6 +1344,7 @@
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/runtime/serializer",
+    "k8s.io/apimachinery/pkg/selection",
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/duration",
     "k8s.io/apimachinery/pkg/util/intstr",

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -86,6 +86,7 @@ func NewManager(
 	analysisRunInformer informers.AnalysisRunInformer,
 	analysisTemplateInformer informers.AnalysisTemplateInformer,
 	resyncPeriod time.Duration,
+	instanceID string,
 	metricsPort int,
 ) *Manager {
 

--- a/experiments/controller_test.go
+++ b/experiments/controller_test.go
@@ -529,6 +529,20 @@ func (f *fixture) expectPatchAnalysisRunAction(r *v1alpha1.AnalysisRun) int {
 	return len
 }
 
+func (f *fixture) getCreatedAnalysisRun(index int) *v1alpha1.AnalysisRun {
+	action := filterInformerActions(f.client.Actions())[index]
+	createAction, ok := action.(core.CreateAction)
+	if !ok {
+		assert.Failf(f.t, "Expected Created action, not %s", action.GetVerb())
+	}
+	obj := createAction.GetObject()
+	ar := &v1alpha1.AnalysisRun{}
+	converter := runtime.NewTestUnstructuredConverter(equality.Semantic)
+	objMap, _ := converter.ToUnstructured(obj)
+	runtime.NewTestUnstructuredConverter(equality.Semantic).FromUnstructured(objMap, ar)
+	return ar
+}
+
 func (f *fixture) getCreatedReplicaSet(index int) *appsv1.ReplicaSet {
 	action := filterInformerActions(f.kubeclient.Actions())[index]
 	createAction, ok := action.(core.CreateAction)

--- a/experiments/experiment.go
+++ b/experiments/experiment.go
@@ -463,6 +463,10 @@ func (ec *experimentContext) newAnalysisRun(analysis v1alpha1.ExperimentAnalysis
 	if err != nil {
 		return nil, err
 	}
+	instanceID := analysisutil.GetInstanceID(ec.ex)
+	if instanceID != "" {
+		run.Labels = map[string]string{v1alpha1.LabelKeyControllerInstanceID: ec.ex.Labels[v1alpha1.LabelKeyControllerInstanceID]}
+	}
 	run.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(ec.ex, controllerKind)}
 	return run, nil
 }

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -66,6 +66,10 @@ const (
 	// DefaultReplicaSetScaleDownDeadlineAnnotationKey is the default key attached to an old stable ReplicaSet after
 	// the rollout transitioned to a new version. It contains the time when the controller can scale down the RS.
 	DefaultReplicaSetScaleDownDeadlineAnnotationKey = "scale-down-deadline"
+
+	// LabelKeyControllerInstanceID is the label the controller uses for the rollout, experiment, analysis segregation
+	// between controllers. Controllers will only operate on objects with the same instanceID as the controller.
+	LabelKeyControllerInstanceID = "argo-rollouts.argoproj.io/controller-instance-id"
 )
 
 // RolloutStrategy defines strategy to apply during next rollout

--- a/pkg/kubectl-argo-rollouts/cmd/create/create.go
+++ b/pkg/kubectl-argo-rollouts/cmd/create/create.go
@@ -37,6 +37,7 @@ type CreateAnalysisRunOptions struct {
 
 	Name         string
 	GenerateName string
+	InstanceID   string
 	ArgFlags     []string
 	From         string
 	FromFile     string
@@ -232,6 +233,11 @@ func NewCmdCreateAnalysisRun(o *options.ArgoRolloutsOptions) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if createOptions.InstanceID != "" {
+				run.Labels = map[string]string{
+					v1alpha1.LabelKeyControllerInstanceID: createOptions.InstanceID,
+				}
+			}
 			created, err := createOptions.RolloutsClientset().ArgoprojV1alpha1().AnalysisRuns(ns).Create(run)
 			if err != nil {
 				return err
@@ -243,6 +249,7 @@ func NewCmdCreateAnalysisRun(o *options.ArgoRolloutsOptions) *cobra.Command {
 	o.AddKubectlFlags(cmd)
 	cmd.Flags().StringVar(&createOptions.Name, "name", "", "Use the specified name for the run")
 	cmd.Flags().StringVar(&createOptions.GenerateName, "generate-name", "", "Use the specified generateName for the run")
+	cmd.Flags().StringVar(&createOptions.InstanceID, "instance-id", "", "Instance-ID for the AnalysisRun")
 	cmd.Flags().StringArrayVarP(&createOptions.ArgFlags, "argument", "a", []string{}, "Arguments to the parameter template")
 	cmd.Flags().StringVar(&createOptions.From, "from", "", "Create an AnalysisRun from an AnalysisTemplate in the cluster")
 	cmd.Flags().StringVar(&createOptions.FromFile, "from-file", "", "Create an AnalysisRun from an AnalysisTemplate in a local file")

--- a/rollout/analysis.go
+++ b/rollout/analysis.go
@@ -119,7 +119,8 @@ func (c *RolloutController) reconcileBackgroundAnalysisRun(roCtx *canaryContext)
 	}
 	if currentAr == nil {
 		podHash := replicasetutil.GetPodTemplateHash(newRS)
-		backgroundLabels := analysisutil.BackgroundLabels(podHash)
+		instanceID := analysisutil.GetInstanceID(rollout)
+		backgroundLabels := analysisutil.BackgroundLabels(podHash, instanceID)
 		currentAr, err := c.createAnalysisRun(roCtx, rollout.Spec.Strategy.Canary.Analysis, nil, backgroundLabels)
 		if err == nil {
 			roCtx.Log().WithField(logutil.AnalysisRunKey, currentAr.Name).Info("Created background AnalysisRun")
@@ -168,7 +169,8 @@ func (c *RolloutController) reconcileStepBasedAnalysisRun(roCtx *canaryContext) 
 	}
 	if currentAr == nil {
 		podHash := replicasetutil.GetPodTemplateHash(newRS)
-		stepLabels := analysisutil.StepLabels(*index, podHash)
+		instanceID := analysisutil.GetInstanceID(rollout)
+		stepLabels := analysisutil.StepLabels(*index, podHash, instanceID)
 		currentAr, err := c.createAnalysisRun(roCtx, step.Analysis, index, stepLabels)
 		if err == nil {
 			roCtx.Log().WithField(logutil.AnalysisRunKey, currentAr.Name).Infof("Created AnalysisRun for step '%d'", *index)
@@ -224,7 +226,6 @@ func (c *RolloutController) newAnalysisRunFromRollout(roCtx *canaryContext, roll
 	}
 	nameParts = append(nameParts, rolloutAnalysisStep.TemplateName)
 	name := strings.Join(nameParts, "-")
-
 	run, err := analysisutil.NewAnalysisRunFromTemplate(template, args, name, "", r.Namespace)
 	if err != nil {
 		return nil, err

--- a/rollout/analysis_test.go
+++ b/rollout/analysis_test.go
@@ -35,9 +35,9 @@ func analysisRun(at *v1alpha1.AnalysisTemplate, analysisRunType string, r *v1alp
 	labels := map[string]string{}
 	podHash := controller.ComputeHash(&r.Spec.Template, r.Status.CollisionCount)
 	if analysisRunType == v1alpha1.RolloutTypeStepLabel {
-		labels = analysisutil.StepLabels(*r.Status.CurrentStepIndex, podHash)
+		labels = analysisutil.StepLabels(*r.Status.CurrentStepIndex, podHash, "")
 	} else if analysisRunType == v1alpha1.RolloutTypeBackgroundRunLabel {
-		labels = analysisutil.BackgroundLabels(podHash)
+		labels = analysisutil.BackgroundLabels(podHash, "")
 	}
 	return &v1alpha1.AnalysisRun{
 		ObjectMeta: metav1.ObjectMeta{

--- a/rollout/experiment.go
+++ b/rollout/experiment.go
@@ -51,6 +51,11 @@ func GetExperimentFromTemplate(r *v1alpha1.Rollout, stableRS, newRS *appsv1.Repl
 		},
 	}
 
+	instanceID := analysisutil.GetInstanceID(r)
+	if instanceID != "" {
+		experiment.Labels[v1alpha1.LabelKeyControllerInstanceID] = instanceID
+	}
+
 	for i := range step.Templates {
 		templateStep := step.Templates[i]
 		template := v1alpha1.TemplateSpec{

--- a/utils/analysis/factory.go
+++ b/utils/analysis/factory.go
@@ -34,21 +34,30 @@ func BuildArgumentsForRolloutAnalysisRun(args []v1alpha1.AnalysisRunArgument, st
 }
 
 // BackgroundLabels returns a map[string]string of common labels for the background analysis
-func BackgroundLabels(podHash string) map[string]string {
-	return map[string]string{
+func BackgroundLabels(podHash, instanceID string) map[string]string {
+	labels := map[string]string{
 		v1alpha1.DefaultRolloutUniqueLabelKey: podHash,
 		v1alpha1.RolloutTypeLabel:             v1alpha1.RolloutTypeBackgroundRunLabel,
 	}
+	if instanceID != "" {
+		labels[v1alpha1.LabelKeyControllerInstanceID] = instanceID
+	}
+	return labels
+
 }
 
 // StepLabels returns a map[string]string of common labels for analysisruns created from an analysis step
-func StepLabels(index int32, podHash string) map[string]string {
+func StepLabels(index int32, podHash, instanceID string) map[string]string {
 	indexStr := strconv.Itoa(int(index))
-	return map[string]string{
+	labels := map[string]string{
 		v1alpha1.DefaultRolloutUniqueLabelKey: podHash,
 		v1alpha1.RolloutTypeLabel:             v1alpha1.RolloutTypeStepLabel,
 		v1alpha1.RolloutCanaryStepIndexLabel:  indexStr,
 	}
+	if instanceID != "" {
+		labels[v1alpha1.LabelKeyControllerInstanceID] = instanceID
+	}
+	return labels
 }
 
 // ValidateMetrics validates an analysis template spec

--- a/utils/analysis/factory_test.go
+++ b/utils/analysis/factory_test.go
@@ -59,8 +59,9 @@ func TestStepLabels(t *testing.T) {
 		v1alpha1.DefaultRolloutUniqueLabelKey: podHash,
 		v1alpha1.RolloutTypeLabel:             v1alpha1.RolloutTypeStepLabel,
 		v1alpha1.RolloutCanaryStepIndexLabel:  "1",
+		v1alpha1.LabelKeyControllerInstanceID: "test",
 	}
-	generated := StepLabels(1, podHash)
+	generated := StepLabels(1, podHash, "test")
 	assert.Equal(t, expected, generated)
 }
 
@@ -69,8 +70,9 @@ func TestBackgroundLabels(t *testing.T) {
 	expected := map[string]string{
 		v1alpha1.DefaultRolloutUniqueLabelKey: podHash,
 		v1alpha1.RolloutTypeLabel:             v1alpha1.RolloutTypeBackgroundRunLabel,
+		v1alpha1.LabelKeyControllerInstanceID: "test",
 	}
-	generated := BackgroundLabels(podHash)
+	generated := BackgroundLabels(podHash, "test")
 	assert.Equal(t, expected, generated)
 }
 

--- a/utils/analysis/helpers_test.go
+++ b/utils/analysis/helpers_test.go
@@ -422,3 +422,20 @@ func TestNewAnalysisRunFromTemplate(t *testing.T) {
 	assert.Equal(t, "my-arg", run.Spec.Args[0].Name)
 	assert.Equal(t, "my-val", *run.Spec.Args[0].Value)
 }
+
+func TestGetInstanceID(t *testing.T) {
+	run := &v1alpha1.AnalysisRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+			Labels: map[string]string{
+				v1alpha1.LabelKeyControllerInstanceID: "test",
+			},
+		},
+	}
+	assert.Equal(t, "test", GetInstanceID(run))
+	run.Labels = nil
+	assert.Equal(t, "", GetInstanceID(run))
+	var nilRun *v1alpha1.AnalysisRun
+	assert.Panics(t, func() { GetInstanceID(nilRun) })
+
+}

--- a/utils/controller/controller_test.go
+++ b/utils/controller/controller_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/argoproj/argo-rollouts/controller/metrics"
@@ -342,4 +343,22 @@ func TestEnqueueParentObjectRecoverTombstoneObject(t *testing.T) {
 	EnqueueParentObject(invalidObject, register.ExperimentKind, enqueueFunc)
 	assert.Len(t, errorMessages, 0)
 	assert.Len(t, enqueuedObjs, 1)
+}
+
+func TestInstanceIDRequirement(t *testing.T) {
+	setWithLabel := labels.Set{
+		v1alpha1.LabelKeyControllerInstanceID: "test",
+	}
+	setWithNoLabel := labels.Set{}
+
+	instanceID := InstanceIDRequirement("test")
+	noInstanceID := InstanceIDRequirement("")
+
+	assert.True(t, instanceID.Matches(setWithLabel))
+	assert.False(t, instanceID.Matches(setWithNoLabel))
+
+	assert.False(t, noInstanceID.Matches(setWithLabel))
+	assert.True(t, noInstanceID.Matches(setWithNoLabel))
+
+	assert.Panics(t, func() { InstanceIDRequirement(".%&(") })
 }


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-rollouts/issues/304

Adds a new flag to the controller called `--instance-id`. This flag indicates that the controller should only operate on Argo Rollout objects that have that label `argo-rollouts.argoproj.io/controller-instance-id` with the same value passed into the flag. If the flag is not listed, the controller operates on any Argo Rollout object that does not have the `argo-rollouts.argoproj.io/controller-instance-id` label.