### PR TITLE
chore: Rerun codegen and gen manifests

### DIFF
--- a/manifests/crds/analysis-run-crd.yaml
+++ b/manifests/crds/analysis-run-crd.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
   name: analysisruns.argoproj.io
 spec:
   additionalPrinterColumns:
@@ -504,9 +502,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -518,9 +515,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -554,9 +550,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -568,9 +563,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -608,9 +602,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -631,9 +624,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -662,10 +654,6 @@ spec:
                                                 - containerPort
                                                 type: object
                                               type: array
-                                              x-kubernetes-list-map-keys:
-                                              - containerPort
-                                              - protocol
-                                              x-kubernetes-list-type: map
                                             readinessProbe:
                                               properties:
                                                 exec:
@@ -698,9 +686,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -721,9 +708,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -815,9 +801,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -838,9 +823,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1043,9 +1027,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -1057,9 +1040,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -1093,9 +1075,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -1107,9 +1088,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -1147,9 +1127,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1170,9 +1149,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1233,9 +1211,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1256,9 +1233,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1350,9 +1326,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1373,9 +1348,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1582,9 +1556,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -1596,9 +1569,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -1632,9 +1604,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -1646,9 +1617,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -1686,9 +1656,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1709,9 +1678,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1740,10 +1708,6 @@ spec:
                                                 - containerPort
                                                 type: object
                                               type: array
-                                              x-kubernetes-list-map-keys:
-                                              - containerPort
-                                              - protocol
-                                              x-kubernetes-list-type: map
                                             readinessProbe:
                                               properties:
                                                 exec:
@@ -1776,9 +1740,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1799,9 +1762,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1893,9 +1855,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1916,9 +1877,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -2123,10 +2083,6 @@ spec:
                                           - whenUnsatisfiable
                                           type: object
                                         type: array
-                                        x-kubernetes-list-map-keys:
-                                        - topologyKey
-                                        - whenUnsatisfiable
-                                        x-kubernetes-list-type: map
                                       volumes:
                                         items:
                                           properties:

--- a/manifests/crds/analysis-template-crd.yaml
+++ b/manifests/crds/analysis-template-crd.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
   name: analysistemplates.argoproj.io
 spec:
   group: argoproj.io
@@ -498,9 +496,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -512,9 +509,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -548,9 +544,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -562,9 +557,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -602,9 +596,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -625,9 +618,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -656,10 +648,6 @@ spec:
                                                 - containerPort
                                                 type: object
                                               type: array
-                                              x-kubernetes-list-map-keys:
-                                              - containerPort
-                                              - protocol
-                                              x-kubernetes-list-type: map
                                             readinessProbe:
                                               properties:
                                                 exec:
@@ -692,9 +680,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -715,9 +702,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -809,9 +795,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -832,9 +817,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1037,9 +1021,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -1051,9 +1034,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -1087,9 +1069,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -1101,9 +1082,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -1141,9 +1121,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1164,9 +1143,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1227,9 +1205,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1250,9 +1227,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1344,9 +1320,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1367,9 +1342,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1576,9 +1550,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -1590,9 +1563,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -1626,9 +1598,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -1640,9 +1611,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -1680,9 +1650,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1703,9 +1672,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1734,10 +1702,6 @@ spec:
                                                 - containerPort
                                                 type: object
                                               type: array
-                                              x-kubernetes-list-map-keys:
-                                              - containerPort
-                                              - protocol
-                                              x-kubernetes-list-type: map
                                             readinessProbe:
                                               properties:
                                                 exec:
@@ -1770,9 +1734,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1793,9 +1756,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1887,9 +1849,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1910,9 +1871,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -2117,10 +2077,6 @@ spec:
                                           - whenUnsatisfiable
                                           type: object
                                         type: array
-                                        x-kubernetes-list-map-keys:
-                                        - topologyKey
-                                        - whenUnsatisfiable
-                                        x-kubernetes-list-type: map
                                       volumes:
                                         items:
                                           properties:

