### PR TITLE
feat: kustomize support for Rollouts v0.8 and Experiment/AnalysisTemplates

### DIFF
--- a/docs/features/kustomize/rollout-transform.yaml
+++ b/docs/features/kustomize/rollout-transform.yaml
@@ -15,6 +15,30 @@ nameReference:
     kind: Rollout
   - path: spec/template/spec/volumes/projected/sources/configMap/name
     kind: Rollout
+  - path: spec/templates/template/spec/volumes/configMap/name
+    kind: Experiment
+  - path: spec/templates/template/spec/containers/env/valueFrom/configMapKeyRef/name
+    kind: Experiment
+  - path: spec/templates/template/spec/initContainers/env/valueFrom/configMapKeyRef/name
+    kind: Experiment
+  - path: spec/templates/template/spec/containers/envFrom/configMapRef/name
+    kind: Experiment
+  - path: spec/templates/template/spec/initContainers/envFrom/configMapRef/name
+    kind: Experiment
+  - path: spec/templates/template/spec/volumes/projected/sources/configMap/name
+    kind: Experiment
+  - path: spec/metrics/provider/job/spec/template/spec/volumes/configMap/name
+    kind: AnalysisTemplate
+  - path: spec/metrics/provider/job/spec/template/spec/containers/env/valueFrom/configMapKeyRef/name
+    kind: AnalysisTemplate
+  - path: spec/metrics/provider/job/spec/template/spec/initContainers/env/valueFrom/configMapKeyRef/name
+    kind: AnalysisTemplate
+  - path: spec/metrics/provider/job/spec/template/spec/containers/envFrom/configMapRef/name
+    kind: AnalysisTemplate
+  - path: spec/metrics/provider/job/spec/template/spec/initContainers/envFrom/configMapRef/name
+    kind: AnalysisTemplate
+  - path: spec/metrics/provider/job/spec/template/spec/volumes/projected/sources/configMap/name
+    kind: AnalysisTemplate
 - kind: Secret
   version: v1
   fieldSpecs:
@@ -32,16 +56,63 @@ nameReference:
     kind: Rollout
   - path: spec/template/spec/volumes/projected/sources/secret/name
     kind: Rollout
+  - path: spec/templates/template/spec/volumes/secret/secretName
+    kind: Experiment
+  - path: spec/templates/template/spec/containers/env/valueFrom/secretKeyRef/name
+    kind: Experiment
+  - path: spec/templates/template/spec/initContainers/env/valueFrom/secretKeyRef/name
+    kind: Experiment
+  - path: spec/templates/template/spec/containers/envFrom/secretRef/name
+    kind: Experiment
+  - path: spec/templates/template/spec/initContainers/envFrom/secretRef/name
+    kind: Experiment
+  - path: spec/templates/template/spec/imagePullSecrets/name
+    kind: Experiment
+  - path: spec/templates/template/spec/volumes/projected/sources/secret/name
+    kind: Experiment
+  - path: spec/metrics/provider/job/spec/template/spec/volumes/secret/secretName
+    kind: AnalysisTemplate
+  - path: spec/metrics/provider/job/spec/template/spec/containers/env/valueFrom/secretKeyRef/name
+    kind: AnalysisTemplate
+  - path: spec/metrics/provider/job/spec/template/spec/initContainers/env/valueFrom/secretKeyRef/name
+    kind: AnalysisTemplate
+  - path: spec/metrics/provider/job/spec/template/spec/containers/envFrom/secretRef/name
+    kind: AnalysisTemplate
+  - path: spec/metrics/provider/job/spec/template/spec/initContainers/envFrom/secretRef/name
+    kind: AnalysisTemplate
+  - path: spec/metrics/provider/job/spec/template/spec/imagePullSecrets/name
+    kind: AnalysisTemplate
+  - path: spec/metrics/provider/job/spec/template/spec/volumes/projected/sources/secret/name
+    kind: AnalysisTemplate
 - kind: ServiceAccount
   version: v1
   fieldSpecs:
   - path: spec/template/spec/serviceAccountName
     kind: Rollout
