### PR TITLE
fix: add the update RBAC verb for some finalizers

### DIFF
--- a/manifests/base/argo-rollouts-role.yaml
+++ b/manifests/base/argo-rollouts-role.yaml
@@ -41,6 +41,12 @@ rules:
 - apiGroups:
   - argoproj.io
   resources:
+  - rollouts/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - argoproj.io
+  resources:
   - analysisruns
   - experiments
   verbs:
@@ -51,6 +57,12 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - analysisruns/finalizers
+  verbs:
+  - update
 - apiGroups:
   - argoproj.io
   resources:

--- a/manifests/base/argo-rollouts-role.yaml
+++ b/manifests/base/argo-rollouts-role.yaml
@@ -61,6 +61,7 @@ rules:
   - argoproj.io
   resources:
   - analysisruns/finalizers
+  - experiments/finalizers
   verbs:
   - update
 - apiGroups:

--- a/manifests/cluster-install/argo-rollouts-clusterrole.yaml
+++ b/manifests/cluster-install/argo-rollouts-clusterrole.yaml
@@ -69,6 +69,7 @@ rules:
   - argoproj.io
   resources:
   - analysisruns/finalizers
+  - experiments/finalizers
   verbs:
   - update
 - apiGroups:

--- a/manifests/cluster-install/argo-rollouts-clusterrole.yaml
+++ b/manifests/cluster-install/argo-rollouts-clusterrole.yaml
@@ -49,6 +49,12 @@ rules:
 - apiGroups:
   - argoproj.io
   resources:
+  - rollouts/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - argoproj.io
+  resources:
   - analysisruns
   - experiments
   verbs:
@@ -59,6 +65,12 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - analysisruns/finalizers
+  verbs:
+  - update
 - apiGroups:
   - argoproj.io
   resources:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -11216,6 +11216,12 @@ rules:
 - apiGroups:
   - argoproj.io
   resources:
+  - rollouts/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - argoproj.io
+  resources:
   - analysisruns
   - experiments
   verbs:
@@ -11226,6 +11232,12 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - analysisruns/finalizers
+  verbs:
+  - update
 - apiGroups:
   - argoproj.io
   resources:
@@ -11407,6 +11419,12 @@ rules:
 - apiGroups:
   - argoproj.io
   resources:
+  - rollouts/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - argoproj.io
+  resources:
   - analysisruns
   - experiments
   verbs:
@@ -11417,6 +11435,12 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - analysisruns/finalizers
+  verbs:
+  - update
 - apiGroups:
   - argoproj.io
   resources:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -11236,6 +11236,7 @@ rules:
   - argoproj.io
   resources:
   - analysisruns/finalizers
+  - experiments/finalizers
   verbs:
   - update
 - apiGroups:
@@ -11439,6 +11440,7 @@ rules:
   - argoproj.io
   resources:
   - analysisruns/finalizers
+  - experiments/finalizers
   verbs:
   - update
 - apiGroups:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -11236,6 +11236,7 @@ rules:
   - argoproj.io
   resources:
   - analysisruns/finalizers
+  - experiments/finalizers
   verbs:
   - update
 - apiGroups:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -11216,6 +11216,12 @@ rules:
 - apiGroups:
   - argoproj.io
   resources:
+  - rollouts/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - argoproj.io
+  resources:
   - analysisruns
   - experiments
   verbs:
@@ -11226,6 +11232,12 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - analysisruns/finalizers
+  verbs:
+  - update
 - apiGroups:
   - argoproj.io
   resources:


### PR DESCRIPTION
When running Rollouts with AnalysisTemplates in OpenShift clusters, I
found that I needed extra RBAC rules to get Rollouts and
AnalysisTemplates to work properly.

The update permission for rollouts/finalizers is required because of
this error message in the Rollout's status.conditions[].message:

  Failed to create new replica set "cddemo-65c4c84fb": replicasets.apps
  "cddemo-65c4c84fb" is forbidden: cannot set blockOwnerDeletion if an
  ownerReference refers to a resource you can't set finalizers on: no RBAC
  policy matched, <nil>

The update permission for analysisruns/finalizers is required because of
this error message in the AnalysisRun's status.message:

  metric "smoketest" assessed Error due to consecutiveErrors (5) >
  consecutiveErrorLimit (4): "Error Message: jobs.batch
  "f7d6e1a4-93c9-11ea-a333-0050560113d3.smoketest.5" is forbidden: cannot
  set blockOwnerDeletion if an ownerReference refers to a resource you
  can't set finalizers on: no RBAC policy matched, <nil>"