### PR TITLE
docs: fix backoffLimit placement in example analysis job

### DIFF
--- a/docs/features/analysis.md
+++ b/docs/features/analysis.md
@@ -711,8 +711,8 @@ successful if the Job completes and had an exit code of zero, otherwise it is fa
     provider:
       job:
         spec:
-          backoffLimit: 1
           template:
+            backoffLimit: 1
             spec:
               containers:
               - name: test


### PR DESCRIPTION
Fix the placement of `backoffLimit` field usage in example analysis job.

Should be on the same level as job spec.

Otherwise this defaults to 6.

https://kubernetes.io/docs/concepts/workloads/controllers/job/