--- a/manifests/crds/experiment-crd.yaml
+++ b/manifests/crds/experiment-crd.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
   name: experiments.argoproj.io
 spec:
   additionalPrinterColumns:
@@ -491,9 +489,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                             scheme:
                                               type: string
                                           required:
@@ -505,9 +502,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                           required:
                                           - port
                                           type: object
@@ -541,9 +537,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                             scheme:
                                               type: string
                                           required:
@@ -555,9 +550,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                           required:
                                           - port
                                           type: object
@@ -595,9 +589,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -618,9 +611,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -649,10 +641,6 @@ spec:
                                     - containerPort
                                     type: object
                                   type: array
-                                  x-kubernetes-list-map-keys:
-                                  - containerPort
-                                  - protocol
-                                  x-kubernetes-list-type: map
                                 readinessProbe:
                                   properties:
                                     exec:
@@ -685,9 +673,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -708,9 +695,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -802,9 +788,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -825,9 +810,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -1030,9 +1014,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                             scheme:
                                               type: string
                                           required:
@@ -1044,9 +1027,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                           required:
                                           - port
                                           type: object
@@ -1080,9 +1062,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                             scheme:
                                               type: string
                                           required:
@@ -1094,9 +1075,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                           required:
                                           - port
                                           type: object
@@ -1134,9 +1114,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -1157,9 +1136,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -1220,9 +1198,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -1243,9 +1220,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -1337,9 +1313,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -1360,9 +1335,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -1569,9 +1543,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                             scheme:
                                               type: string
                                           required:
@@ -1583,9 +1556,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                           required:
                                           - port
                                           type: object
@@ -1619,9 +1591,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                             scheme:
                                               type: string
                                           required:
@@ -1633,9 +1604,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                           required:
                                           - port
                                           type: object
@@ -1673,9 +1643,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -1696,9 +1665,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -1727,10 +1695,6 @@ spec:
                                     - containerPort
                                     type: object
                                   type: array
-                                  x-kubernetes-list-map-keys:
-                                  - containerPort
-                                  - protocol
-                                  x-kubernetes-list-type: map
                                 readinessProbe:
                                   properties:
                                     exec:
@@ -1763,9 +1727,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -1786,9 +1749,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -1880,9 +1842,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -1903,9 +1864,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -2110,10 +2070,6 @@ spec:
                               - whenUnsatisfiable
                               type: object
                             type: array
-                            x-kubernetes-list-map-keys:
-                            - topologyKey
-                            - whenUnsatisfiable
-                            x-kubernetes-list-type: map
                           volumes:
                             items:
                               properties:

--- a/manifests/crds/rollout-crd.yaml
+++ b/manifests/crds/rollout-crd.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
   name: rollouts.argoproj.io
 spec:
   additionalPrinterColumns:
@@ -143,14 +141,12 @@ spec:
                       type: string
                     maxSurge:
                       anyOf:
-                      - type: integer
                       - type: string
-                      x-kubernetes-int-or-string: true
+                      - type: integer
                     maxUnavailable:
                       anyOf:
-                      - type: integer
                       - type: string
-                      x-kubernetes-int-or-string: true
+                      - type: integer
                     stableService:
                       type: string
                     steps:
@@ -692,9 +688,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                       scheme:
                                         type: string
                                     required:
@@ -706,9 +701,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                     required:
                                     - port
                                     type: object
@@ -742,9 +736,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                       scheme:
                                         type: string
                                     required:
@@ -756,9 +749,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                     required:
                                     - port
                                     type: object
@@ -796,9 +788,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -819,9 +810,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -850,10 +840,6 @@ spec:
                               - containerPort
                               type: object
                             type: array
-                            x-kubernetes-list-map-keys:
-                            - containerPort
-                            - protocol
-                            x-kubernetes-list-type: map
                           readinessProbe:
                             properties:
                               exec:
