### PR TITLE
feat: Add Rollout replicas metrics (#507)

### DIFF
--- a/controller/metrics/rollout_test.go
+++ b/controller/metrics/rollout_test.go
@@ -47,11 +47,19 @@ spec:
     blueGreen:
       activeService: active-service
       previewService: preview-service
+status:
+  availableReplicas: 1
 `
 )
 const expectedResponse = `# HELP rollout_info Information about rollout.
 # TYPE rollout_info gauge
-rollout_info{name="guestbook-bluegreen",namespace="default",strategy="blueGreen"} 1`
+rollout_info{name="guestbook-bluegreen",namespace="default",strategy="blueGreen"} 1
+# HELP rollout_info_replicas_available The number of available replicas per rollout.
+# TYPE rollout_info_replicas_available gauge
+rollout_info_replicas_available{name="guestbook-bluegreen",namespace="default",strategy="blueGreen"} 1
+# HELP rollout_info_replicas_unavailable The number of unavailable replicas per rollout.
+# TYPE rollout_info_replicas_unavailable gauge
+rollout_info_replicas_unavailable{name="guestbook-bluegreen",namespace="default",strategy="blueGreen"} 0`
 
 func newFakeRollout(fakeRollout string) *v1alpha1.Rollout {
 	var rollout v1alpha1.Rollout

--- a/controller/metrics/rollout_test.go
+++ b/controller/metrics/rollout_test.go
@@ -48,6 +48,7 @@ spec:
       activeService: active-service
       previewService: preview-service
 status:
+  replicas: 1
   availableReplicas: 1
 `
 )

--- a/controller/metrics/rollouts.go
+++ b/controller/metrics/rollouts.go
@@ -135,7 +135,7 @@ func collectRollouts(ch chan<- prometheus.Metric, rollout *v1alpha1.Rollout) {
 	addGauge(descRolloutInfo, 1)
 
 	addGauge(descRolloutInfoReplicasAvailable, float64(rollout.Status.AvailableReplicas))
-	addGauge(descRolloutInfoReplicasUnavailable, float64(defaults.GetReplicasOrDefault(rollout.Spec.Replicas)-rollout.Status.AvailableReplicas))
+	addGauge(descRolloutInfoReplicasUnavailable, float64(rollout.Status.Replicas-rollout.Status.AvailableReplicas))
 
 	calculatedPhase := calculatePhase(rollout)
 	addGauge(descRolloutPhaseLabels, boolFloat64(calculatedPhase == RolloutCompleted), string(RolloutCompleted))

--- a/controller/metrics/rollouts.go
+++ b/controller/metrics/rollouts.go
@@ -23,6 +23,20 @@ var (
 		nil,
 	)
 
+	descRolloutInfoReplicasAvailable = prometheus.NewDesc(
+		"rollout_info_replicas_available",
+		"The number of available replicas per rollout.",
+		descRolloutWithStrategyLabels,
+		nil,
+	)
+
+	descRolloutInfoReplicasUnavailable = prometheus.NewDesc(
+		"rollout_info_replicas_unavailable",
+		"The number of unavailable replicas per rollout.",
+		descRolloutWithStrategyLabels,
+		nil,
+	)
+
 	descRolloutPhaseLabels = prometheus.NewDesc(
 		"rollout_phase",
 		"Information on the state of the rollout",
@@ -119,6 +133,9 @@ func collectRollouts(ch chan<- prometheus.Metric, rollout *v1alpha1.Rollout) {
 	}
 
 	addGauge(descRolloutInfo, 1)
+
+	addGauge(descRolloutInfoReplicasAvailable, float64(rollout.Status.AvailableReplicas))
+	addGauge(descRolloutInfoReplicasUnavailable, float64(defaults.GetReplicasOrDefault(rollout.Spec.Replicas)-rollout.Status.AvailableReplicas))
 
 	calculatedPhase := calculatePhase(rollout)
 	addGauge(descRolloutPhaseLabels, boolFloat64(calculatedPhase == RolloutCompleted), string(RolloutCompleted))

--- a/docs/features/controller-metrics.md
+++ b/docs/features/controller-metrics.md
@@ -2,25 +2,27 @@
 
 The Argo Rollouts controller publishes the following prometheus metrics about Argo Rollout objects.
 
-| Name                           | Description |
-| ------------------------------ | ----------- |
-| `rollout_created_time`         | Creation time in unix timestamp for an rollout. |
-| `rollout_info`                 | Information about rollout. |
-| `rollout_phase`                | Information on the state of the rollout. |
-| `rollout_reconcile`            | Rollout reconciliation performance. |
-| `rollout_reconcile_error`      | Error occurring during the rollout. |
-| `experiment_created_time`      | Creation time in unix timestamp for an experiment. |
-| `experiment_info`              | Information about Experiment. |
-| `experiment_phase`             | Information on the state of the experiment. |
-| `experiment_reconcile`         | Experiments reconciliation performance. |
-| `experiment_reconcile_error`   | Error occurring during the experiment. |
-| `analysis_run_created_time`    | Creation time in unix timestamp for an Analysis Run. |
-| `analysis_run_info`            | Information about analysis run. |
-| `analysis_run_metric_phase`    | Information on the duration of a specific metric in the Analysis Run. |
-| `analysis_run_metric_type`     | Information on the type of a specific metric in the Analysis Runs. |
-| `analysis_run_phase`           | Information on the state of the Analysis Run. |
-| `analysis_run_reconcile`       | Analysis Run reconciliation performance. |
-| `analysis_run_reconcile_error` | Error occurring during the analysis run. |
+| Name                                | Description |
+| ----------------------------------- | ----------- |
+| `rollout_created_time`              | Creation time in unix timestamp for an rollout. |
+| `rollout_info`                      | Information about rollout. |
+| `rollout_info_replicas_available`   | The number of available replicas per rollout. |
+| `rollout_info_replicas_unavailable` | The number of unavailable replicas per rollout. |
+| `rollout_phase`                     | Information on the state of the rollout. |
+| `rollout_reconcile`                 | Rollout reconciliation performance. |
+| `rollout_reconcile_error`           | Error occurring during the rollout. |
+| `experiment_created_time`           | Creation time in unix timestamp for an experiment. |
+| `experiment_info`                   | Information about Experiment. |
+| `experiment_phase`                  | Information on the state of the experiment. |
+| `experiment_reconcile`              | Experiments reconciliation performance. |
+| `experiment_reconcile_error`        | Error occurring during the experiment. |
+| `analysis_run_created_time`         | Creation time in unix timestamp for an Analysis Run. |
+| `analysis_run_info`                 | Information about analysis run. |
+| `analysis_run_metric_phase`         | Information on the duration of a specific metric in the Analysis Run. |
+| `analysis_run_metric_type`          | Information on the type of a specific metric in the Analysis Runs. |
+| `analysis_run_phase`                | Information on the state of the Analysis Run. |
+| `analysis_run_reconcile`            | Analysis Run reconciliation performance. |
+| `analysis_run_reconcile_error`      | Error occurring during the analysis run. |
 
 The controller also publishes the following Prometheus metrics to describe the controller health.
 

--- a/go.sum
+++ b/go.sum
@@ -237,8 +237,6 @@ github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
-github.com/golang/groupcache v0.0.0-20181024230925-c65c006176ff h1:kOkM9whyQYodu09SJ6W3NCsHG7crFaJILQ22Gozp3lg=
-github.com/golang/groupcache v0.0.0-20181024230925-c65c006176ff/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 h1:ZgQEtGgCBiWRM39fZuwSd1LwSqqSW0hOdXCYYDX0R3I=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.0.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -571,8 +569,6 @@ github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPU
 github.com/valyala/quicktemplate v1.1.1/go.mod h1:EH+4AkTd43SvgIbQHYu59/cJyxDoOVRUAfrukLPuGJ4=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
-github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5 h1:Xim2mBRFdXzXmKRO8DJg/FJtn/8Fj9NOEpO6+WuMPmk=
-github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5/go.mod h1:ppEjwdhyy7Y31EnHRDm1JkChoC7LXIJ7Ex0VYLWtZtQ=
 github.com/vektra/mockery v1.1.2 h1:uc0Yn67rJpjt8U/mAZimdCKn9AeA97BOkjpmtBSlfP4=
 github.com/vektra/mockery v1.1.2/go.mod h1:VcfZjKaFOPO+MpN4ZvwPjs4c48lkq1o3Ym8yHZJu0jU=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
@@ -710,7 +706,6 @@ golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181011042414-1f849cf54d09/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-golang.org/x/tools v0.0.0-20181112210238-4b1f3b6b1646/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181117154741-2ddaf7f79a09/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190110163146-51295c7ec13a/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
close #507

I've added two controller metrics.

* `rollout_info_replicas_available`
* `rollout_info_replicas_unavailable`

Rollout is a custom resource and therefore no metrics are provided by kube-state-metrics.
I think the replicas metrics are useful and well used.
I would be happy to provide replicas metrics in the Rollout controller.