### PR TITLE
chore: set kubectl flags on root command

### DIFF
--- a/pkg/kubectl-argo-rollouts/cmd/abort/abort.go
+++ b/pkg/kubectl-argo-rollouts/cmd/abort/abort.go
@@ -43,6 +43,5 @@ func NewCmdAbort(o *options.ArgoRolloutsOptions) *cobra.Command {
 			return nil
 		},
 	}
-	o.AddKubectlFlags(cmd)
 	return cmd
 }

--- a/pkg/kubectl-argo-rollouts/cmd/abort/abort_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/abort/abort_test.go
@@ -51,6 +51,7 @@ func TestAbortCmd(t *testing.T) {
 	})
 
 	cmd := NewCmdAbort(o)
+	o.AddKubectlFlags(cmd)
 	cmd.PersistentPreRunE = o.PersistentPreRunE
 	cmd.SetArgs([]string{"guestbook", "-n", "test"})
 	err := cmd.Execute()
@@ -67,6 +68,7 @@ func TestAbortCmdError(t *testing.T) {
 	tf, o := options.NewFakeArgoRolloutsOptions(&v1alpha1.Rollout{})
 	defer tf.Cleanup()
 	cmd := NewCmdAbort(o)
+	o.AddKubectlFlags(cmd)
 	cmd.PersistentPreRunE = o.PersistentPreRunE
 	cmd.SetArgs([]string{"doesnotexist", "-n", "test"})
 	err := cmd.Execute()

--- a/pkg/kubectl-argo-rollouts/cmd/cmd.go
+++ b/pkg/kubectl-argo-rollouts/cmd/cmd.go
@@ -37,6 +37,7 @@ func NewCmdArgoRollouts(o *options.ArgoRolloutsOptions) *cobra.Command {
 			return o.UsageErr(c)
 		},
 	}
+	o.AddKubectlFlags(cmd)
 	cmd.AddCommand(create.NewCmdCreate(o))
 	cmd.AddCommand(get.NewCmdGet(o))
 	cmd.AddCommand(list.NewCmdList(o))

--- a/pkg/kubectl-argo-rollouts/cmd/create/create.go
+++ b/pkg/kubectl-argo-rollouts/cmd/create/create.go
@@ -90,8 +90,6 @@ func NewCmdCreate(o *options.ArgoRolloutsOptions) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(NewCmdCreateAnalysisRun(o))
-
-	o.AddKubectlFlags(cmd)
 	cmd.Flags().StringArrayVarP(&createOptions.Files, "filename", "f", []string{}, "Files to use to create the resource")
 	cmd.Flags().BoolVarP(&createOptions.Watch, "watch", "w", false, "Watch live updates to the resource after creating")
 	cmd.Flags().BoolVar(&createOptions.NoColor, "no-color", false, "Do not colorize output")
@@ -246,7 +244,6 @@ func NewCmdCreateAnalysisRun(o *options.ArgoRolloutsOptions) *cobra.Command {
 			return nil
 		},
 	}
-	o.AddKubectlFlags(cmd)
 	cmd.Flags().StringVar(&createOptions.Name, "name", "", "Use the specified name for the run")
 	cmd.Flags().StringVar(&createOptions.GenerateName, "generate-name", "", "Use the specified generateName for the run")
 	cmd.Flags().StringVar(&createOptions.InstanceID, "instance-id", "", "Instance-ID for the AnalysisRun")

--- a/pkg/kubectl-argo-rollouts/cmd/get/get_experiment.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get_experiment.go
@@ -57,7 +57,6 @@ func NewCmdGetExperiment(o *options.ArgoRolloutsOptions) *cobra.Command {
 			return nil
 		},
 	}
-	o.AddKubectlFlags(cmd)
 	cmd.Flags().BoolVarP(&getOptions.Watch, "watch", "w", false, "Watch live updates to the rollout")
 	cmd.Flags().BoolVar(&getOptions.NoColor, "no-color", false, "Do not colorize output")
 	return cmd

--- a/pkg/kubectl-argo-rollouts/cmd/get/get_rollout.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get_rollout.go
@@ -57,7 +57,6 @@ func NewCmdGetRollout(o *options.ArgoRolloutsOptions) *cobra.Command {
 			return nil
 		},
 	}
-	o.AddKubectlFlags(cmd)
 	cmd.Flags().BoolVarP(&getOptions.Watch, "watch", "w", false, "Watch live updates to the rollout")
 	cmd.Flags().BoolVar(&getOptions.NoColor, "no-color", false, "Do not colorize output")
 	return cmd

--- a/pkg/kubectl-argo-rollouts/cmd/list/list_experiments.go
+++ b/pkg/kubectl-argo-rollouts/cmd/list/list_experiments.go
@@ -54,7 +54,6 @@ func NewCmdListExperiments(o *options.ArgoRolloutsOptions) *cobra.Command {
 			return nil
 		},
 	}
