### PR TITLE
feat: add security context to run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,12 +51,6 @@ ARG MAKE_TARGET="controller plugin-linux plugin-darwin"
 RUN make ${MAKE_TARGET}
 
 
-RUN groupadd -g 999 argo-rollouts && \
-    useradd -r -u 999 -g argo-rollouts argo-rollouts && \
-    mkdir -p /home/argo-rollouts && \
-    chown argo-rollouts:argo-rollouts /home/argo-rollouts
-
-
 ####################################################################################################
 # Final image
 ####################################################################################################
@@ -65,10 +59,9 @@ FROM scratch
 COPY --from=argo-rollouts-build /go/src/github.com/argoproj/argo-rollouts/dist/rollouts-controller /bin/
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-# Import the user and group files from the builder.
-COPY --from=argo-rollouts-build /etc/passwd /etc/passwd
-
-USER argo-rollouts
+# Use numeric user, allows kubernetes to identify this user as being
+# non-root when we use a security context with runAsNonRoot: true
+USER 999
 
 WORKDIR /home/argo-rollouts
 

--- a/manifests/base/argo-rollouts-deployment.yaml
+++ b/manifests/base/argo-rollouts-deployment.yaml
@@ -25,6 +25,8 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /tmp
+      securityContext:
+        runAsNonRoot: true
       volumes:
       - name: tmp
         emptyDir: {}

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -11549,6 +11549,8 @@ spec:
         volumeMounts:
         - mountPath: /tmp
           name: tmp
+      securityContext:
+        runAsNonRoot: true
       serviceAccountName: argo-rollouts
       volumes:
       - emptyDir: {}

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -11417,6 +11417,8 @@ spec:
         volumeMounts:
         - mountPath: /tmp
           name: tmp
+      securityContext:
+        runAsNonRoot: true
       serviceAccountName: argo-rollouts
       volumes:
       - emptyDir: {}


### PR DESCRIPTION
Use numeric user in Dockerfile. This allows the use of a security context in kubernetes with `runAsNonRoot: true`, because kubernetes can inspect the image and see that the USER is != 0.

Removed user and group creation, it isn't necessary to get a working docker image. Also when running in openshift, the user in the docker image is usually ignored and a random user is used to run the image.