### PR TITLE
docs: tab issues in analysis docs

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -29,7 +29,7 @@ Argo Rollouts does not require a service mesh or ingress controller to be used. 
 ### Which deployment strategies does Argo Rollouts support?
 Argo Rollouts supports BlueGreen, Canary, and Rolling Update. Additionally, Progressive Delivery features can be enabled on top of the blue-green/canary update, which further provides advanced deployment such as automated analysis and rollback.
 
-## Does the Rollout object follow the provided strategy when it is first created?
+### Does the Rollout object follow the provided strategy when it is first created?
 As with Deployments, Rollouts does not follow the strategy parameters on the initial deploy. The controller tries to get the Rollout into a steady state as fast as possible. The controller tries to get the Rollout into a steady state as fast as possible by creating a fully scaled up ReplicaSet from the provided `.spec.template`. Once the Rollout has a stable ReplicaSet to transition from, the controller starts using the provided strategy to transition the previous ReplicaSet to the desired ReplicaSet.
 
 ### How does BlueGreen rollback work?

--- a/docs/features/traffic-management/smi.md
+++ b/docs/features/traffic-management/smi.md
@@ -1,7 +1,7 @@
 # Service Mesh Interface (SMI)
 
 !!! important
-    This is not implemented yet and is scheduled to be part of the v0.9 release
+    Available since v0.9.0
 
 [Service Mesh Interface](https://smi-spec.io/) (SMI) is a standard interface for service meshes on Kubernetes leveraged by many Service Mesh implementations (like Linkerd). SMI offers this functionality through a set of CRDs, and the Argo Rollouts controller creates these resources to manipulate the traffic routing into the desired state. 
 

--- a/docs/getting-started/smi/index.md
+++ b/docs/getting-started/smi/index.md
@@ -1,7 +1,7 @@
 # Getting Started - SMI (Service Mesh Interface)
 
 !!! important
-    This functionality will be part of the upcoming v0.9 release
+    Available since v0.9
 
 This guide covers how Argo Rollouts integrates with the Service Mesh Interface (SMI), using
 [Linkerd](https://linkerd.io) and 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ markdown_extensions:
 - codehilite
 - admonition
 - pymdownx.superfences
+- pymdownx.tabbed
 - footnotes
 - toc:
     permalink: true


### PR DESCRIPTION
The `yaml tab="Rollout"	` syntax must have stopped working at some point and the docs are formatted incorrectly. This fixes the problem.