### PR TITLE
fix: make controllers tolerant to spec marshalling errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ debug.test
 coverage.out
 coverage.html
 site/
+vendor/
 # generated
 docs/generated

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ all: controller image
 codegen: mocks
 	./hack/update-codegen.sh
 	./hack/update-openapigen.sh
-	go run ./hack/gen-crd-spec/main.go
+	PATH=$$DIST_DIR:$$PATH go run ./hack/gen-crd-spec/main.go
 
 .PHONY: controller
 controller: clean-debug

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -14,7 +14,12 @@ Install:
 Argo Rollout additionally uses `golangci-lint` to lint the project.
 
 Run the following commands to install them:
+
 ```bash
+# macOS
+brew install golangci-lint
+
+# linux
 go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 ```
 

--- a/pkg/apis/rollouts/v1alpha1/register.go
+++ b/pkg/apis/rollouts/v1alpha1/register.go
@@ -11,6 +11,15 @@ import (
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = schema.GroupVersion{Group: rollouts.Group, Version: "v1alpha1"}
 
+var (
+	// GroupVersionResource for all rollout types
+	RolloutGVR                 = SchemeGroupVersion.WithResource("rollouts")
+	AnalysisRunGVR             = SchemeGroupVersion.WithResource("analysisruns")
+	AnalysisTemplateGVR        = SchemeGroupVersion.WithResource("analysistemplates")
+	ClusterAnalysisTemplateGVR = SchemeGroupVersion.WithResource("clusteranalysistemplates")
+	ExperimentGVR              = SchemeGroupVersion.WithResource("experiments")
+)
+
 // Kind takes an unqualified kind and returns back a Group qualified GroupKind
 func Kind(kind string) schema.GroupKind {
 	return SchemeGroupVersion.WithKind(kind).GroupKind()

--- a/test/e2e/expectedfailures/malformed-analysisrun.yaml
+++ b/test/e2e/expectedfailures/malformed-analysisrun.yaml
@@ -1,0 +1,18 @@
+kind: AnalysisRun
+apiVersion: argoproj.io/v1alpha1
+metadata:
+  name: malformed-analysis
+spec:
+  metrics:
+  - name: test
+    provider:
+      job:
+        spec:
+          template:
+            spec:
+              containers:
+              - name: sleep
+                image: alpine:3.8
+                resources:
+                  requests:
+                    memory: invalid # invalid

--- a/test/e2e/expectedfailures/malformed-analysistemplate.yaml
+++ b/test/e2e/expectedfailures/malformed-analysistemplate.yaml
@@ -1,0 +1,18 @@
+kind: AnalysisTemplate
+apiVersion: argoproj.io/v1alpha1
+metadata:
+  name: malformed-analysis
+spec:
+  metrics:
+  - name: test
+    provider:
+      job:
+        spec:
+          template:
+            spec:
+              containers:
+              - name: sleep
+                image: alpine:3.8
+                resources:
+                  requests:
+                    memory: invalid # invalid

--- a/test/e2e/expectedfailures/malformed-clusteranalysistemplate.yaml
+++ b/test/e2e/expectedfailures/malformed-clusteranalysistemplate.yaml
@@ -1,0 +1,18 @@
+kind: ClusterAnalysisTemplate
+apiVersion: argoproj.io/v1alpha1
+metadata:
+  name: malformed-analysis
+spec:
+  metrics:
+  - name: test
+    provider:
+      job:
+        spec:
+          template:
+            spec:
+              containers:
+              - name: sleep
+                image: alpine:3.8
+                resources:
+                  requests:
+                    memory: invalid # invalid

--- a/test/e2e/expectedfailures/malformed-experiment.yaml
+++ b/test/e2e/expectedfailures/malformed-experiment.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Experiment
+metadata:
+  name: malformed-experiment
+spec:
+  duration: 30s
+  templates:
+  - name: canary
+    selector:
+      matchLabels:
+        app: rollouts-demo
+    template:
+      metadata:
+        labels:
+          app: rollouts-demo
+      spec:
+        containers:
+        - name: rollouts-demo
+          image: argoproj/rollouts-demo:yellow
+          resources:
+            requests:
+              memory: invalid # invalid

--- a/test/e2e/expectedfailures/malformed-rollout.yaml
+++ b/test/e2e/expectedfailures/malformed-rollout.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: malformed-rollout
+spec:
+  selector:
+    matchLabels:
+      app: malformed-rollout
+  template:
+    metadata:
+      labels:
+        app: malformed-rollout
+    spec:
+      containers:
+      - name: malformed-rollout
+        image: argoproj/rollouts-demo:blue
+        resources:
+          requests:
+            memory: invalid # invalid
+  strategy:
+    canary: {}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"io/ioutil"
+
+	"github.com/ghodss/yaml"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// ObjectFromYAML returns a runtime.Object from a yaml string
+func ObjectFromYAML(yamlStr string) *unstructured.Unstructured {
+	obj := make(map[string]interface{})
+	err := yaml.Unmarshal([]byte(yamlStr), &obj)
+	if err != nil {
+		panic(err)
+	}
+	return &unstructured.Unstructured{Object: obj}
+}
+
+// ObjectFromPath returns a runtime.Object from the given path. Path is a relative path from source root
+func ObjectFromPath(path string) *unstructured.Unstructured {
+	path = "../../" + path
+	body, err := ioutil.ReadFile(path)
+	if err != nil {
+		panic(err)
+	}
+	return ObjectFromYAML(string(body))
+}

--- a/utils/log/log.go
+++ b/utils/log/log.go
@@ -1,7 +1,10 @@
 package log
 
 import (
+	"strings"
+
 	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 )
@@ -20,6 +23,19 @@ const (
 	// NamespaceKey defines the key for the namespace field
 	NamespaceKey = "namespace"
 )
+
+// WithUnstructured returns an logging context for an unstructured object
+func WithUnstructured(un *unstructured.Unstructured) *log.Entry {
+	logCtx := log.NewEntry(log.StandardLogger())
+	kind, _, _ := unstructured.NestedString(un.Object, "kind")
+	if name, ok, _ := unstructured.NestedString(un.Object, "metadata", "name"); ok {
+		logCtx = logCtx.WithField(strings.ToLower(kind), name)
+	}
+	if namespace, ok, _ := unstructured.NestedString(un.Object, "metadata", "namespace"); ok {
+		logCtx = logCtx.WithField("namespace", namespace)
+	}
+	return logCtx
+}
 
 // WithRollout returns a logging context for Rollouts
 func WithRollout(rollout *v1alpha1.Rollout) *log.Entry {

--- a/utils/tolerantinformer/analysisrun.go
+++ b/utils/tolerantinformer/analysisrun.go
@@ -1,0 +1,86 @@
+package tolerantinformer
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	rolloutinformers "github.com/argoproj/argo-rollouts/pkg/client/informers/externalversions/rollouts/v1alpha1"
+	rolloutlisters "github.com/argoproj/argo-rollouts/pkg/client/listers/rollouts/v1alpha1"
+)
+
+func NewTolerantAnalysisRunInformer(factory dynamicinformer.DynamicSharedInformerFactory) rolloutinformers.AnalysisRunInformer {
+	return &tolerantAnalysisRunInformer{
+		delegate: factory.ForResource(v1alpha1.AnalysisRunGVR),
+	}
+}
+
+type tolerantAnalysisRunInformer struct {
+	delegate informers.GenericInformer
+}
+
+func (i *tolerantAnalysisRunInformer) Informer() cache.SharedIndexInformer {
+	return i.delegate.Informer()
+}
+
+func (i *tolerantAnalysisRunInformer) Lister() rolloutlisters.AnalysisRunLister {
+	return &tolerantAnalysisRunLister{
+		delegate: i.delegate.Lister(),
+	}
+}
+
+type tolerantAnalysisRunLister struct {
+	delegate cache.GenericLister
+}
+
+func (t *tolerantAnalysisRunLister) List(selector labels.Selector) ([]*v1alpha1.AnalysisRun, error) {
+	objects, err := t.delegate.List(selector)
+	if err != nil {
+		return nil, err
+	}
+	return convertObjectsToAnalysisRuns(objects)
+}
+
+func (t *tolerantAnalysisRunLister) AnalysisRuns(namespace string) rolloutlisters.AnalysisRunNamespaceLister {
+	return &tolerantAnalysisRunNamespaceLister{
+		delegate: t.delegate.ByNamespace(namespace),
+	}
+}
+
+type tolerantAnalysisRunNamespaceLister struct {
+	delegate cache.GenericNamespaceLister
+}
+
+func (t *tolerantAnalysisRunNamespaceLister) Get(name string) (*v1alpha1.AnalysisRun, error) {
+	object, err := t.delegate.Get(name)
+	if err != nil {
+		return nil, err
+	}
+	v := &v1alpha1.AnalysisRun{}
+	err = convertObject(object, v)
+	return v, err
+}
+
+func (t *tolerantAnalysisRunNamespaceLister) List(selector labels.Selector) ([]*v1alpha1.AnalysisRun, error) {
+	objects, err := t.delegate.List(selector)
+	if err != nil {
+		return nil, err
+	}
+	return convertObjectsToAnalysisRuns(objects)
+}
+
+func convertObjectsToAnalysisRuns(objects []runtime.Object) ([]*v1alpha1.AnalysisRun, error) {
+	var firstErr error
+	vs := make([]*v1alpha1.AnalysisRun, len(objects))
+	for i, obj := range objects {
+		vs[i] = &v1alpha1.AnalysisRun{}
+		err := convertObject(obj, vs[i])
+		if err != nil && firstErr != nil {
+			firstErr = err
+		}
+	}
+	return vs, firstErr
+}

--- a/utils/tolerantinformer/analysistemplate.go
+++ b/utils/tolerantinformer/analysistemplate.go
@@ -1,0 +1,86 @@
+package tolerantinformer
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	rolloutinformers "github.com/argoproj/argo-rollouts/pkg/client/informers/externalversions/rollouts/v1alpha1"
+	rolloutlisters "github.com/argoproj/argo-rollouts/pkg/client/listers/rollouts/v1alpha1"
+)
+
+func NewTolerantAnalysisTemplateInformer(factory dynamicinformer.DynamicSharedInformerFactory) rolloutinformers.AnalysisTemplateInformer {
+	return &tolerantAnalysisTemplateInformer{
+		delegate: factory.ForResource(v1alpha1.AnalysisTemplateGVR),
+	}
+}
+
+type tolerantAnalysisTemplateInformer struct {
+	delegate informers.GenericInformer
+}
+
+func (i *tolerantAnalysisTemplateInformer) Informer() cache.SharedIndexInformer {
+	return i.delegate.Informer()
+}
+
+func (i *tolerantAnalysisTemplateInformer) Lister() rolloutlisters.AnalysisTemplateLister {
+	return &tolerantAnalysisTemplateLister{
+		delegate: i.delegate.Lister(),
+	}
+}
+
+type tolerantAnalysisTemplateLister struct {
+	delegate cache.GenericLister
+}
+
+func (t *tolerantAnalysisTemplateLister) List(selector labels.Selector) ([]*v1alpha1.AnalysisTemplate, error) {
+	objects, err := t.delegate.List(selector)
+	if err != nil {
+		return nil, err
+	}
+	return convertObjectsToAnalysisTemplates(objects)
+}
+
+func (t *tolerantAnalysisTemplateLister) AnalysisTemplates(namespace string) rolloutlisters.AnalysisTemplateNamespaceLister {
+	return &tolerantAnalysisTemplateNamespaceLister{
+		delegate: t.delegate.ByNamespace(namespace),
+	}
+}
+
+type tolerantAnalysisTemplateNamespaceLister struct {
+	delegate cache.GenericNamespaceLister
+}
+
+func (t *tolerantAnalysisTemplateNamespaceLister) Get(name string) (*v1alpha1.AnalysisTemplate, error) {
+	object, err := t.delegate.Get(name)
+	if err != nil {
+		return nil, err
+	}
+	v := &v1alpha1.AnalysisTemplate{}
+	err = convertObject(object, v)
+	return v, err
+}
+
+func (t *tolerantAnalysisTemplateNamespaceLister) List(selector labels.Selector) ([]*v1alpha1.AnalysisTemplate, error) {
+	objects, err := t.delegate.List(selector)
+	if err != nil {
+		return nil, err
+	}
+	return convertObjectsToAnalysisTemplates(objects)
+}
+
+func convertObjectsToAnalysisTemplates(objects []runtime.Object) ([]*v1alpha1.AnalysisTemplate, error) {
+	var firstErr error
+	vs := make([]*v1alpha1.AnalysisTemplate, len(objects))
+	for i, obj := range objects {
+		vs[i] = &v1alpha1.AnalysisTemplate{}
+		err := convertObject(obj, vs[i])
+		if err != nil && firstErr != nil {
+			firstErr = err
+		}
+	}
+	return vs, firstErr
+}

--- a/utils/tolerantinformer/clusteranalysistemplate.go
+++ b/utils/tolerantinformer/clusteranalysistemplate.go
@@ -1,0 +1,68 @@
+package tolerantinformer
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	rolloutinformers "github.com/argoproj/argo-rollouts/pkg/client/informers/externalversions/rollouts/v1alpha1"
+	rolloutlisters "github.com/argoproj/argo-rollouts/pkg/client/listers/rollouts/v1alpha1"
+)
+
+func NewTolerantClusterAnalysisTemplateInformer(factory dynamicinformer.DynamicSharedInformerFactory) rolloutinformers.ClusterAnalysisTemplateInformer {
+	return &tolerantClusterAnalysisTemplateInformer{
+		delegate: factory.ForResource(v1alpha1.ClusterAnalysisTemplateGVR),
+	}
+}
+
+type tolerantClusterAnalysisTemplateInformer struct {
+	delegate informers.GenericInformer
+}
+
+func (i *tolerantClusterAnalysisTemplateInformer) Informer() cache.SharedIndexInformer {
+	return i.delegate.Informer()
+}
+
+func (i *tolerantClusterAnalysisTemplateInformer) Lister() rolloutlisters.ClusterAnalysisTemplateLister {
+	return &tolerantClusterAnalysisTemplateLister{
+		delegate: i.delegate.Lister(),
+	}
+}
+
+type tolerantClusterAnalysisTemplateLister struct {
+	delegate cache.GenericLister
+}
+
+func (t *tolerantClusterAnalysisTemplateLister) List(selector labels.Selector) ([]*v1alpha1.ClusterAnalysisTemplate, error) {
+	objects, err := t.delegate.List(selector)
+	if err != nil {
+		return nil, err
+	}
+	return convertObjectsToClusterAnalysisTemplates(objects)
+}
+
+func (t *tolerantClusterAnalysisTemplateLister) Get(name string) (*v1alpha1.ClusterAnalysisTemplate, error) {
+	object, err := t.delegate.Get(name)
+	if err != nil {
+		return nil, err
+	}
+	v := &v1alpha1.ClusterAnalysisTemplate{}
+	err = convertObject(object, v)
+	return v, err
+}
+
+func convertObjectsToClusterAnalysisTemplates(objects []runtime.Object) ([]*v1alpha1.ClusterAnalysisTemplate, error) {
+	var firstErr error
+	vs := make([]*v1alpha1.ClusterAnalysisTemplate, len(objects))
+	for i, obj := range objects {
+		vs[i] = &v1alpha1.ClusterAnalysisTemplate{}
+		err := convertObject(obj, vs[i])
+		if err != nil && firstErr != nil {
+			firstErr = err
+		}
+	}
+	return vs, firstErr
+}

