### PR TITLE
chore: Correct output path and improve performance for make codegen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage.html
 site/
 # generated
 docs/generated
+vendor/

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@ all: controller image
 codegen: mocks
 	./hack/update-codegen.sh
 	./hack/update-openapigen.sh
-	go run ./hack/gen-crd-spec/main.go
+	./hack/update-crd-specs.sh
+	rm -rf ./vendor
 
 .PHONY: controller
 controller: clean-debug

--- a/go.sum
+++ b/go.sum
@@ -609,6 +609,7 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586 h1:7KByu05hhLed2MO29w7p1X
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20190312203227-4b39c73a6495 h1:I6A9Ag9FpEKOjcKrRNjQkPHawoXIhKyTGfvvjFAiiAk=
 golang.org/x/exp v0.0.0-20190312203227-4b39c73a6495/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -724,8 +725,10 @@ golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485 h1:OB/uP/Puiu5vS5QMRPrXCDWUPb+kt8f1KW8oQzFejQw=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
+gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e h1:jRyg0XfpwWlhEV8mDfdNGBeSJM2fuyh9Yjrnd8kF2Ts=
 gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e/go.mod h1:kS+toOQn6AQKjmKJ7gzohV1XkqsFehRA2FbsbkopSuQ=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.6.1-0.20190607001116-5213b8090861/go.mod h1:btoxGiFvQNVUZQ8W08zLtrVS08CNpINPEfxXxgJL1Q4=

--- a/hack/library.sh
+++ b/hack/library.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+readonly REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Display a box banner.
+# Parameters: $1 - character to use for the box.
+#             $2 - banner message.
+function make_banner() {
+  local msg="$1$1$1$1 $2 $1$1$1$1"
+  local border="${msg//[-0-9A-Za-z _.,:\/()]/$1}"
+  echo -e "${border}\n${msg}\n${border}"
+}
+
+# Simple header for logging purposes.
+function header() {
+  local upper="$(echo $1 | tr a-z A-Z)"
+  make_banner "+" "${upper}"
+}
+
+# Simple subheader for logging purposes.
+function subheader() {
+  make_banner "-" "$1"
+}
+
+# Simple warning banner for logging purposes.
+function warning() {
+  make_banner "!" "$1"
+}
+
+# Create a temp dir for faked GOPATH.
+function make_fake_paths() {
+  FAKE_GOPATH="$(mktemp -d)"
+  trap 'rm -rf ${FAKE_GOPATH}' EXIT
+  FAKE_REPOPATH="${FAKE_GOPATH}/src/github.com/argoproj/argo-rollouts"
+  mkdir -p "$(dirname "${FAKE_REPOPATH}")" && ln -s "${REPO_ROOT}" "${FAKE_REPOPATH}"
+}
+

--- a/hack/library.sh
+++ b/hack/library.sh
@@ -35,3 +35,8 @@ function make_fake_paths() {
   mkdir -p "$(dirname "${FAKE_REPOPATH}")" && ln -s "${REPO_ROOT}" "${FAKE_REPOPATH}"
 }
 
+ensure_vendor() {
+  if [ ! -d "${REPO_ROOT}/vendor" ]; then
+    go mod vendor
+  fi
+}

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -1,0 +1,23 @@
+// +build tools
+
+// This package contains code generation utilities
+// This package imports things required by build scripts, to force `go mod` to see them as dependencies
+package tools
+
+import (
+	_ "github.com/vektra/mockery/cmd/mockery"
+	_ "k8s.io/code-generator"
+	_ "k8s.io/code-generator/cmd/client-gen"
+	_ "k8s.io/code-generator/cmd/conversion-gen"
+	_ "k8s.io/code-generator/cmd/deepcopy-gen"
+	_ "k8s.io/code-generator/cmd/defaulter-gen"
+	_ "k8s.io/code-generator/cmd/go-to-protobuf"
+	_ "k8s.io/code-generator/cmd/import-boss"
+	_ "k8s.io/code-generator/cmd/informer-gen"
+	_ "k8s.io/code-generator/cmd/lister-gen"
+	_ "k8s.io/code-generator/cmd/openapi-gen"
+	_ "k8s.io/code-generator/cmd/register-gen"
+	_ "k8s.io/code-generator/cmd/set-gen"
+	_ "k8s.io/kube-openapi/cmd/openapi-gen"
+	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
+)

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -8,10 +8,7 @@ source $(dirname $0)/library.sh
 
 header "running codegen"
 
