### PR TITLE
fix: Update RS if RS's annotations need to be changed

### DIFF
--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -1221,7 +1221,7 @@ func TestHandleNilNewRSOnScaleAndImageChange(t *testing.T) {
 	f.rolloutLister = append(f.rolloutLister, r2)
 	f.objects = append(f.objects, r2)
 
-	// f.expectUpdateReplicaSetAction(rs1)
+	f.expectUpdateReplicaSetAction(rs1)
 	patchIndex := f.expectPatchRolloutAction(r2)
 	f.run(getKey(r2, t))
 	patch := f.getPatchedRollout(patchIndex)

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -301,7 +301,7 @@ func (c *RolloutController) isScalingEvent(rollout *v1alpha1.Rollout, rsList []*
 
 func (c *RolloutController) scaleReplicaSetAndRecordEvent(rs *appsv1.ReplicaSet, newScale int32, rollout *v1alpha1.Rollout) (bool, *appsv1.ReplicaSet, error) {
 	// No need to scale
-	if *(rs.Spec.Replicas) == newScale {
+	if *(rs.Spec.Replicas) == newScale && !annotations.ReplicasAnnotationsNeedUpdate(rs, defaults.GetReplicasOrDefault(rollout.Spec.Replicas)) {
 		return false, rs, nil
 	}
 	var scalingOperation string


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-rollouts/issues/412 by allowing the controller to update ReplicaSet if RS's annotations need to be changed.

Noticed that we implemented this fix in https://github.com/argoproj/argo-rollouts/pull/388, but that PR is too large for a patch release.