### PR TITLE
ci: Run Linting as a separate job

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,17 @@ on:
     branches:
       - 'master'
 jobs:
-
+  lint-go:
+    name: Lint Go code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v1
+        with:
+          version: v1.26
+          args: --timeout 5m
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -37,12 +47,6 @@ jobs:
 
     - name: Compile all packages
       run: make controller plugin
-
-    - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v1
-      with:
-        version: v1.26
-        args: --timeout 5m
 
     - name: Test
       run: go test -failfast -covermode=count -coverprofile=coverage.out ./...


### PR DESCRIPTION
The following PR is failing CI at the listing step [here](https://github.com/argoproj/argo-rollouts/pull/560/checks?check_run_id=854578360) 

Per this https://github.com/golangci/golangci-lint-action/issues/23#issuecomment-647177770 issue, the golangci maintainer recommends running the golangci as a separate job.