### PR TITLE
fix: add missing Service name reference in trafficRouting/alb/rootService

### DIFF
--- a/docs/features/kustomize/rollout-transform.yaml
+++ b/docs/features/kustomize/rollout-transform.yaml
@@ -125,6 +125,8 @@ nameReference:
     kind: Rollout
   - path: spec/strategy/canary/stableService
     kind: Rollout
+  - path: spec/strategy/canary/trafficRouting/alb/rootService
+    kind: Rollout
 - kind: VirtualService
   group: networking.istio.io
   fieldSpecs:


### PR DESCRIPTION
canary.trafficRouting.alb.rootService was recently added, but we never added the kustomize name transformer to understand this field references a Service