--- a/utils/tolerantinformer/experiment.go
+++ b/utils/tolerantinformer/experiment.go
@@ -1,0 +1,86 @@
+package tolerantinformer
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	rolloutinformers "github.com/argoproj/argo-rollouts/pkg/client/informers/externalversions/rollouts/v1alpha1"
+	rolloutlisters "github.com/argoproj/argo-rollouts/pkg/client/listers/rollouts/v1alpha1"
+)
+
+func NewTolerantExperimentInformer(factory dynamicinformer.DynamicSharedInformerFactory) rolloutinformers.ExperimentInformer {
+	return &tolerantExperimentInformer{
+		delegate: factory.ForResource(v1alpha1.ExperimentGVR),
+	}
+}
+
+type tolerantExperimentInformer struct {
+	delegate informers.GenericInformer
+}
+
+func (i *tolerantExperimentInformer) Informer() cache.SharedIndexInformer {
+	return i.delegate.Informer()
+}
+
+func (i *tolerantExperimentInformer) Lister() rolloutlisters.ExperimentLister {
+	return &tolerantExperimentLister{
+		delegate: i.delegate.Lister(),
+	}
+}
+
+type tolerantExperimentLister struct {
+	delegate cache.GenericLister
+}
+
+func (t *tolerantExperimentLister) List(selector labels.Selector) ([]*v1alpha1.Experiment, error) {
+	objects, err := t.delegate.List(selector)
+	if err != nil {
+		return nil, err
+	}
+	return convertObjectsToExperiments(objects)
+}
+
+func (t *tolerantExperimentLister) Experiments(namespace string) rolloutlisters.ExperimentNamespaceLister {
+	return &tolerantExperimentNamespaceLister{
+		delegate: t.delegate.ByNamespace(namespace),
+	}
+}
+
+type tolerantExperimentNamespaceLister struct {
+	delegate cache.GenericNamespaceLister
+}
+
+func (t *tolerantExperimentNamespaceLister) Get(name string) (*v1alpha1.Experiment, error) {
+	object, err := t.delegate.Get(name)
+	if err != nil {
+		return nil, err
+	}
+	v := &v1alpha1.Experiment{}
+	err = convertObject(object, v)
+	return v, err
+}
+
+func (t *tolerantExperimentNamespaceLister) List(selector labels.Selector) ([]*v1alpha1.Experiment, error) {
+	objects, err := t.delegate.List(selector)
+	if err != nil {
+		return nil, err
+	}
+	return convertObjectsToExperiments(objects)
+}
+
+func convertObjectsToExperiments(objects []runtime.Object) ([]*v1alpha1.Experiment, error) {
+	var firstErr error
+	vs := make([]*v1alpha1.Experiment, len(objects))
+	for i, obj := range objects {
+		vs[i] = &v1alpha1.Experiment{}
+		err := convertObject(obj, vs[i])
+		if err != nil && firstErr != nil {
+			firstErr = err
+		}
+	}
+	return vs, firstErr
+}

