### PR TITLE
feat: Use managed-by annotation

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -177,14 +177,16 @@ func NewManager(
 		metricsServer,
 		recorder)
 
-	serviceController := service.NewServiceController(
-		kubeclientset,
-		servicesInformer,
-		rolloutsInformer,
-		resyncPeriod,
-		rolloutWorkqueue,
-		serviceWorkqueue,
-		metricsServer)
+	serviceController := service.NewServiceController(service.ControllerConfig{
+		Kubeclientset:     kubeclientset,
+		Argoprojclientset: argoprojclientset,
+		RolloutsInformer:  rolloutsInformer,
+		ServicesInformer:  servicesInformer,
+		RolloutWorkqueue:  rolloutWorkqueue,
+		ServiceWorkqueue:  serviceWorkqueue,
+		ResyncPeriod:      resyncPeriod,
+		MetricsServer:     metricsServer,
+	})
 
 	ingressController := ingress.NewController(ingress.ControllerConfig{
 		IngressInformer:  ingressesInformer,

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -69,7 +69,8 @@ const (
 	// DefaultReplicaSetScaleDownDeadlineAnnotationKey is the default key attached to an old stable ReplicaSet after
 	// the rollout transitioned to a new version. It contains the time when the controller can scale down the RS.
 	DefaultReplicaSetScaleDownDeadlineAnnotationKey = "scale-down-deadline"
-
+	// ManagedByRolloutKey is the key used to indicate which rollout(s) manage a resource but doesn't own it.
+	ManagedByRolloutsKey = "argo-rollouts.argoproj.io/managed-by-rollouts"
 	// LabelKeyControllerInstanceID is the label the controller uses for the rollout, experiment, analysis segregation
 	// between controllers. Controllers will only operate on objects with the same instanceID as the controller.
 	LabelKeyControllerInstanceID = "argo-rollouts.argoproj.io/controller-instance-id"

--- a/rollout/analysis_test.go
+++ b/rollout/analysis_test.go
@@ -1180,9 +1180,9 @@ func TestCreatePrePromotionAnalysisRun(t *testing.T) {
 	conditions.SetRolloutCondition(&r2.Status, pausedCondition)
 
 	previewSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}
-	previewSvc := newService("preview", 80, previewSelector)
+	previewSvc := newService("preview", 80, previewSelector, r2)
 	activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}
-	activeSvc := newService("active", 80, activeSelector)
+	activeSvc := newService("active", 80, activeSelector, r2)
 
 	f.objects = append(f.objects, r2, at)
 	f.kubeobjects = append(f.kubeobjects, previewSvc, activeSvc, rs1, rs2)
@@ -1225,7 +1225,7 @@ func TestDoNotCreatePrePromotionAnalysisAfterPromotionRollout(t *testing.T) {
 	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
 	serviceSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}
-	s := newService("bar", 80, serviceSelector)
+	s := newService("bar", 80, serviceSelector, r2)
 	f.kubeobjects = append(f.kubeobjects, s)
 
 	r2 = updateBlueGreenRolloutStatus(r2, "", rs2PodHash, rs2PodHash, 1, 1, 1, 1, false, true)
@@ -1265,7 +1265,7 @@ func TestDoNotCreatePrePromotionAnalysisRunOnNewRollout(t *testing.T) {
 	r.Status.Conditions = []v1alpha1.RolloutCondition{}
 	f.rolloutLister = append(f.rolloutLister, r)
 	f.objects = append(f.objects, r)
-	activeSvc := newService("active", 80, nil)
+	activeSvc := newService("active", 80, nil, r)
 	f.kubeobjects = append(f.kubeobjects, activeSvc)
 	f.serviceLister = append(f.serviceLister, activeSvc)
 
@@ -1300,9 +1300,9 @@ func TestDoNotCreatePrePromotionAnalysisRunOnNotReadyReplicaSet(t *testing.T) {
 	r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 2, 4, 2, false, true)
 
 	activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}
-	activeSvc := newService("active", 80, activeSelector)
+	activeSvc := newService("active", 80, activeSelector, r2)
 	previewSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}
-	previewSvc := newService("preview", 80, previewSelector)
+	previewSvc := newService("preview", 80, previewSelector, r2)
 
 	f.objects = append(f.objects, r2)
 	f.kubeobjects = append(f.kubeobjects, activeSvc, previewSvc, rs1, rs2)
@@ -1343,7 +1343,7 @@ func TestRolloutPrePromotionAnalysisBecomesInconclusive(t *testing.T) {
 	conditions.SetRolloutCondition(&r2.Status, pausedCondition)
 
 	activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}
-	activeSvc := newService("active", 80, activeSelector)
+	activeSvc := newService("active", 80, activeSelector, r2)
 
 	f.objects = append(f.objects, r2, at, ar)
 	f.kubeobjects = append(f.kubeobjects, activeSvc, rs1, rs2)
@@ -1403,7 +1403,7 @@ func TestRolloutPrePromotionAnalysisSwitchServiceAfterSuccess(t *testing.T) {
 	conditions.SetRolloutCondition(&r2.Status, pausedCondition)
 
 	activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}
-	activeSvc := newService("active", 80, activeSelector)
+	activeSvc := newService("active", 80, activeSelector, r2)
 
 	f.objects = append(f.objects, r2, at, ar)
 	f.kubeobjects = append(f.kubeobjects, activeSvc, rs1, rs2)
@@ -1461,7 +1461,7 @@ func TestRolloutPrePromotionAnalysisHonorAutoPromotionSeconds(t *testing.T) {
 	conditions.SetRolloutCondition(&r2.Status, pausedCondition)
 
 	activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}
-	activeSvc := newService("active", 80, activeSelector)
+	activeSvc := newService("active", 80, activeSelector, r2)
 
 	f.objects = append(f.objects, r2, at, ar)
 	f.kubeobjects = append(f.kubeobjects, activeSvc, rs1, rs2)
@@ -1521,7 +1521,7 @@ func TestRolloutPrePromotionAnalysisDoNothingOnInconclusiveAnalysis(t *testing.T
 	conditions.SetRolloutCondition(&r2.Status, pausedCondition)
 
 	activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}
-	activeSvc := newService("active", 80, activeSelector)
+	activeSvc := newService("active", 80, activeSelector, r2)
 
 	f.objects = append(f.objects, r2, at, ar)
 	f.kubeobjects = append(f.kubeobjects, activeSvc, rs1, rs2)
@@ -1561,7 +1561,7 @@ func TestAbortRolloutOnErrorPrePromotionAnalysis(t *testing.T) {
 	conditions.SetRolloutCondition(&r2.Status, pausedCondition)
 
 	activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}
-	activeSvc := newService("active", 80, activeSelector)
+	activeSvc := newService("active", 80, activeSelector, r2)
 
 	f.objects = append(f.objects, r2, at, ar)
 	f.kubeobjects = append(f.kubeobjects, activeSvc, rs1, rs2)
@@ -1609,7 +1609,7 @@ func TestCreatePostPromotionAnalysisRun(t *testing.T) {
 	r2 = updateBlueGreenRolloutStatus(r2, "", rs2PodHash, rs1PodHash, 1, 1, 2, 1, false, true)
 
 	activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}
-	activeSvc := newService("active", 80, activeSelector)
+	activeSvc := newService("active", 80, activeSelector, r2)
 
 	f.objects = append(f.objects, r2, at)
 	f.kubeobjects = append(f.kubeobjects, activeSvc, rs1, rs2)
@@ -1656,7 +1656,7 @@ func TestRolloutPostPromotionAnalysisSuccess(t *testing.T) {
 	r2 = updateBlueGreenRolloutStatus(r2, "", rs2PodHash, rs1PodHash, 1, 1, 1, 1, false, true)
 
 	activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}
-	activeSvc := newService("active", 80, activeSelector)
+	activeSvc := newService("active", 80, activeSelector, r2)
 
 	f.objects = append(f.objects, r2, at, ar)
 	f.kubeobjects = append(f.kubeobjects, activeSvc, rs1, rs2)
@@ -1710,7 +1710,7 @@ func TestPostPromotionAnalysisRunHandleInconclusive(t *testing.T) {
 	conditions.SetRolloutCondition(&r2.Status, pausedCondition)
 
 	activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}
-	activeSvc := newService("active", 80, activeSelector)
+	activeSvc := newService("active", 80, activeSelector, r2)
 
 	f.objects = append(f.objects, r2, at)
 	f.kubeobjects = append(f.kubeobjects, activeSvc, rs1, rs2)
@@ -1759,7 +1759,7 @@ func TestAbortRolloutOnErrorPostPromotionAnalysis(t *testing.T) {
 	conditions.SetRolloutCondition(&r2.Status, pausedCondition)
 
 	activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}
-	activeSvc := newService("active", 80, activeSelector)
+	activeSvc := newService("active", 80, activeSelector, r2)
 
 	f.objects = append(f.objects, r2, at, ar)
 	f.kubeobjects = append(f.kubeobjects, activeSvc, rs1, rs2)

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -960,8 +960,8 @@ func TestCanaryRolloutWithCanaryService(t *testing.T) {
 	f := newFixture(t)
 	defer f.Close()
 
-	canarySvc := newService("canary", 80, nil)
 	rollout := newCanaryRollout("foo", 0, nil, nil, nil, intstr.FromInt(1), intstr.FromInt(0))
+	canarySvc := newService("canary", 80, nil, rollout)
 	rs := newReplicaSetWithStatus(rollout, 0, 0)
 	rollout.Spec.Strategy.Canary.CanaryService = canarySvc.Name
 
@@ -979,8 +979,8 @@ func TestCanaryRolloutWithInvalidCanaryServiceName(t *testing.T) {
 	f := newFixture(t)
 	defer f.Close()
 
-	canarySvc := newService("invalid-canary", 80, make(map[string]string))
 	rollout := newCanaryRollout("foo", 0, nil, nil, nil, intstr.FromInt(1), intstr.FromInt(0))
+	canarySvc := newService("invalid-canary", 80, make(map[string]string), rollout)
 	rs := newReplicaSetWithStatus(rollout, 0, 0)
 	rollout.Spec.Strategy.Canary.CanaryService = canarySvc.Name
 
@@ -1010,8 +1010,8 @@ func TestCanaryRolloutWithStableService(t *testing.T) {
 	f := newFixture(t)
 	defer f.Close()
 
-	stableSvc := newService("stable", 80, nil)
 	rollout := newCanaryRollout("foo", 0, nil, nil, nil, intstr.FromInt(1), intstr.FromInt(0))
+	stableSvc := newService("stable", 80, nil, rollout)
 	rs := newReplicaSetWithStatus(rollout, 0, 0)
 	rollout.Spec.Strategy.Canary.StableService = stableSvc.Name
 	rollout.Status.StableRS = rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -570,7 +570,7 @@ func filterInformerActions(actions []core.Action) []core.Action {
 }
 
 func (f *fixture) expectPatchServiceAction(s *corev1.Service, newLabel string) int {
-	patch := fmt.Sprintf(switchSelectorPatch, v1alpha1.DefaultRolloutUniqueLabelKey, newLabel)
+	patch := fmt.Sprintf(switchSelectorPatch, newLabel)
 	serviceSchema := schema.GroupVersionResource{
 		Resource: "services",
 		Version:  "v1",
@@ -713,7 +713,7 @@ func (f *fixture) getUpdatedReplicaSet(index int) *appsv1.ReplicaSet {
 	return rs
 }
 
-func (f *fixture) verifyPatchedReplicaSet(index int, scaleDownDelaySeconds int32) bool {
+func (f *fixture) verifyPatchedReplicaSet(index int, scaleDownDelaySeconds int32) {
 	action := filterInformerActions(f.kubeclient.Actions())[index]
 	patchAction, ok := action.(core.PatchAction)
 	if !ok {
@@ -721,17 +721,20 @@ func (f *fixture) verifyPatchedReplicaSet(index int, scaleDownDelaySeconds int32
 	}
 	now := metav1.Now().Add(time.Duration(scaleDownDelaySeconds) * time.Second).UTC().Format(time.RFC3339)
 	patch := fmt.Sprintf(addScaleDownAtAnnotationsPatch, v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey, now)
-	return string(patchAction.GetPatch()) == patch
+	assert.Equal(f.t, string(patchAction.GetPatch()), patch)
 }
 
-func (f *fixture) verifyPatchedService(index int, newPodHash string) bool {
+func (f *fixture) verifyPatchedService(index int, newPodHash string, managedBy string) {
 	action := filterInformerActions(f.kubeclient.Actions())[index]
 	patchAction, ok := action.(core.PatchAction)
 	if !ok {
 		assert.Fail(f.t, "Expected Patch action, not %s", action.GetVerb())
 	}
-	patch := fmt.Sprintf(switchSelectorPatch, v1alpha1.DefaultRolloutUniqueLabelKey, newPodHash)
-	return string(patchAction.GetPatch()) == patch
+	patch := fmt.Sprintf(switchSelectorPatch, newPodHash)
+	if managedBy != "" {
+		patch = fmt.Sprintf(switchSelectorAndAddManagedByPatch, managedBy, newPodHash)
+	}
+	assert.Equal(f.t, patch, string(patchAction.GetPatch()))
 }
 
 func (f *fixture) verifyPatchedAnalysisRun(index int, ar *v1alpha1.AnalysisRun) bool {
@@ -891,8 +894,8 @@ func TestAdoptReplicaSet(t *testing.T) {
 	r.Status.Conditions = []v1alpha1.RolloutCondition{}
 	f.rolloutLister = append(f.rolloutLister, r)
 	f.objects = append(f.objects, r)
-	previewSvc := newService("preview", 80, nil)
-	activeSvc := newService("active", 80, nil)
+	previewSvc := newService("preview", 80, nil, r)
+	activeSvc := newService("active", 80, nil, r)
 
 	rs := newReplicaSet(r, 1)
 	f.kubeobjects = append(f.kubeobjects, previewSvc, activeSvc, rs)
@@ -1075,7 +1078,7 @@ requests:
 	for _, r := range []*v1alpha1.Rollout{r1, r2} {
 		f := newFixture(t)
 		defer f.Close()
-		activeSvc := newService("active", 80, nil)
+		activeSvc := newService("active", 80, nil, r)
 		f.kubeobjects = append(f.kubeobjects, activeSvc)
 		f.rolloutLister = append(f.rolloutLister, r)
 		f.serviceLister = append(f.serviceLister, activeSvc)
@@ -1144,7 +1147,7 @@ func TestComputeHashChangeTolerationBlueGreen(t *testing.T) {
 
 	f.rolloutLister = append(f.rolloutLister, r)
 	f.objects = append(f.objects, r)
-	activeSvc := newService("active", 80, selector.MatchLabels)
+	activeSvc := newService("active", 80, selector.MatchLabels, r)
 
 	f.kubeobjects = append(f.kubeobjects, activeSvc, rs)
 	f.replicaSetLister = append(f.replicaSetLister, rs)

--- a/utils/conditions/conditions.go
+++ b/utils/conditions/conditions.go
@@ -133,6 +133,10 @@ const (
 	ServiceNotFoundReason = "ServiceNotFound"
 	// ServiceNotFoundMessage is added in a rollout when the service defined in the spec is not found
 	ServiceNotFoundMessage = "Service %q is not found"
+	// ServiceReferenceReason is added to a Rollout when there is an error with a Service reference
+	ServiceReferenceReason = "ServiceReferenceError"
+	// MultipleRolloutsMangingServiceMessage is added in a rollout when the multiple rollouts reference a Rollout
+	ServiceReferencingManagedService = "Service %q is managed by another Rollout"
 )
 
 // NewRolloutCondition creates a new rollout condition.

--- a/utils/service/service.go
+++ b/utils/service/service.go
@@ -43,3 +43,11 @@ func GetRolloutServiceKeys(rollout *v1alpha1.Rollout) []string {
 	}
 	return services
 }
+
+func HasManagedByAnnotation(service *corev1.Service) (string, bool) {
+	if service.Annotations == nil {
+		return "", false
+	}
+	annotation, exists := service.Annotations[v1alpha1.ManagedByRolloutsKey]
+	return annotation, exists
+}

--- a/utils/service/service_test.go
+++ b/utils/service/service_test.go
@@ -78,3 +78,18 @@ func TestGetRolloutServiceKeysForBlueGreen(t *testing.T) {
 	})
 	assert.ElementsMatch(t, keys, []string{"default/preview-service", "default/active-service"})
 }
+
+func TestHasManagedByAnnotation(t *testing.T) {
+	service := &corev1.Service{}
+	managedBy, exists := HasManagedByAnnotation(service)
+	assert.False(t, exists)
+	assert.Equal(t, "", managedBy)
+
+	service.Annotations = map[string]string{
+		v1alpha1.ManagedByRolloutsKey: "test",
+	}
+	managedBy, exists = HasManagedByAnnotation(service)
+	assert.True(t, exists)
+	assert.Equal(t, "test", managedBy)
+
+}


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-rollouts/issues/443 by introducing a new annotation called `argo-rollouts.argoproj.io/managed-by-rollouts` that indicates a Service is managed by a Rollout.