### PR TITLE
feat: Add more command aliases in kubectl plugin

### DIFF
--- a/docs/features/kubectl-plugin.md
+++ b/docs/features/kubectl-plugin.md
@@ -6,10 +6,10 @@ Argo Rollouts offers a Kubectl plugin to enrich the experience with Rollouts, Ex
 ## Installation
 
 ### Manual
-1. Install Argo Rollouts Kubectl plugin with curl.
+1. Install [Argo Rollouts Kubectl plugin](https://github.com/argoproj/argo-rollouts/releases) with curl.
 
 ```bash
-curl -LO https://github.com/argoproj/argo-rollouts/releases/download/v0.6.0/kubectl-argo-rollouts-darwin-amd64
+curl -LO https://github.com/argoproj/argo-rollouts/releases/latest/download/kubectl-argo-rollouts-darwin-amd64
 ```
 
 Note: For Linux dist, replace `darwin` with `linux`
@@ -39,7 +39,7 @@ Currently not supported, but there are plans to make the Argo Rollouts kubectl a
 ## Usage
 The best way to get information on the available Argo Rollouts kubectl plugin commands is by run `kubectl argo rollouts`. The plugin lists all the available commands that the tool can execute along with a description of each commend. All the plugin's commands interact with the Kubernetes API server and use KubeConfig credentials for authentication. Since the plugin leverages the KubeConfig of the user running the command, the plugin has the permissions of those configs. 
 
-Similar to kubectl, the plugin uses many of the same flags as the kubectl. For example, the `kubectl argo rollouts get canary-demo -w` command starts a watch on the `canary-demo` rollout object similar to how the `kubectl get deployment canary-demo -w` command starts a watch on a deployment.
+Similar to kubectl, the plugin uses many of the same flags as the kubectl. For example, the `kubectl argo rollouts get rollout canary-demo -w` command starts a watch on the `canary-demo` rollout object similar to how the `kubectl get deployment canary-demo -w` command starts a watch on a deployment.
 
 ## Visualizing Rollouts and Experiments
 In addition to encapsulating many routine commands, the Argo Rollouts kubectl plugin supports visualizing rollouts and experiments with the get command. The get command provides a clean representation of either the rollouts or the experiments running in a cluster. It returns a bunch of metadata on a resource and a tree view of the child resources created by the parent. As an example, here is a rollout retrieved with a get command:

--- a/pkg/kubectl-argo-rollouts/cmd/get/get_experiment.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get_experiment.go
@@ -23,7 +23,7 @@ func NewCmdGetExperiment(o *options.ArgoRolloutsOptions) *cobra.Command {
 
 	var cmd = &cobra.Command{
 		Use:     "experiment EXPERIMENT",
-		Aliases: []string{"exp"},
+		Aliases: []string{"exp", "experiments"},
 		Short:   "Get details about an Experiment",
 		Example: o.Example(`
   # Get an experiment

--- a/pkg/kubectl-argo-rollouts/cmd/get/get_rollout.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get_rollout.go
@@ -23,7 +23,7 @@ func NewCmdGetRollout(o *options.ArgoRolloutsOptions) *cobra.Command {
 
 	var cmd = &cobra.Command{
 		Use:     "rollout ROLLOUT",
-		Aliases: []string{"ro"},
+		Aliases: []string{"ro", "rollouts"},
 		Short:   "Get details about a rollout",
 		Example: o.Example(`
   # Get a rollout

--- a/pkg/kubectl-argo-rollouts/cmd/get/get_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get_test.go
@@ -56,6 +56,9 @@ func TestGetRolloutUsage(t *testing.T) {
 	cmd.SetArgs([]string{})
 	err := cmd.Execute()
 	assert.Error(t, err)
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	expectedOut := "Aliases:\n  rollout, ro, rollouts"
+	assert.Contains(t, stderr, expectedOut)
 }
 
 func TestGetExperimentUsage(t *testing.T) {
@@ -66,6 +69,9 @@ func TestGetExperimentUsage(t *testing.T) {
 	cmd.SetArgs([]string{})
 	err := cmd.Execute()
 	assert.Error(t, err)
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	expectedOut := "Aliases:\n  experiment, exp, experiments"
+	assert.Contains(t, stderr, expectedOut)
 }
 
 func TestRolloutNotFound(t *testing.T) {

--- a/pkg/kubectl-argo-rollouts/cmd/list/list_experiments.go
+++ b/pkg/kubectl-argo-rollouts/cmd/list/list_experiments.go
@@ -21,7 +21,7 @@ func NewCmdListExperiments(o *options.ArgoRolloutsOptions) *cobra.Command {
 
 	var cmd = &cobra.Command{
 		Use:     "experiments",
-		Aliases: []string{"exp"},
+		Aliases: []string{"exp", "experiment"},
 		Short:   "List experiments",
 		Example: o.Example(`
   # List rollouts

--- a/pkg/kubectl-argo-rollouts/cmd/list/list_rollouts.go
+++ b/pkg/kubectl-argo-rollouts/cmd/list/list_rollouts.go
@@ -22,7 +22,7 @@ func NewCmdListRollouts(o *options.ArgoRolloutsOptions) *cobra.Command {
 
 	var cmd = &cobra.Command{
 		Use:     "rollouts",
-		Aliases: []string{"ro"},
+		Aliases: []string{"ro", "rollout"},
 		Short:   "List rollouts",
 		Example: o.Example(`
   # List rollouts

--- a/pkg/kubectl-argo-rollouts/cmd/list/list_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/list/list_test.go
@@ -77,6 +77,42 @@ func newBlueGreenRollout() *v1alpha1.Rollout {
 	}
 }
 
+func TestListCmdUsage(t *testing.T) {
+	tf, o := options.NewFakeArgoRolloutsOptions()
+	defer tf.Cleanup()
+	cmd := NewCmdList(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	assert.Error(t, err)
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "Usage:\n  list [flags]\n  list [command]")
+}
+
+func TestListRolloutsCmdUsage(t *testing.T) {
+	tf, o := options.NewFakeArgoRolloutsOptions()
+	defer tf.Cleanup()
+	cmd := NewCmdListRollouts(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{"-h"})
+	usage := cmd.UsageString()
+	assert.Contains(t, usage, "Usage:\n  rollouts [flags]")
+	assert.Contains(t, usage, "Aliases:\n  rollouts, ro, rollout")
+}
+
+func TestListExperimentsCmdUsage(t *testing.T) {
+	tf, o := options.NewFakeArgoRolloutsOptions()
+	defer tf.Cleanup()
+	cmd := NewCmdListExperiments(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{})
+	usage := cmd.UsageString()
+	assert.Contains(t, usage, "Usage:\n  experiments [flags]")
+	assert.Contains(t, usage, "Aliases:\n  experiments, exp, experiment")
+}
+
 func TestListRolloutsNoResources(t *testing.T) {
 	tf, o := options.NewFakeArgoRolloutsOptions()
 	defer tf.Cleanup()

--- a/pkg/kubectl-argo-rollouts/cmd/retry/retry.go
+++ b/pkg/kubectl-argo-rollouts/cmd/retry/retry.go
@@ -39,7 +39,7 @@ func NewCmdRetry(o *options.ArgoRolloutsOptions) *cobra.Command {
 func NewCmdRetryRollout(o *options.ArgoRolloutsOptions) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:     "rollout ROLLOUT",
-		Aliases: []string{"ro"},
+		Aliases: []string{"ro", "rollouts"},
 		Short:   "Retry an aborted rollout",
 		Example: o.Example(`
   # Retry an aborted rollout
@@ -70,7 +70,7 @@ func NewCmdRetryRollout(o *options.ArgoRolloutsOptions) *cobra.Command {
 func NewCmdRetryExperiment(o *options.ArgoRolloutsOptions) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:     "experiment EXPERIMENT",
-		Aliases: []string{"exp"},
+		Aliases: []string{"exp", "experiments"},
 		Short:   "Retry an experiment",
 		Example: o.Example(`
   # Retry an experiment

--- a/pkg/kubectl-argo-rollouts/cmd/retry/retry_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/retry/retry_test.go
@@ -25,8 +25,7 @@ func TestRetryCmdUsage(t *testing.T) {
 	stdout := o.Out.(*bytes.Buffer).String()
 	stderr := o.ErrOut.(*bytes.Buffer).String()
 	assert.Empty(t, stdout)
-	assert.Contains(t, stderr, "Usage:")
-	assert.Contains(t, stderr, "retry <rollout|experiment> RESOURCE")
+	assert.Contains(t, stderr, "Usage:\n  retry <rollout|experiment> RESOURCE")
 }
 
 func TestRetryRolloutCmdUsage(t *testing.T) {
@@ -40,8 +39,8 @@ func TestRetryRolloutCmdUsage(t *testing.T) {
 	stdout := o.Out.(*bytes.Buffer).String()
 	stderr := o.ErrOut.(*bytes.Buffer).String()
 	assert.Empty(t, stdout)
-	assert.Contains(t, stderr, "Usage:")
-	assert.Contains(t, stderr, "rollout ROLLOUT")
+	assert.Contains(t, stderr, "Usage:\n  rollout ROLLOUT")
+	assert.Contains(t, stderr, "Aliases:\n  rollout, ro, rollouts")
 }
 
 func TestRetryExperimentCmdUsage(t *testing.T) {
@@ -55,8 +54,8 @@ func TestRetryExperimentCmdUsage(t *testing.T) {
 	stdout := o.Out.(*bytes.Buffer).String()
 	stderr := o.ErrOut.(*bytes.Buffer).String()
 	assert.Empty(t, stdout)
-	assert.Contains(t, stderr, "Usage:")
-	assert.Contains(t, stderr, "experiment EXPERIMENT")
+	assert.Contains(t, stderr, "Usage:\n  experiment EXPERIMENT")
+	assert.Contains(t, stderr, "Aliases:\n  experiment, exp, experiments")
 }
 
 func TestRetryRolloutCmd(t *testing.T) {

--- a/pkg/kubectl-argo-rollouts/cmd/terminate/terminate_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/terminate/terminate_test.go
@@ -25,8 +25,7 @@ func TestTerminateCmdUsage(t *testing.T) {
 	stdout := o.Out.(*bytes.Buffer).String()
 	stderr := o.ErrOut.(*bytes.Buffer).String()
 	assert.Empty(t, stdout)
-	assert.Contains(t, stderr, "Usage:")
-	assert.Contains(t, stderr, "terminate <analysisrun|experiment> RESOURCE")
+	assert.Contains(t, stderr, "Usage:\n  terminate <analysisrun|experiment> RESOURCE")
 }
 
 func TestTerminateAnalysisCmdUsage(t *testing.T) {
@@ -40,8 +39,8 @@ func TestTerminateAnalysisCmdUsage(t *testing.T) {
 	stdout := o.Out.(*bytes.Buffer).String()
 	stderr := o.ErrOut.(*bytes.Buffer).String()
 	assert.Empty(t, stdout)
-	assert.Contains(t, stderr, "Usage:")
-	assert.Contains(t, stderr, "analysisrun ANALYSISRUN")
+	assert.Contains(t, stderr, "Usage:\n  analysisrun ANALYSISRUN")
+	assert.Contains(t, stderr, "Aliases:\n  analysisrun, ar, analysisruns")
 }
 
 func TestTerminateExperimentCmdUsage(t *testing.T) {
@@ -55,8 +54,8 @@ func TestTerminateExperimentCmdUsage(t *testing.T) {
 	stdout := o.Out.(*bytes.Buffer).String()
 	stderr := o.ErrOut.(*bytes.Buffer).String()
 	assert.Empty(t, stdout)
-	assert.Contains(t, stderr, "Usage:")
-	assert.Contains(t, stderr, "experiment EXPERIMENT")
+	assert.Contains(t, stderr, "Usage:\n  experiment EXPERIMENT")
+	assert.Contains(t, stderr, "Aliases:\n  experiment, exp, experiments")
 }
 
 func TestTerminateAnalysisRunCmd(t *testing.T) {


### PR DESCRIPTION
Add resource aliases consistent with crds to kubectl plugin commands (`get`, `list`, `retry`, `terminate`)
- Rollout = rollouts, rollout, ro
- Experiment = experiments, experiment, exp
- AnalysisRun = analysisruns, analysisrun, ar

Closes #402