### PR TITLE
fix: Set the currentStepIndex to max after bg to canary

### DIFF
--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -407,10 +407,10 @@ func MaxSurge(rollout *v1alpha1.Rollout) int32 {
 }
 
 // checkStepHashChange indicates if the rollout's step for the strategy have changed. This causes the rollout to reset the
-// currentStepIndex to zero. If there is no previous pod spec to compare to the function defaults to false
+// currentStepIndex to zero. If there was no previously recorded step hash to compare to the function defaults to true
 func checkStepHashChange(rollout *v1alpha1.Rollout) bool {
 	if rollout.Status.CurrentStepHash == "" {
-		return false
+		return true
 	}
 	// TODO: conditions.ComputeStepHash is not stable and will change
 	stepsHash := conditions.ComputeStepHash(rollout)

--- a/utils/replicaset/replicaset_test.go
+++ b/utils/replicaset/replicaset_test.go
@@ -633,7 +633,8 @@ func TestCheckPodSpecChange(t *testing.T) {
 
 func TestCheckStepHashChange(t *testing.T) {
 	ro := generateRollout("ngnix")
-	assert.False(t, checkStepHashChange(&ro))
+	ro.Spec.Strategy.Canary = &v1alpha1.CanaryStrategy{}
+	assert.True(t, checkStepHashChange(&ro))
 	ro.Status.CurrentStepHash = conditions.ComputeStepHash(&ro)
 	assert.False(t, checkStepHashChange(&ro))
 


### PR DESCRIPTION
closes https://github.com/argoproj/argo-rollouts/issues/555.

@jessesuen do you know why we defaulted checkStepHashChange to return false if the currentStepHash is empty?