### PR TITLE
fix: Prevent StableRS from being counted in olderRS

### DIFF
--- a/rollout/context.go
+++ b/rollout/context.go
@@ -122,7 +122,8 @@ func (bgCtx *blueGreenContext) NewStatus() v1alpha1.RolloutStatus {
 
 func newCanaryCtx(r *v1alpha1.Rollout, newRS *appsv1.ReplicaSet, otherRSs []*appsv1.ReplicaSet, exList []*v1alpha1.Experiment, arList []*v1alpha1.AnalysisRun) *canaryContext {
 	allRSs := append(otherRSs, newRS)
-	stableRS, oldRSs := replicasetutil.GetStableRS(r, newRS, otherRSs)
+	stableRS := replicasetutil.GetStableRS(r, newRS, otherRSs)
+	oldRSs := replicasetutil.GetOlderRSs(r, newRS, stableRS, otherRSs)
 
 	currentArs, otherArs := analysisutil.FilterCurrentRolloutAnalysisRuns(arList, r)
 	currentEx := experimentutil.GetCurrentExperiment(r, exList)

--- a/utils/replicaset/canary_test.go
+++ b/utils/replicaset/canary_test.go
@@ -388,6 +388,31 @@ func TestCalculateReplicaCountsForCanaryStableRSdEdgeCases(t *testing.T) {
 	assert.Equal(t, int32(0), stableRSReplicaCount)
 }
 
+func TestGetOlderRSs(t *testing.T) {
+	rs := func(podHash string) appsv1.ReplicaSet {
+		return appsv1.ReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: podHash,
+			},
+		}
+	}
+	rollout := &v1alpha1.Rollout{}
+	rs1 := rs("1")
+	rs2 := rs("2")
+	handleNil := GetOlderRSs(rollout, nil, nil, []*appsv1.ReplicaSet{&rs1})
+	assert.Len(t, handleNil, 1)
+	assert.Equal(t, *handleNil[0], rs1)
+
+	handleExistingNewRS := GetOlderRSs(rollout, &rs1, nil, []*appsv1.ReplicaSet{&rs1, &rs2})
+	assert.Len(t, handleExistingNewRS, 1)
+	assert.Equal(t, *handleExistingNewRS[0], rs2)
+
+	handleExistingStableRS := GetOlderRSs(rollout, nil, &rs1, []*appsv1.ReplicaSet{&rs1, &rs2})
+	assert.Len(t, handleExistingStableRS, 1)
+	assert.Equal(t, *handleExistingStableRS[0], rs2)
+
+}
+
 func TestGetStableRS(t *testing.T) {
 	rs := func(podHash string) appsv1.ReplicaSet {
 		return appsv1.ReplicaSet{
@@ -404,19 +429,18 @@ func TestGetStableRS(t *testing.T) {
 	rs1 := rs("1")
 	rs2 := rs("2")
 	rs3 := rs("3")
-	noStable, rsList := GetStableRS(rollout, &rs1, []*appsv1.ReplicaSet{&rs2, &rs3})
+	noStable := GetStableRS(rollout, &rs1, []*appsv1.ReplicaSet{&rs2, &rs3})
 	assert.Nil(t, noStable)
-	assert.Len(t, rsList, 2)
 
 	rollout.Status.Canary.StableRS = "1"
-	sameAsNewRS, rsList := GetStableRS(rollout, &rs1, []*appsv1.ReplicaSet{&rs2, &rs3})
+	stableNotFound := GetStableRS(rollout, &rs2, []*appsv1.ReplicaSet{&rs3})
+	assert.Nil(t, stableNotFound)
+
+	sameAsNewRS := GetStableRS(rollout, &rs1, []*appsv1.ReplicaSet{&rs2, &rs3})
 	assert.Equal(t, *sameAsNewRS, rs1)
-	assert.Len(t, rsList, 2)
 
-	stableInOtherRSs, rsList := GetStableRS(rollout, &rs2, []*appsv1.ReplicaSet{&rs1, &rs2, &rs3})
+	stableInOtherRSs := GetStableRS(rollout, &rs2, []*appsv1.ReplicaSet{&rs1, &rs2, &rs3})
 	assert.Equal(t, *stableInOtherRSs, rs1)
-	assert.Len(t, rsList, 1)
-
 }
 func TestGetCurrentCanaryStep(t *testing.T) {
 	rollout := newRollout(10, 10, intstr.FromInt(0), intstr.FromInt(1), "", "")

--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -95,7 +95,8 @@ func NewRSNewReplicas(rollout *v1alpha1.Rollout, allRSs []*appsv1.ReplicaSet, ne
 		return defaults.GetReplicasOrDefault(rollout.Spec.Replicas), nil
 	}
 	if rollout.Spec.Strategy.Canary != nil {
-		stableRS, olderRSs := GetStableRS(rollout, newRS, allRSs)
+		stableRS := GetStableRS(rollout, newRS, allRSs)
+		olderRSs := GetOlderRSs(rollout, newRS, stableRS, allRSs)
 		newRSReplicaCount, _ := CalculateReplicaCountsForCanary(rollout, newRS, stableRS, olderRSs)
 		return newRSReplicaCount, nil
 	}


### PR DESCRIPTION
The controller calls the GetStableRS function to calculate the stable RS and the older RSs from the new RS and the list of other ReplicaSets. The GetStableRS function assumes that the list of other ReplicaSets does not have the new RS in it. However, if the stableRS is the same as the new RS (which happens when the Rollout finishes progressing through the steps), the new RS would be included in the list of older RSs. 

If the user scaled their rollout with only a stable RS, the controller counted the stable RS in the list of old RSs and pass the max surge limit. As a result, the rollout wouldn't be able to make any progress. This issue would reported [here](https://github.com/argoproj/argo-rollouts/issues/332)

The fix separated the get the Stable RS and older RSs logic into two separate functions. The Get Older RSs function ensures that the stable and new RS are not in the list of older RSs. 