### PR TITLE
fix: Add missing clusterrole for deleting pods

### DIFF
--- a/manifests/cluster-install/argo-rollouts-clusterrole.yaml
+++ b/manifests/cluster-install/argo-rollouts-clusterrole.yaml
@@ -105,3 +105,10 @@ rules:
   - watch
   - get
   - update
+- apiGroups:
+    - ""
+  resources:
+    - pods
+  verbs:
+    - list
+    - delete

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -11463,6 +11463,13 @@ rules:
   - watch
   - get
   - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Needed to restart Rollouts