### PR TITLE
fix: Add Go mod download command to contributor docs

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -12,12 +12,10 @@ Install:
 * [minikube](https://kubernetes.io/docs/setup/minikube/) or Docker for Desktop
 
 Argo Rollout additionally uses
-* `controller-gen` binary in order to auto-generate the crd manifest
 * `golangci-lint` to lint the project.
 
 Run the following commands to install them:
 ```bash
-go get -u github.com/kubernetes-sigs/controller-tools/cmd/controller-gen
 go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 ```
 
@@ -41,6 +39,12 @@ Checkout the code:
 go get -u github.com/argoproj/argo-rollouts
 cd ~/go/src/github.com/argoproj/argo-rollouts
 ```
+
+Run the following command to download all the dependencies:
+```
+go mod download
+```
+
 
 ## Building
 


### PR DESCRIPTION
Fixes the issue where a new developer would run `make codegen` and the mockery binary wouldn't be downloaded.