@@ -886,9 +872,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -909,9 +894,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -1003,9 +987,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -1026,9 +1009,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -1231,9 +1213,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                       scheme:
                                         type: string
                                     required:
@@ -1245,9 +1226,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                     required:
                                     - port
                                     type: object
@@ -1281,9 +1261,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                       scheme:
                                         type: string
                                     required:
@@ -1295,9 +1274,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                     required:
                                     - port
                                     type: object
@@ -1335,9 +1313,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -1358,9 +1335,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -1421,9 +1397,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -1444,9 +1419,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -1538,9 +1512,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -1561,9 +1534,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -1770,9 +1742,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                       scheme:
                                         type: string
                                     required:
@@ -1784,9 +1755,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                     required:
                                     - port
                                     type: object
@@ -1820,9 +1790,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                       scheme:
                                         type: string
                                     required:
@@ -1834,9 +1803,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                     required:
                                     - port
                                     type: object
@@ -1874,9 +1842,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -1897,9 +1864,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -1928,10 +1894,6 @@ spec:
                               - containerPort
                               type: object
                             type: array
-                            x-kubernetes-list-map-keys:
-                            - containerPort
-                            - protocol
-                            x-kubernetes-list-type: map
                           readinessProbe:
                             properties:
                               exec:
@@ -1964,9 +1926,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -1987,9 +1948,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -2081,9 +2041,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -2104,9 +2063,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -2311,10 +2269,6 @@ spec:
                         - whenUnsatisfiable
                         type: object
                       type: array
-                      x-kubernetes-list-map-keys:
-                      - topologyKey
-                      - whenUnsatisfiable
-                      x-kubernetes-list-type: map
                     volumes:
                       items:
                         properties:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -2,8 +2,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
   name: analysisruns.argoproj.io
 spec:
   additionalPrinterColumns:
@@ -58,6 +56,8 @@ spec:
                   inconclusiveLimit:
                     format: int32
                     type: integer
+                  initialDelay:
+                    type: string
                   interval:
                     type: string
                   name:
@@ -503,9 +503,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -517,9 +516,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -553,9 +551,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -567,9 +564,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -607,9 +603,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -630,9 +625,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -693,9 +687,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -716,9 +709,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -810,9 +802,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -833,9 +824,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1038,9 +1028,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -1052,9 +1041,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -1088,9 +1076,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -1102,9 +1089,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -1142,9 +1128,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1165,9 +1150,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1228,9 +1212,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1251,9 +1234,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1345,9 +1327,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1368,9 +1349,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1577,9 +1557,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -1591,9 +1570,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -1627,9 +1605,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -1641,9 +1618,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -1681,9 +1657,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1704,9 +1679,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1767,9 +1741,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1790,9 +1763,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1884,9 +1856,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1907,9 +1878,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -2631,7 +2601,13 @@ spec:
                           query:
                             type: string
                         type: object
-<<<<<<< HEAD
+                      wavefront:
+                        properties:
+                          address:
+                            type: string
+                          query:
+                            type: string
+                        type: object
                       web:
                         properties:
                           headers:
@@ -2655,18 +2631,8 @@ spec:
                         required:
                         - jsonPath
                         - url
-=======
-                      wavefront:
-                        properties:
-                          address:
-                            type: string
-                          query:
-                            type: string
->>>>>>> c79494b99e33e54ab9734f885c196d1d81e8f1f6
                         type: object
                     type: object
-                  startDelay:
-                    type: string
                   successCondition:
                     type: string
                 required:
@@ -2761,8 +2727,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
   name: analysistemplates.argoproj.io
 spec:
   group: argoproj.io
@@ -2811,6 +2775,8 @@ spec:
                   inconclusiveLimit:
                     format: int32
                     type: integer
+                  initialDelay:
+                    type: string
                   interval:
                     type: string
                   name:
@@ -3256,9 +3222,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -3270,9 +3235,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -3306,9 +3270,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -3320,9 +3283,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -3360,9 +3322,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -3383,9 +3344,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -3446,9 +3406,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -3469,9 +3428,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -3563,9 +3521,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -3586,9 +3543,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -3791,9 +3747,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -3805,9 +3760,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -3841,9 +3795,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -3855,9 +3808,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -3895,9 +3847,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -3918,9 +3869,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -3981,9 +3931,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -4004,9 +3953,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -4098,9 +4046,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -4121,9 +4068,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -4330,9 +4276,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -4344,9 +4289,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -4380,9 +4324,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -4394,9 +4337,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -4434,9 +4376,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -4457,9 +4398,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -4520,9 +4460,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -4543,9 +4482,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -4637,9 +4575,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -4660,9 +4597,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -5384,7 +5320,13 @@ spec:
                           query:
                             type: string
                         type: object
-<<<<<<< HEAD
+                      wavefront:
+                        properties:
+                          address:
+                            type: string
+                          query:
+                            type: string
+                        type: object
                       web:
                         properties:
                           headers:
@@ -5408,18 +5350,8 @@ spec:
                         required:
                         - jsonPath
                         - url
-=======
-                      wavefront:
-                        properties:
-                          address:
-                            type: string
-                          query:
-                            type: string
->>>>>>> c79494b99e33e54ab9734f885c196d1d81e8f1f6
                         type: object
                     type: object
-                  startDelay:
-                    type: string
                   successCondition:
                     type: string
                 required:
@@ -5442,8 +5374,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
   name: experiments.argoproj.io
 spec:
   additionalPrinterColumns:
@@ -5932,9 +5862,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                             scheme:
                                               type: string
                                           required:
@@ -5946,9 +5875,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                           required:
                                           - port
                                           type: object
@@ -5982,9 +5910,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                             scheme:
                                               type: string
                                           required:
@@ -5996,9 +5923,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                           required:
                                           - port
                                           type: object
@@ -6036,9 +5962,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -6059,9 +5984,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -6122,9 +6046,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -6145,9 +6068,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -6239,9 +6161,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -6262,9 +6183,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -6467,9 +6387,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                             scheme:
                                               type: string
                                           required:
@@ -6481,9 +6400,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                           required:
                                           - port
                                           type: object
@@ -6517,9 +6435,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                             scheme:
                                               type: string
                                           required:
@@ -6531,9 +6448,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                           required:
                                           - port
                                           type: object
@@ -6571,9 +6487,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -6594,9 +6509,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -6657,9 +6571,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -6680,9 +6593,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -6774,9 +6686,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -6797,9 +6708,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -7006,9 +6916,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                             scheme:
                                               type: string
                                           required:
@@ -7020,9 +6929,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                           required:
                                           - port
                                           type: object
@@ -7056,9 +6964,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                             scheme:
                                               type: string
                                           required:
@@ -7070,9 +6977,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                           required:
                                           - port
                                           type: object
@@ -7110,9 +7016,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -7133,9 +7038,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -7196,9 +7100,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -7219,9 +7122,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -7313,9 +7215,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -7336,9 +7237,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -7985,8 +7885,6 @@ spec:
                     type: string
                   phase:
                     type: string
-                  requiredForCompletion:
-                    type: boolean
                 required:
                 - analysisRun
                 - name
@@ -8074,8 +7972,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
   name: rollouts.argoproj.io
 spec:
   additionalPrinterColumns:
@@ -8204,7 +8100,7 @@ spec:
                             - name
                             type: object
                           type: array
-                        startAtStep:
+                        startingStep:
                           format: int32
                           type: integer
                         templateName:
@@ -8216,19 +8112,14 @@ spec:
                       type: string
                     maxSurge:
                       anyOf:
-                      - type: integer
                       - type: string
