### PR TITLE
feat: Improve wavefront provider

### DIFF
--- a/metricproviders/wavefront/wavefront.go
+++ b/metricproviders/wavefront/wavefront.go
@@ -120,7 +120,7 @@ func (p *Provider) GarbageCollect(run *v1alpha1.AnalysisRun, metric v1alpha1.Met
 	return nil
 }
 
-func findDataPointValue(datapoints []wavefrontapi.DataPoint, startTime metav1.Time) (float64, string) {
+func (p *Provider) findDataPointValue(datapoints []wavefrontapi.DataPoint, startTime metav1.Time) (float64, string) {
 	currentValue := float64(0)
 	currentTime := float64(0)
 	delta := math.Inf(1)
@@ -133,6 +133,7 @@ func findDataPointValue(datapoints []wavefrontapi.DataPoint, startTime metav1.Ti
 			delta = newDelta
 		}
 	}
+	p.logCtx.Infof("Selected Timestamp has drift of %.0f seconds", delta)
 	return currentValue, fmt.Sprintf("%.0f", currentTime)
 }
 
@@ -140,7 +141,7 @@ func (p *Provider) processResponse(metric v1alpha1.Metric, response *wavefrontap
 	wavefrontResponse := wavefrontResponse{}
 	if len(response.TimeSeries) == 1 {
 		series := response.TimeSeries[0]
-		value, time := findDataPointValue(series.DataPoints, startTime) // Wavefront DataPoint struct is of type []float{<timestamp>, <value>}
+		value, time := p.findDataPointValue(series.DataPoints, startTime) // Wavefront DataPoint struct is of type []float{<timestamp>, <value>}
 		wavefrontResponse.newValue = fmt.Sprintf("%.2f", value)
 		wavefrontResponse.epochsUsed = time
 		if math.IsNaN(value) {
@@ -155,7 +156,7 @@ func (p *Provider) processResponse(metric v1alpha1.Metric, response *wavefrontap
 		valueStr := "["
 		epochsStr := "["
 		for _, series := range response.TimeSeries {
-			value, epoch := findDataPointValue(series.DataPoints, startTime) // Wavefront DataPoint struct is of type []float{<timestamp>, <value>}
+			value, epoch := p.findDataPointValue(series.DataPoints, startTime) // Wavefront DataPoint struct is of type []float{<timestamp>, <value>}
 			valueStr = valueStr + fmt.Sprintf("%.2f", value) + ","
 			epochsStr = epochsStr + epoch + ","
 			results = append(results, value)

--- a/metricproviders/wavefront/wavefront.go
+++ b/metricproviders/wavefront/wavefront.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 	wavefrontapi "github.com/spaceapegames/go-wavefront"
@@ -76,8 +75,8 @@ func (p *Provider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1alph
 
 	queryParams := &wavefrontapi.QueryParams{
 		QueryString:             metric.Provider.Wavefront.Query,
-		StartTime:               strconv.FormatInt(time.Now().Unix()*1000, 10),
-		EndTime:                 strconv.FormatInt(time.Now().Unix()*1000, 10),
+		StartTime:               strconv.FormatInt(startTime.Unix()*1000, 10),
+		EndTime:                 strconv.FormatInt(startTime.Unix()*1000, 10),
 		MaxPoints:               "1",
 		Granularity:             "s",
 		SeriesOutsideTimeWindow: false,
@@ -97,7 +96,7 @@ func (p *Provider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1alph
 	}
 	newMeasurement.Value = result.newValue
 	newMeasurement.Phase = result.newStatus
-	newMeasurement.Metadata["epochs-used"] = result.epochsUsed
+	newMeasurement.Metadata["timestamps"] = result.epochsUsed
 	finishedTime := metav1.Now()
 	newMeasurement.FinishedAt = &finishedTime
 	return newMeasurement

--- a/metricproviders/wavefront/wavefront_test.go
+++ b/metricproviders/wavefront/wavefront_test.go
@@ -36,7 +36,7 @@ func TestType(t *testing.T) {
 }
 
 func TestRunSuccessfully(t *testing.T) {
-	e := log.Entry{}
+	e := log.WithField("", "")
 	mockSeries := wavefrontapi.TimeSeries{
 		DataPoints: []wavefrontapi.DataPoint{
 			[]float64{12000, 10},
@@ -47,7 +47,7 @@ func TestRunSuccessfully(t *testing.T) {
 			TimeSeries: []wavefrontapi.TimeSeries{mockSeries},
 		}}
 
-	p := NewWavefrontProvider(&mock, e)
+	p := NewWavefrontProvider(&mock, *e)
 	metric := v1alpha1.Metric{
 		Name:             "foo",
 		SuccessCondition: "result == 10",
@@ -251,6 +251,9 @@ func TestNewWavefrontAPI(t *testing.T) {
 }
 
 func TestFindDataPointValue(t *testing.T) {
+	e := log.WithField("", "")
+	mock := mockAPI{}
+	p := NewWavefrontProvider(mock, *e)
 	dp := func(time, value float64) []float64 {
 		return []float64{time, value}
 	}
@@ -259,7 +262,7 @@ func TestFindDataPointValue(t *testing.T) {
 			dp(0, 1),
 			dp(5, 2),
 		}
-		value, epoch := findDataPointValue(dataPoints, metav1.Unix(1, 0))
+		value, epoch := p.findDataPointValue(dataPoints, metav1.Unix(1, 0))
 		assert.Equal(t, float64(1), value)
 		assert.Equal(t, "0", epoch)
 	})
@@ -269,7 +272,7 @@ func TestFindDataPointValue(t *testing.T) {
 			dp(0, 1),
 			dp(5, 2),
 		}
-		value, epoch := findDataPointValue(dataPoints, metav1.Unix(4, 0))
+		value, epoch := p.findDataPointValue(dataPoints, metav1.Unix(4, 0))
 		assert.Equal(t, float64(2), value)
 		assert.Equal(t, "5", epoch)
 	})
@@ -279,7 +282,7 @@ func TestFindDataPointValue(t *testing.T) {
 			dp(0, 1),
 			dp(5, 2),
 		}
-		value, epoch := findDataPointValue(dataPoints, metav1.Unix(0, 0))
+		value, epoch := p.findDataPointValue(dataPoints, metav1.Unix(0, 0))
 		assert.Equal(t, float64(1), value)
 		assert.Equal(t, "0", epoch)
 	})

--- a/metricproviders/wavefront/wavefront_test.go
+++ b/metricproviders/wavefront/wavefront_test.go
@@ -95,6 +95,7 @@ func TestRunWithEvaluationError(t *testing.T) {
 	mock := mockAPI{
 		response: &wavefrontapi.QueryResponse{
 			TimeSeries: []wavefrontapi.TimeSeries{},
+			Warnings:   "No query provided",
 		}}
 	p := NewWavefrontProvider(mock, *e)
 	metric := v1alpha1.Metric{
@@ -109,6 +110,7 @@ func TestRunWithEvaluationError(t *testing.T) {
 	}
 	measurement := p.Run(newAnalysisRun(), metric)
 	assert.Equal(t, "No TimeSeries found in response from Wavefront", measurement.Message)
+	assert.Equal(t, "No query provided", measurement.Metadata["warnings"])
 	assert.NotNil(t, measurement.StartedAt)
 	assert.Equal(t, "", measurement.Value)
 	assert.NotNil(t, measurement.FinishedAt)


### PR DESCRIPTION
Closes #452 by
* Grabbing the datapoint closest to the startTime and records which Epoch was used in the metadata
* Adds an Endtime equal to the StartTime so that the query is easily reproducible (where before the EndTime was null which wavefront treats as now)
* Adds the warning if the response includes them

This PR also changes the service controller to use a merge patch instead of a JSON patch.