### PR TITLE
chore: Add StableRS to rolloutStatus

### DIFF
--- a/manifests/crds/rollout-crd.yaml
+++ b/manifests/crds/rollout-crd.yaml
@@ -2940,6 +2940,8 @@ spec:
               type: integer
             selector:
               type: string
+            stableRS:
+              type: string
             updatedReplicas:
               format: int32
               type: integer

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -11263,6 +11263,8 @@ spec:
               type: integer
             selector:
               type: string
+            stableRS:
+              type: string
             updatedReplicas:
               format: int32
               type: integer

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -11263,6 +11263,8 @@ spec:
               type: integer
             selector:
               type: string
+            stableRS:
+              type: string
             updatedReplicas:
               format: int32
               type: integer

--- a/pkg/apis/rollouts/v1alpha1/openapi_generated.go
+++ b/pkg/apis/rollouts/v1alpha1/openapi_generated.go
@@ -2452,6 +2452,13 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutStatus(ref common.ReferenceCallbac
 							Format:      "",
 						},
 					},
+					"stableRS": {
+						SchemaProps: spec.SchemaProps{
+							Description: "StableRS indicates the replicaset that has successfully rolled out",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -440,6 +440,9 @@ type RolloutStatus struct {
 	// Selector that identifies the pods that are receiving active traffic
 	// +optional
 	Selector string `json:"selector,omitempty"`
+	// StableRS indicates the replicaset that has successfully rolled out
+	// +optional
+	StableRS string `json:"stableRS,omitempty"`
 }
 
 // BlueGreenStatus status fields that only pertain to the blueGreen rollout

--- a/pkg/kubectl-argo-rollouts/info/info_test.go
+++ b/pkg/kubectl-argo-rollouts/info/info_test.go
@@ -225,12 +225,12 @@ func TestRolloutStatusProgressing(t *testing.T) {
 	}
 	{
 		ro := newCanaryRollout()
-		ro.Status.Canary.StableRS = ""
+		ro.Status.StableRS = ""
 		assert.Equal(t, "Progressing", RolloutStatusString(ro))
 	}
 	{
 		ro := newCanaryRollout()
-		ro.Status.Canary.StableRS = "abc1234"
+		ro.Status.StableRS = "abc1234"
 		ro.Status.CurrentPodHash = "def5678"
 		assert.Equal(t, "Progressing", RolloutStatusString(ro))
 	}
@@ -254,7 +254,7 @@ func TestRolloutStatusHealthy(t *testing.T) {
 		ro.Status.UpdatedReplicas = 1
 		ro.Status.AvailableReplicas = 1
 		ro.Status.ReadyReplicas = 1
-		ro.Status.Canary.StableRS = "abc1234"
+		ro.Status.StableRS = "abc1234"
 		ro.Status.CurrentPodHash = "abc1234"
 		assert.Equal(t, "Healthy", RolloutStatusString(ro))
 	}

--- a/pkg/kubectl-argo-rollouts/info/replicaset_info.go
+++ b/pkg/kubectl-argo-rollouts/info/replicaset_info.go
@@ -56,7 +56,7 @@ func getReplicaSetInfo(ownerUID types.UID, ro *v1alpha1.Rollout, allReplicaSets 
 
 		if ro != nil {
 			if ro.Spec.Strategy.Canary != nil && rs.Labels != nil {
-				if ro.Status.Canary.StableRS == rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] {
+				if ro.Status.StableRS == rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] {
 					rsInfo.Stable = true
 				} else if ro.Status.CurrentPodHash == rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] {
 					rsInfo.Canary = true

--- a/pkg/kubectl-argo-rollouts/info/rollout_info.go
+++ b/pkg/kubectl-argo-rollouts/info/rollout_info.go
@@ -121,7 +121,7 @@ func RolloutStatusString(ro *v1alpha1.Rollout) string {
 			// old replicas are pending termination
 			return "Progressing"
 		}
-		if ro.Status.Canary.StableRS != "" && ro.Status.Canary.StableRS == ro.Status.CurrentPodHash {
+		if ro.Status.StableRS != "" && ro.Status.StableRS == ro.Status.CurrentPodHash {
 			return "Healthy"
 		}
 		// Waiting for rollout to finish steps

--- a/pkg/kubectl-argo-rollouts/info/testdata/canary/canary-rollout.yaml
+++ b/pkg/kubectl-argo-rollouts/info/testdata/canary/canary-rollout.yaml
@@ -57,8 +57,8 @@ status:
   HPAReplicas: 6
   availableReplicas: 5
   blueGreen: {}
-  canary:
-    stableRS: 877894d5b
+  canary: {}
+  stableRS: 877894d5b
   conditions:
   - lastTransitionTime: "2019-10-25T06:07:29Z"
     lastUpdateTime: "2019-10-25T06:07:29Z"

--- a/pkg/kubectl-argo-rollouts/info/testdata/experiment-analysis/rollout-experiment-analysis.yaml
+++ b/pkg/kubectl-argo-rollouts/info/testdata/experiment-analysis/rollout-experiment-analysis.yaml
@@ -47,7 +47,7 @@ status:
   blueGreen: {}
   canary:
     currentExperiment: rollout-experiment-analysis-6f646bf7b7-1-vcv27
-    stableRS: f6db98dff
+  stableRS: f6db98dff
   conditions:
   - lastTransitionTime: "2019-10-30T07:26:49Z"
     lastUpdateTime: "2019-10-30T07:26:49Z"

--- a/pkg/kubectl-argo-rollouts/info/testdata/experiment-step/canary-demo.yaml
+++ b/pkg/kubectl-argo-rollouts/info/testdata/experiment-step/canary-demo.yaml
@@ -58,7 +58,7 @@ status:
   blueGreen: {}
   canary:
     currentExperiment: canary-demo-645d5dbc4c-2-0
-    stableRS: 877894d5b
+  stableRS: 877894d5b
   conditions:
   - lastTransitionTime: "2019-11-07T22:38:11Z"
     lastUpdateTime: "2019-11-07T22:38:11Z"

--- a/rollout/analysis.go
+++ b/rollout/analysis.go
@@ -163,7 +163,7 @@ func (c *RolloutController) reconcileBackgroundAnalysisRun(roCtx rolloutContext)
 	}
 
 	// Do not create a background run if the rollout is completely rolled out, just created, before the starting step
-	if rollout.Status.Canary.StableRS == rollout.Status.CurrentPodHash || rollout.Status.CurrentPodHash == "" || replicasetutil.BeforeStartingStep(rollout) {
+	if rollout.Status.StableRS == rollout.Status.CurrentPodHash || rollout.Status.CurrentPodHash == "" || replicasetutil.BeforeStartingStep(rollout) {
 		return nil, nil
 	}
 

--- a/rollout/analysis_test.go
+++ b/rollout/analysis_test.go
@@ -1172,7 +1172,7 @@ func TestCreatePrePromotionAnalysisRun(t *testing.T) {
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-	r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
+	r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
 	pausedCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2)
 	conditions.SetRolloutCondition(&r2.Status, pausedCondition)
 
@@ -1225,7 +1225,7 @@ func TestDoNotCreatePrePromotionAnalysisAfterPromotionRollout(t *testing.T) {
 	s := newService("bar", 80, serviceSelector)
 	f.kubeobjects = append(f.kubeobjects, s)
 
-	r2 = updateBlueGreenRolloutStatus(r2, "", rs2PodHash, 1, 1, 1, 1, false, true)
+	r2 = updateBlueGreenRolloutStatus(r2, "", rs2PodHash, rs2PodHash, 1, 1, 1, 1, false, true)
 	r2.Status.ObservedGeneration = conditions.ComputeGenerationHash(r2.Spec)
 
 	f.rolloutLister = append(f.rolloutLister, r2)
@@ -1294,7 +1294,7 @@ func TestDoNotCreatePrePromotionAnalysisRunOnNotReadyReplicaSet(t *testing.T) {
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-	r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, 1, 2, 4, 2, false, true)
+	r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 2, 4, 2, false, true)
 
 	activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}
 	activeSvc := newService("active", 80, activeSelector)
@@ -1335,7 +1335,7 @@ func TestRolloutPrePromotionAnalysisBecomesInconclusive(t *testing.T) {
 	rs2 := newReplicaSetWithStatus(r2, 1, 1)
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-	r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, 1, 1, 2, 1, true, true)
+	r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
 	pausedCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2)
 	conditions.SetRolloutCondition(&r2.Status, pausedCondition)
 
@@ -1395,7 +1395,7 @@ func TestRolloutPrePromotionAnalysisSwitchServiceAfterSuccess(t *testing.T) {
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-	r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, 1, 1, 2, 1, true, true)
+	r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
 	pausedCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2)
 	conditions.SetRolloutCondition(&r2.Status, pausedCondition)
 
@@ -1451,7 +1451,7 @@ func TestRolloutPrePromotionAnalysisHonorAutoPromotionSeconds(t *testing.T) {
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-	r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, 1, 1, 2, 1, true, true)
+	r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
 	now := metav1.NewTime(metav1.Now().Add(-10 * time.Second))
 	r2.Status.PauseConditions[0].StartTime = now
 	pausedCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2)
@@ -1507,7 +1507,7 @@ func TestRolloutPrePromotionAnalysisDoNothingOnInconclusiveAnalysis(t *testing.T
 	rs2 := newReplicaSetWithStatus(r2, 1, 1)
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-	r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, 1, 1, 2, 1, true, true)
+	r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
 	inconclusivePauseCondition := v1alpha1.PauseCondition{
 		Reason:    v1alpha1.PauseReasonInconclusiveAnalysis,
 		StartTime: metav1.Now(),
@@ -1553,7 +1553,7 @@ func TestAbortRolloutOnErrorPrePromotionAnalysis(t *testing.T) {
 	rs2 := newReplicaSetWithStatus(r2, 1, 1)
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-	r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, 1, 1, 2, 1, true, true)
+	r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
 	pausedCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2)
 	conditions.SetRolloutCondition(&r2.Status, pausedCondition)
 

--- a/rollout/bluegreen_test.go
+++ b/rollout/bluegreen_test.go
@@ -58,10 +58,11 @@ func TestBlueGreenCreatesReplicaSet(t *testing.T) {
 				"previewSelector": "%s"
 			},
 			"conditions": %s,
-			"selector": "foo=bar"
+			"selector": "foo=bar",
+			"stableRS": "%s"
 		}
 	}`
-	expectedPatch := calculatePatch(r, fmt.Sprintf(expectedPatchWithoutSubs, rsPodHash, generatedConditions))
+	expectedPatch := calculatePatch(r, fmt.Sprintf(expectedPatchWithoutSubs, rsPodHash, generatedConditions, rsPodHash))
 	patchRolloutIndex := f.expectPatchRolloutActionWithPatch(r, expectedPatch)
 	f.run(getKey(r, t))
 
@@ -119,7 +120,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 		rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, 1, 2, 4, 2, false, true)
+		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 2, 4, 2, false, true)
 
 		activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}
 		activeSvc := newService("active", 80, activeSelector)
@@ -150,7 +151,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 		rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, 1, 1, 2, 1, false, true)
+		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 1, 2, 1, false, true)
 		previewSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}
 		previewSvc := newService("preview", 80, previewSelector)
 		activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}
@@ -196,7 +197,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 		rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
+		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
 
 		previewSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}
 		previewSvc := newService("preview", 80, previewSelector)
@@ -236,7 +237,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 		rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
+		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
 		pausedCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2)
 		conditions.SetRolloutCondition(&r2.Status, pausedCondition)
 
@@ -275,7 +276,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 		rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, 1, 1, 2, 1, false, true)
+		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 1, 2, 1, false, true)
 		now := metav1.Now()
 		r2.Status.PauseConditions = append(r2.Status.PauseConditions, v1alpha1.PauseCondition{
 			Reason:    v1alpha1.PauseReasonInconclusiveAnalysis,
@@ -315,7 +316,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 		rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
+		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
 		pausedCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2)
 		conditions.SetRolloutCondition(&r2.Status, pausedCondition)
 
@@ -350,7 +351,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 		rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
+		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
 		now := metav1.Now()
 		before := metav1.NewTime(now.Add(-1 * time.Minute))
 		r2.Status.PauseConditions[0].StartTime = before
@@ -403,7 +404,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 		rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
+		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
 		now := metav1.Now()
 		before := metav1.NewTime(now.Add(-1 * time.Minute))
 		r2.Status.PauseConditions[0].StartTime = before
@@ -443,7 +444,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 		rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-		r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, 1, 1, 2, 1, false, true)
+		r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, rs1PodHash, 1, 1, 2, 1, false, true)
 		r2.Spec.Strategy.BlueGreen.ScaleDownDelaySeconds = pointer.Int32Ptr(10)
 
 		progressingCondition, _ := newProgressingCondition(conditions.NewReplicaSetReason, rs2)
@@ -493,7 +494,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		rs2 := newReplicaSetWithStatus(r2, 1, 1)
 		rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-		r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, 1, 1, 2, 1, false, true)
+		r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, rs1PodHash, 1, 1, 2, 1, false, true)
 
 		progressingCondition, _ := newProgressingCondition(conditions.NewReplicaSetReason, rs2)
 		conditions.SetRolloutCondition(&r2.Status, progressingCondition)
@@ -534,7 +535,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		rs1 := newReplicaSetWithStatus(r1, 1, 1)
 		rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-		r1 = updateBlueGreenRolloutStatus(r1, "", "", 1, 1, 1, 1, false, false)
+		r1 = updateBlueGreenRolloutStatus(r1, "", "", "", 1, 1, 1, 1, false, false)
 
 		activeSelector := map[string]string{"foo": "bar"}
 
@@ -552,6 +553,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 				"blueGreen": {
 					"activeSelector": "%s"
 				},
+				"stableRS": "%s",
 				"conditions": %s,
 				"selector": "%s"
 			}
@@ -559,7 +561,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 
 		generateConditions := generateConditionsPatch(true, conditions.ReplicaSetUpdatedReason, rs1, false)
 		newSelector := metav1.FormatLabelSelector(rs1.Spec.Selector)
-		expectedPatch := calculatePatch(r1, fmt.Sprintf(expectedPatchWithoutSubs, rs1PodHash, generateConditions, newSelector))
+		expectedPatch := calculatePatch(r1, fmt.Sprintf(expectedPatchWithoutSubs, rs1PodHash, rs1PodHash, generateConditions, newSelector))
 		patchRolloutIndex := f.expectPatchRolloutActionWithPatch(r1, expectedPatch)
 		f.run(getKey(r1, t))
 
@@ -583,7 +585,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
 		r2.Spec.Strategy.BlueGreen.ScaleDownDelaySeconds = pointer.Int32Ptr(10)
-		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, 1, 1, 2, 1, false, true)
+		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 1, 2, 1, false, true)
 		r2.Status.ControllerPause = true
 		pausedCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, rs2)
 		conditions.SetRolloutCondition(&r2.Status, pausedCondition)
@@ -652,7 +654,7 @@ func TestBlueGreenAddScaleDownDelayToPreviousActiveReplicaSet(t *testing.T) {
 	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
 
 	r2.Spec.Strategy.BlueGreen.ScaleDownDelaySeconds = pointer.Int32Ptr(10)
-	r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, 1, 1, 2, 1, false, true)
+	r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, rs1PodHash, 1, 1, 2, 1, false, true)
 	f.rolloutLister = append(f.rolloutLister, r2)
 	f.objects = append(f.objects, r2)
 	f.serviceLister = append(f.serviceLister, s)
@@ -695,7 +697,7 @@ func TestBlueGreenRolloutStatusHPAStatusFieldsActiveSelectorSet(t *testing.T) {
 	previewSvc := newService("preview", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash})
 	activeSvc := newService("active", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash})
 
-	r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, 0, 0, 0, 0, true, false)
+	r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 0, 0, 0, 0, true, false)
 	r2.Status.Selector = ""
 	pausedCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, rs2)
 	conditions.SetRolloutCondition(&r2.Status, pausedCondition)
@@ -731,6 +733,7 @@ func TestBlueGreenRolloutStatusHPAStatusFieldsNoActiveSelector(t *testing.T) {
 	rs := newReplicaSetWithStatus(ro, 1, 1)
 	roCtx := newBlueGreenCtx(ro, rs, nil, nil)
 	ro.Status.CurrentPodHash = rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	ro.Status.StableRS = rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 	activeSvc := newService("active", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: ""})
 
 	progressingCondition, progressingConditionStr := newProgressingCondition(conditions.ReplicaSetUpdatedReason, rs)
@@ -781,7 +784,7 @@ func TestBlueGreenRolloutScaleUpdateActiveRS(t *testing.T) {
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-	r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, 1, 1, 1, 1, false, true)
+	r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 1, 1, 1, false, true)
 	f.objects = append(f.objects, r2)
 	previewSvc := newService("preview", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash})
 	activeSvc := newService("active", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash})
@@ -815,7 +818,7 @@ func TestPreviewReplicaCountHandleScaleUpPreviewCheckPoint(t *testing.T) {
 
 		activeSvc := newService("active", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash})
 
-		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, 3, 3, 8, 5, false, true)
+		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 3, 3, 8, 5, false, true)
 		f.rolloutLister = append(f.rolloutLister, r2)
 		f.objects = append(f.objects, r2)
 		f.kubeobjects = append(f.kubeobjects, activeSvc)
@@ -849,7 +852,7 @@ func TestPreviewReplicaCountHandleScaleUpPreviewCheckPoint(t *testing.T) {
 
 		activeSvc := newService("active", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash})
 
-		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, 5, 5, 8, 5, false, true)
+		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 5, 5, 8, 5, false, true)
 		r2.Status.BlueGreen.ScaleUpPreviewCheckPoint = true
 		f.rolloutLister = append(f.rolloutLister, r2)
 		f.objects = append(f.objects, r2)
@@ -881,7 +884,7 @@ func TestPreviewReplicaCountHandleScaleUpPreviewCheckPoint(t *testing.T) {
 
 		activeSvc := newService("active", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash})
 
-		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, 5, 5, 8, 5, false, true)
+		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 5, 5, 8, 5, false, true)
 		r2.Status.BlueGreen.ScaleUpPreviewCheckPoint = true
 		f.rolloutLister = append(f.rolloutLister, r2)
 		f.objects = append(f.objects, r2)
@@ -915,7 +918,7 @@ func TestBlueGreenRolloutIgnoringScalingUsePreviewRSCount(t *testing.T) {
 	previewSvc := newService("preview", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash})
 	activeSvc := newService("active", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash})
 
-	r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, 2, 1, 1, 1, false, true)
+	r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 2, 1, 1, 1, false, true)
 	// Scaling up the rollout
 	r2.Spec.Replicas = pointer.Int32Ptr(2)
 	f.rolloutLister = append(f.rolloutLister, r2)
@@ -948,7 +951,7 @@ func TestBlueGreenRolloutCompleted(t *testing.T) {
 	s := newService("bar", 80, serviceSelector)
 	f.kubeobjects = append(f.kubeobjects, s)
 
-	r2 = updateBlueGreenRolloutStatus(r2, "", rs2PodHash, 1, 1, 1, 1, false, true)
+	r2 = updateBlueGreenRolloutStatus(r2, "", rs2PodHash, rs2PodHash, 1, 1, 1, 1, false, true)
 	r2.Status.ObservedGeneration = conditions.ComputeGenerationHash(r2.Spec)
 
 	f.rolloutLister = append(f.rolloutLister, r2)
@@ -987,7 +990,7 @@ func TestBlueGreenUnableToReadScaleDownAt(t *testing.T) {
 	f.kubeobjects = append(f.kubeobjects, s, rs1, rs2)
 	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
 
-	r2 = updateBlueGreenRolloutStatus(r2, "", rs2PodHash, 1, 1, 2, 1, false, true)
+	r2 = updateBlueGreenRolloutStatus(r2, "", rs2PodHash, rs2PodHash, 1, 1, 2, 1, false, true)
 	f.rolloutLister = append(f.rolloutLister, r2)
 	f.objects = append(f.objects, r2)
 	f.serviceLister = append(f.serviceLister, s)
@@ -1024,7 +1027,7 @@ func TestBlueGreenNotReadyToScaleDownOldReplica(t *testing.T) {
 	f.kubeobjects = append(f.kubeobjects, s, rs1, rs2)
 	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
 
-	r2 = updateBlueGreenRolloutStatus(r2, "", rs2PodHash, 1, 1, 2, 1, false, true)
+	r2 = updateBlueGreenRolloutStatus(r2, "", rs2PodHash, rs2PodHash, 1, 1, 2, 1, false, true)
 	f.rolloutLister = append(f.rolloutLister, r2)
 	f.objects = append(f.objects, r2)
 	f.serviceLister = append(f.serviceLister, s)
@@ -1057,7 +1060,7 @@ func TestBlueGreenReadyToScaleDownOldReplica(t *testing.T) {
 	f.kubeobjects = append(f.kubeobjects, s, rs1, rs2)
 	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
 
-	r2 = updateBlueGreenRolloutStatus(r2, "", rs2PodHash, 1, 1, 2, 1, false, true)
+	r2 = updateBlueGreenRolloutStatus(r2, "", rs2PodHash, rs2PodHash, 1, 1, 2, 1, false, true)
 	f.rolloutLister = append(f.rolloutLister, r2)
 	f.objects = append(f.objects, r2)
 	f.serviceLister = append(f.serviceLister, s)
@@ -1070,6 +1073,7 @@ func TestBlueGreenReadyToScaleDownOldReplica(t *testing.T) {
 	assert.Equal(t, "", updatedRS.Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey])
 
 	patch := f.getPatchedRollout(patchIndex)
+	//TODO: fix
 	expectedPatch := calculatePatch(r2, OnlyObservedGenerationPatch)
 	assert.Equal(t, expectedPatch, patch)
 }
@@ -1101,7 +1105,7 @@ func TestFastRollback(t *testing.T) {
 	r2.Status.CurrentPodHash = rs1PodHash
 	rs1.Annotations[annotations.RevisionAnnotation] = "3"
 
-	r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, 1, 1, 2, 1, false, true)
+	r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, rs1PodHash, 1, 1, 2, 1, false, true)
 	f.rolloutLister = append(f.rolloutLister, r2)
 	f.objects = append(f.objects, r2)
 	f.serviceLister = append(f.serviceLister, s)
@@ -1139,7 +1143,7 @@ func TestScaleDownLimit(t *testing.T) {
 	f.kubeobjects = append(f.kubeobjects, s, rs1, rs2, rs3)
 	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2, rs3)
 
-	r3 = updateBlueGreenRolloutStatus(r3, "", rs3PodHash, 1, 1, 3, 1, false, true)
+	r3 = updateBlueGreenRolloutStatus(r3, "", rs3PodHash, rs3PodHash, 1, 1, 3, 1, false, true)
 	f.rolloutLister = append(f.rolloutLister, r3)
 	f.objects = append(f.objects, r3)
 	f.serviceLister = append(f.serviceLister, s)
@@ -1180,7 +1184,7 @@ func TestBlueGreenAbort(t *testing.T) {
 	f.kubeobjects = append(f.kubeobjects, s, rs1, rs2)
 	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
 
-	r2 = updateBlueGreenRolloutStatus(r2, "", rs2PodHash, 1, 1, 2, 1, false, true)
+	r2 = updateBlueGreenRolloutStatus(r2, "", rs2PodHash, rs2PodHash, 1, 1, 2, 1, false, true)
 	f.rolloutLister = append(f.rolloutLister, r2)
 	f.objects = append(f.objects, r2)
 	f.serviceLister = append(f.serviceLister, s)

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -304,9 +304,7 @@ func TestCanaryRolloutUpdateStatusWhenAtEndOfSteps(t *testing.T) {
 	patch := f.getPatchedRollout(patchIndex)
 	expectedPatchWithoutStableRS := `{
 		"status": {
-			"canary": {
-				"stableRS": "%s"
-			},
+			"stableRS": "%s",
 			"conditions": %s
 		}
 	}`
@@ -427,9 +425,7 @@ func TestCanaryRolloutCreateFirstReplicasetNoSteps(t *testing.T) {
 	patch := f.getPatchedRollout(patchIndex)
 	expectedPatch := `{
 		"status":{
-			"canary":{
-				"stableRS":"` + rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] + `"
-			},
+			"stableRS":"` + rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] + `",
 			"currentPodHash":"` + rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] + `",
 			"conditions": %s
 		}
@@ -468,9 +464,7 @@ func TestCanaryRolloutCreateFirstReplicasetWithSteps(t *testing.T) {
 	patch := f.getPatchedRollout(patchIndex)
 	expectedPatchWithSub := `{
 		"status":{
-			"canary":{
-				"stableRS":"` + rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] + `"
-			},
+			"stableRS":"` + rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] + `",
 			"currentStepIndex":1,
 			"currentPodHash":"` + rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] + `",
 			"conditions": %s
@@ -489,7 +483,7 @@ func TestCanaryRolloutCreateNewReplicaWithCorrectWeight(t *testing.T) {
 		SetWeight: int32Ptr(10),
 	}}
 	r1 := newCanaryRollout("foo", 10, nil, steps, int32Ptr(0), intstr.FromInt(1), intstr.FromInt(0))
-	r1.Status.Canary.StableRS = "895c6c4f9"
+	r1.Status.StableRS = "895c6c4f9"
 	r2 := bumpVersion(r1)
 
 	f.rolloutLister = append(f.rolloutLister, r2)
@@ -524,7 +518,7 @@ func TestCanaryRolloutScaleUpNewReplicaWithCorrectWeight(t *testing.T) {
 		SetWeight: int32Ptr(40),
 	}}
 	r1 := newCanaryRollout("foo", 5, nil, steps, int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
-	r1.Status.Canary.StableRS = "895c6c4f9"
+	r1.Status.StableRS = "895c6c4f9"
 	r2 := bumpVersion(r1)
 
 	f.rolloutLister = append(f.rolloutLister, r2)
@@ -553,7 +547,7 @@ func TestCanaryRolloutScaleDownStableToMatchWeight(t *testing.T) {
 		SetWeight: int32Ptr(10),
 	}}
 	r1 := newCanaryRollout("foo", 10, nil, steps, int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
-	r1.Status.Canary.StableRS = r1.Status.CurrentPodHash
+	r1.Status.StableRS = r1.Status.CurrentPodHash
 
 	r2 := bumpVersion(r1)
 	f.rolloutLister = append(f.rolloutLister, r2)
@@ -584,7 +578,7 @@ func TestCanaryRolloutScaleDownOldRs(t *testing.T) {
 		SetWeight: int32Ptr(10),
 	}}
 	r1 := newCanaryRollout("foo", 10, nil, steps, int32Ptr(0), intstr.FromInt(1), intstr.FromInt(0))
-	r1.Status.Canary.StableRS = r1.Status.CurrentPodHash
+	r1.Status.StableRS = r1.Status.CurrentPodHash
 
 	r2 := bumpVersion(r1)
 
@@ -884,7 +878,7 @@ func TestSyncRolloutWaitIncrementStepIndex(t *testing.T) {
 		},
 	}
 	r1 := newCanaryRollout("foo", 10, nil, steps, int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
-	r1.Status.Canary.StableRS = "895c6c4f9"
+	r1.Status.StableRS = "895c6c4f9"
 
 	r2 := bumpVersion(r1)
 	rs1 := newReplicaSetWithStatus(r1, 9, 9)
@@ -1020,7 +1014,7 @@ func TestCanaryRolloutWithStableService(t *testing.T) {
 	rollout := newCanaryRollout("foo", 0, nil, nil, nil, intstr.FromInt(1), intstr.FromInt(0))
 	rs := newReplicaSetWithStatus(rollout, 0, 0)
 	rollout.Spec.Strategy.Canary.StableService = stableSvc.Name
-	rollout.Status.Canary.StableRS = rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rollout.Status.StableRS = rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
 	f.rolloutLister = append(f.rolloutLister, rollout)
 	f.objects = append(f.objects, rollout)
@@ -1039,7 +1033,7 @@ func TestCanaryRolloutWithInvalidStableServiceName(t *testing.T) {
 	rollout := newCanaryRollout("foo", 0, nil, nil, nil, intstr.FromInt(1), intstr.FromInt(0))
 	rs := newReplicaSetWithStatus(rollout, 0, 0)
 	rollout.Spec.Strategy.Canary.StableService = "invalid-stable"
-	rollout.Status.Canary.StableRS = rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rollout.Status.StableRS = rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
 	f.rolloutLister = append(f.rolloutLister, rollout)
 	f.objects = append(f.objects, rollout)

--- a/rollout/controller.go
+++ b/rollout/controller.go
@@ -252,6 +252,13 @@ func (c *RolloutController) syncHandler(key string) error {
 	r := remarshalRollout(rollout)
 	logCtx := logutil.WithRollout(r)
 
+	// TODO(dthomson) remove in v0.9.0
+	migrated := c.migrateCanaryStableRS(r)
+	if migrated {
+		logutil.WithRollout(r).Info("Migrated stableRS field")
+		return nil
+	}
+
 	if r.ObjectMeta.DeletionTimestamp != nil {
 		logCtx.Info("No reconciliation as rollout marked for deletion")
 		return nil
@@ -319,6 +326,19 @@ func (c *RolloutController) syncHandler(key string) error {
 		return c.rolloutCanary(r, rsList)
 	}
 	return fmt.Errorf("no rollout strategy selected")
+}
+
+func (c *RolloutController) migrateCanaryStableRS(rollout *v1alpha1.Rollout) bool {
+	if rollout.Status.Canary.StableRS == "" {
+		return false
+	}
+	rollout.Status.StableRS = rollout.Status.Canary.StableRS
+	rollout.Status.Canary.StableRS = ""
+	_, err := c.argoprojclientset.ArgoprojV1alpha1().Rollouts(rollout.Namespace).Update(rollout)
+	if err != nil {
+		logutil.WithRollout(rollout).Errorf("Unable to migrate Rollout's status.canary.stableRS to status.stableRS")
+	}
+	return true
 }
 
 func remarshalRollout(r *v1alpha1.Rollout) *v1alpha1.Rollout {

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -245,7 +245,7 @@ func generateConditionsPatch(available bool, progressingReason string, progressi
 }
 
 // func updateBlueGreenRolloutStatus(r *v1alpha1.Rollout, preview, active string, availableReplicas, updatedReplicas, hpaReplicas int32, pause bool, available bool, progressingStatus string) *v1alpha1.Rollout {
-func updateBlueGreenRolloutStatus(r *v1alpha1.Rollout, preview, active string, availableReplicas, updatedReplicas, totalReplicas, hpaReplicas int32, pause bool, available bool) *v1alpha1.Rollout {
+func updateBlueGreenRolloutStatus(r *v1alpha1.Rollout, preview, active, stable string, availableReplicas, updatedReplicas, totalReplicas, hpaReplicas int32, pause bool, available bool) *v1alpha1.Rollout {
 	newRollout := updateBaseRolloutStatus(r, availableReplicas, updatedReplicas, totalReplicas, hpaReplicas)
 	selector := newRollout.Spec.Selector.DeepCopy()
 	if active != "" {
@@ -254,6 +254,7 @@ func updateBlueGreenRolloutStatus(r *v1alpha1.Rollout, preview, active string, a
 	newRollout.Status.Selector = metav1.FormatLabelSelector(selector)
 	newRollout.Status.BlueGreen.ActiveSelector = active
 	newRollout.Status.BlueGreen.PreviewSelector = preview
+	newRollout.Status.StableRS = stable
 	cond, _ := newAvailableCondition(available)
 	newRollout.Status.Conditions = append(newRollout.Status.Conditions, cond)
 	if pause {
@@ -346,8 +347,14 @@ func calculatePatch(ro *v1alpha1.Rollout, patch string) string {
 
 func cleanPatch(expectedPatch string) string {
 	patch := make(map[string]interface{})
-	json.Unmarshal([]byte(expectedPatch), &patch)
-	patchStr, _ := json.Marshal(patch)
+	err := json.Unmarshal([]byte(expectedPatch), &patch)
+	if err != nil {
+		panic(err)
+	}
+	patchStr, err := json.Marshal(patch)
+	if err != nil {
+		panic(err)
+	}
 	return string(patchStr)
 }
 
@@ -1091,6 +1098,7 @@ func TestComputeHashChangeTolerationBlueGreen(t *testing.T) {
 
 	r := newBlueGreenRollout("foo", 1, nil, "active", "")
 	r.Status.CurrentPodHash = "fakepodhash"
+	r.Status.StableRS = "fakepodhash"
 	r.Status.AvailableReplicas = 1
 	r.Status.ReadyReplicas = 1
 	r.Status.BlueGreen.ActiveSelector = "fakepodhash"

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -1189,3 +1189,18 @@ func TestComputeHashChangeTolerationCanary(t *testing.T) {
 	patch := f.getPatchedRollout(patchIndex)
 	assert.Equal(t, expectedPatch, patch)
 }
+
+func TestMigrateCanaryStableRS(t *testing.T) {
+	f := newFixture(t)
+
+	r := newCanaryRollout("foo", 1, nil, nil, nil, intstr.FromInt(0), intstr.FromInt(1))
+	r.Status.Canary.StableRS = "fakepodhash"
+	index := f.expectUpdateRolloutAction(r)
+	f.rolloutLister = append(f.rolloutLister, r)
+	f.objects = append(f.objects, r)
+
+	f.run(getKey(r, t))
+	updatedRollout := f.getUpdatedRollout(index)
+	assert.Equal(t, "fakepodhash", updatedRollout.Status.StableRS)
+	assert.Equal(t, "", updatedRollout.Status.Canary.StableRS)
+}

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -270,7 +270,7 @@ func updateBlueGreenRolloutStatus(r *v1alpha1.Rollout, preview, active, stable s
 }
 func updateCanaryRolloutStatus(r *v1alpha1.Rollout, stableRS string, availableReplicas, updatedReplicas, hpaReplicas int32, pause bool) *v1alpha1.Rollout {
 	newRollout := updateBaseRolloutStatus(r, availableReplicas, updatedReplicas, availableReplicas, hpaReplicas)
-	newRollout.Status.Canary.StableRS = stableRS
+	newRollout.Status.StableRS = stableRS
 	if pause {
 		now := metav1.Now()
 		cond := v1alpha1.PauseCondition{
@@ -1154,7 +1154,7 @@ func TestComputeHashChangeTolerationCanary(t *testing.T) {
 	r := newCanaryRollout("foo", 1, nil, nil, nil, intstr.FromInt(0), intstr.FromInt(1))
 
 	r.Status.CurrentPodHash = "fakepodhash"
-	r.Status.Canary.StableRS = "fakepodhash"
+	r.Status.StableRS = "fakepodhash"
 	r.Status.AvailableReplicas = 1
 	r.Status.ReadyReplicas = 1
 	r.Status.ObservedGeneration = "fakeobservedgeneration"

--- a/rollout/experiment_test.go
+++ b/rollout/experiment_test.go
@@ -478,7 +478,7 @@ func TestGetExperimentFromTemplate(t *testing.T) {
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
 	r2.Status.CurrentStepIndex = pointer.Int32Ptr(0)
-	r2.Status.Canary.StableRS = rs1PodHash
+	r2.Status.StableRS = rs1PodHash
 
 	stable, err := GetExperimentFromTemplate(r2, rs1, rs2)
 	assert.Nil(t, err)

--- a/utils/conditions/conditions.go
+++ b/utils/conditions/conditions.go
@@ -205,7 +205,7 @@ func RolloutProgressing(rollout *v1alpha1.Rollout, newStatus *v1alpha1.RolloutSt
 	}
 
 	if rollout.Spec.Strategy.Canary != nil {
-		stableRSChange := newStatus.Canary.StableRS != oldStatus.Canary.StableRS
+		stableRSChange := newStatus.StableRS != oldStatus.StableRS
 		incrementStepIndex := false
 		if newStatus.CurrentStepIndex != nil && oldStatus.CurrentStepIndex != nil {
 			incrementStepIndex = *newStatus.CurrentStepIndex != *oldStatus.CurrentStepIndex
@@ -245,7 +245,7 @@ func RolloutComplete(rollout *v1alpha1.Rollout, newStatus *v1alpha1.RolloutStatu
 		if stepCount > 0 && newStatus.CurrentStepIndex != nil {
 			executedAllSteps = int32(stepCount) == *newStatus.CurrentStepIndex
 		}
-		currentRSIsStable := newStatus.Canary.StableRS != "" && newStatus.Canary.StableRS == newStatus.CurrentPodHash
+		currentRSIsStable := newStatus.StableRS != "" && newStatus.StableRS == newStatus.CurrentPodHash
 		scaleDownOldReplicas := newStatus.Replicas == replicas
 		completedStrategy = executedAllSteps && currentRSIsStable && scaleDownOldReplicas
 	}

--- a/utils/conditions/rollouts_test.go
+++ b/utils/conditions/rollouts_test.go
@@ -469,7 +469,7 @@ func TestRolloutProgressing(t *testing.T) {
 	}
 	canaryStatus := func(current, updated, ready, available int32, stableRS string, index int32, stepHash string) v1alpha1.RolloutStatus {
 		status := rolloutStatus(current, updated, ready, available)
-		status.Canary.StableRS = stableRS
+		status.StableRS = stableRS
 		status.CurrentStepIndex = &index
 		status.CurrentStepHash = stepHash
 		return status
@@ -621,7 +621,7 @@ func TestRolloutComplete(t *testing.T) {
 				Steps: steps,
 			},
 		}
-		r.Status.Canary.StableRS = stableRS
+		r.Status.StableRS = stableRS
 		r.Status.CurrentStepIndex = stepIndex
 		if correctObservedGeneration {
 			r.Status.ObservedGeneration = ComputeGenerationHash(r.Spec)

--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -298,16 +298,16 @@ func GetOlderRSs(rollout *v1alpha1.Rollout, newRS, stableRS *appsv1.ReplicaSet, 
 
 // GetStableRS finds the stable RS using the RS's RolloutUniqueLabelKey and the stored StableRS in the rollout status
 func GetStableRS(rollout *v1alpha1.Rollout, newRS *appsv1.ReplicaSet, rslist []*appsv1.ReplicaSet) *appsv1.ReplicaSet {
-	if rollout.Status.Canary.StableRS == "" {
+	if rollout.Status.StableRS == "" {
 		return nil
 	}
-	if newRS != nil && newRS.Labels != nil && newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] == rollout.Status.Canary.StableRS {
+	if newRS != nil && newRS.Labels != nil && newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] == rollout.Status.StableRS {
 		return newRS
 	}
 	for i := range rslist {
 		rs := rslist[i]
 		if rs != nil {
-			if rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] == rollout.Status.Canary.StableRS {
+			if rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] == rollout.Status.StableRS {
 				return rs
 			}
 		}

--- a/utils/replicaset/canary_test.go
+++ b/utils/replicaset/canary_test.go
@@ -442,7 +442,7 @@ func TestGetStableRS(t *testing.T) {
 	noStable := GetStableRS(rollout, &rs1, []*appsv1.ReplicaSet{&rs2, &rs3})
 	assert.Nil(t, noStable)
 
-	rollout.Status.Canary.StableRS = "1"
+	rollout.Status.StableRS = "1"
 	stableNotFound := GetStableRS(rollout, &rs2, []*appsv1.ReplicaSet{&rs3})
 	assert.Nil(t, stableNotFound)
 


### PR DESCRIPTION
Created a follow up issue to remove the deprecated .status.canary.stableRS field [here](https://github.com/argoproj/argo-rollouts/issues/440)