--- a/utils/tolerantinformer/rollout.go
+++ b/utils/tolerantinformer/rollout.go
@@ -1,0 +1,86 @@
+package tolerantinformer
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	rolloutinformers "github.com/argoproj/argo-rollouts/pkg/client/informers/externalversions/rollouts/v1alpha1"
+	rolloutlisters "github.com/argoproj/argo-rollouts/pkg/client/listers/rollouts/v1alpha1"
+)
+
+func NewTolerantRolloutInformer(factory dynamicinformer.DynamicSharedInformerFactory) rolloutinformers.RolloutInformer {
+	return &tolerantRolloutInformer{
+		delegate: factory.ForResource(v1alpha1.RolloutGVR),
+	}
+}
+
+type tolerantRolloutInformer struct {
+	delegate informers.GenericInformer
+}
+
+func (i *tolerantRolloutInformer) Informer() cache.SharedIndexInformer {
+	return i.delegate.Informer()
+}
+
+func (i *tolerantRolloutInformer) Lister() rolloutlisters.RolloutLister {
+	return &tolerantRolloutLister{
+		delegate: i.delegate.Lister(),
+	}
+}
+
+type tolerantRolloutLister struct {
+	delegate cache.GenericLister
+}
+
+func (t *tolerantRolloutLister) List(selector labels.Selector) ([]*v1alpha1.Rollout, error) {
+	objects, err := t.delegate.List(selector)
+	if err != nil {
+		return nil, err
+	}
+	return convertObjectsToRollouts(objects)
+}
+
+func (t *tolerantRolloutLister) Rollouts(namespace string) rolloutlisters.RolloutNamespaceLister {
+	return &tolerantRolloutNamespaceLister{
+		delegate: t.delegate.ByNamespace(namespace),
+	}
+}
+
+type tolerantRolloutNamespaceLister struct {
+	delegate cache.GenericNamespaceLister
+}
+
+func (t *tolerantRolloutNamespaceLister) Get(name string) (*v1alpha1.Rollout, error) {
+	object, err := t.delegate.Get(name)
+	if err != nil {
+		return nil, err
+	}
+	v := &v1alpha1.Rollout{}
+	err = convertObject(object, v)
+	return v, err
+}
+
+func (t *tolerantRolloutNamespaceLister) List(selector labels.Selector) ([]*v1alpha1.Rollout, error) {
+	objects, err := t.delegate.List(selector)
+	if err != nil {
+		return nil, err
+	}
+	return convertObjectsToRollouts(objects)
+}
+
+func convertObjectsToRollouts(objects []runtime.Object) ([]*v1alpha1.Rollout, error) {
+	var firstErr error
+	vs := make([]*v1alpha1.Rollout, len(objects))
+	for i, obj := range objects {
+		vs[i] = &v1alpha1.Rollout{}
+		err := convertObject(obj, vs[i])
+		if err != nil && firstErr != nil {
+			firstErr = err
+		}
+	}
+	return vs, firstErr
+}

