### PR TITLE
fix: Remove unreachable code at rollout/controller

### DIFF
--- a/rollout/controller.go
+++ b/rollout/controller.go
@@ -360,10 +360,9 @@ func (c *Controller) syncHandler(key string) error {
 	if rollout.Spec.Strategy.BlueGreen != nil {
 		return c.rolloutBlueGreen(r, rsList)
 	}
-	if rollout.Spec.Strategy.Canary != nil {
-		return c.rolloutCanary(r, rsList)
-	}
-	return fmt.Errorf("no rollout strategy selected")
+
+	// Due to the rollout validation before this, when we get here strategy is canary
+	return c.rolloutCanary(r, rsList)
 }
 
 func (c *Controller) getRolloutValidationErrors(rollout *v1alpha1.Rollout) error {


### PR DESCRIPTION
The return statement at the end of syncHandler below will not execute as if both canary and bluegreen are nil, the validation on the spec will fail earlier.

https://github.com/argoproj/argo-rollouts/blob/fc0c05410702267062cdd766f7bb20876aca337b/rollout/controller.go#L376

https://github.com/argoproj/argo-rollouts/blob/fc0c05410702267062cdd766f7bb20876aca337b/pkg/apis/rollouts/validation/validation.go#L126

https://github.com/argoproj/argo-rollouts/blob/fc0c05410702267062cdd766f7bb20876aca337b/rollout/controller.go#L325-L326

Therefore, removing the unreachable statement at the end. Also added unit test for covering the case where strategy is not on the spec.

Ran make test and make test-bdd