### PR TITLE
docs: plugin command enhancements

### DIFF
--- a/docs/features/analysis.md
+++ b/docs/features/analysis.md
@@ -392,9 +392,6 @@ completes before then, the Rollout will not create another AnalysisRun and wait 
 
 ## BlueGreen Post Promotion Analysis
 
-!!! warning "Not Implemented"
-    This feature is not yet implemenated.
-
 A Rollout using a BlueGreen strategy can launch an analysis run after the traffic switch to new version. If the analysis
 run fails or errors out, the Rollout enters an aborted state and switch traffic back to the previous stable Replicaset.
 If `scaleDownDelaySeconds` is specified, the controller will cancel any AnalysisRuns at time of `scaleDownDelay` to 

--- a/docs/features/bluegreen.md
+++ b/docs/features/bluegreen.md
@@ -60,6 +60,7 @@ spec:
       autoPromotionSeconds: *int32
       previewService: string
       prePromotionAnalysis: object
+      postPromotionAnalysis: object
       previewReplicaCount: *int32
       scaleDownDelaySeconds: *int32
       scaleDownDelayRevisionLimit: *int32
@@ -76,9 +77,20 @@ The AutoPromotionSeconds will make the rollout automatically promote the new Rep
 Defaults to nil
 
 ### prePromotionAnalysis