--- a/utils/tolerantinformer/tolerantinformer_test.go
+++ b/utils/tolerantinformer/tolerantinformer_test.go
@@ -1,0 +1,225 @@
+package tolerantinformer
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	testutil "github.com/argoproj/argo-rollouts/test/util"
+)
+
+const (
+	dummyNamespace = "dummy-namespace"
+)
+
+func newFakeDynamicInformer(objs ...runtime.Object) dynamicinformer.DynamicSharedInformerFactory {
+	dynamicClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), objs...)
+	dynamicInformerFactory := dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0)
+
+	// The dynamic informer factory relies on calling ForResource on any GVR which wish to be
+	// monitored *before* calling .Start(), in order to work properly.
+	dynamicInformerFactory.ForResource(v1alpha1.RolloutGVR)
+	dynamicInformerFactory.ForResource(v1alpha1.AnalysisTemplateGVR)
+	dynamicInformerFactory.ForResource(v1alpha1.AnalysisRunGVR)
+	dynamicInformerFactory.ForResource(v1alpha1.ExperimentGVR)
+	dynamicInformerFactory.ForResource(v1alpha1.ClusterAnalysisTemplateGVR)
+
+	// Start then stop the informer. We just want the informer to be filled in with the fake objects
+	// and not really be running in the background.
+	stopCh := make(chan struct{})
+	dynamicInformerFactory.Start(stopCh)
+	synced := dynamicInformerFactory.WaitForCacheSync(stopCh)
+	close(stopCh)
+	if len(synced) != 5 {
+		panic("could not sync fake informer")
+	}
+	for gvr, isSynced := range synced {
+		if !isSynced {
+			panic(fmt.Sprintf("could not sync %v", gvr))
+		}
+	}
+	return dynamicInformerFactory
+}
+
+func TestMalformedRollout(t *testing.T) {
+	good := testutil.ObjectFromPath("examples/rollout-canary.yaml")
+	good.SetNamespace("default")
+	bad := testutil.ObjectFromPath("test/e2e/expectedfailures/malformed-rollout.yaml")
+	bad.SetNamespace(dummyNamespace)
+	dynInformerFactory := newFakeDynamicInformer(good, bad)
+	informer := NewTolerantRolloutInformer(dynInformerFactory)
+
+	verify := func(ro *v1alpha1.Rollout) {
+		assert.True(t, ro.Spec.Strategy.Canary != nil)
+		assert.Len(t, ro.Spec.Template.Spec.Containers[0].Resources.Requests, 0)
+	}
+
+	// test cluster scoped list
+	list, err := informer.Lister().List(labels.NewSelector())
+	assert.NoError(t, err)
+	assert.Len(t, list, 2)
+	for _, obj := range list {
+		if obj.Name == "malformed-rollout" {
+			verify(obj)
+		}
+	}
+
+	// test namespaced scoped get
+	obj, err := informer.Lister().Rollouts(dummyNamespace).Get("malformed-rollout")
+	assert.NoError(t, err)
+	verify(obj)
+
+	// test namespaced scoped list
+	list, err = informer.Lister().Rollouts(dummyNamespace).List(labels.NewSelector())
+	assert.NoError(t, err)
+	assert.Len(t, list, 1)
+	verify(list[0])
+}
+
+func verifyAnalysisSpec(t *testing.T, s interface{}) {
+	//   metrics:
+	//   - name: test
+	//     provider:
+	//       job:
+	//         spec:
+	//           template:
+	//             spec:
+	//               containers:
+	//               - name: sleep
+	//                 image: alpine:3.8
+	//                 resources:
+	//                   requests:
+	//                     memory: invalid # invalid
+	if spec, ok := s.(v1alpha1.AnalysisRunSpec); ok {
+		assert.Len(t, spec.Metrics[0].Provider.Job.Spec.Template.Spec.Containers[0].Resources.Requests, 0)
+	} else {
+		spec := s.(v1alpha1.AnalysisTemplateSpec)
+		assert.Len(t, spec.Metrics[0].Provider.Job.Spec.Template.Spec.Containers[0].Resources.Requests, 0)
+	}
+}
+
+func TestMalformedAnalysisRun(t *testing.T) {
+	good := testutil.ObjectFromPath("test/e2e/functional/analysis-run-job.yaml")
+	good.SetNamespace("default")
+	bad := testutil.ObjectFromPath("test/e2e/expectedfailures/malformed-analysisrun.yaml")
+	bad.SetNamespace(dummyNamespace)
+	dynInformerFactory := newFakeDynamicInformer(good, bad)
+	informer := NewTolerantAnalysisRunInformer(dynInformerFactory)
+
+	// test cluster scoped list
+	list, err := informer.Lister().List(labels.NewSelector())
+	assert.NoError(t, err)
+	assert.Len(t, list, 2)
+	for _, obj := range list {
+		if obj.Name == "malformed-analysis" {
+			verifyAnalysisSpec(t, obj.Spec)
+		}
+	}
+
+	// test namespaced scoped get
+	obj, err := informer.Lister().AnalysisRuns(dummyNamespace).Get("malformed-analysis")
+	assert.NoError(t, err)
+	verifyAnalysisSpec(t, obj.Spec)
+
+	// test namespaced scoped list
+	list, err = informer.Lister().AnalysisRuns(dummyNamespace).List(labels.NewSelector())
+	assert.NoError(t, err)
+	assert.Len(t, list, 1)
+	verifyAnalysisSpec(t, obj.Spec)
+}
+
+func TestMalformedAnalysisTemplate(t *testing.T) {
+	good := testutil.ObjectFromPath("test/e2e/functional/analysis-run-job.yaml")
+	good.SetNamespace("default")
+	good.SetKind("AnalysisTemplate")
+	bad := testutil.ObjectFromPath("test/e2e/expectedfailures/malformed-analysistemplate.yaml")
+	bad.SetNamespace(dummyNamespace)
+	dynInformerFactory := newFakeDynamicInformer(good, bad)
+	informer := NewTolerantAnalysisTemplateInformer(dynInformerFactory)
+
+	// test cluster scoped list
+	list, err := informer.Lister().List(labels.NewSelector())
+	assert.NoError(t, err)
+	assert.Len(t, list, 2)
+	for _, obj := range list {
+		if obj.Name == "malformed-analysis" {
+			verifyAnalysisSpec(t, obj.Spec)
+		}
+	}
+
+	// test namespaced scoped get
+	obj, err := informer.Lister().AnalysisTemplates(dummyNamespace).Get("malformed-analysis")
+	assert.NoError(t, err)
+	verifyAnalysisSpec(t, obj.Spec)
+
+	// test namespaced scoped list
+	list, err = informer.Lister().AnalysisTemplates(dummyNamespace).List(labels.NewSelector())
+	assert.NoError(t, err)
+	assert.Len(t, list, 1)
+	verifyAnalysisSpec(t, obj.Spec)
+}
+
+func TestMalformedClusterAnalysisTemplate(t *testing.T) {
+	good := testutil.ObjectFromPath("test/e2e/functional/analysis-run-job.yaml")
+	good.SetKind("ClusterAnalysisTemplate")
+	bad := testutil.ObjectFromPath("test/e2e/expectedfailures/malformed-clusteranalysistemplate.yaml")
+	dynInformerFactory := newFakeDynamicInformer(good, bad)
+	informer := NewTolerantClusterAnalysisTemplateInformer(dynInformerFactory)
+
+	// test cluster scoped list
+	list, err := informer.Lister().List(labels.NewSelector())
+	assert.NoError(t, err)
+	assert.Len(t, list, 2)
+	for _, obj := range list {
+		if obj.Name == "malformed-analysis" {
+			verifyAnalysisSpec(t, obj.Spec)
+		}
+	}
+
+	// test cluster scoped get
+	obj, err := informer.Lister().Get("malformed-analysis")
+	assert.NoError(t, err)
+	verifyAnalysisSpec(t, obj.Spec)
+}
+
+func TestMalformedExperiment(t *testing.T) {
+	good := testutil.ObjectFromPath("test/e2e/functional/experiment-basic.yaml")
+	good.SetNamespace("default")
+	good.SetGenerateName("")
+	good.SetName("good-experiment")
+	bad := testutil.ObjectFromPath("test/e2e/expectedfailures/malformed-experiment.yaml")
+	bad.SetNamespace(dummyNamespace)
+	dynInformerFactory := newFakeDynamicInformer(good, bad)
+	informer := NewTolerantExperimentInformer(dynInformerFactory)
+
+	verify := func(ex *v1alpha1.Experiment) {
+		assert.Len(t, ex.Spec.Templates[0].Template.Spec.Containers[0].Resources.Requests, 0)
+	}
+
+	// test cluster scoped list
+	list, err := informer.Lister().List(labels.NewSelector())
+	assert.NoError(t, err)
+	assert.Len(t, list, 2)
+	for _, obj := range list {
+		if obj.Name == "malformed-experiment" {
+			verify(obj)
+		}
+	}
+
+	// test namespaced scoped get
+	obj, err := informer.Lister().Experiments(dummyNamespace).Get("malformed-experiment")
+	assert.NoError(t, err)
+	verify(obj)
+
+	// test namespaced scoped list
+	list, err = informer.Lister().Experiments(dummyNamespace).List(labels.NewSelector())
+	assert.NoError(t, err)
+	assert.Len(t, list, 1)
+	verify(obj)
+}