-                      x-kubernetes-int-or-string: true
+                      - type: integer
                     maxUnavailable:
                       anyOf:
-                      - type: integer
-<<<<<<< HEAD
                       - type: string
-                      x-kubernetes-int-or-string: true
-=======
+                      - type: integer
                     stableService:
                       type: string
->>>>>>> c79494b99e33e54ab9734f885c196d1d81e8f1f6
                     steps:
                       items:
                         properties:
@@ -8768,9 +8659,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                       scheme:
                                         type: string
                                     required:
@@ -8782,9 +8672,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                     required:
                                     - port
                                     type: object
@@ -8818,9 +8707,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                       scheme:
                                         type: string
                                     required:
@@ -8832,9 +8720,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                     required:
                                     - port
                                     type: object
@@ -8872,9 +8759,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -8895,9 +8781,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -8958,9 +8843,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -8981,9 +8865,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -9075,9 +8958,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -9098,9 +8980,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -9303,9 +9184,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                       scheme:
                                         type: string
                                     required:
@@ -9317,9 +9197,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                     required:
                                     - port
                                     type: object
@@ -9353,9 +9232,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                       scheme:
                                         type: string
                                     required:
@@ -9367,9 +9245,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                     required:
                                     - port
                                     type: object
@@ -9407,9 +9284,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -9430,9 +9306,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -9493,9 +9368,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -9516,9 +9390,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -9610,9 +9483,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -9633,9 +9505,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -9842,9 +9713,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                       scheme:
                                         type: string
                                     required:
@@ -9856,9 +9726,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                     required:
                                     - port
                                     type: object
@@ -9892,9 +9761,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                       scheme:
                                         type: string
                                     required:
@@ -9906,9 +9774,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                     required:
                                     - port
                                     type: object
@@ -9946,9 +9813,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -9969,9 +9835,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -10032,9 +9897,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -10055,9 +9919,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -10149,9 +10012,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -10172,9 +10034,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2,8 +2,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
   name: analysisruns.argoproj.io
 spec:
   additionalPrinterColumns:
@@ -58,6 +56,8 @@ spec:
                   inconclusiveLimit:
                     format: int32
                     type: integer
+                  initialDelay:
+                    type: string
                   interval:
                     type: string
                   name:
@@ -503,9 +503,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -517,9 +516,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -553,9 +551,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -567,9 +564,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -607,9 +603,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -630,9 +625,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -693,9 +687,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -716,9 +709,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -810,9 +802,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -833,9 +824,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1038,9 +1028,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -1052,9 +1041,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -1088,9 +1076,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -1102,9 +1089,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -1142,9 +1128,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1165,9 +1150,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1228,9 +1212,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1251,9 +1234,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1345,9 +1327,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1368,9 +1349,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1577,9 +1557,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -1591,9 +1570,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -1627,9 +1605,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -1641,9 +1618,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -1681,9 +1657,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1704,9 +1679,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1767,9 +1741,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1790,9 +1763,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -1884,9 +1856,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -1907,9 +1878,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -2631,7 +2601,13 @@ spec:
                           query:
                             type: string
                         type: object
-<<<<<<< HEAD
+                      wavefront:
+                        properties:
+                          address:
+                            type: string
+                          query:
+                            type: string
+                        type: object
                       web:
                         properties:
                           headers:
@@ -2655,18 +2631,8 @@ spec:
                         required:
                         - jsonPath
                         - url
-=======
-                      wavefront:
-                        properties:
-                          address:
-                            type: string
-                          query:
-                            type: string
->>>>>>> c79494b99e33e54ab9734f885c196d1d81e8f1f6
                         type: object
                     type: object
-                  startDelay:
-                    type: string
                   successCondition:
                     type: string
                 required:
@@ -2761,8 +2727,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
   name: analysistemplates.argoproj.io
 spec:
   group: argoproj.io