+  - path: spec/templates/template/spec/serviceAccountName
+    kind: Experiment
+  - path: spec/metrics/provider/job/spec/template/spec/serviceAccountName
+    kind: AnalysisTemplate
 - kind: PersistentVolumeClaim
   version: v1
   fieldSpecs:
   - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
     kind: Rollout
+  - path: spec/templates/template/spec/volumes/persistentVolumeClaim/claimName
+    kind: Experiment
+  - path: spec/metrics/provider/job/spec/template/spec/volumes/persistentVolumeClaim/claimName
+    kind: AnalysisTemplate
+- kind: PriorityClass
+  version: v1
+  group: scheduling.k8s.io
+  fieldSpecs:
+  - path: spec/template/spec/priorityClassName
+    kind: Rollout
+  - path: spec/templates/template/spec/priorityClassName
+    kind: Experiment
+  - path: spec/metrics/provider/job/spec/template/spec/priorityClassName
+    kind: AnalysisTemplate
+
 # The name references below are unique to Rollouts and not applicable to Deployment
 - kind: Service
   version: v1
@@ -59,6 +130,48 @@ nameReference:
   fieldSpecs:
   - path: spec/strategy/canary/trafficRouting/istio/virtualService/name
     kind: Rollout
+- kind: Ingress
+  group: networking.k8s.io
+  fieldSpecs:
+  - path: spec/strategy/canary/trafficRouting/alb/ingress
+    kind: Rollout
+  - path: spec/strategy/canary/trafficRouting/nginx/stableIngress
+    kind: Rollout
+- kind: Ingress
+  group: extensions
+  fieldSpecs:
+  - path: spec/strategy/canary/trafficRouting/alb/ingress
+    kind: Rollout
+  - path: spec/strategy/canary/trafficRouting/nginx/stableIngress
+    kind: Rollout
+- kind: AnalysisTemplate
+  group: argoproj.io
+  fieldSpecs:
+  - path: spec/strategy/blueGreen/prePromotionAnalysis/templates/name
+    kind: Rollout
+  - path: spec/strategy/blueGreen/postPromotionAnalysis/templates/name
+    kind: Rollout
+  - path: spec/strategy/canary/analysis/templates/name
+    kind: Rollout
+  - path: spec/strategy/canary/steps/analysis/templates/name
+    kind: Rollout
+  - path: spec/strategy/canary/steps/experiment/analyses/templateName
+    kind: Rollout
+  - path: spec/analyses/templateName
+    kind: Experiment
+    # NOTE: templateName is deprecated in the below fields, in favor of templates[].name
+  - path: spec/strategy/blueGreen/prePromotionAnalysis/templateName   
+    kind: Rollout
+  - path: spec/strategy/blueGreen/postPromotionAnalysis/templateName
+    kind: Rollout
+  - path: spec/strategy/canary/analysis/templateName
+    kind: Rollout
+  - path: spec/strategy/canary/steps/analysis/templateName
+    kind: Rollout
+- kind: Rollout
+  fieldSpecs:
+  - path: spec/scaleTargetRef/name
+    kind: HorizontalPodAutoscaler
 
 # https://github.com/kubernetes-sigs/kustomize/blob/master/api/konfig/builtinpluginconsts/commonlabels.go
 commonLabels:
@@ -105,6 +218,40 @@ varReference:
   kind: Rollout
 - path: spec/template/spec/initContainers/volumeMounts/mountPath
   kind: Rollout