-if [ ! -d "${REPO_ROOT}/vendor" ]; then
-  go mod vendor
-fi
-
+ensure_vendor
 make_fake_paths
 
 export GOPATH="${FAKE_GOPATH}"

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -1,34 +1,27 @@
+#!/bin/bash
+
 set -o errexit
 set -o nounset
 set -o pipefail
 
+source $(dirname $0)/library.sh
 
-# code-generator does work with go.mod but makes assumptions about the project living in `$GOPATH/src`. 
-# To work around this and support any location: 
-#   create a temporary directory, use this as an output base, and copy everything back once generated.
-export GOPATH=$(go env GOPATH) # export gopath so it's available to generate scripts
-SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null 2>&1 && pwd )"
-CODEGEN_VERSION=$(go list -m k8s.io/code-generator | awk '{print $NF}' | head -1)
-CODEGEN_PKG="${GOPATH}/pkg/mod/k8s.io/code-generator@${CODEGEN_VERSION}"
-TEMP_DIR=$(mktemp -d)
-cleanup() {
-    rm -rf ${TEMP_DIR}
-}
-trap "cleanup" EXIT SIGINT
+header "running codegen"
 
+if [ ! -d "${REPO_ROOT}/vendor" ]; then
+  go mod vendor
+fi
 
-chmod +x ${CODEGEN_PKG}/generate-groups.sh
+make_fake_paths
 
-${CODEGEN_PKG}/generate-groups.sh "deepcopy,client,informer,lister" \
+export GOPATH="${FAKE_GOPATH}"
+export GO111MODULE="off"
+
+cd "${FAKE_REPOPATH}"
+CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${FAKE_REPOPATH}"; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
+
+bash -x ${CODEGEN_PKG}/generate-groups.sh "deepcopy,client,informer,lister" \
   github.com/argoproj/argo-rollouts/pkg/client github.com/argoproj/argo-rollouts/pkg/apis \
   "rollouts:v1alpha1" \
-  --output-base "${TEMP_DIR}" \
-  --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt
+  --go-header-file ${REPO_ROOT}/hack/boilerplate.go.txt
 
-cp -r "${TEMP_DIR}/github.com/argoproj/argo-rollouts/." "${SCRIPT_ROOT}/"
-# To use your own boilerplate text use:
-#   --go-header-file ${SCRIPT_ROOT}/hack/custom-boilerplate.go.txt
-
-CONTROLLERGEN_VERSION=$(go list -m sigs.k8s.io/controller-tools | awk '{print $2}' | head -1)
-CONTROLLERGEN_PKG=$(echo `go env GOPATH`"/pkg/mod/sigs.k8s.io/controller-tools@${CONTROLLERGEN_VERSION}")
-go build -o dist/controller-gen $CONTROLLERGEN_PKG/cmd/controller-gen/

--- a/hack/update-crd-specs.sh
+++ b/hack/update-crd-specs.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source $(dirname $0)/library.sh
+
+header "updating crd specs"
+
+if [ "`command -v controller-gen`" = "" ]; then
+  go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5
+fi
+
+go run ./hack/gen-crd-spec/main.go
+

--- a/hack/update-mocks.sh
+++ b/hack/update-mocks.sh
@@ -7,10 +7,7 @@ set -o pipefail
 source $(dirname $0)/library.sh
 
 header "updating mock files"
