### PR TITLE
docs: fix analysis template args examples

### DIFF
--- a/docs/features/experiment.md
+++ b/docs/features/experiment.md
@@ -127,7 +127,7 @@ spec:
           specRef: canary
           analysis:
             templateName: mann-whitney
-            arguments:
+            args:
             - name: stable-hash
             valueFrom:
               podTemplateHash: baseline


### PR DESCRIPTION
* use `args` instead of `arguments` and `inputs` in specs
* update template placeholders to use `args.*` instead of `inputs.*`
* fix some bullet list rendering issues
* fix "Job Metrics" example
  - move `metrics.job` to `metrics.provider.job`
  - move `job.template` to `job.spec.template`