--- a/utils/tolerantinformer/tollerantinformer.go
+++ b/utils/tolerantinformer/tollerantinformer.go
@@ -1,0 +1,44 @@
+package tolerantinformer
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	logutil "github.com/argoproj/argo-rollouts/utils/log"
+)
+
+// convertObject converts a runtime.Object into the supplied concrete typed object
+// typedObj should be a pointer to a typed object which is desired to be filled in.
+// This is a best effort conversion which ignores unmarshalling errors.
+func convertObject(object runtime.Object, typedObj interface{}) error {
+	un, ok := object.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("malformed object: expected \"*unstructured.Unstructured\", got \"%s\"", reflect.TypeOf(object).Name())
+	}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, typedObj)
+	if err != nil {
+		logCtx := logutil.WithUnstructured(un)
+		logCtx.Warnf("malformed object: %v", err)
+		// When DefaultUnstructuredConverter.FromUnstructured fails to convert an object, it
+		// fails fast, not bothering to unmarshal the rest of the contents.
+		// When this happens, we fall back to golang json unmarshalling, since golang json
+		// unmarshalling continues to unmarshal all the remaining fields, which allows us to
+		// return back a mostly complete, and likely still usable object. This approach is
+		// preferred over the other options, which is to either return an error, or ignore the
+		// object completely.
+		_ = fromUnstructuredViaJSON(un.Object, typedObj)
+	}
+	return nil
+}
+
+func fromUnstructuredViaJSON(u map[string]interface{}, obj interface{}) error {
+	data, err := json.Marshal(u)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, obj)
+}


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/389, https://github.com/argoproj/argo-rollouts/issues/517

Uses a new, specialized "tolerant" dynamic informer which tolerates malformed objects that cannot unmarshal properly, preventing the issue where a unmarshallable object renders the entire controller unusable. When an object is discovered to be malformed, the informer will return a best effort version of the object via json unmarshalling (dropping all fields which could not be marshalled properly). This allows the controller to proceed as if the mistake was never made.

A consequence of this change is that the malformed field is silently dropped. But this is at least better behavior than stopping the controller.