@@ -2811,6 +2775,8 @@ spec:
                   inconclusiveLimit:
                     format: int32
                     type: integer
+                  initialDelay:
+                    type: string
                   interval:
                     type: string
                   name:
@@ -3256,9 +3222,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -3270,9 +3235,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -3306,9 +3270,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -3320,9 +3283,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -3360,9 +3322,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -3383,9 +3344,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -3446,9 +3406,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -3469,9 +3428,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -3563,9 +3521,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -3586,9 +3543,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -3791,9 +3747,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -3805,9 +3760,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -3841,9 +3795,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -3855,9 +3808,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -3895,9 +3847,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -3918,9 +3869,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -3981,9 +3931,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -4004,9 +3953,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -4098,9 +4046,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -4121,9 +4068,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -4330,9 +4276,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -4344,9 +4289,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -4380,9 +4324,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                         scheme:
                                                           type: string
                                                       required:
@@ -4394,9 +4337,8 @@ spec:
                                                           type: string
                                                         port:
                                                           anyOf:
-                                                          - type: integer
                                                           - type: string
-                                                          x-kubernetes-int-or-string: true
+                                                          - type: integer
                                                       required:
                                                       - port
                                                       type: object
@@ -4434,9 +4376,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -4457,9 +4398,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -4520,9 +4460,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -4543,9 +4482,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -4637,9 +4575,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                     scheme:
                                                       type: string
                                                   required:
@@ -4660,9 +4597,8 @@ spec:
                                                       type: string
                                                     port:
                                                       anyOf:
-                                                      - type: integer
                                                       - type: string
-                                                      x-kubernetes-int-or-string: true
+                                                      - type: integer
                                                   required:
                                                   - port
                                                   type: object
@@ -5384,7 +5320,13 @@ spec:
                           query:
                             type: string
                         type: object
-<<<<<<< HEAD
+                      wavefront:
+                        properties:
+                          address:
+                            type: string
+                          query:
+                            type: string
+                        type: object
                       web:
                         properties:
                           headers:
@@ -5408,18 +5350,8 @@ spec:
                         required:
                         - jsonPath
                         - url
-=======
-                      wavefront:
-                        properties:
-                          address:
-                            type: string
-                          query:
-                            type: string
->>>>>>> c79494b99e33e54ab9734f885c196d1d81e8f1f6
                         type: object
                     type: object
-                  startDelay:
-                    type: string
                   successCondition:
                     type: string
                 required:
@@ -5442,8 +5374,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
   name: experiments.argoproj.io
 spec:
   additionalPrinterColumns:
@@ -5932,9 +5862,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                             scheme:
                                               type: string
                                           required:
@@ -5946,9 +5875,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                           required:
                                           - port
                                           type: object
@@ -5982,9 +5910,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                             scheme:
                                               type: string
                                           required:
@@ -5996,9 +5923,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                           required:
                                           - port
                                           type: object
@@ -6036,9 +5962,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -6059,9 +5984,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -6122,9 +6046,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -6145,9 +6068,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -6239,9 +6161,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -6262,9 +6183,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -6467,9 +6387,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                             scheme:
                                               type: string
                                           required:
@@ -6481,9 +6400,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                           required:
                                           - port
                                           type: object
@@ -6517,9 +6435,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                             scheme:
                                               type: string
                                           required:
@@ -6531,9 +6448,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                           required:
                                           - port
                                           type: object
@@ -6571,9 +6487,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -6594,9 +6509,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -6657,9 +6571,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -6680,9 +6593,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -6774,9 +6686,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -6797,9 +6708,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -7006,9 +6916,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                             scheme:
                                               type: string
                                           required:
@@ -7020,9 +6929,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                           required:
                                           - port
                                           type: object
@@ -7056,9 +6964,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                             scheme:
                                               type: string
                                           required:
@@ -7070,9 +6977,8 @@ spec:
                                               type: string
                                             port:
                                               anyOf:
