### PR TITLE
feat: Allow ex to use availableAt and end Time as args

### DIFF
--- a/docs/features/analysis.md
+++ b/docs/features/analysis.md
@@ -399,9 +399,9 @@ spec:
     templateName: mann-whitney
     args:
     - name: start-time
-      value: 2019-09-14T01:40:10Z
+      value: "{{experiment.availableAt}}"
     - name: end-time
-      value: 2019-09-14T02:40:10Z
+      value: "{{experiment.finishedAt}}"
 ```
 
 


### PR DESCRIPTION
This feature better enables the Kayenta use case by dynamically setting the Start and End times for the Kayenta query.