### PR TITLE
chore: Consistently use Config struct for controller constructors

### DIFF
--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -40,7 +40,7 @@ type metricTask struct {
 	incompleteMeasurement *v1alpha1.Measurement
 }
 
-func (c *AnalysisController) reconcileAnalysisRun(origRun *v1alpha1.AnalysisRun) *v1alpha1.AnalysisRun {
+func (c *Controller) reconcileAnalysisRun(origRun *v1alpha1.AnalysisRun) *v1alpha1.AnalysisRun {
 	if origRun.Status.Phase.Completed() {
 		return origRun
 	}
@@ -109,7 +109,7 @@ func (c *AnalysisController) reconcileAnalysisRun(origRun *v1alpha1.AnalysisRun)
 // resolveMetricArgs resolves args for single metric in AnalysisRun
 // Returns resolved metric
 // Uses ResolveQuotedArgs to handle escaped quotes
-func (c *AnalysisController) resolveMetricArgs(metric v1alpha1.Metric, args []v1alpha1.Argument) (*v1alpha1.Metric, error) {
+func (c *Controller) resolveMetricArgs(metric v1alpha1.Metric, args []v1alpha1.Argument) (*v1alpha1.Metric, error) {
 	metricBytes, err := json.Marshal(metric)
 	if err != nil {
 		return nil, err
@@ -207,7 +207,7 @@ func generateMetricTasks(run *v1alpha1.AnalysisRun) []metricTask {
 
 // resolveArgs resolves args for metricTasks, including secret references
 // returns resolved metricTasks and secrets for log redaction
-func (c *AnalysisController) resolveArgs(tasks []metricTask, args []v1alpha1.Argument, namespace string) ([]metricTask, []string, error) {
+func (c *Controller) resolveArgs(tasks []metricTask, args []v1alpha1.Argument, namespace string) ([]metricTask, []string, error) {
 	//create set of secret values for redaction
 	secretSet := map[string]bool{}
 	for i, arg := range args {
@@ -262,7 +262,7 @@ func (c *AnalysisController) resolveArgs(tasks []metricTask, args []v1alpha1.Arg
 }
 
 // runMeasurements iterates a list of metric tasks, and runs, resumes, or terminates measurements
-func (c *AnalysisController) runMeasurements(run *v1alpha1.AnalysisRun, tasks []metricTask) error {
+func (c *Controller) runMeasurements(run *v1alpha1.AnalysisRun, tasks []metricTask) error {
 	var wg sync.WaitGroup
 	// resultsLock should be held whenever we are accessing or setting status.metricResults since
 	// we are performing queries in parallel
@@ -376,7 +376,7 @@ func (c *AnalysisController) runMeasurements(run *v1alpha1.AnalysisRun, tasks []
 // assessRunStatus assesses the overall status of this AnalysisRun
 // If any metric is not yet completed, the AnalysisRun is still considered Running
 // Once all metrics are complete, the worst status is used as the overall AnalysisRun status
-func (c *AnalysisController) assessRunStatus(run *v1alpha1.AnalysisRun) (v1alpha1.AnalysisPhase, string) {
+func (c *Controller) assessRunStatus(run *v1alpha1.AnalysisRun) (v1alpha1.AnalysisPhase, string) {
 	var worstStatus v1alpha1.AnalysisPhase
 	var worstMessage string
 	terminating := analysisutil.IsTerminating(run)
@@ -574,7 +574,7 @@ func calculateNextReconcileTime(run *v1alpha1.AnalysisRun) *time.Time {
 }
 
 // garbageCollectMeasurements trims the measurement history to the specified limit and GCs old measurements
-func (c *AnalysisController) garbageCollectMeasurements(run *v1alpha1.AnalysisRun, limit int) error {
+func (c *Controller) garbageCollectMeasurements(run *v1alpha1.AnalysisRun, limit int) error {
 	var errors []error
 
 	metricsByName := make(map[string]v1alpha1.Metric)

--- a/analysis/sync.go
+++ b/analysis/sync.go
@@ -8,7 +8,7 @@ import (
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
 )
 
-func (c *AnalysisController) persistAnalysisRunStatus(orig *v1alpha1.AnalysisRun, newStatus v1alpha1.AnalysisRunStatus) error {
+func (c *Controller) persistAnalysisRunStatus(orig *v1alpha1.AnalysisRun, newStatus v1alpha1.AnalysisRunStatus) error {
 	logCtx := logutil.WithAnalysisRun(orig)
 	patch, modified, err := diff.CreateTwoWayMergePatch(
 		&v1alpha1.AnalysisRun{

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -61,10 +61,10 @@ const (
 // Manager is the controller implementation for Argo-Rollout resources
 type Manager struct {
 	metricsServer        *metrics.MetricsServer
-	rolloutController    *rollout.RolloutController
-	experimentController *experiments.ExperimentController
-	analysisController   *analysis.AnalysisController
-	serviceController    *service.ServiceController
+	rolloutController    *rollout.Controller
+	experimentController *experiments.Controller
+	analysisController   *analysis.Controller
+	serviceController    *service.Controller
 	ingressController    *ingress.Controller
 
 	rolloutSynced          cache.InformerSynced
@@ -135,51 +135,54 @@ func NewManager(
 	serviceWorkqueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Services")
 	ingressWorkqueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Ingresses")
 
-	rolloutController := rollout.NewRolloutController(
-		namespace,
-		kubeclientset,
-		argoprojclientset,
-		dynamicclientset,
-		experimentsInformer,
-		analysisRunInformer,
-		analysisTemplateInformer,
-		replicaSetInformer,
-		servicesInformer,
-		ingressesInformer,
-		rolloutsInformer,
-		resyncPeriod,
-		rolloutWorkqueue,
-		serviceWorkqueue,
-		ingressWorkqueue,
-		metricsServer,
-		recorder,
-		defaultIstioVersion)
+	rolloutController := rollout.NewController(rollout.ControllerConfig{
+		Namespace:                namespace,
+		KubeClientSet:            kubeclientset,
+		ArgoProjClientset:        argoprojclientset,
+		DynamicClientSet:         dynamicclientset,
+		ExperimentInformer:       experimentsInformer,
+		AnalysisRunInformer:      analysisRunInformer,
+		AnalysisTemplateInformer: analysisTemplateInformer,
+		ReplicaSetInformer:       replicaSetInformer,
+		ServicesInformer:         servicesInformer,
+		IngressInformer:          ingressesInformer,
+		RolloutsInformer:         rolloutsInformer,
+		ResyncPeriod:             resyncPeriod,
+		RolloutWorkQueue:         rolloutWorkqueue,
+		ServiceWorkQueue:         serviceWorkqueue,
+		IngressWorkQueue:         ingressWorkqueue,
+		MetricsServer:            metricsServer,
+		Recorder:                 recorder,
+		DefaultIstioVersion:      defaultIstioVersion,
+	})
 
-	experimentController := experiments.NewExperimentController(
-		kubeclientset,
-		argoprojclientset,
-		replicaSetInformer,
-		experimentsInformer,
-		analysisRunInformer,
-		analysisTemplateInformer,
-		resyncPeriod,
-		rolloutWorkqueue,
-		experimentWorkqueue,
-		metricsServer,
-		recorder)
+	experimentController := experiments.NewController(experiments.ControllerConfig{
+		KubeClientSet:            kubeclientset,
+		ArgoProjClientset:        argoprojclientset,
+		ReplicaSetInformer:       replicaSetInformer,
+		ExperimentsInformer:      experimentsInformer,
+		AnalysisRunInformer:      analysisRunInformer,
+		AnalysisTemplateInformer: analysisTemplateInformer,
+		ResyncPeriod:             resyncPeriod,
+		RolloutWorkQueue:         rolloutWorkqueue,
+		ExperimentWorkQueue:      experimentWorkqueue,
+		MetricsServer:            metricsServer,
+		Recorder:                 recorder,
+	})
 
-	analysisController := analysis.NewAnalysisController(
-		kubeclientset,
-		argoprojclientset,
-		analysisRunInformer,
-		secretInformer,
-		jobInformer,
-		resyncPeriod,
-		analysisRunWorkqueue,
-		metricsServer,
-		recorder)
+	analysisController := analysis.NewController(analysis.ControllerConfig{
+		KubeClientSet:        kubeclientset,
+		ArgoProjClientset:    argoprojclientset,
+		AnalysisRunInformer:  analysisRunInformer,
+		SecretInformer:       secretInformer,
+		JobInformer:          jobInformer,
+		ResyncPeriod:         resyncPeriod,
+		AnalysisRunWorkQueue: analysisRunWorkqueue,
+		MetricsServer:        metricsServer,
+		Recorder:             recorder,
+	})
 
-	serviceController := service.NewServiceController(service.ControllerConfig{
+	serviceController := service.NewController(service.ControllerConfig{
 		Kubeclientset:     kubeclientset,
 		Argoprojclientset: argoprojclientset,
 		RolloutsInformer:  rolloutsInformer,

--- a/experiments/replicaset.go
+++ b/experiments/replicaset.go
@@ -31,7 +31,7 @@ const (
 
 var controllerKind = v1alpha1.SchemeGroupVersion.WithKind("Experiment")
 
-func (c *ExperimentController) getReplicaSetsForExperiment(experiment *v1alpha1.Experiment) (map[string]*appsv1.ReplicaSet, error) {
+func (c *Controller) getReplicaSetsForExperiment(experiment *v1alpha1.Experiment) (map[string]*appsv1.ReplicaSet, error) {
 	rsList, err := c.replicaSetLister.ReplicaSets(experiment.Namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -8,7 +8,7 @@ set -o pipefail
 #   create a temporary directory, use this as an output base, and copy everything back once generated.
 export GOPATH=$(go env GOPATH) # export gopath so it's available to generate scripts
 SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null 2>&1 && pwd )"
-CODEGEN_VERSION=$(go list -m k8s.io/code-generator | awk '{print $2}' | head -1)
+CODEGEN_VERSION=$(go list -m k8s.io/code-generator | awk '{print $NF}' | head -1)
 CODEGEN_PKG="${GOPATH}/pkg/mod/k8s.io/code-generator@${CODEGEN_VERSION}"
 TEMP_DIR=$(mktemp -d)
 cleanup() {

--- a/rollout/analysis.go
+++ b/rollout/analysis.go
@@ -27,7 +27,7 @@ const (
 )
 
 // getAnalysisRunsForRollout get all analysisRuns owned by the Rollout
-func (c *RolloutController) getAnalysisRunsForRollout(rollout *v1alpha1.Rollout) ([]*v1alpha1.AnalysisRun, error) {
+func (c *Controller) getAnalysisRunsForRollout(rollout *v1alpha1.Rollout) ([]*v1alpha1.AnalysisRun, error) {
 	analysisRuns, err := c.analysisRunLister.AnalysisRuns(rollout.Namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func (c *RolloutController) getAnalysisRunsForRollout(rollout *v1alpha1.Rollout)
 	return ownedByRollout, nil
 }
 
-func (c *RolloutController) reconcileAnalysisRuns(roCtx rolloutContext) error {
+func (c *Controller) reconcileAnalysisRuns(roCtx rolloutContext) error {
 	otherArs := roCtx.OtherAnalysisRuns()
 	if roCtx.PauseContext().IsAborted() {
 		allArs := append(roCtx.CurrentAnalysisRuns(), otherArs...)
@@ -117,7 +117,7 @@ func (c *RolloutController) reconcileAnalysisRuns(roCtx rolloutContext) error {
 	return nil
 }
 
-func (c *RolloutController) reconcilePrePromotionAnalysisRun(roCtx rolloutContext) (*v1alpha1.AnalysisRun, error) {
+func (c *Controller) reconcilePrePromotionAnalysisRun(roCtx rolloutContext) (*v1alpha1.AnalysisRun, error) {
 	rollout := roCtx.Rollout()
 	newRS := roCtx.NewRS()
 	currentArs := roCtx.CurrentAnalysisRuns()
@@ -159,7 +159,7 @@ func (c *RolloutController) reconcilePrePromotionAnalysisRun(roCtx rolloutContex
 	return currentAr, nil
 }
 
-func (c *RolloutController) reconcilePostPromotionAnalysisRun(roCtx rolloutContext) (*v1alpha1.AnalysisRun, error) {
+func (c *Controller) reconcilePostPromotionAnalysisRun(roCtx rolloutContext) (*v1alpha1.AnalysisRun, error) {
 	rollout := roCtx.Rollout()
 	newRS := roCtx.NewRS()
 	currentArs := roCtx.CurrentAnalysisRuns()
@@ -202,7 +202,7 @@ func (c *RolloutController) reconcilePostPromotionAnalysisRun(roCtx rolloutConte
 	return currentAr, nil
 }
 
-func (c *RolloutController) reconcileBackgroundAnalysisRun(roCtx rolloutContext) (*v1alpha1.AnalysisRun, error) {
+func (c *Controller) reconcileBackgroundAnalysisRun(roCtx rolloutContext) (*v1alpha1.AnalysisRun, error) {
 	rollout := roCtx.Rollout()
 	newRS := roCtx.NewRS()
 	currentArs := roCtx.CurrentAnalysisRuns()
@@ -240,7 +240,7 @@ func (c *RolloutController) reconcileBackgroundAnalysisRun(roCtx rolloutContext)
 	return currentAr, nil
 }
 
-func (c *RolloutController) createAnalysisRun(roCtx rolloutContext, rolloutAnalysis *v1alpha1.RolloutAnalysis, stepIdx *int32, labels map[string]string) (*v1alpha1.AnalysisRun, error) {
+func (c *Controller) createAnalysisRun(roCtx rolloutContext, rolloutAnalysis *v1alpha1.RolloutAnalysis, stepIdx *int32, labels map[string]string) (*v1alpha1.AnalysisRun, error) {
 	newRS := roCtx.NewRS()
 	stableRS := roCtx.StableRS()
 	args := analysisutil.BuildArgumentsForRolloutAnalysisRun(rolloutAnalysis.Args, stableRS, newRS)
@@ -256,7 +256,7 @@ func (c *RolloutController) createAnalysisRun(roCtx rolloutContext, rolloutAnaly
 	return analysisutil.CreateWithCollisionCounter(roCtx.Log(), analysisRunIf, *ar)
 }
 
-func (c *RolloutController) reconcileStepBasedAnalysisRun(roCtx rolloutContext) (*v1alpha1.AnalysisRun, error) {
+func (c *Controller) reconcileStepBasedAnalysisRun(roCtx rolloutContext) (*v1alpha1.AnalysisRun, error) {
 	rollout := roCtx.Rollout()
 	currentArs := roCtx.CurrentAnalysisRuns()
 	newRS := roCtx.NewRS()
@@ -292,7 +292,7 @@ func (c *RolloutController) reconcileStepBasedAnalysisRun(roCtx rolloutContext) 
 	return currentAr, nil
 }
 
-func (c *RolloutController) cancelAnalysisRuns(roCtx rolloutContext, analysisRuns []*v1alpha1.AnalysisRun) error {
+func (c *Controller) cancelAnalysisRuns(roCtx rolloutContext, analysisRuns []*v1alpha1.AnalysisRun) error {
 	logctx := roCtx.Log()
 	for i := range analysisRuns {
 		ar := analysisRuns[i]
@@ -313,7 +313,7 @@ func (c *RolloutController) cancelAnalysisRuns(roCtx rolloutContext, analysisRun
 }
 
 // newAnalysisRunFromRollout generates an AnalysisRun from the rollouts, the AnalysisRun Step, the new/stable ReplicaSet, and any extra objects.
-func (c *RolloutController) newAnalysisRunFromRollout(roCtx rolloutContext, rolloutAnalysis *v1alpha1.RolloutAnalysis, args []v1alpha1.Argument, podHash string, stepIdx *int32, labels map[string]string) (*v1alpha1.AnalysisRun, error) {
+func (c *Controller) newAnalysisRunFromRollout(roCtx rolloutContext, rolloutAnalysis *v1alpha1.RolloutAnalysis, args []v1alpha1.Argument, podHash string, stepIdx *int32, labels map[string]string) (*v1alpha1.AnalysisRun, error) {
 	r := roCtx.Rollout()
 	logctx := roCtx.Log()
 	revision := r.Annotations[annotations.RevisionAnnotation]
@@ -366,7 +366,7 @@ func (c *RolloutController) newAnalysisRunFromRollout(roCtx rolloutContext, roll
 	return run, nil
 }
 
-func (c *RolloutController) deleteAnalysisRuns(roCtx rolloutContext, ars []*v1alpha1.AnalysisRun) error {
+func (c *Controller) deleteAnalysisRuns(roCtx rolloutContext, ars []*v1alpha1.AnalysisRun) error {
 	for i := range ars {
 		ar := ars[i]
 		if ar.DeletionTimestamp != nil {

--- a/rollout/bluegreen.go
+++ b/rollout/bluegreen.go
@@ -18,7 +18,7 @@ import (
 )
 
 // rolloutBlueGreen implements the logic for rolling a new replica set.
-func (c *RolloutController) rolloutBlueGreen(r *v1alpha1.Rollout, rsList []*appsv1.ReplicaSet) error {
+func (c *Controller) rolloutBlueGreen(r *v1alpha1.Rollout, rsList []*appsv1.ReplicaSet) error {
 	previewSvc, activeSvc, err := c.getPreviewAndActiveServices(r)
 	if err != nil {
 		return err
@@ -74,7 +74,7 @@ func (c *RolloutController) rolloutBlueGreen(r *v1alpha1.Rollout, rsList []*apps
 	return c.syncRolloutStatusBlueGreen(previewSvc, activeSvc, roCtx)
 }
 
-func (c *RolloutController) reconcileStableReplicaSet(roCtx *blueGreenContext, activeSvc *corev1.Service) error {
+func (c *Controller) reconcileStableReplicaSet(roCtx *blueGreenContext, activeSvc *corev1.Service) error {
 	rollout := roCtx.Rollout()
 
 	if _, ok := activeSvc.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey]; !ok {
@@ -99,7 +99,7 @@ func (c *RolloutController) reconcileStableReplicaSet(roCtx *blueGreenContext, a
 	return err
 }
 
-func (c *RolloutController) reconcileBlueGreenReplicaSets(roCtx *blueGreenContext, activeSvc *corev1.Service) error {
+func (c *Controller) reconcileBlueGreenReplicaSets(roCtx *blueGreenContext, activeSvc *corev1.Service) error {
 	logCtx := roCtx.Log()
 	oldRSs := roCtx.OlderRSs()
 	err := c.reconcileStableReplicaSet(roCtx, activeSvc)
@@ -157,7 +157,7 @@ func skipPause(roCtx *blueGreenContext, activeSvc *corev1.Service) bool {
 	return false
 }
 
-func (c *RolloutController) reconcileBlueGreenPause(activeSvc, previewSvc *corev1.Service, roCtx *blueGreenContext) {
+func (c *Controller) reconcileBlueGreenPause(activeSvc, previewSvc *corev1.Service, roCtx *blueGreenContext) {
 	rollout := roCtx.Rollout()
 	newRS := roCtx.NewRS()
 
@@ -199,7 +199,7 @@ func (c *RolloutController) reconcileBlueGreenPause(activeSvc, previewSvc *corev
 }
 
 // scaleDownOldReplicaSetsForBlueGreen scales down old replica sets when rollout strategy is "Blue Green".
-func (c *RolloutController) scaleDownOldReplicaSetsForBlueGreen(oldRSs []*appsv1.ReplicaSet, roCtx *blueGreenContext) (bool, error) {
+func (c *Controller) scaleDownOldReplicaSetsForBlueGreen(oldRSs []*appsv1.ReplicaSet, roCtx *blueGreenContext) (bool, error) {
 	rollout := roCtx.Rollout()
 	logCtx := roCtx.Log()
 	if getPauseCondition(rollout, v1alpha1.PauseReasonInconclusiveAnalysis) != nil {
@@ -255,7 +255,7 @@ func (c *RolloutController) scaleDownOldReplicaSetsForBlueGreen(oldRSs []*appsv1
 	return hasScaled, nil
 }
 
-func (c *RolloutController) syncRolloutStatusBlueGreen(previewSvc *corev1.Service, activeSvc *corev1.Service, roCtx *blueGreenContext) error {
+func (c *Controller) syncRolloutStatusBlueGreen(previewSvc *corev1.Service, activeSvc *corev1.Service, roCtx *blueGreenContext) error {
 	r := roCtx.Rollout()
 	newRS := roCtx.NewRS()
 	oldRSs := roCtx.OlderRSs()

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -18,7 +18,7 @@ import (
 	replicasetutil "github.com/argoproj/argo-rollouts/utils/replicaset"
 )
 
-func (c *RolloutController) rolloutCanary(rollout *v1alpha1.Rollout, rsList []*appsv1.ReplicaSet) error {
+func (c *Controller) rolloutCanary(rollout *v1alpha1.Rollout, rsList []*appsv1.ReplicaSet) error {
 	exList, err := c.getExperimentsForRollout(rollout)
 	if err != nil {
 		return err
@@ -100,7 +100,7 @@ func (c *RolloutController) rolloutCanary(rollout *v1alpha1.Rollout, rsList []*a
 	return c.syncRolloutStatusCanary(roCtx)
 }
 
-func (c *RolloutController) reconcileStableRS(roCtx *canaryContext) (bool, error) {
+func (c *Controller) reconcileStableRS(roCtx *canaryContext) (bool, error) {
 	logCtx := roCtx.Log()
 	rollout := roCtx.Rollout()
 	newRS := roCtx.NewRS()
@@ -115,7 +115,7 @@ func (c *RolloutController) reconcileStableRS(roCtx *canaryContext) (bool, error
 	return scaled, err
 }
 
-func (c *RolloutController) reconcileCanaryPause(roCtx *canaryContext) bool {
+func (c *Controller) reconcileCanaryPause(roCtx *canaryContext) bool {
 	rollout := roCtx.Rollout()
 	logCtx := roCtx.Log()
 
@@ -156,7 +156,7 @@ func (c *RolloutController) reconcileCanaryPause(roCtx *canaryContext) bool {
 	return true
 }
 
-func (c *RolloutController) reconcileOldReplicaSetsCanary(allRSs []*appsv1.ReplicaSet, oldRSs []*appsv1.ReplicaSet, roCtx *canaryContext) (bool, error) {
+func (c *Controller) reconcileOldReplicaSetsCanary(allRSs []*appsv1.ReplicaSet, oldRSs []*appsv1.ReplicaSet, roCtx *canaryContext) (bool, error) {
 	rollout := roCtx.Rollout()
 	logCtx := roCtx.Log()
 	oldPodsCount := replicasetutil.GetReplicaCountForReplicaSets(oldRSs)
@@ -183,7 +183,7 @@ func (c *RolloutController) reconcileOldReplicaSetsCanary(allRSs []*appsv1.Repli
 }
 
 // scaleDownOldReplicaSetsForCanary scales down old replica sets when rollout strategy is "canary".
-func (c *RolloutController) scaleDownOldReplicaSetsForCanary(allRSs []*appsv1.ReplicaSet, oldRSs []*appsv1.ReplicaSet, rollout *v1alpha1.Rollout) (int32, error) {
+func (c *Controller) scaleDownOldReplicaSetsForCanary(allRSs []*appsv1.ReplicaSet, oldRSs []*appsv1.ReplicaSet, rollout *v1alpha1.Rollout) (int32, error) {
 	logCtx := logutil.WithRollout(rollout)
 	availablePodCount := replicasetutil.GetAvailableReplicaCountForReplicaSets(allRSs)
 	minAvailable := defaults.GetReplicasOrDefault(rollout.Spec.Replicas) - replicasetutil.MaxUnavailable(rollout)
@@ -253,7 +253,7 @@ func completedCurrentCanaryStep(roCtx *canaryContext) bool {
 	return false
 }
 
-func (c *RolloutController) syncRolloutStatusCanary(roCtx *canaryContext) error {
+func (c *Controller) syncRolloutStatusCanary(roCtx *canaryContext) error {
 	r := roCtx.Rollout()
 	logCtx := roCtx.Log()
 	newRS := roCtx.NewRS()
@@ -356,7 +356,7 @@ func (c *RolloutController) syncRolloutStatusCanary(roCtx *canaryContext) error 
 	return c.persistRolloutStatus(roCtx, &newStatus)
 }
 
-func (c *RolloutController) reconcileCanaryReplicaSets(roCtx *canaryContext) (bool, error) {
+func (c *Controller) reconcileCanaryReplicaSets(roCtx *canaryContext) (bool, error) {
 	logCtx := roCtx.Log()
 	logCtx.Info("Reconciling StableRS")
 	scaledStableRS, err := c.reconcileStableRS(roCtx)

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -54,7 +54,7 @@ func bumpVersion(rollout *v1alpha1.Rollout) *v1alpha1.Rollout {
 func TestReconcileCanaryStepsHandleBaseCases(t *testing.T) {
 	fake := fake.Clientset{}
 	k8sfake := k8sfake.Clientset{}
-	controller := &RolloutController{
+	controller := &Controller{
 		argoprojclientset: &fake,
 		kubeclientset:     &k8sfake,
 		recorder:          &record.FakeRecorder{},

--- a/rollout/context.go
+++ b/rollout/context.go
@@ -128,20 +128,20 @@ func (bgCtx *blueGreenContext) OtherAnalysisRuns() []*v1alpha1.AnalysisRun {
 	return bgCtx.otherArs
 }
 
-func (cCtx *blueGreenContext) SetCurrentAnalysisRuns(ars []*v1alpha1.AnalysisRun) {
-	cCtx.currentArs = ars
+func (bgCtx *blueGreenContext) SetCurrentAnalysisRuns(ars []*v1alpha1.AnalysisRun) {
+	bgCtx.currentArs = ars
 	currPrePromoAr := analysisutil.GetCurrentAnalysisRunByType(ars, v1alpha1.RolloutTypePrePromotionLabel)
-	if currPrePromoAr != nil && !cCtx.PauseContext().IsAborted() {
+	if currPrePromoAr != nil && !bgCtx.PauseContext().IsAborted() {
 		switch currPrePromoAr.Status.Phase {
 		case v1alpha1.AnalysisPhasePending, v1alpha1.AnalysisPhaseRunning, v1alpha1.AnalysisPhaseSuccessful, "":
-			cCtx.newStatus.BlueGreen.PrePromotionAnalysisRun = currPrePromoAr.Name
+			bgCtx.newStatus.BlueGreen.PrePromotionAnalysisRun = currPrePromoAr.Name
 		}
 	}
 	currPostPromoAr := analysisutil.GetCurrentAnalysisRunByType(ars, v1alpha1.RolloutTypePostPromotionLabel)
-	if currPostPromoAr != nil && !cCtx.PauseContext().IsAborted() {
+	if currPostPromoAr != nil && !bgCtx.PauseContext().IsAborted() {
 		switch currPostPromoAr.Status.Phase {
 		case v1alpha1.AnalysisPhasePending, v1alpha1.AnalysisPhaseRunning, v1alpha1.AnalysisPhaseSuccessful, "":
-			cCtx.newStatus.BlueGreen.PostPromotionAnalysisRun = currPostPromoAr.Name
+			bgCtx.newStatus.BlueGreen.PostPromotionAnalysisRun = currPostPromoAr.Name
 		}
 	}
 }

--- a/rollout/experiment.go
+++ b/rollout/experiment.go
@@ -116,7 +116,7 @@ func GetExperimentFromTemplate(r *v1alpha1.Rollout, stableRS, newRS *appsv1.Repl
 
 // getExperimentsForRollout get all experiments owned by the Rollout
 // changing steps in the Rollout Spec would cause multiple experiments to exist which is why it returns an array
-func (c *RolloutController) getExperimentsForRollout(rollout *v1alpha1.Rollout) ([]*v1alpha1.Experiment, error) {
+func (c *Controller) getExperimentsForRollout(rollout *v1alpha1.Rollout) ([]*v1alpha1.Experiment, error) {
 	experiments, err := c.experimentsLister.Experiments(rollout.Namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
@@ -132,7 +132,7 @@ func (c *RolloutController) getExperimentsForRollout(rollout *v1alpha1.Rollout) 
 	return ownedByRollout, nil
 }
 
-func (c *RolloutController) reconcileExperiments(roCtx *canaryContext) error {
+func (c *Controller) reconcileExperiments(roCtx *canaryContext) error {
 	rollout := roCtx.Rollout()
 	logCtx := roCtx.Log()
 	newRS := roCtx.NewRS()
@@ -205,7 +205,7 @@ func (c *RolloutController) reconcileExperiments(roCtx *canaryContext) error {
 
 // createExperimentWithCollisionHandling creates the given experiment, but with a new name
 // in the event that an experiment with the same name already exists
-func (c *RolloutController) createExperimentWithCollisionHandling(roCtx *canaryContext, newEx *v1alpha1.Experiment) (*v1alpha1.Experiment, error) {
+func (c *Controller) createExperimentWithCollisionHandling(roCtx *canaryContext, newEx *v1alpha1.Experiment) (*v1alpha1.Experiment, error) {
 	collisionCount := 1
 	baseName := newEx.Name
 	for {
@@ -234,7 +234,7 @@ func (c *RolloutController) createExperimentWithCollisionHandling(roCtx *canaryC
 	}
 }
 
-func (c *RolloutController) cancelExperiments(roCtx *canaryContext, exs []*v1alpha1.Experiment) error {
+func (c *Controller) cancelExperiments(roCtx *canaryContext, exs []*v1alpha1.Experiment) error {
 	for i := range exs {
 		ex := exs[i]
 		if ex == nil {
@@ -251,7 +251,7 @@ func (c *RolloutController) cancelExperiments(roCtx *canaryContext, exs []*v1alp
 	return nil
 }
 
-func (c *RolloutController) deleteExperiments(roCtx rolloutContext, exs []*v1alpha1.Experiment) error {
+func (c *Controller) deleteExperiments(roCtx rolloutContext, exs []*v1alpha1.Experiment) error {
 	for i := range exs {
 		ex := exs[i]
 		if ex.DeletionTimestamp != nil {

--- a/rollout/pause.go
+++ b/rollout/pause.go
@@ -185,7 +185,7 @@ func (pCtx *pauseContext) CompletedPauseStep(pause v1alpha1.RolloutPause) bool {
 	return false
 }
 
-func (c *RolloutController) checkEnqueueRolloutDuringWait(rollout *v1alpha1.Rollout, startTime metav1.Time, durationInSeconds int32) {
+func (c *Controller) checkEnqueueRolloutDuringWait(rollout *v1alpha1.Rollout, startTime metav1.Time, durationInSeconds int32) {
 	logCtx := logutil.WithRollout(rollout)
 	now := metav1.Now()
 	expiredTime := startTime.Add(time.Duration(durationInSeconds) * time.Second)

--- a/rollout/replicaset.go
+++ b/rollout/replicaset.go
@@ -23,7 +23,7 @@ const (
 	removeScaleDownAtAnnotationsPatch = `[{ "op": "remove", "path": "/metadata/annotations/%s"}]`
 )
 
-func (c *RolloutController) removeScaleDownDelay(roCtx rolloutContext, rs *appsv1.ReplicaSet) error {
+func (c *Controller) removeScaleDownDelay(roCtx rolloutContext, rs *appsv1.ReplicaSet) error {
 	logCtx := roCtx.Log()
 	logCtx.Infof("Removing '%s' annotation on RS '%s'", v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey, rs.Name)
 	patch := fmt.Sprintf(removeScaleDownAtAnnotationsPatch, v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey)
@@ -31,7 +31,7 @@ func (c *RolloutController) removeScaleDownDelay(roCtx rolloutContext, rs *appsv
 	return err
 }
 
-func (c *RolloutController) addScaleDownDelay(roCtx rolloutContext, rs *appsv1.ReplicaSet) error {
+func (c *Controller) addScaleDownDelay(roCtx rolloutContext, rs *appsv1.ReplicaSet) error {
 	logCtx := roCtx.Log()
 	logCtx.Infof("Adding '%s' annotation to RS '%s'", v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey, rs.Name)
 	scaleDownDelaySeconds := time.Duration(defaults.GetScaleDownDelaySecondsOrDefault(roCtx.Rollout()))
@@ -41,7 +41,7 @@ func (c *RolloutController) addScaleDownDelay(roCtx rolloutContext, rs *appsv1.R
 	return err
 }
 
-func (c *RolloutController) getReplicaSetsForRollouts(r *v1alpha1.Rollout) ([]*appsv1.ReplicaSet, error) {
+func (c *Controller) getReplicaSetsForRollouts(r *v1alpha1.Rollout) ([]*appsv1.ReplicaSet, error) {
 	// List all ReplicaSets to find those we own but that no longer match our
 	// selector. They will be orphaned by ClaimReplicaSets().
 	rsList, err := c.replicaSetLister.ReplicaSets(r.Namespace).List(labels.Everything())
@@ -68,7 +68,7 @@ func (c *RolloutController) getReplicaSetsForRollouts(r *v1alpha1.Rollout) ([]*a
 	return cm.ClaimReplicaSets(rsList)
 }
 
-func (c *RolloutController) reconcileNewReplicaSet(roCtx rolloutContext) (bool, error) {
+func (c *Controller) reconcileNewReplicaSet(roCtx rolloutContext) (bool, error) {
 	rollout := roCtx.Rollout()
 	newRS := roCtx.NewRS()
 	if newRS == nil {
@@ -84,7 +84,7 @@ func (c *RolloutController) reconcileNewReplicaSet(roCtx rolloutContext) (bool, 
 	return scaled, err
 }
 
-func (c *RolloutController) reconcileOldReplicaSets(oldRSs []*appsv1.ReplicaSet, roCtx rolloutContext) (bool, error) {
+func (c *Controller) reconcileOldReplicaSets(oldRSs []*appsv1.ReplicaSet, roCtx rolloutContext) (bool, error) {
 	rollout := roCtx.Rollout()
 
 	oldPodsCount := replicasetutil.GetReplicaCountForReplicaSets(oldRSs)
@@ -117,7 +117,7 @@ func (c *RolloutController) reconcileOldReplicaSets(oldRSs []*appsv1.ReplicaSet,
 }
 
 // cleanupUnhealthyReplicas will scale down old replica sets with unhealthy replicas, so that all unhealthy replicas will be deleted.
-func (c *RolloutController) cleanupUnhealthyReplicas(oldRSs []*appsv1.ReplicaSet, roCtx rolloutContext) ([]*appsv1.ReplicaSet, bool, error) {
+func (c *Controller) cleanupUnhealthyReplicas(oldRSs []*appsv1.ReplicaSet, roCtx rolloutContext) ([]*appsv1.ReplicaSet, bool, error) {
 	logCtx := roCtx.Log()
 	sort.Sort(controller.ReplicaSetsByCreationTimestamp(oldRSs))
 	// Safely scale down all old replica sets with unhealthy replicas. Replica set will sort the pods in the order

--- a/rollout/replicaset_test.go
+++ b/rollout/replicaset_test.go
@@ -156,7 +156,7 @@ func TestReconcileNewReplicaSet(t *testing.T) {
 			bgCtx := newBlueGreenCtx(rollout, newRS, nil, nil)
 			fake := fake.Clientset{}
 			k8sfake := k8sfake.Clientset{}
-			controller := &RolloutController{
+			controller := &Controller{
 				argoprojclientset: &fake,
 				kubeclientset:     &k8sfake,
 				recorder:          &record.FakeRecorder{},

--- a/rollout/service.go
+++ b/rollout/service.go
@@ -46,7 +46,7 @@ func generatePatch(service *corev1.Service, newRolloutUniqueLabelValue string, r
 }
 
 // switchSelector switch the selector on an existing service to a new value
-func (c RolloutController) switchServiceSelector(service *corev1.Service, newRolloutUniqueLabelValue string, r *v1alpha1.Rollout) error {
+func (c Controller) switchServiceSelector(service *corev1.Service, newRolloutUniqueLabelValue string, r *v1alpha1.Rollout) error {
 	if service.Spec.Selector == nil {
 		service.Spec.Selector = make(map[string]string)
 	}
@@ -67,7 +67,7 @@ func (c RolloutController) switchServiceSelector(service *corev1.Service, newRol
 	return err
 }
 
-func (c *RolloutController) reconcilePreviewService(roCtx *blueGreenContext, previewSvc *corev1.Service) error {
+func (c *Controller) reconcilePreviewService(roCtx *blueGreenContext, previewSvc *corev1.Service) error {
 	r := roCtx.Rollout()
 	logCtx := roCtx.Log()
 	newRS := roCtx.NewRS()
@@ -85,7 +85,7 @@ func (c *RolloutController) reconcilePreviewService(roCtx *blueGreenContext, pre
 	return nil
 }
 
-func (c *RolloutController) reconcileActiveService(roCtx *blueGreenContext, previewSvc, activeSvc *corev1.Service) error {
+func (c *Controller) reconcileActiveService(roCtx *blueGreenContext, previewSvc, activeSvc *corev1.Service) error {
 	r := roCtx.Rollout()
 	newRS := roCtx.NewRS()
 	allRSs := roCtx.AllRSs()
@@ -122,7 +122,7 @@ func (c *RolloutController) reconcileActiveService(roCtx *blueGreenContext, prev
 }
 
 // getReferencedService returns service references in rollout spec and sets warning condition if service does not exist
-func (c *RolloutController) getReferencedService(r *v1alpha1.Rollout, serviceName string) (*corev1.Service, error) {
+func (c *Controller) getReferencedService(r *v1alpha1.Rollout, serviceName string) (*corev1.Service, error) {
 	svc, err := c.servicesLister.Services(r.Namespace).Get(serviceName)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -146,7 +146,7 @@ func (c *RolloutController) getReferencedService(r *v1alpha1.Rollout, serviceNam
 	return svc, nil
 }
 
-func (c *RolloutController) getPreviewAndActiveServices(r *v1alpha1.Rollout) (*corev1.Service, *corev1.Service, error) {
+func (c *Controller) getPreviewAndActiveServices(r *v1alpha1.Rollout) (*corev1.Service, *corev1.Service, error) {
 	var previewSvc *corev1.Service
 	var activeSvc *corev1.Service
 	var err error
@@ -167,7 +167,7 @@ func (c *RolloutController) getPreviewAndActiveServices(r *v1alpha1.Rollout) (*c
 	return previewSvc, activeSvc, nil
 }
 
-func (c *RolloutController) reconcileStableAndCanaryService(roCtx *canaryContext) error {
+func (c *Controller) reconcileStableAndCanaryService(roCtx *canaryContext) error {
 	r := roCtx.Rollout()
 	newRS := roCtx.NewRS()
 	stableRS := roCtx.StableRS()

--- a/rollout/sync_test.go
+++ b/rollout/sync_test.go
@@ -190,7 +190,7 @@ func TestCleanupRollouts(t *testing.T) {
 			roCtx := newBlueGreenCtx(r, nil, test.replicaSets, nil)
 			fake := fake.Clientset{}
 			k8sfake := k8sfake.Clientset{}
-			c := &RolloutController{
+			c := &Controller{
 				argoprojclientset: &fake,
 				kubeclientset:     &k8sfake,
 				recorder:          &record.FakeRecorder{},

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -16,7 +16,7 @@ type TrafficRoutingReconciler interface {
 }
 
 // NewTrafficRoutingReconciler identifies return the TrafficRouting Plugin that the rollout wants to modify
-func (c *RolloutController) NewTrafficRoutingReconciler(roCtx rolloutContext) TrafficRoutingReconciler {
+func (c *Controller) NewTrafficRoutingReconciler(roCtx rolloutContext) TrafficRoutingReconciler {
 	rollout := roCtx.Rollout()
 	if rollout.Spec.Strategy.Canary.TrafficRouting == nil {
 		return nil
@@ -46,7 +46,7 @@ func (c *RolloutController) NewTrafficRoutingReconciler(roCtx rolloutContext) Tr
 	return nil
 }
 
-func (c *RolloutController) reconcileTrafficRouting(roCtx *canaryContext) error {
+func (c *Controller) reconcileTrafficRouting(roCtx *canaryContext) error {
 	rollout := roCtx.Rollout()
 	reconciler := c.newTrafficRoutingReconciler(roCtx)
 	if reconciler == nil {

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -163,7 +163,7 @@ func TestRolloutSetWeightToZeroWhenFullyRolledOut(t *testing.T) {
 }
 
 func TestNewTrafficRoutingReconciler(t *testing.T) {
-	rc := RolloutController{}
+	rc := Controller{}
 	steps := []v1alpha1.CanaryStep{
 		{
 			SetWeight: pointer.Int32Ptr(10),

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -45,7 +45,7 @@ func TestGenerateRemovePatch(t *testing.T) {
 	assert.Equal(t, removeSelectorAndManagedByPatch, generateRemovePatch(svc))
 }
 
-func newFakeServiceController(svc *corev1.Service, rollout *v1alpha1.Rollout) (*ServiceController, *k8sfake.Clientset, *fake.Clientset, map[string]int) {
+func newFakeServiceController(svc *corev1.Service, rollout *v1alpha1.Rollout) (*Controller, *k8sfake.Clientset, *fake.Clientset, map[string]int) {
 	client := fake.NewSimpleClientset()
 	if rollout != nil {
 		client = fake.NewSimpleClientset(rollout)
@@ -63,7 +63,7 @@ func newFakeServiceController(svc *corev1.Service, rollout *v1alpha1.Rollout) (*
 		Addr:               "localhost:8080",
 		K8SRequestProvider: &metrics.K8sRequestsCountProvider{},
 	})
-	c := NewServiceController(ControllerConfig{
+	c := NewController(ControllerConfig{
 		Kubeclientset:     kubeclient,
 		Argoprojclientset: client,
 		RolloutsInformer:  i.Argoproj().V1alpha1().Rollouts(),


### PR DESCRIPTION
Starting in #426 we changed the constructors for the new ingress controller, and the one for the `service` controller to accept a config struct to avoid potential issues with out of order parameters.

This extends that change to the remaining controllers and also removes "stuttering" (`analysis.AnalysisController -> analysis.Controller`)