+- path: spec/templates/template/spec/containers/args
+  kind: Experiment
+- path: spec/templates/template/spec/containers/command
+  kind: Experiment
+- path: spec/templates/template/spec/containers/env/value
+  kind: Experiment
+- path: spec/templates/template/spec/containers/volumeMounts/mountPath
+  kind: Experiment
+- path: spec/templates/template/spec/initContainers/args
+  kind: Experiment
+- path: spec/templates/template/spec/initContainers/command
+  kind: Experiment
+- path: spec/templates/template/spec/initContainers/env/value
+  kind: Experiment
+- path: spec/templates/template/spec/initContainers/volumeMounts/mountPath
+  kind: Experiment
+- path: spec/metrics/provider/job/spec/template/spec/containers/args
+  kind: AnalysisTemplate
+- path: spec/metrics/provider/job/spec/template/spec/containers/command
+  kind: AnalysisTemplate
+- path: spec/metrics/provider/job/spec/template/spec/containers/env/value
+  kind: AnalysisTemplate
+- path: spec/metrics/provider/job/spec/template/spec/containers/volumeMounts/mountPath
+  kind: AnalysisTemplate
+- path: spec/metrics/provider/job/spec/template/spec/initContainers/args
+  kind: AnalysisTemplate
+- path: spec/metrics/provider/job/spec/template/spec/initContainers/command
+  kind: AnalysisTemplate
+- path: spec/metrics/provider/job/spec/template/spec/initContainers/env/value
+  kind: AnalysisTemplate
+- path: spec/metrics/provider/job/spec/template/spec/initContainers/volumeMounts/mountPath
+  kind: AnalysisTemplate
+- path: spec/metrics/provider/job/spec/template/spec/volumes/nfs/server
+  kind: AnalysisTemplate
 
 # https://github.com/kubernetes-sigs/kustomize/blob/master/api/konfig/builtinpluginconsts/replicas.go
 replicas:

--- a/test/kustomize/rollout/expected.yaml
+++ b/test/kustomize/rollout/expected.yaml
@@ -1,4 +1,13 @@
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    foo: bar
+  labels:
+    foo: bar
+  name: my-robot
+---
+apiVersion: v1
 data:
   FOO: BAR
 kind: ConfigMap
@@ -56,6 +65,73 @@ spec:
     foo: bar
 ---
 apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  annotations:
+    foo: bar
+  labels:
+    foo: bar
+  name: my-random-fail
+spec:
+  metrics:
+  - failureLimit: 1
+    interval: 5s
+    name: random-fail
+    provider:
+      job:
+        spec:
+          backoffLimit: 0
+          template:
+            spec:
+              containers:
+              - command:
+                - ping my-guestbook-stable-svc
+                image: alpine:3.8
+                name: sleep
+              restartPolicy: Never
+              serviceAccountName: my-robot
+              volumes:
+              - configMap:
+                  name: my-guestbook-cm-bt8kmct6gk
+                name: config-volume
+              - name: secret-volume
+                secret:
+                  secretName: my-guestbook-secret-t95h96m85d
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Experiment
+metadata:
+  annotations:
+    foo: bar
+  labels:
+    foo: bar
+  name: my-experiment
+spec:
+  analyses:
+  - name: random-fail
+    templateName: my-random-fail
+  templates:
+  - metadata:
+      labels:
+        app: guestbook
+    name: foo
+    template:
+      spec:
+        containers:
+        - command:
+          - ping my-guestbook-stable-svc
+          image: guestbook:v2
+          name: guestbook
+        serviceAccountName: my-robot
+        volumes:
+        - configMap:
+            name: my-guestbook-cm-bt8kmct6gk
+          name: config-volume
+        - name: secret-volume
+          secret:
+            secretName: my-guestbook-secret-t95h96m85d
+---
+apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
   annotations:
@@ -71,14 +147,32 @@ spec:
       foo: bar
   strategy:
     canary:
+      analysis:
+        templates:
+        - name: my-random-fail
       canaryService: my-guestbook-canary-svc
       stableService: my-guestbook-stable-svc
+      steps:
+      - experiment:
+          analyses:
+          - name: random-fail
+            templateName: my-random-fail
+          templates:
+          - name: canary
+            specRef: canary
+      - analysis:
+          templates:
+          - name: my-random-fail
       trafficRouting:
+        alb:
+          ingress: my-networking-ingress
         istio:
           virtualService:
             name: my-guestbook-vsvc
             routes:
             - primary
+        nginx:
+          stableIngress: my-extensions-ingress
   template:
     metadata:
       annotations:
@@ -120,6 +214,7 @@ spec:
           name: config-volume
         - mountPath: /etc/secrets
           name: secret-volume
+      serviceAccountName: my-robot
       volumes:
       - configMap:
           name: my-guestbook-cm-bt8kmct6gk
@@ -127,6 +222,44 @@ spec:
       - name: secret-volume
         secret:
           secretName: my-guestbook-secret-t95h96m85d
