### PR TITLE
feat: add shortened option -A for --all-namespaces

### DIFF
--- a/pkg/kubectl-argo-rollouts/cmd/list/list_rollouts.go
+++ b/pkg/kubectl-argo-rollouts/cmd/list/list_rollouts.go
@@ -69,7 +69,7 @@ func NewCmdListRollouts(o *options.ArgoRolloutsOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&listOptions.name, "name", "", "Only show rollout with specified name")
-	cmd.Flags().BoolVar(&listOptions.allNamespaces, "all-namespaces", false, "Include all namespaces")
+	cmd.Flags().BoolVarP(&listOptions.allNamespaces, "all-namespaces", "A", false, "Include all namespaces")
 	cmd.Flags().BoolVarP(&listOptions.watch, "watch", "w", false, "Watch for changes")
 	cmd.Flags().BoolVar(&listOptions.timestamps, "timestamps", false, "Print timestamps on updates")
 	return cmd


### PR DESCRIPTION
kubectl's `--all-namespaces` has an shortened alias `-A`.
It would be nice if kubectl-argo-rollouts has the same alias.
