### PR TITLE
fix: add missing log message when a controller's syncHandler returns error

### DIFF
--- a/utils/controller/controller.go
+++ b/utils/controller/controller.go
@@ -153,6 +153,7 @@ func processNextWorkItem(workqueue workqueue.RateLimitingInterface, objType stri
 		// Run the syncHandler, passing it the namespace/name string of the
 		// Rollout resource to be synced.
 		if err := runSyncHandler(); err != nil {
+			logCtx.Errorf("%s syncHandler error: %v", objType, err)
 			metricsServer.IncError(namespace, name, objType)
 			// Put the item back on
 			// the workqueue to handle any transient errors.


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/651