+---
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  annotations:
+    foo: bar
+  labels:
+    foo: bar
+  name: my-hpa
+spec:
+  maxReplicas: 3
+  metrics:
+  - resource:
+      name: cpu
+      targetAverageUtilization: 50
+    type: Resource
+  minReplicas: 3
+  scaleTargetRef:
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
+    name: my-guestbook
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    foo: bar
+  labels:
+    foo: bar
+  name: my-extensions-ingress
+spec:
+  rules:
+  - host: www.mysite.com
+    http:
+      paths:
+      - backend:
+          serviceName: website
+          servicePort: 80
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -150,3 +283,20 @@ spec:
     - destination:
         host: guestbook-canary-svc
       weight: 0
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    foo: bar
+  labels:
+    foo: bar
+  name: my-networking-ingress
+spec:
+  rules:
+  - host: www.mysite.com
+    http:
+      paths:
+      - backend:
+          serviceName: website
+          servicePort: 80

--- a/test/kustomize/rollout/rollout.yaml
+++ b/test/kustomize/rollout/rollout.yaml
@@ -11,6 +11,7 @@ spec:
       labels:
         app: guestbook
     spec:
+      serviceAccountName: robot
       volumes:
       - name: config-volume
         configMap:
@@ -60,6 +61,54 @@ spec:
             name: guestbook-vsvc
             routes:
               - primary
+        nginx:
+          stableIngress: extensions-ingress
+        alb:
+          ingress: networking-ingress
+      analysis:
+        templates:
+        - name: random-fail
+      steps:
+      - experiment:
+          templates:
+          - name: canary
+            specRef: canary
+          analyses:
+          - name: random-fail
+            templateName: random-fail
+      - analysis:
+          templates:
+          - name: random-fail
+
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Experiment
+metadata:
+  name: experiment
+spec:
+  templates:
+  - name: foo
+    metadata:
+      labels:
+        app: guestbook
+    template:
+      spec:
+        serviceAccountName: robot
+        volumes:
+        - name: config-volume
+          configMap:
+            name: guestbook-cm
+        - name: secret-volume
+          secret:
+            secretName: guestbook-secret
+        containers:
+        - name: guestbook
+          image: guestbook:v1
+          command:
+          - ping $(SERVICE_NAME)
+  analyses:
+  - name: random-fail
+    templateName: random-fail
 
 ---
 apiVersion: networking.istio.io/v1alpha3
@@ -106,3 +155,86 @@ spec:
   - protocol: TCP
     port: 80
     targetPort: 8080
+
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: networking-ingress
+spec:
+  rules:
+  - host: www.mysite.com
+    http:
+      paths:
+      - backend:
+          serviceName: website
+          servicePort: 80
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: extensions-ingress
+spec:
+  rules:
+  - host: www.mysite.com
+    http:
+      paths:
+      - backend:
+          serviceName: website
+          servicePort: 80
+
+---
+kind: AnalysisTemplate
+apiVersion: argoproj.io/v1alpha1
+metadata:
+  name: random-fail
+spec:
+  metrics:
+  - name: random-fail
+    interval: 5s
+    failureLimit: 1
+    provider:
+      job:
+        spec:
+          template:
+            spec:
+              serviceAccountName: robot
+              volumes:
+              - name: config-volume
+                configMap:
+                  name: guestbook-cm
+              - name: secret-volume
+                secret:
+                  secretName: guestbook-secret
+              containers:
+              - name: sleep
+                image: alpine:3.8
+                command: [ping $(SERVICE_NAME)]
+              restartPolicy: Never
+          backoffLimit: 0
+
+---
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: hpa
+spec:
+  minReplicas: 3
+  maxReplicas: 3
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: 50
+  scaleTargetRef:
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
+    name: guestbook
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: robot
+  


### PR DESCRIPTION
Adds support for:
* Ingress (extensions/networking.k8s.io) name references in ALB and NGINX
* AnalysisTemplate name references in Rollout and Experiment
* ConfigMap/Secret/ServiceAccount/etc... name references in Experiments
* ConfigMap/Secret/ServiceAccount/etc... name references in AnalysisTemplate jobs
* Rollout name reference from a HPA scaleTargetRef