### PR TITLE
docs: Update install caveat to include v1.14

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,9 +8,7 @@
 Argo Rollouts can be installed at a cluster or namespace level. 
 
 !!! important
-    Since the API server rejects CRD manifests with unknown fields, the Argo Rollout's CRDs do not work with **v1.13.x** 
-    because they have a new field from the v1.14. Adding the `--validate=false` to the commands below allows the cluster to 
-    accept the Argo Rollouts CRDs.
+    When installing Argo Rollouts on Kubernetes v1.14 or lower, the CRD manifests must be kubectl applied with the --validate=false option. This is caused by use of new CRD fields introduced in v1.15, which are rejected by default in lower API servers.
 
 ### Cluster-Level installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,9 @@ $ kubectl create namespace argo-rollouts
 $ kubectl apply -n argo-rollouts -f https://raw.githubusercontent.com/argoproj/argo-rollouts/stable/manifests/install.yaml
 ```
 
+!!! important
+    When installing Argo Rollouts on Kubernetes v1.14 or lower, the CRD manifests must be kubectl applied with the --validate=false option. This is caused by use of new CRD fields introduced in v1.15, which are rejected by default in lower API servers.
+
 Check out the [getting started guide](getting-started.md) to walk through creating and then updating a rollout object. 
 
 ### How does it work?


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-rollouts/issues/476. This issue occurs because Argo Rollouts v0.8 is starting to use the `x-kubernetes-int-or-string` in the validation, which is not available before v1.15.