-                                              - type: integer
                                               - type: string
-                                              x-kubernetes-int-or-string: true
+                                              - type: integer
                                           required:
                                           - port
                                           type: object
@@ -7110,9 +7016,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -7133,9 +7038,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -7196,9 +7100,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -7219,9 +7122,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -7313,9 +7215,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                         scheme:
                                           type: string
                                       required:
@@ -7336,9 +7237,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
                                           - type: string
-                                          x-kubernetes-int-or-string: true
+                                          - type: integer
                                       required:
                                       - port
                                       type: object
@@ -7985,8 +7885,6 @@ spec:
                     type: string
                   phase:
                     type: string
-                  requiredForCompletion:
-                    type: boolean
                 required:
                 - analysisRun
                 - name
@@ -8074,8 +7972,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
   name: rollouts.argoproj.io
 spec:
   additionalPrinterColumns:
@@ -8204,7 +8100,7 @@ spec:
                             - name
                             type: object
                           type: array
-                        startAtStep:
+                        startingStep:
                           format: int32
                           type: integer
                         templateName:
@@ -8216,19 +8112,14 @@ spec:
                       type: string
                     maxSurge:
                       anyOf:
-                      - type: integer
                       - type: string
-                      x-kubernetes-int-or-string: true
+                      - type: integer
                     maxUnavailable:
                       anyOf:
-                      - type: integer
-<<<<<<< HEAD
                       - type: string
-                      x-kubernetes-int-or-string: true
-=======
+                      - type: integer
                     stableService:
                       type: string
->>>>>>> c79494b99e33e54ab9734f885c196d1d81e8f1f6
                     steps:
                       items:
                         properties:
@@ -8768,9 +8659,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                       scheme:
                                         type: string
                                     required:
@@ -8782,9 +8672,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                     required:
                                     - port
                                     type: object
@@ -8818,9 +8707,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                       scheme:
                                         type: string
                                     required:
@@ -8832,9 +8720,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                     required:
                                     - port
                                     type: object
@@ -8872,9 +8759,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -8895,9 +8781,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -8958,9 +8843,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -8981,9 +8865,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -9075,9 +8958,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -9098,9 +8980,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -9303,9 +9184,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                       scheme:
                                         type: string
                                     required:
@@ -9317,9 +9197,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                     required:
                                     - port
                                     type: object
@@ -9353,9 +9232,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                       scheme:
                                         type: string
                                     required:
@@ -9367,9 +9245,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                     required:
                                     - port
                                     type: object
@@ -9407,9 +9284,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -9430,9 +9306,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -9493,9 +9368,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -9516,9 +9390,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -9610,9 +9483,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -9633,9 +9505,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -9842,9 +9713,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                       scheme:
                                         type: string
                                     required:
@@ -9856,9 +9726,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                     required:
                                     - port
                                     type: object
@@ -9892,9 +9761,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                       scheme:
                                         type: string
                                     required:
@@ -9906,9 +9774,8 @@ spec:
                                         type: string
                                       port:
                                         anyOf:
-                                        - type: integer
                                         - type: string
-                                        x-kubernetes-int-or-string: true
+                                        - type: integer
                                     required:
                                     - port
                                     type: object
@@ -9946,9 +9813,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -9969,9 +9835,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -10032,9 +9897,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -10055,9 +9919,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object
@@ -10149,9 +10012,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                   scheme:
                                     type: string
                                 required:
@@ -10172,9 +10034,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
-                                    x-kubernetes-int-or-string: true
+                                    - type: integer
                                 required:
                                 - port
                                 type: object


### PR DESCRIPTION
Looks like the https://github.com/argoproj/argo-rollouts/pull/318 merge, a merge conflict with the manifests get in and that commit used a different version of the codegen. This PR fixes the merge conflict and uses the older version of the codegen (the same version the maintainers are using). I will open up another issue to standardize the version of the code generator.