-
-if [ ! -d "${REPO_ROOT}/vendor" ]; then
-  go mod vendor
-fi
+ensure_vendor
 
 cd ${REPO_ROOT}
 

--- a/hack/update-mocks.sh
+++ b/hack/update-mocks.sh
@@ -4,13 +4,19 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-PROJECT_ROOT=$(cd $(dirname "$0")/.. ; pwd)
-MOCKERY_VERSION=$(go list -m github.com/vektra/mockery | awk '{print $2}' | head -1)
-MOCKERY_PKG=$(echo `go env GOPATH`"/pkg/mod/github.com/vektra/mockery@${MOCKERY_VERSION}")
+source $(dirname $0)/library.sh
 
+header "updating mock files"
 
-go run "${MOCKERY_PKG}"/cmd/mockery/mockery.go \
-    -dir "${PROJECT_ROOT}"/metricproviders \
+if [ ! -d "${REPO_ROOT}/vendor" ]; then
+  go mod vendor
+fi
+
+cd ${REPO_ROOT}
+
+MOCKERY_PKG="${REPO_ROOT}/vendor/github.com/vektra/mockery"
+go run "${MOCKERY_PKG}"/cmd/mockery \
+    -dir "${REPO_ROOT}"/metricproviders \
     -name Provider \
-    -output "${PROJECT_ROOT}"/metricproviders/mocks
+    -output "${REPO_ROOT}"/metricproviders/mocks
 

--- a/hack/update-openapigen.sh
+++ b/hack/update-openapigen.sh
@@ -8,10 +8,7 @@ source $(dirname $0)/library.sh
 
 header "running openapigen"
 
-if [ ! -d "${REPO_ROOT}/vendor" ]; then
-  go mod vendor
-fi
-
+ensure_vendor
 make_fake_paths
 
 export GOPATH="${FAKE_GOPATH}"

--- a/hack/update-openapigen.sh
+++ b/hack/update-openapigen.sh
@@ -4,14 +4,26 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export GOPATH=$(go env GOPATH) # export gopath do generator output goes to the correct location
-PROJECT_ROOT=$(cd $(dirname "$0")/.. ; pwd)
-CODEGEN_VERSION=$(go list -m k8s.io/kube-openapi | awk '{print $2}' | head -1)
-CODEGEN_PKG="${GOPATH}/pkg/mod/k8s.io/kube-openapi@${CODEGEN_VERSION}"
+source $(dirname $0)/library.sh
+
+header "running openapigen"
+
+if [ ! -d "${REPO_ROOT}/vendor" ]; then
+  go mod vendor
+fi
+
+make_fake_paths
+
+export GOPATH="${FAKE_GOPATH}"
+export GO111MODULE="off"
+
+CODEGEN_PKG=${FAKE_REPOPATH}/vendor/k8s.io/kube-openapi
 VERSION="v1alpha1"
 
+cd "${FAKE_REPOPATH}"
+
 go run ${CODEGEN_PKG}/cmd/openapi-gen/openapi-gen.go \
-  --go-header-file ${PROJECT_ROOT}/hack/custom-boilerplate.go.txt \
+  --go-header-file ${REPO_ROOT}/hack/custom-boilerplate.go.txt \
   --input-dirs github.com/argoproj/argo-rollouts/pkg/apis/rollouts/${VERSION} \
   --output-package github.com/argoproj/argo-rollouts/pkg/apis/rollouts/${VERSION} \
   --report-filename pkg/apis/api-rules/violation_exceptions.list \


### PR DESCRIPTION
This change:

1. Makes it possible to clone argo-rollouts repo to any directory on your computer. Currently `./hack/update-openapigen.sh` still generates the outputs under `$GOPATH`.
2. Improves the performance of `make codegen`.

`make codegen` time cost with this:

```
real	0m23.852s
user	0m41.239s
sys	0m12.971s
```

Before:
```
real	1m7.595s
user	1m38.522s
sys	1m20.477s
```