-	o.AddKubectlFlags(cmd)
 	cmd.Flags().BoolVar(&listOptions.allNamespaces, "all-namespaces", false, "Include all namespaces")
 	return cmd
 }

--- a/pkg/kubectl-argo-rollouts/cmd/list/list_rollouts.go
+++ b/pkg/kubectl-argo-rollouts/cmd/list/list_rollouts.go
@@ -62,7 +62,6 @@ func NewCmdListRollouts(o *options.ArgoRolloutsOptions) *cobra.Command {
 			return nil
 		},
 	}
-	o.AddKubectlFlags(cmd)
 	cmd.Flags().StringVar(&listOptions.name, "name", "", "Only show rollout with specified name")
 	cmd.Flags().BoolVar(&listOptions.allNamespaces, "all-namespaces", false, "Include all namespaces")
 	cmd.Flags().BoolVarP(&listOptions.watch, "watch", "w", false, "Watch for changes")

--- a/pkg/kubectl-argo-rollouts/cmd/pause/pause.go
+++ b/pkg/kubectl-argo-rollouts/cmd/pause/pause.go
@@ -39,6 +39,5 @@ func NewCmdPause(o *options.ArgoRolloutsOptions) *cobra.Command {
 			return nil
 		},
 	}
-	o.AddKubectlFlags(cmd)
 	return cmd
 }

--- a/pkg/kubectl-argo-rollouts/cmd/pause/pause_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/pause/pause_test.go
@@ -66,6 +66,7 @@ func TestPauseCmdError(t *testing.T) {
 	tf, o := options.NewFakeArgoRolloutsOptions(&v1alpha1.Rollout{})
 	defer tf.Cleanup()
 	cmd := NewCmdPause(o)
+	o.AddKubectlFlags(cmd)
 	cmd.PersistentPreRunE = o.PersistentPreRunE
 	cmd.SetArgs([]string{"doesnotexist", "-n", "test"})
 	err := cmd.Execute()

--- a/pkg/kubectl-argo-rollouts/cmd/promote/promote.go
+++ b/pkg/kubectl-argo-rollouts/cmd/promote/promote.go
@@ -77,10 +77,8 @@ func NewCmdPromote(o *options.ArgoRolloutsOptions) *cobra.Command {
 			return nil
 		},
 	}
-	o.AddKubectlFlags(cmd)
 	cmd.Flags().BoolVarP(&skipCurrentStep, "skip-current-step", "c", false, "Skip current step")
 	cmd.Flags().BoolVarP(&skipAllSteps, "skip-all-steps", "a", false, "Skip remaining steps")
-
 	return cmd
 }
 

--- a/pkg/kubectl-argo-rollouts/cmd/retry/retry.go
+++ b/pkg/kubectl-argo-rollouts/cmd/retry/retry.go
@@ -62,7 +62,6 @@ func NewCmdRetryRollout(o *options.ArgoRolloutsOptions) *cobra.Command {
 			return nil
 		},
 	}
-	o.AddKubectlFlags(cmd)
 	return cmd
 }
 
@@ -93,6 +92,5 @@ func NewCmdRetryExperiment(o *options.ArgoRolloutsOptions) *cobra.Command {
 			return nil
 		},
 	}
-	o.AddKubectlFlags(cmd)
 	return cmd
 }

--- a/pkg/kubectl-argo-rollouts/cmd/retry/retry_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/retry/retry_test.go
@@ -80,6 +80,7 @@ func TestRetryRolloutCmd(t *testing.T) {
 	})
 
 	cmd := NewCmdRetryRollout(o)
+	o.AddKubectlFlags(cmd)
 	cmd.PersistentPreRunE = o.PersistentPreRunE
 	cmd.SetArgs([]string{"guestbook", "-n", "test"})
 	err := cmd.Execute()
@@ -96,6 +97,7 @@ func TestRetryRolloutCmdError(t *testing.T) {
 	tf, o := options.NewFakeArgoRolloutsOptions(&v1alpha1.Rollout{})
 	defer tf.Cleanup()
 	cmd := NewCmdRetryRollout(o)
+	o.AddKubectlFlags(cmd)
 	cmd.PersistentPreRunE = o.PersistentPreRunE
 	cmd.SetArgs([]string{"doesnotexist", "-n", "test"})
 	err := cmd.Execute()
@@ -128,6 +130,7 @@ func TestRetryExperimentCmd(t *testing.T) {
 	})
 
 	cmd := NewCmdRetryExperiment(o)
+	o.AddKubectlFlags(cmd)
 	cmd.PersistentPreRunE = o.PersistentPreRunE
 	cmd.SetArgs([]string{"guestbook", "-n", "test"})
 	err := cmd.Execute()
