### PR TITLE
fix: remove clusteranalysistemplates from argo-rollouts-role

### DIFF
--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -14101,7 +14101,6 @@ rules:
   - argoproj.io
   resources:
   - analysistemplates
-  - clusteranalysistemplates
   verbs:
   - get
   - list


### PR DESCRIPTION
This entry does not do anything and can be misleading.
I believe only ClusterRoles can grant access to cluster-scoped
resources. See https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole.


Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).