### PR TITLE
docs: Fix backoffLimit in wrong place

### DIFF
--- a/docs/features/analysis.md
+++ b/docs/features/analysis.md
@@ -710,8 +710,8 @@ successful if the Job completes and had an exit code of zero, otherwise it is fa
   - name: test
     provider:
       job:
-        backoffLimit: 1
         spec:
+          backoffLimit: 1
           template:
             spec:
               containers:


### PR DESCRIPTION
The property `backoffLimit` should be in `.job.spec.backoffLimit` rather than `.job.backoffLimit`.