### PR TITLE
chore: Add autogenerated sites/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ cmd/**/debug
 debug.test
 coverage.out
 coverage.html
+site/


### PR DESCRIPTION
When we deploy the documentation to https://argoproj.github.io/argo-rollouts/, the mkdocs command creates a directory called `site/`. Since this directory is auto-generated from the docs folder, there is no reason for us to keep the code in Git. 