### PR TITLE
feat: Add Blue Green Post Promotion Analysis

### DIFF
--- a/manifests/crds/rollout-crd.yaml
+++ b/manifests/crds/rollout-crd.yaml
@@ -97,6 +97,36 @@ spec:
                     autoPromotionSeconds:
                       format: int32
                       type: integer
+                    postPromotionAnalysis:
+                      properties:
+                        args:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                              valueFrom:
+                                properties:
+                                  podTemplateHashValue:
+                                    type: string
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        templateName:
+                          type: string
+                        templates:
+                          items:
+                            properties:
+                              templateName:
+                                type: string
+                            required:
+                            - templateName
+                            type: object
+                          type: array
+                      type: object
                     prePromotionAnalysis:
                       properties:
                         args:
@@ -2868,6 +2898,8 @@ spec:
             blueGreen:
               properties:
                 activeSelector:
+                  type: string
+                postPromotionAnalysisRun:
                   type: string
                 prePromotionAnalysisRun:
                   type: string

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -8420,6 +8420,36 @@ spec:
                     autoPromotionSeconds:
                       format: int32
                       type: integer
+                    postPromotionAnalysis:
+                      properties:
+                        args:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                              valueFrom:
+                                properties:
+                                  podTemplateHashValue:
+                                    type: string
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        templateName:
+                          type: string
+                        templates:
+                          items:
+                            properties:
+                              templateName:
+                                type: string
+                            required:
+                            - templateName
+                            type: object
+                          type: array
+                      type: object
                     prePromotionAnalysis:
                       properties:
                         args:
@@ -11191,6 +11221,8 @@ spec:
             blueGreen:
               properties:
                 activeSelector:
+                  type: string
+                postPromotionAnalysisRun:
                   type: string
                 prePromotionAnalysisRun:
                   type: string

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -8420,6 +8420,36 @@ spec:
                     autoPromotionSeconds:
                       format: int32
                       type: integer
+                    postPromotionAnalysis:
+                      properties:
+                        args:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                              valueFrom:
+                                properties:
+                                  podTemplateHashValue:
+                                    type: string
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        templateName:
+                          type: string
+                        templates:
+                          items:
+                            properties:
+                              templateName:
+                                type: string
+                            required:
+                            - templateName
+                            type: object
+                          type: array
+                      type: object
                     prePromotionAnalysis:
                       properties:
                         args:
@@ -11191,6 +11221,8 @@ spec:
             blueGreen:
               properties:
                 activeSelector:
+                  type: string
+                postPromotionAnalysisRun:
                   type: string
                 prePromotionAnalysisRun:
                   type: string

--- a/pkg/apis/rollouts/v1alpha1/openapi_generated.go
+++ b/pkg/apis/rollouts/v1alpha1/openapi_generated.go
@@ -573,6 +573,13 @@ func schema_pkg_apis_rollouts_v1alpha1_BlueGreenStatus(ref common.ReferenceCallb
 							Format:      "",
 						},
 					},
+					"postPromotionAnalysisRun": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PostPromotionAnalysisRun is the current analysis run running after the active service promotion",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -640,6 +647,12 @@ func schema_pkg_apis_rollouts_v1alpha1_BlueGreenStrategy(ref common.ReferenceCal
 					"prePromotionAnalysis": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PrePromotionAnalysis configuration to run analysis before a selector switch",
+							Ref:         ref("github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.RolloutAnalysis"),
+						},
+					},
+					"postPromotionAnalysis": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PostPromotionAnalysis configuration to run analysis after a selector switch",
 							Ref:         ref("github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.RolloutAnalysis"),
 						},
 					},

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -116,6 +116,8 @@ type BlueGreenStrategy struct {
 	ScaleDownDelayRevisionLimit *int32 `json:"scaleDownDelayRevisionLimit,omitempty"`
 	// PrePromotionAnalysis configuration to run analysis before a selector switch
 	PrePromotionAnalysis *RolloutAnalysis `json:"prePromotionAnalysis,omitempty"`
+	// PostPromotionAnalysis configuration to run analysis after a selector switch
+	PostPromotionAnalysis *RolloutAnalysis `json:"postPromotionAnalysis,omitempty"`
 }
 
 // CanaryStrategy defines parameters for a Replica Based Canary
