### PR TITLE
docs: Use correct podTemplateHashValue attribute for valueFrom

### DIFF
--- a/docs/features/analysis.md
+++ b/docs/features/analysis.md
@@ -457,10 +457,10 @@ spec:
             args:
             - name: stable-hash
               valueFrom:
-                podTemplateHash: Stable
+                podTemplateHashValue: Stable
             - name: canary-hash
               valueFrom:
-                podTemplateHash: Latest
+                podTemplateHashValue: Latest
 ```
 
 


### PR DESCRIPTION
The `valueFrom` attribute for analysis args is `podTemplateHashValue`.

See: https://godoc.org/github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1#ArgumentValueFrom