### PR TITLE
feat: Add option to specify the namespace of istio virtual service

### DIFF
--- a/manifests/crds/rollout-crd.yaml
+++ b/manifests/crds/rollout-crd.yaml
@@ -421,6 +421,8 @@ spec:
                               properties:
                                 name:
                                   type: string
+                                namespace:
+                                  type: string
                                 routes:
                                   items:
                                     type: string

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -11372,6 +11372,8 @@ spec:
                               properties:
                                 name:
                                   type: string
+                                namespace:
+                                  type: string
                                 routes:
                                   items:
                                     type: string

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -11372,6 +11372,8 @@ spec:
                               properties:
                                 name:
                                   type: string
+                                namespace:
+                                  type: string
                                 routes:
                                   items:
                                     type: string

--- a/pkg/apis/rollouts/v1alpha1/openapi_generated.go
+++ b/pkg/apis/rollouts/v1alpha1/openapi_generated.go
@@ -1441,6 +1441,13 @@ func schema_pkg_apis_rollouts_v1alpha1_IstioVirtualService(ref common.ReferenceC
 				Description: "IstioVirtualService holds information on the virtual service the rollout needs to modify",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"namespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Namespace holds the namespace of the VirtualService",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name holds the name of the VirtualService",
@@ -1463,7 +1470,7 @@ func schema_pkg_apis_rollouts_v1alpha1_IstioVirtualService(ref common.ReferenceC
 						},
 					},
 				},
-				Required: []string{"name", "routes"},
+				Required: []string{"namespace", "name", "routes"},
 			},
 		},
 	}

--- a/pkg/apis/rollouts/v1alpha1/openapi_generated.go
+++ b/pkg/apis/rollouts/v1alpha1/openapi_generated.go
@@ -1470,7 +1470,7 @@ func schema_pkg_apis_rollouts_v1alpha1_IstioVirtualService(ref common.ReferenceC
 						},
 					},
 				},
-				Required: []string{"namespace", "name", "routes"},
+				Required: []string{"name", "routes"},
 			},
 		},
 	}

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -246,6 +246,8 @@ type IstioTrafficRouting struct {
 
 // IstioVirtualService holds information on the virtual service the rollout needs to modify
 type IstioVirtualService struct {
+	// Namespace holds the namespace of the VirtualService
+	Namespace string `json:"namespace"`
 	// Name holds the name of the VirtualService
 	Name string `json:"name"`
 	// Routes list of routes within VirtualService to edit

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -247,7 +247,7 @@ type IstioTrafficRouting struct {
 // IstioVirtualService holds information on the virtual service the rollout needs to modify
 type IstioVirtualService struct {
 	// Namespace holds the namespace of the VirtualService
-	Namespace string `json:"namespace"`
+	Namespace string `json:"namespace,omitempty"`
 	// Name holds the name of the VirtualService
 	Name string `json:"name"`
 	// Routes list of routes within VirtualService to edit

--- a/rollout/trafficrouting/istio/istio_test.go
+++ b/rollout/trafficrouting/istio/istio_test.go
@@ -329,4 +329,9 @@ func TestGetRolloutVirtualServiceKeys(t *testing.T) {
 	keys := GetRolloutVirtualServiceKeys(ro)
 	assert.Len(t, keys, 1)
 	assert.Equal(t, keys[0], "default/test")
+
+	ro.Spec.Strategy.Canary.TrafficRouting.Istio.VirtualService.Namespace = "abc"
+	keys2 := GetRolloutVirtualServiceKeys(ro)
+	assert.Len(t, keys2, 1)
+	assert.Equal(t, keys2[0], "abc/test")
 }


### PR DESCRIPTION
Sometimes virtual services are not in the same namespace as workloads.
So I think I would be nice if namespace can be specified along with the name of virtual service.