@@ -481,6 +483,8 @@ type BlueGreenStatus struct {
 	ScaleUpPreviewCheckPoint bool `json:"scaleUpPreviewCheckPoint,omitempty"`
 	// PrePromotionAnalysisRun is the current analysis run running before the active service promotion
 	PrePromotionAnalysisRun string `json:"prePromotionAnalysisRun,omitempty"`
+	// PostPromotionAnalysisRun is the current analysis run running after the active service promotion
+	PostPromotionAnalysisRun string `json:"postPromotionAnalysisRun,omitempty"`
 }
 
 // CanaryStatus status fields that only pertain to the canary rollout

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -336,6 +336,8 @@ const (
 	RolloutTypeBackgroundRunLabel = "Background"
 	// RolloutTypePrePromotionLabel indicates that the analysisRun was created before the active service promotion
 	RolloutTypePrePromotionLabel = "PrePromotion"
+	// RolloutTypePostPromotionLabel indicates that the analysisRun was created after the active service promotion
+	RolloutTypePostPromotionLabel = "PostPromotion"
 	// RolloutCanaryStepIndexLabel indicates which step created this analysisRun
 	RolloutCanaryStepIndexLabel = "step-index"
 )

--- a/pkg/apis/rollouts/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/rollouts/v1alpha1/zz_generated.deepcopy.go
@@ -355,6 +355,11 @@ func (in *BlueGreenStrategy) DeepCopyInto(out *BlueGreenStrategy) {
 		*out = new(RolloutAnalysis)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.PostPromotionAnalysis != nil {
+		in, out := &in.PostPromotionAnalysis, &out.PostPromotionAnalysis
+		*out = new(RolloutAnalysis)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/kubectl-argo-rollouts/cmd/get/get_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get_test.go
@@ -240,7 +240,6 @@ NAME                                        KIND        STATUS        AGE  INFO
 	assertStdout(t, expectedOut, o.IOStreams)
 }
 
-
 func TestGetCanaryRollout(t *testing.T) {
 	rolloutObjs := testdata.NewCanaryRollout()
 

--- a/pkg/kubectl-argo-rollouts/cmd/get/get_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get_test.go
@@ -193,6 +193,54 @@ NAME                                        KIND        STATUS        AGE  INFO
 	assertStdout(t, expectedOut, o.IOStreams)
 }
 
+func TestGetBlueGreenRolloutScaleDownDelayPassed(t *testing.T) {
+	rolloutObjs := testdata.NewBlueGreenRollout()
+	anHourAgo := metav1.Now().Add(-1 * time.Hour).Truncate(time.Second).UTC().Format(time.RFC3339)
+	rolloutObjs.ReplicaSets[2].Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey] = anHourAgo
+	delete(rolloutObjs.ReplicaSets[2].Labels, v1alpha1.DefaultRolloutUniqueLabelKey)
+
+	tf, o := options.NewFakeArgoRolloutsOptions(rolloutObjs.AllObjects()...)
+	o.RESTClientGetter = tf.WithNamespace(rolloutObjs.Rollouts[0].Namespace)
+	defer tf.Cleanup()
+	cmd := NewCmdGetRollout(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{rolloutObjs.Rollouts[0].Name, "--no-color"})
+	err := cmd.Execute()
+	assert.NoError(t, err)
+
+	expectedOut := strings.TrimPrefix(`
+Name:            bluegreen-demo
+Namespace:       jesse-test
+Status:          ॥ Paused
+Strategy:        BlueGreen
+Images:          argoproj/rollouts-demo:blue (active)
+                 argoproj/rollouts-demo:green
+Replicas:
+  Desired:       3
+  Current:       6
+  Updated:       3
+  Ready:         6
+  Available:     3
+
+NAME                                        KIND        STATUS        AGE  INFO
+⟳ bluegreen-demo                            Rollout     ॥ Paused      7d
+├──# revision:11
+│  └──⧉ bluegreen-demo-74b948fccb           ReplicaSet  ✔ Healthy     7d   delay:passed
+│     ├──□ bluegreen-demo-74b948fccb-5jz59  Pod         ✔ Running     7d   ready:1/1
+│     ├──□ bluegreen-demo-74b948fccb-mkhrl  Pod         ✔ Running     7d   ready:1/1
+│     └──□ bluegreen-demo-74b948fccb-vvj2t  Pod         ✔ Running     7d   ready:1/1
+├──# revision:10
+│  └──⧉ bluegreen-demo-6cbccd9f99           ReplicaSet  ✔ Healthy     7d   active
+│     ├──□ bluegreen-demo-6cbccd9f99-gk78v  Pod         ✔ Running     7d   ready:1/1
+│     ├──□ bluegreen-demo-6cbccd9f99-kxj8g  Pod         ✔ Running     7d   ready:1/1
+│     └──□ bluegreen-demo-6cbccd9f99-t2d4f  Pod         ✔ Running     7d   ready:1/1
+└──# revision:8
+   └──⧉ bluegreen-demo-746d5fddf6           ReplicaSet  • ScaledDown  7d
+`, "\n")
+	assertStdout(t, expectedOut, o.IOStreams)
+}
+
+
 func TestGetCanaryRollout(t *testing.T) {
 	rolloutObjs := testdata.NewCanaryRollout()
 

--- a/pkg/kubectl-argo-rollouts/info/replicaset_info.go
+++ b/pkg/kubectl-argo-rollouts/info/replicaset_info.go
@@ -131,7 +131,11 @@ func getReplicaSetCondition(status appsv1.ReplicaSetStatus, condType appsv1.Repl
 
 func (rs ReplicaSetInfo) ScaleDownDelay() string {
 	if deadline, err := time.Parse(time.RFC3339, rs.ScaleDownDeadline); err == nil {
-		return duration.HumanDuration(deadline.Sub(metav1.Now().Time))
+		now := metav1.Now().Time
+		if deadline.Before(now) {
+			return "passed"
+		}
+		return duration.HumanDuration(deadline.Sub(now))
 	}
 	return ""
 }

--- a/rollout/analysis.go
+++ b/rollout/analysis.go
@@ -202,7 +202,6 @@ func (c *RolloutController) reconcilePostPromotionAnalysisRun(roCtx rolloutConte
 	return currentAr, nil
 }
 
-
 func (c *RolloutController) reconcileBackgroundAnalysisRun(roCtx rolloutContext) (*v1alpha1.AnalysisRun, error) {
 	rollout := roCtx.Rollout()
 	newRS := roCtx.NewRS()

--- a/rollout/analysis_test.go
+++ b/rollout/analysis_test.go
@@ -1703,7 +1703,7 @@ func TestPostPromotionAnalysisRunHandleInconclusive(t *testing.T) {
 
 	r2 = updateBlueGreenRolloutStatus(r2, "", rs2PodHash, rs1PodHash, 1, 1, 2, 1, false, true)
 	r2.Status.PauseConditions = []v1alpha1.PauseCondition{{
-		Reason:v1alpha1.PauseReasonInconclusiveAnalysis,
+		Reason:    v1alpha1.PauseReasonInconclusiveAnalysis,
 		StartTime: metav1.Now(),
 	}}
 	pausedCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2, "")

--- a/rollout/analysis_test.go
+++ b/rollout/analysis_test.go
@@ -44,6 +44,9 @@ func analysisRun(at *v1alpha1.AnalysisTemplate, analysisRunType string, r *v1alp
 	} else if analysisRunType == v1alpha1.RolloutTypePrePromotionLabel {
 		labels = analysisutil.PrePromotionLabels(podHash, "")
 		name = fmt.Sprintf("%s-%s-%s", r.Name, podHash, "2")
+	} else if analysisRunType == v1alpha1.RolloutTypePostPromotionLabel {
+		labels = analysisutil.PostPromotionLabels(podHash, "")
+		name = fmt.Sprintf("%s-%s-%s", r.Name, podHash, "2")
 	}
 	return &v1alpha1.AnalysisRun{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1578,6 +1581,204 @@ func TestAbortRolloutOnErrorPrePromotionAnalysis(t *testing.T) {
 			"controllerPause":null,
 			"blueGreen": {
 				"prePromotionAnalysisRun": null
+			}
+		}
+	}`
+	assert.Equal(t, calculatePatch(r2, expectedPatch), patch)
+}
+
+func TestCreatePostPromotionAnalysisRun(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	at := analysisTemplate("bar")
+	r1 := newBlueGreenRollout("foo", 1, nil, "active", "")
+	r2 := bumpVersion(r1)
+	r2.Spec.Strategy.BlueGreen.PostPromotionAnalysis = &v1alpha1.RolloutAnalysis{
+		Templates: []v1alpha1.RolloutAnalysisTemplates{{
+			TemplateName: at.Name,
+		}},
+	}
+	ar := analysisRun(at, v1alpha1.RolloutTypePostPromotionLabel, r2)
+	rs1 := newReplicaSetWithStatus(r1, 1, 1)
+	rs1.Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey] = nowFn().Add(10 * time.Second).Format(time.RFC3339)
+	rs2 := newReplicaSetWithStatus(r2, 1, 1)
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+
+	r2 = updateBlueGreenRolloutStatus(r2, "", rs2PodHash, rs1PodHash, 1, 1, 2, 1, false, true)
+
+	activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}
+	activeSvc := newService("active", 80, activeSelector)
+
+	f.objects = append(f.objects, r2, at)
+	f.kubeobjects = append(f.kubeobjects, activeSvc, rs1, rs2)
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.analysisTemplateLister = append(f.analysisTemplateLister, at)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+	f.serviceLister = append(f.serviceLister, activeSvc)
+
+	f.expectCreateAnalysisRunAction(ar)
+	patchIndex := f.expectPatchRolloutActionWithPatch(r2, OnlyObservedGenerationPatch)
+	f.run(getKey(r2, t))
+	patch := f.getPatchedRollout(patchIndex)
+	expectedPatch := fmt.Sprintf(`{
+		"status": {
+			"blueGreen": {
+				"postPromotionAnalysisRun": "%s"
+			}
+		}
+	}`, ar.Name)
+	assert.Equal(t, calculatePatch(r2, expectedPatch), patch)
+}
+
+func TestRolloutPostPromotionAnalysisSuccess(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	at := analysisTemplate("bar")
+	r1 := newBlueGreenRollout("foo", 1, nil, "active", "")
+	r2 := bumpVersion(r1)
+	r2.Spec.Strategy.BlueGreen.PostPromotionAnalysis = &v1alpha1.RolloutAnalysis{
+		Templates: []v1alpha1.RolloutAnalysisTemplates{{
+			TemplateName: at.Name,
+		}},
+	}
+	ar := analysisRun(at, v1alpha1.RolloutTypePostPromotionLabel, r2)
+	ar.Status.Phase = v1alpha1.AnalysisPhaseSuccessful
+	r2.Status.BlueGreen.PostPromotionAnalysisRun = ar.Name
+
+	rs1 := newReplicaSetWithStatus(r1, 0, 0)
+	rs2 := newReplicaSetWithStatus(r2, 1, 1)
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+
+	r2 = updateBlueGreenRolloutStatus(r2, "", rs2PodHash, rs1PodHash, 1, 1, 1, 1, false, true)
+
+	activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}
+	activeSvc := newService("active", 80, activeSelector)
+
+	f.objects = append(f.objects, r2, at, ar)
+	f.kubeobjects = append(f.kubeobjects, activeSvc, rs1, rs2)
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.analysisTemplateLister = append(f.analysisTemplateLister, at)
+	f.analysisRunLister = append(f.analysisRunLister, ar)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+	f.serviceLister = append(f.serviceLister, activeSvc)
+
+	patchIndex := f.expectPatchRolloutAction(r2)
+	f.run(getKey(r2, t))
+	patch := f.getPatchedRollout(patchIndex)
+	expectedPatch := fmt.Sprintf(`{
+		"status": {
+			"stableRS": "%s"
+		}
+	}`, rs2PodHash)
+	assert.Equal(t, calculatePatch(r2, expectedPatch), patch)
+}
+
+// TestPostPromotionAnalysisRunHandleInconclusive ensures that the Rollout does not scale down a old ReplicaSet if
+// it's paused for a inconclusive analysis run
+func TestPostPromotionAnalysisRunHandleInconclusive(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	at := analysisTemplate("bar")
+	r1 := newBlueGreenRollout("foo", 1, nil, "active", "")
+	r2 := bumpVersion(r1)
+	r2.Spec.Strategy.BlueGreen.PostPromotionAnalysis = &v1alpha1.RolloutAnalysis{
+		Templates: []v1alpha1.RolloutAnalysisTemplates{{
+			TemplateName: at.Name,
+		}},
+	}
+	ar := analysisRun(at, v1alpha1.RolloutTypePostPromotionLabel, r2)
+	ar.Status.Phase = v1alpha1.AnalysisPhaseInconclusive
+	r2.Status.BlueGreen.PostPromotionAnalysisRun = ar.Name
+
+	rs1 := newReplicaSetWithStatus(r1, 1, 1)
+	rs1.Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey] = nowFn().Add(-10 * time.Second).Format(time.RFC3339)
+	rs2 := newReplicaSetWithStatus(r2, 1, 1)
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+
+	r2 = updateBlueGreenRolloutStatus(r2, "", rs2PodHash, rs1PodHash, 1, 1, 2, 1, false, true)
+	r2.Status.PauseConditions = []v1alpha1.PauseCondition{{
+		Reason:v1alpha1.PauseReasonInconclusiveAnalysis,
+		StartTime: metav1.Now(),
+	}}
+	pausedCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2, "")
+	conditions.SetRolloutCondition(&r2.Status, pausedCondition)
+
+	activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}
+	activeSvc := newService("active", 80, activeSelector)
+
+	f.objects = append(f.objects, r2, at)
+	f.kubeobjects = append(f.kubeobjects, activeSvc, rs1, rs2)
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.analysisTemplateLister = append(f.analysisTemplateLister, at)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+	f.serviceLister = append(f.serviceLister, activeSvc)
+
+	patchIndex := f.expectPatchRolloutActionWithPatch(r2, OnlyObservedGenerationPatch)
+	f.run(getKey(r2, t))
+	patch := f.getPatchedRollout(patchIndex)
+	expectedPatch := fmt.Sprint(`{
+		"status": {
+			"blueGreen": {
+				"postPromotionAnalysisRun": null
+			}
+		}
+	}`)
+	assert.Equal(t, calculatePatch(r2, expectedPatch), patch)
+}
+
+func TestAbortRolloutOnErrorPostPromotionAnalysis(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	at := analysisTemplate("bar")
+	r1 := newBlueGreenRollout("foo", 1, nil, "active", "")
+	r2 := bumpVersion(r1)
+	r2.Spec.Strategy.BlueGreen.PostPromotionAnalysis = &v1alpha1.RolloutAnalysis{
+		Templates: []v1alpha1.RolloutAnalysisTemplates{{
+			TemplateName: at.Name,
+		}},
+	}
+	ar := analysisRun(at, v1alpha1.RolloutTypePrePromotionLabel, r2)
+	ar.Status.Phase = v1alpha1.AnalysisPhaseError
+	r2.Status.BlueGreen.PostPromotionAnalysisRun = ar.Name
+
+	rs1 := newReplicaSetWithStatus(r1, 1, 1)
+	rs1.Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey] = nowFn().Add(10 * time.Second).Format(time.RFC3339)
+	rs2 := newReplicaSetWithStatus(r2, 1, 1)
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+
+	r2 = updateBlueGreenRolloutStatus(r2, "", rs2PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
+	pausedCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2, "")
+	conditions.SetRolloutCondition(&r2.Status, pausedCondition)
+
+	activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}
+	activeSvc := newService("active", 80, activeSelector)
+
+	f.objects = append(f.objects, r2, at, ar)
+	f.kubeobjects = append(f.kubeobjects, activeSvc, rs1, rs2)
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.analysisTemplateLister = append(f.analysisTemplateLister, at)
+	f.analysisRunLister = append(f.analysisRunLister, ar)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+	f.serviceLister = append(f.serviceLister, activeSvc)
+
+	patchIndex := f.expectPatchRolloutActionWithPatch(r2, OnlyObservedGenerationPatch)
+	f.run(getKey(r2, t))
+	patch := f.getPatchedRollout(patchIndex)
+	expectedPatch := `{
+		"status": {
+			"abort": true,
+			"pauseConditions": null,
+			"controllerPause":null,
+			"blueGreen": {
+				"postPromotionAnalysisRun": null
 			}
 		}
 	}`

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -290,7 +290,6 @@ func (c *RolloutController) syncRolloutStatusCanary(roCtx *canaryContext) error 
 				c.recorder.Event(r, corev1.EventTypeNormal, "SettingStableRS", msg)
 			}
 			newStatus.CurrentStepIndex = &stepCount
-
 		}
 		roCtx.PauseContext().ClearPauseConditions()
 		roCtx.PauseContext().RemoveAbort()

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -239,7 +239,7 @@ func completedCurrentCanaryStep(roCtx *canaryContext) bool {
 		return true
 	}
 	currentArs := roCtx.CurrentAnalysisRuns()
-	currentStepAr := analysisutil.GetCurrentStepAnalysisRun(currentArs)
+	currentStepAr := analysisutil.GetCurrentAnalysisRunByType(currentArs, v1alpha1.RolloutTypeStepLabel)
 	analysisExistsAndCompleted := currentStepAr != nil && currentStepAr.Status.Phase.Completed()
 	if currentStep.Analysis != nil && analysisExistsAndCompleted && currentStepAr.Status.Phase == v1alpha1.AnalysisPhaseSuccessful {
 		return true

--- a/rollout/context.go
+++ b/rollout/context.go
@@ -134,6 +134,13 @@ func (cCtx *blueGreenContext) SetCurrentAnalysisRuns(ars []*v1alpha1.AnalysisRun
 			cCtx.newStatus.BlueGreen.PrePromotionAnalysisRun = currPrePromoAr.Name
 		}
 	}
+	currPostPromoAr := analysisutil.GetCurrentAnalysisRunByType(ars, v1alpha1.RolloutTypePostPromotionLabel)
+	if currPostPromoAr != nil && !cCtx.PauseContext().IsAborted() {
+		switch currPostPromoAr.Status.Phase {
+		case v1alpha1.AnalysisPhasePending, v1alpha1.AnalysisPhaseRunning, v1alpha1.AnalysisPhaseSuccessful, "":
+			cCtx.newStatus.BlueGreen.PostPromotionAnalysisRun = currPostPromoAr.Name
+		}
+	}
 }
 
 func (bgCtx *blueGreenContext) OtherExperiments() []*v1alpha1.Experiment {

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -1155,7 +1155,7 @@ func TestComputeHashChangeTolerationBlueGreen(t *testing.T) {
 	// this should only update observedGeneration and nothing else
 	// NOTE: This test will fail on every k8s library upgrade.
 	// To fix it, update expectedPatch to match the new hash.
-	expectedPatch := `{"status":{"observedGeneration":"54665d4445"}}`
+	expectedPatch := `{"status":{"observedGeneration":"5dd485db97"}}`
 	patch := f.getPatchedRollout(patchIndex)
 	assert.Equal(t, expectedPatch, patch)
 }

--- a/rollout/replicaset.go
+++ b/rollout/replicaset.go
@@ -106,7 +106,8 @@ func (c *RolloutController) reconcileOldReplicaSets(oldRSs []*appsv1.ReplicaSet,
 
 	// Scale down old replica sets
 	if rollout.Spec.Strategy.BlueGreen != nil {
-		hasScaled, err = c.scaleDownOldReplicaSetsForBlueGreen(oldRSs, rollout)
+		bgCtx := roCtx.(*blueGreenContext)
+		hasScaled, err = c.scaleDownOldReplicaSetsForBlueGreen(oldRSs, bgCtx)
 		if err != nil {
 			return false, nil
 		}

--- a/utils/analysis/factory.go
+++ b/utils/analysis/factory.go
@@ -33,6 +33,19 @@ func BuildArgumentsForRolloutAnalysisRun(args []v1alpha1.AnalysisRunArgument, st
 	return arguments
 }
 
+// PostPromotionLabels returns a map[string]string of common labels for the post promotion analysis
+func PostPromotionLabels(podHash, instanceID string) map[string]string {
+	labels := map[string]string{
+		v1alpha1.DefaultRolloutUniqueLabelKey: podHash,
+		v1alpha1.RolloutTypeLabel:             v1alpha1.RolloutTypePostPromotionLabel,
+	}
+	if instanceID != "" {
+		labels[v1alpha1.LabelKeyControllerInstanceID] = instanceID
+	}
+	return labels
+
+}
+
 // PrePromotionLabels returns a map[string]string of common labels for the pre promotion analysis
 func PrePromotionLabels(podHash, instanceID string) map[string]string {
 	labels := map[string]string{

--- a/utils/analysis/factory_test.go
+++ b/utils/analysis/factory_test.go
@@ -64,6 +64,17 @@ func TestPrePromotionLabels(t *testing.T) {
 	assert.Equal(t, expected, generated)
 }
 
+func TestPostPromotionLabels(t *testing.T) {
+	podHash := "abcd123"
+	expected := map[string]string{
+		v1alpha1.LabelKeyControllerInstanceID: "test",
+		v1alpha1.RolloutTypeLabel:             v1alpha1.RolloutTypePostPromotionLabel,
+		v1alpha1.DefaultRolloutUniqueLabelKey: podHash,
+	}
+	generated := PostPromotionLabels(podHash, "test")
+	assert.Equal(t, expected, generated)
+}
+
 func TestStepLabels(t *testing.T) {
 	podHash := "abcd123"
 	expected := map[string]string{

--- a/utils/analysis/filter.go
+++ b/utils/analysis/filter.go
@@ -6,18 +6,6 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 )
 
-//GetCurrentStepAnalysisRun filters the currentArs and returns the step based analysis run
-func GetCurrentStepAnalysisRun(currentArs []*v1alpha1.AnalysisRun) *v1alpha1.AnalysisRun {
-	for i := range currentArs {
-		ar := currentArs[i]
-		rolloutType, ok := ar.Labels[v1alpha1.RolloutTypeLabel]
-		if ok && rolloutType == v1alpha1.RolloutTypeStepLabel {
-			return ar
-		}
-	}
-	return nil
-}
-
 func GetCurrentAnalysisRunByType(currentArs []*v1alpha1.AnalysisRun, kind string) *v1alpha1.AnalysisRun {
 	for i := range currentArs {
 		ar := currentArs[i]

--- a/utils/analysis/filter.go
+++ b/utils/analysis/filter.go
@@ -41,6 +41,9 @@ func FilterCurrentRolloutAnalysisRuns(analysisRuns []*v1alpha1.AnalysisRun, r *v
 		if ar.Name == r.Status.BlueGreen.PrePromotionAnalysisRun {
 			return true
 		}
+		if ar.Name == r.Status.BlueGreen.PostPromotionAnalysisRun {
+			return true
+		}
 		return false
 	})
 }

--- a/utils/analysis/filter_test.go
+++ b/utils/analysis/filter_test.go
@@ -77,7 +77,7 @@ func TestFilterCurrentRolloutAnalysisRuns(t *testing.T) {
 		r := &v1alpha1.Rollout{
 			Status: v1alpha1.RolloutStatus{
 				BlueGreen: v1alpha1.BlueGreenStatus{
-					PrePromotionAnalysisRun: "foo",
+					PrePromotionAnalysisRun:  "foo",
 					PostPromotionAnalysisRun: "bar",
 				},
 			},

--- a/utils/analysis/filter_test.go
+++ b/utils/analysis/filter_test.go
@@ -78,13 +78,15 @@ func TestFilterCurrentRolloutAnalysisRuns(t *testing.T) {
 			Status: v1alpha1.RolloutStatus{
 				BlueGreen: v1alpha1.BlueGreenStatus{
 					PrePromotionAnalysisRun: "foo",
+					PostPromotionAnalysisRun: "bar",
 				},
 			},
 		}
 		currentArs, nonCurrentArs := FilterCurrentRolloutAnalysisRuns(ars, r)
-		assert.Len(t, currentArs, 1)
-		assert.Len(t, nonCurrentArs, 2)
+		assert.Len(t, currentArs, 2)
+		assert.Len(t, nonCurrentArs, 1)
 		assert.Contains(t, currentArs, ars[0])
+		assert.Contains(t, currentArs, ars[1])
 	})
 }
 


### PR DESCRIPTION
Closes #348.

Add the ability for a BlueGreen Rollout to launch an AnalysisRun after the active Service's selector is switched.