### PR TITLE
docs: Update description of paused field in specification

### DIFF
--- a/docs/features/specification.md
+++ b/docs/features/specification.md
@@ -31,7 +31,7 @@ spec:
   revisionHistoryLimit: 3
   # Pause allows a user to manually pause a rollout at any time. A rollout will not advance through
   # its steps while it is manually paused, but HPA auto-scaling will still occur.
-  # If true, at initial creation of Rollout, replicas are not scaled up automatically from zero unless manually promoted.
+  # Usually not used in the manifest, but if true at initial creation of Rollout, replicas are not scaled up automatically from zero unless manually promoted.
   paused: true
   # The maximum time in seconds in which a rollout must make progress during an update, before it is
   # considered to be failed. Argo Rollouts will continue to process failed rollouts and a condition


### PR DESCRIPTION
Hello,

Thank you for let me add some description to Rollout specification in #655 .
At the time I didn't understand that `paused` is not usually assumed to be used in the manifest (<- Is it right?).
So, I tried to add some more words to the description.

Thank you.

---

Checklist:

* [x] (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).