@@ -144,6 +147,7 @@ func TestRetryExperimentCmdError(t *testing.T) {
 	tf, o := options.NewFakeArgoRolloutsOptions(&v1alpha1.Rollout{})
 	defer tf.Cleanup()
 	cmd := NewCmdRetryExperiment(o)
+	o.AddKubectlFlags(cmd)
 	cmd.PersistentPreRunE = o.PersistentPreRunE
 	cmd.SetArgs([]string{"doesnotexist", "-n", "test"})
 	err := cmd.Execute()

--- a/pkg/kubectl-argo-rollouts/cmd/set/set.go
+++ b/pkg/kubectl-argo-rollouts/cmd/set/set.go
@@ -24,7 +24,6 @@ func NewCmdSet(o *options.ArgoRolloutsOptions) *cobra.Command {
 			return o.UsageErr(c)
 		},
 	}
-	o.AddKubectlFlags(cmd)
 	cmd.AddCommand(NewCmdSetImage(o))
 	return cmd
 }

--- a/pkg/kubectl-argo-rollouts/cmd/set/set_image.go
+++ b/pkg/kubectl-argo-rollouts/cmd/set/set_image.go
@@ -58,7 +58,6 @@ func NewCmdSetImage(o *options.ArgoRolloutsOptions) *cobra.Command {
 			return nil
 		},
 	}
-	o.AddKubectlFlags(cmd)
 	return cmd
 }
 

--- a/pkg/kubectl-argo-rollouts/cmd/terminate/terminate.go
+++ b/pkg/kubectl-argo-rollouts/cmd/terminate/terminate.go
@@ -61,7 +61,6 @@ func NewCmdTerminateAnalysisRun(o *options.ArgoRolloutsOptions) *cobra.Command {
 			return nil
 		},
 	}
-	o.AddKubectlFlags(cmd)
 	return cmd
 }
 
@@ -92,6 +91,5 @@ func NewCmdTerminateExperiment(o *options.ArgoRolloutsOptions) *cobra.Command {
 			return nil
 		},
 	}
-	o.AddKubectlFlags(cmd)
 	return cmd
 }

--- a/pkg/kubectl-argo-rollouts/cmd/terminate/terminate_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/terminate/terminate_test.go
@@ -80,6 +80,7 @@ func TestTerminateAnalysisRunCmd(t *testing.T) {
 	})
 
 	cmd := NewCmdTerminateAnalysisRun(o)
+	o.AddKubectlFlags(cmd)
 	cmd.PersistentPreRunE = o.PersistentPreRunE
 	cmd.SetArgs([]string{"guestbook", "-n", "test"})
 	err := cmd.Execute()
@@ -96,6 +97,7 @@ func TestTerminateAnalysisRunCmdError(t *testing.T) {
 	tf, o := options.NewFakeArgoRolloutsOptions(&v1alpha1.AnalysisRun{})
 	defer tf.Cleanup()
 	cmd := NewCmdTerminateAnalysisRun(o)
+	o.AddKubectlFlags(cmd)
 	cmd.PersistentPreRunE = o.PersistentPreRunE
 	cmd.SetArgs([]string{"doesnotexist", "-n", "test"})
 	err := cmd.Execute()
@@ -128,6 +130,7 @@ func TestTerminateExperimentCmd(t *testing.T) {
 	})
 
 	cmd := NewCmdTerminateExperiment(o)
+	o.AddKubectlFlags(cmd)
 	cmd.PersistentPreRunE = o.PersistentPreRunE
 	cmd.SetArgs([]string{"guestbook", "-n", "test"})
 	err := cmd.Execute()
@@ -144,6 +147,7 @@ func TestTerminateExperimentCmdError(t *testing.T) {
 	tf, o := options.NewFakeArgoRolloutsOptions(&v1alpha1.AnalysisRun{})
 	defer tf.Cleanup()
 	cmd := NewCmdTerminateExperiment(o)
+	o.AddKubectlFlags(cmd)
 	cmd.PersistentPreRunE = o.PersistentPreRunE
 	cmd.SetArgs([]string{"doesnotexist", "-n", "test"})
 	err := cmd.Execute()

--- a/pkg/kubectl-argo-rollouts/options/options.go
+++ b/pkg/kubectl-argo-rollouts/options/options.go
@@ -86,7 +86,7 @@ func (o *ArgoRolloutsOptions) PersistentPreRunE(c *cobra.Command, args []string)
 
 // AddKubectlFlags adds kubectl related flags to the command
 func (o *ArgoRolloutsOptions) AddKubectlFlags(cmd *cobra.Command) {
-	flags := cmd.Flags()
+	flags := cmd.PersistentFlags()
 	o.ConfigFlags.AddFlags(flags)
 	flags.IntVarP(&o.KlogLevel, "kloglevel", "v", 0, "Log level for kubernetes client library")
 	flags.StringVar(&o.LogLevel, "loglevel", log.InfoLevel.String(), "Log level for kubectl argo rollouts")


### PR DESCRIPTION
This changeset compliments #454 by making the cli flags more
readable in documentation and usage help.

The options AddKubectlFlags is only applied to the the root
argo rollouts command and has been removed from all the child
commands. The result of this from a documentation perspective
is options are now split between options specific to the command
and options inherited from parent.

One side effect of this is tests that use inherited args need to call
`o.AddKubectlFlags(cmd)` explicitly.