### PR TITLE
docs: Add comment to Rollout specification

### DIFF
--- a/docs/features/specification.md
+++ b/docs/features/specification.md
@@ -31,6 +31,7 @@ spec:
   revisionHistoryLimit: 3
   # Pause allows a user to manually pause a rollout at any time. A rollout will not advance through
   # its steps while it is manually paused, but HPA auto-scaling will still occur.
+  # If true, at initial creation of Rollout, replicas are not scaled up automatically from zero unless manually promoted.
   paused: true
   # The maximum time in seconds in which a rollout must make progress during an update, before it is
   # considered to be failed. Argo Rollouts will continue to process failed rollouts and a condition


### PR DESCRIPTION
Recently I've been trying Argo Rollouts and Rollout resource for the purpose of Blue/Green Deployment.
I think Argo Rollouts is very hopeful and useful for me (and my organization).

While reading Rollout specification, I wondered which key affects automatically-scaling-up replicas **at initial creation of Rollout**, and noticed that `paused` is the key.
So, I'd like to add these description to "Rollout Spec" page. How about this idea?

Thank you.