### PR TITLE
fix: Fix ActualWeight for canary

### DIFF
--- a/pkg/kubectl-argo-rollouts/info/rollout_info.go
+++ b/pkg/kubectl-argo-rollouts/info/rollout_info.go
@@ -65,13 +65,18 @@ func NewRolloutInfo(
 
 		roInfo.ActualWeight = "0"
 		currentStep, _ := replicasetutil.GetCurrentCanaryStep(ro)
+
 		if currentStep == nil {
 			roInfo.ActualWeight = "100"
 		} else if ro.Status.AvailableReplicas > 0 {
-			for _, rs := range roInfo.ReplicaSets {
-				if rs.Canary {
-					roInfo.ActualWeight = fmt.Sprintf("%d", (rs.Available*100)/ro.Status.AvailableReplicas)
+			if ro.Spec.Strategy.Canary.TrafficRouting == nil {
+				for _, rs := range roInfo.ReplicaSets {
+					if rs.Canary {
+						roInfo.ActualWeight = fmt.Sprintf("%d", (rs.Available*100)/ro.Status.AvailableReplicas)
+					}
 				}
+			} else {
+				roInfo.ActualWeight = roInfo.SetWeight
 			}
 		}
 	} else if ro.Spec.Strategy.BlueGreen != nil {


### PR DESCRIPTION
https://github.com/argoproj/argo-rollouts/issues/568

As described in the issue, the `ActualWeight` for canary was wrong, so I've fixed it to show the right weight.