-Configures the [Analysis](analysis.md#bluegreen-pre-promotion-analysis) before it switches traffic to the new version. If the analysis is not successful the rollout will be aborted.
+Configures the [Analysis](analysis.md#bluegreen-pre-promotion-analysis) before it switches traffic to the new version. The
+AnalysisRun can be used to block the Service selector switch until the AnalysisRun finishes successful. The success or
+failure of the analysis run decides if the Rollout will switch traffic, or abort the Rollout completely.
 
-Default to nil
+Defaults to nil
+
+### postPromotionAnalysis
+Configures the [Analysis](analysis.md#bluegreen-pre-promotion-analysis) after the traffic switch to new version. If the analysis
+run fails or errors out, the Rollout enters an aborted state and switch traffic back to the previous stable Replicaset.
+If `scaleDownDelaySeconds` is specified, the controller will cancel any AnalysisRuns at time of `scaleDownDelay` to 
+scale down the ReplicaSet. If it is omitted, and post analysis is specified, it will scale down the ReplicaSet only 
+after the AnalysisRun completes (with a minimum of 30 seconds).
+
+Defaults to nil
 
 ### previewService
 The PreviewService field references a Service that will be modified to send traffic to the new replicaset before the new one is promoted to receiving traffic from the active service. Once the new replicaset start receives traffic from the active service, the preview service will be modified to send traffic to no ReplicaSets. The Rollout always makes sure that the preview service is sending traffic to the new ReplicaSet.  As a result, if a new version is introduced before the old version is promoted to the active service, the controller will immediately switch over to the new version.
@@ -102,4 +114,4 @@ Defaults to 30
 ### scaleDownDelayRevisionLimit
 The ScaleDownDelayRevisionLimit limits the number of old active ReplicaSets to keep scaled up while they wait for the scaleDownDelay to pass after being removed from the active service. 
 
-Default to nil
+Defaults to nil

--- a/docs/features/canary.md
+++ b/docs/features/canary.md
@@ -82,7 +82,7 @@ spec:
 ### analysis
 Configure the background [Analysis](analysis.md) to execute during the rollout. If the analysis is unsuccessful the rollout will be aborted.
 
-Default to nil
+Defaults to nil
 
 ### canaryService
 `canaryService` references a Service that will be modified to send traffic to only the canary ReplicaSet. This allows users to only hit the canary ReplicaSet.

--- a/docs/features/canary.md
+++ b/docs/features/canary.md
@@ -75,8 +75,10 @@ spec:
     canary:
       analysis: object
       canaryService: string
+      stableService: string
       maxSurge: stringOrInt
       maxUnavailable: stringOrInt
+      trafficRouting: object
 ```
 
 ### analysis
@@ -89,6 +91,11 @@ Defaults to nil
 
 Defaults to an empty string
 
+### stableService
+`stableService` the name of a Service which selects pods with stable version and don't select any pods with canary version. This allows users to only hit the stable ReplicaSet.
+
+Defaults to an empty string
+
 ### maxSurge
 `maxSurge` defines the maximum number of replicas the rollout can create to move to the correct ratio set by the last setWeight. Max Surge can either be an integer or percentage as a string (i.e. "20%")
 
@@ -98,3 +105,8 @@ Defaults to "25%".
 The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxSurge is 0.
 
 Defaults to 0
+
+### trafficRouting
+The [traffic management](traffic-management/index.md) rules to apply to control the flow of traffic between the active and canary versions. If not set, the default weighted pod replica based routing will be used.
+
+Defaults to nil

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -61,6 +61,8 @@ spec:
     canary:
       # CanaryService holds the name of a service which selects pods with canary version and don't select any pods with stable version. +optional
       canaryService: canary-service
+      # StableService holds the name of a service which selects pods with stable version and don't select any pods with canary version. +optional
+      stableService: stable-service
       # The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total pods at the start of update (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. By default, a fixed value of 1 is used. Example: when this is set to 30%, the old RC can be scaled down by 30% immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that at least 70% of original number of pods are available at all times during the update. +optional
       maxUnavailable: 1
       # The maximum number of pods that can be scheduled above the original number of pods. Value can be an absolute number (ex: 5) or a percentage of total pods at the start of the update (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. By default, a value of 1 is used. Example: when this is set to 30%, the new RC can be scaled up by 30% immediately when the rolling update starts. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of original pods. +optional

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/valyala/fasttemplate v1.0.1
 	github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.17.3
 	k8s.io/apiextensions-apiserver v0.17.0
 	k8s.io/apimachinery v0.17.3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,15 +2,15 @@ site_name: Argo Rollouts - Advanced Kubernetes Deployment Controller
 repo_url: https://github.com/argoproj/argo-rollouts
 strict: true
 theme:
+  font:
+    text: Work Sans
+  logo: assets/logo.png
   name: material
   palette:
     primary: teal
-  font:
-    text: 'Work Sans'
-  logo: 'assets/logo.png'
 google_analytics:
-- 'UA-105170809-3'
-- 'auto'
+- UA-105170809-3
+- auto
 markdown_extensions:
 - codehilite
 - admonition
@@ -19,27 +19,48 @@ markdown_extensions:
 - toc:
     permalink: true
 nav:
-  - Overview: index.md
-  - Concepts: deployment-concepts.md
-  - Getting Started: getting-started.md
-  - Features:
-    - features/index.md
-    - BlueGreen: features/bluegreen.md
-    - Canary: features/canary.md
-    - Traffic Management: 
-      - Overview: features/traffic-management/index.md
-      - Istio: features/traffic-management/istio.md 
-      - NGINX: features/traffic-management/nginx.md
-      - AWS ALB: features/traffic-management/alb.md 
-    - HPA Support: features/hpa-support.md
-    - Kustomize Support: features/kustomize.md
-    - Controller Metrics: features/controller-metrics.md
-  - Experiments: features/experiment.md
-  - Analysis: features/analysis.md
-  - Kubectl Plugin: 
-        - Overview: features/kubectl-plugin.md
-        - Commands: generated/kubectl-argo-rollouts/kubectl-argo-rollouts.md
-  - Contributing: CONTRIBUTING.md
-  - Releases ⧉: https://github.com/argoproj/argo-rollouts/releases
-  - Roadmap ⧉: https://github.com/argoproj/argo-rollouts/milestones
-  - Blog ⧉: https://blog.argoproj.io/
+- Overview: index.md
+- Concepts: deployment-concepts.md
+- Getting Started: getting-started.md
+- Features:
+  - features/index.md
+  - BlueGreen: features/bluegreen.md
+  - Canary: features/canary.md
+  - Traffic Management:
+    - Overview: features/traffic-management/index.md
+    - Istio: features/traffic-management/istio.md
+    - NGINX: features/traffic-management/nginx.md
+    - AWS ALB: features/traffic-management/alb.md
+  - HPA Support: features/hpa-support.md
+  - Kustomize Support: features/kustomize.md
+  - Controller Metrics: features/controller-metrics.md
+- Experiments: features/experiment.md
+- Analysis: features/analysis.md
+- Kubectl Plugin:
+  - Overview: features/kubectl-plugin.md
+  - Commands:
+    - generated/kubectl-argo-rollouts/kubectl-argo-rollouts.md
+    - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_abort.md
+    - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_create.md
+    - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_create_analysisrun.md
+    - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_get.md
+    - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_get_experiment.md
+    - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_get_rollout.md
+    - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_list.md
+    - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_list_experiments.md
+    - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_list_rollouts.md
+    - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_pause.md
+    - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_promote.md
+    - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_retry.md
+    - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_retry_experiment.md
+    - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_retry_rollout.md
+    - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_set.md
+    - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_set_image.md
+    - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_terminate.md
+    - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_terminate_analysisrun.md
+    - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_terminate_experiment.md
+    - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_version.md
+- Contributing: CONTRIBUTING.md
+- Releases ⧉: https://github.com/argoproj/argo-rollouts/releases
+- Roadmap ⧉: https://github.com/argoproj/argo-rollouts/milestones
+- Blog ⧉: https://blog.argoproj.io/

--- a/pkg/kubectl-argo-rollouts/cmd/abort/abort.go
+++ b/pkg/kubectl-argo-rollouts/cmd/abort/abort.go
@@ -10,15 +10,14 @@ import (
 )
 
 const (
-	example = `
+	abortExample = `
   # Abort a rollout
-  %[1]s abort guestbook
-`
+  %[1]s abort guestbook`
+
 	abortUsage = `This command stops progressing the current rollout and reverts all steps. The previous ReplicaSet will be active.
 
 Note the 'spec.template' still represents the new rollout version. If the Rollout leaves the aborted state, it will try to go to the new version. 
-Updating the 'spec.template' back to the previous version will fully revert the rollout.
-`
+Updating the 'spec.template' back to the previous version will fully revert the rollout.`
 )
 
 const (
@@ -31,7 +30,7 @@ func NewCmdAbort(o *options.ArgoRolloutsOptions) *cobra.Command {
 		Use:          "abort ROLLOUT_NAME",
 		Short:        "Abort a rollout",
 		Long:         abortUsage,
-		Example:      o.Example(example),
+		Example:      o.Example(abortExample),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) == 0 {

--- a/pkg/kubectl-argo-rollouts/cmd/abort/abort.go
+++ b/pkg/kubectl-argo-rollouts/cmd/abort/abort.go
@@ -14,6 +14,11 @@ const (
   # Abort a rollout
   %[1]s abort guestbook
 `
+	abortUsage = `This command stops progressing the current rollout and reverts all steps. The previous ReplicaSet will be active.
+
+Note the 'spec.template' still represents the new rollout version. If the Rollout leaves the aborted state, it will try to go to the new version. 
+Updating the 'spec.template' back to the previous version will fully revert the rollout.
+`
 )
 
 const (
@@ -23,8 +28,9 @@ const (
 // NewCmdAbort returns a new instance of an `rollouts abort` command
 func NewCmdAbort(o *options.ArgoRolloutsOptions) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:          "abort ROLLOUT",
+		Use:          "abort ROLLOUT_NAME",
 		Short:        "Abort a rollout",
+		Long:         abortUsage,
 		Example:      o.Example(example),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {

--- a/pkg/kubectl-argo-rollouts/cmd/cmd.go
+++ b/pkg/kubectl-argo-rollouts/cmd/cmd.go
@@ -26,7 +26,12 @@ const (
 
   # Promote the guestbook rollout
   %[1]s promote guestbook
-`
+  
+  # Abort the guestbook rollout
+  %[1]s abort guestbook
+
+  # Retry the guestbook rollout
+  %[1]s retry guestbook`
 )
 
 // NewCmdArgoRollouts returns new instance of rollouts command.

--- a/pkg/kubectl-argo-rollouts/cmd/cmd.go
+++ b/pkg/kubectl-argo-rollouts/cmd/cmd.go
@@ -18,6 +18,9 @@ import (
 
 const (
 	example = `
+  # Get guestbook rollout and watch progress
+  %[1]s get rollout guestbook -w
+
   # Pause the guestbook rollout
   %[1]s pause guestbook
 
@@ -26,10 +29,12 @@ const (
 `
 )
 
+// NewCmdArgoRollouts returns new instance of rollouts command.
 func NewCmdArgoRollouts(o *options.ArgoRolloutsOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "kubectl-argo-rollouts COMMAND",
 		Short:             "Manage argo rollouts",
+		Long:              "This command consists of multiple subcommands which can be used to manage Argo Rollouts.",
 		Example:           o.Example(example),
 		SilenceUsage:      true,
 		PersistentPreRunE: o.PersistentPreRunE,

--- a/pkg/kubectl-argo-rollouts/cmd/create/create.go
+++ b/pkg/kubectl-argo-rollouts/cmd/create/create.go
@@ -49,12 +49,11 @@ const (
 	%[1]s create -f my-experiment.yaml -w`
 
 	createAnalysisRunExample = `
-  # Create an AnalysisRun from a local template file
-  %[1]s create analysisrun --from-file my-analysis-template.yaml
+  	# Create an AnalysisRun from a local template file
+  	%[1]s create analysisrun --from-file my-analysis-template.yaml
   
-  # Create an AnalysisRun from a template in the cluster
-  %[1]s create analysisrun --from my-analysis-template
-`
+  	# Create an AnalysisRun from a template in the cluster
+  	%[1]s create analysisrun --from my-analysis-template`
 )
 
 // NewCmdCreate returns a new instance of an `rollouts create` command

--- a/pkg/kubectl-argo-rollouts/cmd/create/create.go
+++ b/pkg/kubectl-argo-rollouts/cmd/create/create.go
@@ -43,18 +43,30 @@ type CreateAnalysisRunOptions struct {
 	FromFile     string
 }
 
+const (
+	createExample = `
+	# Create an experiement and watch it
+	%[1]s create -f my-experiment.yaml -w`
+
+	createAnalysisRunExample = `
+  # Create an AnalysisRun from a local template file
+  %[1]s create analysisrun --from-file my-analysis-template.yaml
+  
+  # Create an AnalysisRun from a template in the cluster
+  %[1]s create analysisrun --from my-analysis-template
+`
+)
+
 // NewCmdCreate returns a new instance of an `rollouts create` command
 func NewCmdCreate(o *options.ArgoRolloutsOptions) *cobra.Command {
 	createOptions := CreateOptions{
 		ArgoRolloutsOptions: *o,
 	}
 	var cmd = &cobra.Command{
-		Use:   "create -f my-experiment.yaml",
-		Short: "Create a rollout resource",
-		Example: o.Example(`
-  # Create a resource and watch it
-  %[1]s create -f my-experiment.yaml -w
-`),
+		Use:          "create",
+		Short:        "Create a Rollout, Experiment, AnalysisTemplate, or AnalysisRun resource",
+		Long:         "This command creates a new Rollout, Experiment, AnalysisTemplate, or AnalysisRun resource from a file.",
+		Example:      o.Example(createExample),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(createOptions.Files) == 0 {
@@ -190,15 +202,11 @@ func NewCmdCreateAnalysisRun(o *options.ArgoRolloutsOptions) *cobra.Command {
 		ArgoRolloutsOptions: *o,
 	}
 	var cmd = &cobra.Command{
-		Use:     "analysisrun",
-		Aliases: []string{"ar"},
-		Short:   "Create an AnalysisRun from a template",
-		Example: o.Example(`
-  # Create an AnalysisRun from a local template file
-  %[1]s create analysisrun --from-file my-analysis-template.yaml
-  # Create an AnalysisRun from a template in the cluster
-  %[1]s create analysisrun --from my-analysis-template
-`),
+		Use:          "analysisrun",
+		Aliases:      []string{"ar"},
+		Short:        "Create an AnalysisRun from a template",
+		Long:         "This command creates a new AnalysisRun from an existing AnalysisTemplate resources or from an AnalysisTemplate file.",
+		Example:      o.Example(createAnalysisRunExample),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			froms := 0

--- a/pkg/kubectl-argo-rollouts/cmd/get/get.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get.go
@@ -66,6 +66,34 @@ const (
 	FgHiBlue  = 94
 )
 
+const (
+	getExample = `
+	# Get a rollout
+	%[1]s get rollout guestbook
+
+	# Watch a rollouts progress
+	%[1]s get rollout guestbook -w
+  
+	# Get an experiment
+	%[1]s get experiment my-experiment`
+
+	getUsage = `This command consists of multiple subcommands which can be used to get extended information about a rollout or experiment.`
+
+	getUsageCommon = `It returns a bunch of metadata on a resource and a tree view of the child resources created by the parent.
+	
+Tree view icons
+
+| Icon | Kind |
+|:----:|:-----------:|
+| ⟳ | Rollout |
+| Σ | Experiment |
+| α | AnalysisRun |
+| # | Revision |
+| ⧉ | ReplicaSet |
+| □ | Pod |
+| ⊞ | Job |`
+)
+
 type GetOptions struct {
 	Watch   bool
 	NoColor bool
@@ -76,14 +104,10 @@ type GetOptions struct {
 // NewCmdGet returns a new instance of an `rollouts get` command
 func NewCmdGet(o *options.ArgoRolloutsOptions) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "get <rollout|experiment> RESOURCE",
-		Short: "Get details about rollouts, experiments",
-		Example: o.Example(`
-  # Get a rollout
-  %[1]s get rollout ROLLOUT
-  # Get an experiment
-  %[1]s get experiment EXPERIMENT
-`),
+		Use:          "get <rollout|experiment> RESOURCE_NAME",
+		Short:        "Get details about rollouts and experiments",
+		Long:         getUsage,
+		Example:      o.Example(getExample),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			return o.UsageErr(c)

--- a/pkg/kubectl-argo-rollouts/cmd/get/get_experiment.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get_experiment.go
@@ -15,6 +15,15 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/viewcontroller"
 )
 
+const (
+	experimentExample = `
+	# Get an experiment
+	%[1]s get experiment my-experiment
+	
+	# Watch experiment progress
+	%[1]s get experiment my-experiment -w`
+)
+
 // NewCmdGetExperiment returns a new instance of an `rollouts get experiment` command
 func NewCmdGetExperiment(o *options.ArgoRolloutsOptions) *cobra.Command {
 	getOptions := GetOptions{
@@ -22,13 +31,11 @@ func NewCmdGetExperiment(o *options.ArgoRolloutsOptions) *cobra.Command {
 	}
 
 	var cmd = &cobra.Command{
-		Use:     "experiment EXPERIMENT",
-		Aliases: []string{"exp", "experiments"},
-		Short:   "Get details about an Experiment",
-		Example: o.Example(`
-  # Get an experiment
-  %[1]s get experiment EXPERIMENT
-`),
+		Use:          "experiment EXPERIMENT_NAME",
+		Aliases:      []string{"exp", "experiments"},
+		Short:        "Get details about an Experiment",
+		Long:         "Get details about and visual representation of a experiment. " + getUsageCommon,
+		Example:      o.Example(experimentExample),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) != 1 {

--- a/pkg/kubectl-argo-rollouts/cmd/get/get_rollout.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get_rollout.go
@@ -15,20 +15,27 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/viewcontroller"
 )
 
-// NewCmdGet returns a new instance of an `rollouts get rollout` command
+const (
+	getRolloutExample = `
+	# Get a rollout
+	%[1]s get rollout guestbook
+
+	# Watch progress of a rollout
+  	%[1]s get rollout guestbook -w`
+)
+
+// NewCmdGetRollout returns a new instance of an `rollouts get rollout` command
 func NewCmdGetRollout(o *options.ArgoRolloutsOptions) *cobra.Command {
 	getOptions := GetOptions{
 		ArgoRolloutsOptions: *o,
 	}
 
 	var cmd = &cobra.Command{
-		Use:     "rollout ROLLOUT",
-		Aliases: []string{"ro", "rollouts"},
-		Short:   "Get details about a rollout",
-		Example: o.Example(`
-  # Get a rollout
-  %[1]s get ROLLOUT
-`),
+		Use:          "rollout ROLLOUT_NAME",
+		Short:        "Get details about a rollout",
+		Long:         "Get details about and visual representation of a rollout. " + getUsageCommon,
+		Aliases:      []string{"ro", "rollouts"},
+		Example:      o.Example(getRolloutExample),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) != 1 {

--- a/pkg/kubectl-argo-rollouts/cmd/list/list.go
+++ b/pkg/kubectl-argo-rollouts/cmd/list/list.go
@@ -27,7 +27,8 @@ const (
 	# List experiments
 	%[1]s list experiments`
 
-	listUsage = `This command consists of multiple subcommands which can be used to lists all of the rollouts or experiments for a specified namespace (uses current namespace context if namespace not specified).`
+	listUsage = `This command consists of multiple subcommands which can be used to lists all of the 
+rollouts or experiments for a specified namespace (uses current namespace context if namespace not specified).`
 )
 
 // NewCmdList returns a new instance of an `rollouts list` command
@@ -35,6 +36,7 @@ func NewCmdList(o *options.ArgoRolloutsOptions) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:          "list <rollout|experiment>",
 		Short:        "List rollouts or experiments",
+		Long:         listUsage,
 		Example:      o.Example(listExample),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {

--- a/pkg/kubectl-argo-rollouts/cmd/list/list.go
+++ b/pkg/kubectl-argo-rollouts/cmd/list/list.go
@@ -19,15 +19,23 @@ type ListOptions struct {
 	options.ArgoRolloutsOptions
 }
 
+const (
+	listExample = `
+	# List rollouts
+	%[1]s list rollouts
+	
+	# List experiments
+	%[1]s list experiments`
+
+	listUsage = `This command consists of multiple subcommands which can be used to lists all of the rollouts or experiments for a specified namespace (uses current namespace context if namespace not specified).`
+)
+
 // NewCmdList returns a new instance of an `rollouts list` command
 func NewCmdList(o *options.ArgoRolloutsOptions) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "list <rollout|experiment> RESOURCE",
-		Short: "List rollouts, experiments",
-		Example: o.Example(`
-  # List rollouts
-  %[1]s list rollouts
-`),
+		Use:          "list <rollout|experiment>",
+		Short:        "List rollouts or experiments",
+		Example:      o.Example(listExample),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			return o.UsageErr(c)

--- a/pkg/kubectl-argo-rollouts/cmd/list/list_experiments.go
+++ b/pkg/kubectl-argo-rollouts/cmd/list/list_experiments.go
@@ -13,6 +13,20 @@ import (
 	experimentutil "github.com/argoproj/argo-rollouts/utils/experiment"
 )
 
+const (
+	listExperimentsExample = `
+	# List rollouts
+	%[1]s list experiments
+  
+	# List rollouts from all namespaces
+	%[1]s list experiments --all-namespaces
+  
+	# List rollouts and watch for changes
+	%[1]s list experiments --watch`
+
+	listExperimentsUsage = `This command lists all of the experiments for a specified namespace (uses current namespace context if namespace not specified).`
+)
+
 // NewCmdListExperiments returns a new instance of an `rollouts list experiments` command
 func NewCmdListExperiments(o *options.ArgoRolloutsOptions) *cobra.Command {
 	listOptions := ListOptions{
@@ -20,19 +34,11 @@ func NewCmdListExperiments(o *options.ArgoRolloutsOptions) *cobra.Command {
 	}
 
 	var cmd = &cobra.Command{
-		Use:     "experiments",
-		Aliases: []string{"exp", "experiment"},
-		Short:   "List experiments",
-		Example: o.Example(`
-  # List rollouts
-  %[1]s list experiments
-
-  # List rollouts from all namespaces
-  %[1]s list experiments --all-namespaces
-
-  # List rollouts and watch for changes
-  %[1]s list experiments --watch
-`),
+		Use:          "experiments",
+		Short:        "List experiments",
+		Long:         listExperimentsUsage,
+		Example:      o.Example(listExperimentsExample),
+		Aliases:      []string{"exp", "experiment"},
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			var namespace string

--- a/pkg/kubectl-argo-rollouts/cmd/list/list_rollouts.go
+++ b/pkg/kubectl-argo-rollouts/cmd/list/list_rollouts.go
@@ -14,6 +14,20 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options"
 )
 
+const (
+	listRolloutsExample = `
+	# List rollouts
+	%[1]s list rollouts
+  
+	# List rollouts from all namespaces
+	%[1]s list rollouts --all-namespaces
+  
+	# List rollouts and watch for changes
+	%[1]s list rollouts --watch`
+
+	listRolloutsUsage = `This command lists all of the rollouts for a specified namespace (uses current namespace context if namespace not specified).`
+)
+
 // NewCmdListRollouts returns a new instance of an `rollouts list rollouts` command
 func NewCmdListRollouts(o *options.ArgoRolloutsOptions) *cobra.Command {
 	listOptions := ListOptions{
@@ -21,19 +35,11 @@ func NewCmdListRollouts(o *options.ArgoRolloutsOptions) *cobra.Command {
 	}
 
 	var cmd = &cobra.Command{
-		Use:     "rollouts",
-		Aliases: []string{"ro", "rollout"},
-		Short:   "List rollouts",
-		Example: o.Example(`
-  # List rollouts
-  %[1]s list rollouts
-
-  # List rollouts from all namespaces
-  %[1]s list rollouts --all-namespaces
-
-  # List rollouts and watch for changes
-  %[1]s list rollouts --watch
-`),
+		Use:          "rollouts",
+		Short:        "List rollouts",
+		Long:         listRolloutsUsage,
+		Aliases:      []string{"ro", "rollout"},
+		Example:      o.Example(listRolloutsExample),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			var namespace string

--- a/pkg/kubectl-argo-rollouts/cmd/list/list_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/list/list_test.go
@@ -88,7 +88,7 @@ func TestListCmdUsage(t *testing.T) {
 	stdout := o.Out.(*bytes.Buffer).String()
 	stderr := o.ErrOut.(*bytes.Buffer).String()
 	assert.Empty(t, stdout)
-	assert.Contains(t, stderr, "Usage:\n  list <rollout|experiment> RESOURCE [flags]\n  list [command]")
+	assert.Contains(t, stderr, "Usage:\n  list <rollout|experiment> [flags]\n  list [command]")
 }
 
 func TestListRolloutsCmdUsage(t *testing.T) {

--- a/pkg/kubectl-argo-rollouts/cmd/pause/pause.go
+++ b/pkg/kubectl-argo-rollouts/cmd/pause/pause.go
@@ -12,15 +12,15 @@ import (
 const (
 	example = `
   # Pause a rollout
-  %[1]s pause guestbook
-`
+  %[1]s pause guestbook`
 )
 
 // NewCmdPause returns a new instance of an `rollouts pause` command
 func NewCmdPause(o *options.ArgoRolloutsOptions) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:          "pause ROLLOUT",
+		Use:          "pause ROLLOUT_NAME",
 		Short:        "Pause a rollout",
+		Long:         "Set the rollout paused state to 'true'",
 		Example:      o.Example(example),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {

--- a/pkg/kubectl-argo-rollouts/cmd/pause/pause.go
+++ b/pkg/kubectl-argo-rollouts/cmd/pause/pause.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	example = `
+	pauseExample = `
   # Pause a rollout
   %[1]s pause guestbook`
 )
@@ -21,7 +21,7 @@ func NewCmdPause(o *options.ArgoRolloutsOptions) *cobra.Command {
 		Use:          "pause ROLLOUT_NAME",
 		Short:        "Pause a rollout",
 		Long:         "Set the rollout paused state to 'true'",
-		Example:      o.Example(example),
+		Example:      o.Example(pauseExample),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) == 0 {

--- a/pkg/kubectl-argo-rollouts/cmd/promote/promote.go
+++ b/pkg/kubectl-argo-rollouts/cmd/promote/promote.go
@@ -14,9 +14,18 @@ import (
 
 const (
 	example = `
-	# Promote a rollout with the canary strategy
-	%[1]s promote guestbook [--skip-steps] [--skip-current-step]
+	# Promote a paused rollout
+	%[1]s promote guestbook
+
+	# Promote a canary rollout and skip all remaining stpes
+	%[1]s promote guestbook --skip-all-steps
 `
+	promoteUsage = `Unpause a Canary or BlueGreen rollout or skip Canary rollout steps.
+
+If a Canary rollout has more steps the rollout will proceed to the next step in the rollout. Use '--skip-all-steps' to skip and remaining steps. 
+If not on a pause step use '--skip-current-step' to progress to the next step in the rollout.
+`
+
 	setCurrentStepIndex = `{
 	"status": {
 		"currentStepIndex": %d
@@ -43,8 +52,9 @@ func NewCmdPromote(o *options.ArgoRolloutsOptions) *cobra.Command {
 		skipAllSteps    = false
 	)
 	var cmd = &cobra.Command{
-		Use:          "promote ROLLOUT",
+		Use:          "promote ROLLOUT_NAME",
 		Short:        "Promote a rollout",
+		Long:         promoteUsage,
 		Example:      o.Example(example),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {

--- a/pkg/kubectl-argo-rollouts/cmd/promote/promote.go
+++ b/pkg/kubectl-argo-rollouts/cmd/promote/promote.go
@@ -13,19 +13,20 @@ import (
 )
 
 const (
-	example = `
+	promoteExample = `
 	# Promote a paused rollout
 	%[1]s promote guestbook
 
 	# Promote a canary rollout and skip all remaining stpes
-	%[1]s promote guestbook --skip-all-steps
-`
+	%[1]s promote guestbook --skip-all-steps`
+
 	promoteUsage = `Unpause a Canary or BlueGreen rollout or skip Canary rollout steps.
 
 If a Canary rollout has more steps the rollout will proceed to the next step in the rollout. Use '--skip-all-steps' to skip and remaining steps. 
-If not on a pause step use '--skip-current-step' to progress to the next step in the rollout.
-`
+If not on a pause step use '--skip-current-step' to progress to the next step in the rollout.`
+)
 
+const (
 	setCurrentStepIndex = `{
 	"status": {
 		"currentStepIndex": %d
@@ -55,7 +56,7 @@ func NewCmdPromote(o *options.ArgoRolloutsOptions) *cobra.Command {
 		Use:          "promote ROLLOUT_NAME",
 		Short:        "Promote a rollout",
 		Long:         promoteUsage,
-		Example:      o.Example(example),
+		Example:      o.Example(promoteExample),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) != 1 {

--- a/pkg/kubectl-argo-rollouts/cmd/retry/retry.go
+++ b/pkg/kubectl-argo-rollouts/cmd/retry/retry.go
@@ -10,15 +10,25 @@ import (
 )
 
 const (
-	example = `
+	retryRolloutPatch    = `{"status":{"abort":false}}`
+	retryExperimentPatch = `{"status":null}`
+)
+
+const (
+	retryExample = `
 	# Retry an aborted rollout
 	%[1]s retry rollout guestbook
 
 	# Retry a failed experiment
-	%[1]s retry experiment my-experiment
-`
-	retryRolloutPatch    = `{"status":{"abort":false}}`
-	retryExperimentPatch = `{"status":null}`
+	%[1]s retry experiment my-experiment`
+
+	retryRolloutExample = `
+	# Retry an aborted rollout
+	%[1]s retry rollout guestbook`
+
+	retryExperimentExample = `
+	# Retry an experiment
+	%[1]s retry experiment my-experiment`
 )
 
 // NewCmdRetry returns a new instance of an `argo rollouts retry` command
@@ -27,7 +37,7 @@ func NewCmdRetry(o *options.ArgoRolloutsOptions) *cobra.Command {
 		Use:          "retry <rollout|experiment> RESOURCE_NAME",
 		Short:        "Retry a rollout or experiment",
 		Long:         "This command consists of multiple subcommands which can be used to restart an aborted rollout or a failed experiement.",
-		Example:      o.Example(example),
+		Example:      o.Example(retryExample),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			return o.UsageErr(c)
@@ -41,13 +51,10 @@ func NewCmdRetry(o *options.ArgoRolloutsOptions) *cobra.Command {
 // NewCmdRetryRollout returns a new instance of an `argo rollouts retry rollout` command
 func NewCmdRetryRollout(o *options.ArgoRolloutsOptions) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:     "rollout ROLLOUT_NAME",
-		Aliases: []string{"ro", "rollouts"},
-		Short:   "Retry an aborted rollout",
-		Example: o.Example(`
-  # Retry an aborted rollout
-  %[1]s retry rollout guestbook
-`),
+		Use:          "rollout ROLLOUT_NAME",
+		Aliases:      []string{"ro", "rollouts"},
+		Short:        "Retry an aborted rollout",
+		Example:      o.Example(retryRolloutExample),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -72,14 +79,11 @@ func NewCmdRetryRollout(o *options.ArgoRolloutsOptions) *cobra.Command {
 // NewCmdRetryExperiment returns a new instance of an `argo rollouts retry experiment` command
 func NewCmdRetryExperiment(o *options.ArgoRolloutsOptions) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:     "experiment EXPERIMENT_NAME",
-		Aliases: []string{"exp", "experiments"},
-		Short:   "Retry an experiment",
-		Long:    "Retry a failed experiment.",
-		Example: o.Example(`
-  # Retry an experiment
-  %[1]s retry experiment my-experiment
-`),
+		Use:          "experiment EXPERIMENT_NAME",
+		Aliases:      []string{"exp", "experiments"},
+		Short:        "Retry an experiment",
+		Long:         "Retry a failed experiment.",
+		Example:      o.Example(retryExperimentExample),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) == 0 {

--- a/pkg/kubectl-argo-rollouts/cmd/retry/retry.go
+++ b/pkg/kubectl-argo-rollouts/cmd/retry/retry.go
@@ -10,6 +10,13 @@ import (
 )
 
 const (
+	example = `
+	# Retry an aborted rollout
+	%[1]s retry rollout guestbook
+
+	# Retry a failed experiment
+	%[1]s retry experiment my-experiment
+`
 	retryRolloutPatch    = `{"status":{"abort":false}}`
 	retryExperimentPatch = `{"status":null}`
 )
@@ -17,14 +24,10 @@ const (
 // NewCmdRetry returns a new instance of an `argo rollouts retry` command
 func NewCmdRetry(o *options.ArgoRolloutsOptions) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "retry <rollout|experiment> RESOURCE",
-		Short: "Retry a rollout or experiment",
-		Example: o.Example(`
-  # Retry an aborted rollout
-  %[1]s retry rollout ROLLOUT
-  # Retry a failed experiment
-  %[1]s retry experiment EXPERIMENT
-`),
+		Use:          "retry <rollout|experiment> RESOURCE_NAME",
+		Short:        "Retry a rollout or experiment",
+		Long:         "This command consists of multiple subcommands which can be used to restart an aborted rollout or a failed experiement.",
+		Example:      o.Example(example),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			return o.UsageErr(c)
@@ -38,12 +41,12 @@ func NewCmdRetry(o *options.ArgoRolloutsOptions) *cobra.Command {
 // NewCmdRetryRollout returns a new instance of an `argo rollouts retry rollout` command
 func NewCmdRetryRollout(o *options.ArgoRolloutsOptions) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:     "rollout ROLLOUT",
+		Use:     "rollout ROLLOUT_NAME",
 		Aliases: []string{"ro", "rollouts"},
 		Short:   "Retry an aborted rollout",
 		Example: o.Example(`
   # Retry an aborted rollout
-  %[1]s retry rollout ROLLOUT
+  %[1]s retry rollout guestbook
 `),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
@@ -69,12 +72,13 @@ func NewCmdRetryRollout(o *options.ArgoRolloutsOptions) *cobra.Command {
 // NewCmdRetryExperiment returns a new instance of an `argo rollouts retry experiment` command
 func NewCmdRetryExperiment(o *options.ArgoRolloutsOptions) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:     "experiment EXPERIMENT",
+		Use:     "experiment EXPERIMENT_NAME",
 		Aliases: []string{"exp", "experiments"},
 		Short:   "Retry an experiment",
+		Long:    "Retry a failed experiment.",
 		Example: o.Example(`
   # Retry an experiment
-  %[1]s retry experiment EXPERIMENT
+  %[1]s retry experiment my-experiment
 `),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {

--- a/pkg/kubectl-argo-rollouts/cmd/set/set.go
+++ b/pkg/kubectl-argo-rollouts/cmd/set/set.go
@@ -18,6 +18,7 @@ func NewCmdSet(o *options.ArgoRolloutsOptions) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:          "set COMMAND",
 		Short:        "Update various values on resources",
+		Long:         "This command consists of multiple subcommands which can be used to update rollout resources.",
 		Example:      o.Example(example),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {

--- a/pkg/kubectl-argo-rollouts/cmd/set/set.go
+++ b/pkg/kubectl-argo-rollouts/cmd/set/set.go
@@ -7,10 +7,9 @@ import (
 )
 
 const (
-	example = `
+	setExample = `
   # Set rollout image
-  %[1]s set image my-rollout argoproj/rollouts-demo:yellow
-`
+  %[1]s set image my-rollout argoproj/rollouts-demo:yellow`
 )
 
 // NewCmdSet returns a new instance of an `rollouts set` command
@@ -19,7 +18,7 @@ func NewCmdSet(o *options.ArgoRolloutsOptions) *cobra.Command {
 		Use:          "set COMMAND",
 		Short:        "Update various values on resources",
 		Long:         "This command consists of multiple subcommands which can be used to update rollout resources.",
-		Example:      o.Example(example),
+		Example:      o.Example(setExample),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			return o.UsageErr(c)

--- a/pkg/kubectl-argo-rollouts/cmd/set/set_image.go
+++ b/pkg/kubectl-argo-rollouts/cmd/set/set_image.go
@@ -16,8 +16,7 @@ import (
 const (
 	setImageExample = `
   # Set rollout image
-  %[1]s set image my-rollout www=image:v2
-`
+  %[1]s set image my-rollout www=image:v2`
 )
 
 const (

--- a/pkg/kubectl-argo-rollouts/cmd/set/set_image.go
+++ b/pkg/kubectl-argo-rollouts/cmd/set/set_image.go
@@ -27,7 +27,7 @@ const (
 // NewCmdSetImage returns a new instance of an `rollouts set image` command
 func NewCmdSetImage(o *options.ArgoRolloutsOptions) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:          "image ROLLOUT CONTAINER=IMAGE",
+		Use:          "image ROLLOUT_NAME CONTAINER=IMAGE",
 		Short:        "Update the image of a rollout",
 		Example:      o.Example(setImageExample),
 		SilenceUsage: true,

--- a/pkg/kubectl-argo-rollouts/cmd/terminate/terminate.go
+++ b/pkg/kubectl-argo-rollouts/cmd/terminate/terminate.go
@@ -13,17 +13,30 @@ const (
 	terminatePatch = `{"spec":{"terminate":true}}`
 )
 
+const (
+	terminateExample = `
+	# Terminate an analysisRun
+	%[1]s terminate analysisrun guestbook-877894d5b-4-success-rate.1
+
+	# Terminate a failed experiment
+	%[1]s terminate experiment my-experiment`
+
+	terminateAnalysisRunExample = `
+	# Terminate an AnalysisRun
+	%[1]s terminate analysis guestbook-877894d5b-4-success-rate.1`
+
+	terminateExperimentExample = `
+	# Terminate an experiment
+	%[1]s terminate experiment my-experiment`
+)
+
 // NewCmdTerminate returns a new instance of an `argo rollouts terminate` command
 func NewCmdTerminate(o *options.ArgoRolloutsOptions) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "terminate <analysisrun|experiment> RESOURCE",
-		Short: "Terminate an AalysisRun or experiment",
-		Example: o.Example(`
-  # Terminate an analysisRun
-  %[1]s terminate analysisrun ANALYSISRUN
-  # Terminate a failed experiment
-  %[1]s terminate experiment EXPERIMENT
-`),
+		Use:          "terminate <analysisrun|experiment> RESOURCE_NAME",
+		Short:        "Terminate an AalysisRun or Experiment",
+		Long:         "This command consists of multiple subcommands which can be used to terminate an AnalysisRun or Experiment that is in progress.",
+		Example:      o.Example(terminateExample),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			return o.UsageErr(c)
@@ -37,13 +50,11 @@ func NewCmdTerminate(o *options.ArgoRolloutsOptions) *cobra.Command {
 // NewCmdTerminateAnalysisRun returns a new instance of an `argo rollouts terminate analysisRun` command
 func NewCmdTerminateAnalysisRun(o *options.ArgoRolloutsOptions) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:     "analysisrun ANALYSISRUN",
-		Aliases: []string{"ar", "analysisruns"},
-		Short:   "Terminate an AnalysisRun",
-		Example: o.Example(`
-  # Terminate an AnalysisRun
-  %[1]s terminate ANALYSISRUN
-`),
+		Use:          "analysisrun ANALYSISRUN_NAME",
+		Aliases:      []string{"ar", "analysisruns"},
+		Short:        "Terminate an AnalysisRun",
+		Long:         "This command terminates an AnalysisRun.",
+		Example:      o.Example(terminateAnalysisRunExample),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -68,13 +79,11 @@ func NewCmdTerminateAnalysisRun(o *options.ArgoRolloutsOptions) *cobra.Command {
 // NewCmdTerminateExperiment returns a new instance of an `argo rollouts terminate experiment` command
 func NewCmdTerminateExperiment(o *options.ArgoRolloutsOptions) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:     "experiment EXPERIMENT",
-		Aliases: []string{"exp", "experiments"},
-		Short:   "Terminate an experiment",
-		Example: o.Example(`
-  # Terminate an experiment
-  %[1]s terminate experiment EXPERIMENT
-`),
+		Use:          "experiment EXPERIMENT_NAME",
+		Aliases:      []string{"exp", "experiments"},
+		Short:        "Terminate an experiment",
+		Long:         "This command terminates an Experiment.",
+		Example:      o.Example(terminateExperimentExample),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) == 0 {

--- a/pkg/kubectl-argo-rollouts/cmd/version/version.go
+++ b/pkg/kubectl-argo-rollouts/cmd/version/version.go
@@ -10,6 +10,15 @@ import (
 	versionutils "github.com/argoproj/argo-rollouts/utils/version"
 )
 
+const (
+	versionExample = `
+	# Get full version info
+	%[1]s version
+	
+	# Get just plugin version number
+	%[1]s version --short`
+)
+
 // NewCmdVersion returns a new instance of an `rollouts version` command
 func NewCmdVersion(o *options.ArgoRolloutsOptions) *cobra.Command {
 	var (
@@ -19,6 +28,7 @@ func NewCmdVersion(o *options.ArgoRolloutsOptions) *cobra.Command {
 		Use:          "version",
 		Short:        "Print version",
 		Long:         "Show the version and build information of the Argo Rollouts plugin.",
+		Example:      o.Example(versionExample),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			PrintVersion(o.Out, short)

--- a/pkg/kubectl-argo-rollouts/cmd/version/version.go
+++ b/pkg/kubectl-argo-rollouts/cmd/version/version.go
@@ -18,6 +18,7 @@ func NewCmdVersion(o *options.ArgoRolloutsOptions) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:          "version",
 		Short:        "Print version",
+		Long:         "Show the version and build information of the Argo Rollouts plugin.",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			PrintVersion(o.Out, short)


### PR DESCRIPTION
- remove "not implemented" warning for BG postPromotionAnalysis
- add missing postPromotionAnalysis property from BG
- add long descriptions to each command for synopsis section
- normalize cmd examples
- update gen-plugin-docs script to
    - update mkdocs nav with command list
    - friendlier titles