### PR TITLE
chore: Reduce log from error to warning

### DIFF
--- a/utils/controller/controller.go
+++ b/utils/controller/controller.go
@@ -56,7 +56,7 @@ func WatchResource(client dynamic.Interface, namespace string, gvk schema.GroupV
 	}
 
 	if err != nil {
-		log.Errorf("Error with watch: %v", err)
+		log.Warningf("Error with watch: %v", err)
 		return err
 	}
 	for watchEvent := range watchI.ResultChan() {


### PR DESCRIPTION
Reduced message from error to warning since this is a common error when clusters don't have Istio installed.