### PR TITLE
refactor: move reconciliation logic into rolloutContext

### DIFF
--- a/rollout/analysis.go
+++ b/rollout/analysis.go
@@ -131,7 +131,7 @@ func needsNewAnalysisRun(currentAr *v1alpha1.AnalysisRun, rollout *v1alpha1.Roll
 }
 
 // emitAnalysisRunStatusChanges emits a Kubernetes event if the analysis run of that type has changed status
-func (c *rolloutContext) emitAnalysisRunStatusChanges(r *v1alpha1.Rollout, prevStatus *v1alpha1.RolloutAnalysisRunStatus, ar *v1alpha1.AnalysisRun, arType string) {
+func (c *rolloutContext) emitAnalysisRunStatusChanges(prevStatus *v1alpha1.RolloutAnalysisRunStatus, ar *v1alpha1.AnalysisRun, arType string) {
 	if ar != nil {
 		if prevStatus == nil || prevStatus.Name == ar.Name && prevStatus.Status != ar.Status.Phase {
 			prevStatusStr := "NoPreviousStatus"
@@ -144,7 +144,7 @@ func (c *rolloutContext) emitAnalysisRunStatusChanges(r *v1alpha1.Rollout, prevS
 				eventType = corev1.EventTypeWarning
 			}
 			msg := fmt.Sprintf("%s Analysis Run '%s' Status New: '%s' Previous: '%s'", arType, ar.Name, ar.Status.Phase, prevStatusStr)
-			c.recorder.Event(r, eventType, "AnalysisRunStatusChange", msg)
+			c.recorder.Event(c.rollout, eventType, "AnalysisRunStatusChange", msg)
 		}
 	}
 }
@@ -153,28 +153,24 @@ func (c *rolloutContext) emitAnalysisRunStatusChanges(r *v1alpha1.Rollout, prevS
 // for that type
 func (c *rolloutContext) reconcileAnalysisRunStatusChanges(currARs analysisutil.CurrentAnalysisRuns) {
 	c.emitAnalysisRunStatusChanges(
-		c.rollout,
 		c.rollout.Status.BlueGreen.PostPromotionAnalysisRunStatus,
 		currARs.BlueGreenPostPromotion,
 		v1alpha1.RolloutTypePostPromotionLabel,
 	)
 
 	c.emitAnalysisRunStatusChanges(
-		c.rollout,
 		c.rollout.Status.BlueGreen.PrePromotionAnalysisRunStatus,
 		currARs.BlueGreenPrePromotion,
 		v1alpha1.RolloutTypePrePromotionLabel,
 	)
 
 	c.emitAnalysisRunStatusChanges(
-		c.rollout,
 		c.rollout.Status.Canary.CurrentStepAnalysisRunStatus,
 		currARs.CanaryStep,
 		v1alpha1.RolloutTypeStepLabel,
 	)
 
 	c.emitAnalysisRunStatusChanges(
-		c.rollout,
 		c.rollout.Status.Canary.CurrentBackgroundAnalysisRunStatus,
 		currARs.CanaryBackground,
 		v1alpha1.RolloutTypeBackgroundRunLabel,

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -17,15 +17,16 @@ import (
 )
 
 func (c *rolloutContext) rolloutCanary() error {
+	var err error
 	if replicasetutil.PodTemplateOrStepsChanged(c.rollout, c.newRS) {
-		err := c.getAllReplicaSetsAndSyncRevision(false)
+		c.newRS, err = c.getAllReplicaSetsAndSyncRevision(false)
 		if err != nil {
 			return err
 		}
 		return c.syncRolloutStatusCanary()
 	}
 
-	err := c.getAllReplicaSetsAndSyncRevision(true)
+	c.newRS, err = c.getAllReplicaSetsAndSyncRevision(true)
 	if err != nil {
 		return err
 	}

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -13,151 +13,125 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
-	logutil "github.com/argoproj/argo-rollouts/utils/log"
 	replicasetutil "github.com/argoproj/argo-rollouts/utils/replicaset"
 )
 
-func (c *Controller) rolloutCanary(rollout *v1alpha1.Rollout, rsList []*appsv1.ReplicaSet) error {
-	exList, err := c.getExperimentsForRollout(rollout)
-	if err != nil {
-		return err
-	}
-
-	arList, err := c.getAnalysisRunsForRollout(rollout)
-	if err != nil {
-		return err
-	}
-
-	newRS := replicasetutil.FindNewReplicaSet(rollout, rsList)
-	if replicasetutil.PodTemplateOrStepsChanged(rollout, newRS) {
-		newRS, previousRSs, err := c.getAllReplicaSetsAndSyncRevision(rollout, rsList, false)
+func (c *rolloutContext) rolloutCanary() error {
+	if replicasetutil.PodTemplateOrStepsChanged(c.rollout, c.newRS) {
+		err := c.getAllReplicaSetsAndSyncRevision(false)
 		if err != nil {
 			return err
 		}
-		roCtx := newCanaryCtx(rollout, newRS, previousRSs, exList, arList)
-		return c.syncRolloutStatusCanary(roCtx)
+		return c.syncRolloutStatusCanary()
 	}
 
-	newRS, previousRSs, err := c.getAllReplicaSetsAndSyncRevision(rollout, rsList, true)
+	err := c.getAllReplicaSetsAndSyncRevision(true)
 	if err != nil {
 		return err
 	}
 
-	roCtx := newCanaryCtx(rollout, newRS, previousRSs, exList, arList)
-
-	err = c.podRestarter.Reconcile(roCtx)
+	err = c.podRestarter.Reconcile(c)
 	if err != nil {
 		return err
 	}
 
-	logCtx := roCtx.Log()
-	logCtx.Info("Cleaning up old replicasets, experiments, and analysis runs")
-	if err := c.cleanupRollouts(roCtx.OlderRSs(), roCtx); err != nil {
+	c.log.Info("Cleaning up old replicasets, experiments, and analysis runs")
+	if err := c.cleanupRollouts(c.olderRSs); err != nil {
 		return err
 	}
 
-	if err := c.reconcileStableAndCanaryService(roCtx); err != nil {
+	if err := c.reconcileStableAndCanaryService(); err != nil {
 		return err
 	}
 
-	if err := c.reconcileTrafficRouting(roCtx); err != nil {
+	if err := c.reconcileTrafficRouting(); err != nil {
 		return err
 	}
 
-	logCtx.Info("Reconciling Experiment step")
-	err = c.reconcileExperiments(roCtx)
+	c.log.Info("Reconciling Experiment step")
+	err = c.reconcileExperiments()
 	if err != nil {
 		return err
 	}
 
-	logCtx.Info("Reconciling AnalysisRun step")
-	err = c.reconcileAnalysisRuns(roCtx)
-	if roCtx.PauseContext().HasAddPause() {
-		logCtx.Info("Detected pause due to inconclusive AnalysisRun")
-		return c.syncRolloutStatusCanary(roCtx)
+	c.log.Info("Reconciling AnalysisRun step")
+	err = c.reconcileAnalysisRuns()
+	if c.pauseContext.HasAddPause() {
+		c.log.Info("Detected pause due to inconclusive AnalysisRun")
+		return c.syncRolloutStatusCanary()
 	}
 	if err != nil {
 		return err
 	}
 
-	noScalingOccured, err := c.reconcileCanaryReplicaSets(roCtx)
+	noScalingOccured, err := c.reconcileCanaryReplicaSets()
 	if err != nil {
 		return err
 	}
 	if noScalingOccured {
-		logCtx.Info("Not finished reconciling ReplicaSets")
-		return c.syncRolloutStatusCanary(roCtx)
+		c.log.Info("Not finished reconciling ReplicaSets")
+		return c.syncRolloutStatusCanary()
 	}
 
-	logCtx.Info("Reconciling Canary Pause")
-	stillReconciling := c.reconcileCanaryPause(roCtx)
+	c.log.Info("Reconciling Canary Pause")
+	stillReconciling := c.reconcileCanaryPause()
 	if stillReconciling {
-		logCtx.Infof("Not finished reconciling Canary Pause")
-		return c.syncRolloutStatusCanary(roCtx)
+		c.log.Infof("Not finished reconciling Canary Pause")
+		return c.syncRolloutStatusCanary()
 	}
 
-	return c.syncRolloutStatusCanary(roCtx)
+	return c.syncRolloutStatusCanary()
 }
 
-func (c *Controller) reconcileStableRS(roCtx *canaryContext) (bool, error) {
-	logCtx := roCtx.Log()
-	rollout := roCtx.Rollout()
-	newRS := roCtx.NewRS()
-	stableRS := roCtx.StableRS()
-	olderRSs := roCtx.OlderRSs()
-	if !replicasetutil.CheckStableRSExists(newRS, stableRS) {
-		logCtx.Info("No StableRS exists to reconcile or matches newRS")
+func (c *rolloutContext) reconcileStableRS() (bool, error) {
+	if !replicasetutil.CheckStableRSExists(c.newRS, c.stableRS) {
+		c.log.Info("No StableRS exists to reconcile or matches newRS")
 		return false, nil
 	}
-	_, stableRSReplicaCount := replicasetutil.CalculateReplicaCountsForCanary(rollout, newRS, stableRS, olderRSs)
-	scaled, _, err := c.scaleReplicaSetAndRecordEvent(stableRS, stableRSReplicaCount, rollout)
+	_, stableRSReplicaCount := replicasetutil.CalculateReplicaCountsForCanary(c.rollout, c.newRS, c.stableRS, c.olderRSs)
+	scaled, _, err := c.scaleReplicaSetAndRecordEvent(c.stableRS, stableRSReplicaCount)
 	return scaled, err
 }
 
-func (c *Controller) reconcileCanaryPause(roCtx *canaryContext) bool {
-	rollout := roCtx.Rollout()
-	logCtx := roCtx.Log()
-
-	if rollout.Spec.Paused {
+func (c *rolloutContext) reconcileCanaryPause() bool {
+	if c.rollout.Spec.Paused {
 		return false
 	}
 
-	if len(rollout.Spec.Strategy.Canary.Steps) == 0 {
-		logCtx.Info("Rollout does not have any steps")
+	if len(c.rollout.Spec.Strategy.Canary.Steps) == 0 {
+		c.log.Info("Rollout does not have any steps")
 		return false
 	}
-	currentStep, currentStepIndex := replicasetutil.GetCurrentCanaryStep(rollout)
+	currentStep, currentStepIndex := replicasetutil.GetCurrentCanaryStep(c.rollout)
 
-	if len(rollout.Spec.Strategy.Canary.Steps) <= int(*currentStepIndex) {
-		logCtx.Info("No Steps remain in the canary steps")
+	if len(c.rollout.Spec.Strategy.Canary.Steps) <= int(*currentStepIndex) {
+		c.log.Info("No Steps remain in the canary steps")
 		return false
 	}
 
 	if currentStep.Pause == nil {
 		return false
 	}
-	cond := getPauseCondition(rollout, v1alpha1.PauseReasonCanaryPauseStep)
+	cond := getPauseCondition(c.rollout, v1alpha1.PauseReasonCanaryPauseStep)
 	if cond == nil {
 		// When the pause condition is null, that means the rollout is in an not paused state.
 		// As a result,, the controller needs to detect whether a rollout was unpaused or the
 		// rollout needs to be paused for the first time. If the ControllerPause is false,
 		// the controller has not paused the rollout yet and needs to do so before it
 		// can proceed.
-		if !rollout.Status.ControllerPause {
-			roCtx.PauseContext().AddPauseCondition(v1alpha1.PauseReasonCanaryPauseStep)
+		if !c.rollout.Status.ControllerPause {
+			c.pauseContext.AddPauseCondition(v1alpha1.PauseReasonCanaryPauseStep)
 		}
 		return true
 	}
 	if currentStep.Pause.Duration == nil {
 		return true
 	}
-	c.checkEnqueueRolloutDuringWait(rollout, cond.StartTime, currentStep.Pause.DurationSeconds())
+	c.checkEnqueueRolloutDuringWait(cond.StartTime, currentStep.Pause.DurationSeconds())
 	return true
 }
 
-func (c *Controller) reconcileOldReplicaSetsCanary(allRSs []*appsv1.ReplicaSet, oldRSs []*appsv1.ReplicaSet, roCtx *canaryContext) (bool, error) {
-	rollout := roCtx.Rollout()
-	logCtx := roCtx.Log()
+func (c *rolloutContext) reconcileOldReplicaSetsCanary(allRSs []*appsv1.ReplicaSet, oldRSs []*appsv1.ReplicaSet) (bool, error) {
 	oldPodsCount := replicasetutil.GetReplicaCountForReplicaSets(oldRSs)
 	if oldPodsCount == 0 {
 		// Can't scale down further
@@ -166,32 +140,31 @@ func (c *Controller) reconcileOldReplicaSetsCanary(allRSs []*appsv1.ReplicaSet, 
 
 	// Clean up unhealthy replicas first, otherwise unhealthy replicas will block rollout
 	// and cause timeout. See https://github.com/kubernetes/kubernetes/issues/16737
-	oldRSs, cleanedUpRSs, err := c.cleanupUnhealthyReplicas(oldRSs, roCtx)
+	oldRSs, cleanedUpRSs, err := c.cleanupUnhealthyReplicas(oldRSs)
 	if err != nil {
 		return false, nil
 	}
 
 	// Scale down old replica sets, need check replicasToKeep to ensure we can scale down
-	scaledDownCount, err := c.scaleDownOldReplicaSetsForCanary(allRSs, oldRSs, rollout)
+	scaledDownCount, err := c.scaleDownOldReplicaSetsForCanary(allRSs, oldRSs)
 	if err != nil {
 		return false, nil
 	}
-	logCtx.Infof("Scaled down old RSes by %d", scaledDownCount)
+	c.log.Infof("Scaled down old RSes by %d", scaledDownCount)
 
 	return cleanedUpRSs || scaledDownCount > 0, nil
 }
 
 // scaleDownOldReplicaSetsForCanary scales down old replica sets when rollout strategy is "canary".
-func (c *Controller) scaleDownOldReplicaSetsForCanary(allRSs []*appsv1.ReplicaSet, oldRSs []*appsv1.ReplicaSet, rollout *v1alpha1.Rollout) (int32, error) {
-	logCtx := logutil.WithRollout(rollout)
+func (c *rolloutContext) scaleDownOldReplicaSetsForCanary(allRSs []*appsv1.ReplicaSet, oldRSs []*appsv1.ReplicaSet) (int32, error) {
 	availablePodCount := replicasetutil.GetAvailableReplicaCountForReplicaSets(allRSs)
-	minAvailable := defaults.GetReplicasOrDefault(rollout.Spec.Replicas) - replicasetutil.MaxUnavailable(rollout)
+	minAvailable := defaults.GetReplicasOrDefault(c.rollout.Spec.Replicas) - replicasetutil.MaxUnavailable(c.rollout)
 	maxScaleDown := availablePodCount - minAvailable
 	if maxScaleDown <= 0 {
 		// Cannot scale down.
 		return 0, nil
 	}
-	logCtx.Infof("Found %d available pods, scaling down old RSes", availablePodCount)
+	c.log.Infof("Found %d available pods, scaling down old RSes", availablePodCount)
 
 	sort.Sort(controller.ReplicaSetsByCreationTimestamp(oldRSs))
 
@@ -210,7 +183,7 @@ func (c *Controller) scaleDownOldReplicaSetsForCanary(allRSs []*appsv1.ReplicaSe
 		if scaleDownCount > maxScaleDown {
 			newReplicasCount = maxScaleDown
 		}
-		_, _, err := c.scaleReplicaSetAndRecordEvent(targetRS, newReplicasCount, rollout)
+		_, _, err := c.scaleReplicaSetAndRecordEvent(targetRS, newReplicasCount)
 		if err != nil {
 			return totalScaledDown, err
 		}
@@ -221,29 +194,27 @@ func (c *Controller) scaleDownOldReplicaSetsForCanary(allRSs []*appsv1.ReplicaSe
 	return totalScaledDown, nil
 }
 
-func completedCurrentCanaryStep(roCtx *canaryContext) bool {
-	r := roCtx.Rollout()
-	if r.Spec.Paused {
+func (c *rolloutContext) completedCurrentCanaryStep() bool {
+	if c.rollout.Spec.Paused {
 		return false
 	}
-	logCtx := roCtx.Log()
-	currentStep, _ := replicasetutil.GetCurrentCanaryStep(r)
+	currentStep, _ := replicasetutil.GetCurrentCanaryStep(c.rollout)
 	if currentStep == nil {
 		return false
 	}
 	if currentStep.Pause != nil {
-		return roCtx.PauseContext().CompletedPauseStep(*currentStep.Pause)
+		return c.pauseContext.CompletedPauseStep(*currentStep.Pause)
 	}
 	modifyReplicasStep := currentStep.SetWeight != nil || currentStep.SetCanaryScale != nil
-	if modifyReplicasStep && replicasetutil.AtDesiredReplicaCountsForCanary(r, roCtx.NewRS(), roCtx.StableRS(), roCtx.OlderRSs()) {
-		logCtx.Info("Rollout has reached the desired state for the correct weight")
+	if modifyReplicasStep && replicasetutil.AtDesiredReplicaCountsForCanary(c.rollout, c.newRS, c.stableRS, c.olderRSs) {
+		c.log.Info("Rollout has reached the desired state for the correct weight")
 		return true
 	}
-	experiment := roCtx.CurrentExperiment()
+	experiment := c.currentEx
 	if currentStep.Experiment != nil && experiment != nil && experiment.Status.Phase.Completed() && experiment.Status.Phase == v1alpha1.AnalysisPhaseSuccessful {
 		return true
 	}
-	currentStepAr := roCtx.CurrentAnalysisRuns().CanaryStep
+	currentStepAr := c.currentArs.CanaryStep
 	analysisExistsAndCompleted := currentStepAr != nil && currentStepAr.Status.Phase.Completed()
 	if currentStep.Analysis != nil && analysisExistsAndCompleted && currentStepAr.Status.Phase == v1alpha1.AnalysisPhaseSuccessful {
 		return true
@@ -252,63 +223,57 @@ func completedCurrentCanaryStep(roCtx *canaryContext) bool {
 	return false
 }
 
-func (c *Controller) syncRolloutStatusCanary(roCtx *canaryContext) error {
-	r := roCtx.Rollout()
-	logCtx := roCtx.Log()
-	newRS := roCtx.NewRS()
-	stableRS := roCtx.StableRS()
-	allRSs := roCtx.AllRSs()
+func (c *rolloutContext) syncRolloutStatusCanary() error {
+	newStatus := c.calculateBaseStatus()
+	newStatus.AvailableReplicas = replicasetutil.GetAvailableReplicaCountForReplicaSets(c.allRSs)
+	newStatus.HPAReplicas = replicasetutil.GetActualReplicaCountForReplicaSets(c.allRSs)
+	newStatus.Selector = metav1.FormatLabelSelector(c.rollout.Spec.Selector)
 
-	newStatus := c.calculateBaseStatus(roCtx)
-	newStatus.AvailableReplicas = replicasetutil.GetAvailableReplicaCountForReplicaSets(allRSs)
-	newStatus.HPAReplicas = replicasetutil.GetActualReplicaCountForReplicaSets(allRSs)
-	newStatus.Selector = metav1.FormatLabelSelector(r.Spec.Selector)
-
-	_, currentStepIndex := replicasetutil.GetCurrentCanaryStep(r)
-	newStatus.StableRS = r.Status.StableRS
+	_, currentStepIndex := replicasetutil.GetCurrentCanaryStep(c.rollout)
+	newStatus.StableRS = c.rollout.Status.StableRS
 	//TODO(dthomson) Remove in v0.9.0
-	newStatus.Canary.StableRS = r.Status.Canary.StableRS
-	newStatus.CurrentStepHash = conditions.ComputeStepHash(r)
-	stepCount := int32(len(r.Spec.Strategy.Canary.Steps))
+	newStatus.Canary.StableRS = c.rollout.Status.Canary.StableRS
+	newStatus.CurrentStepHash = conditions.ComputeStepHash(c.rollout)
+	stepCount := int32(len(c.rollout.Spec.Strategy.Canary.Steps))
 
-	if replicasetutil.PodTemplateOrStepsChanged(r, newRS) {
-		newStatus.CurrentStepIndex = replicasetutil.ResetCurrentStepIndex(r)
-		if newRS != nil && r.Status.StableRS == replicasetutil.GetPodTemplateHash(newRS) {
+	if replicasetutil.PodTemplateOrStepsChanged(c.rollout, c.newRS) {
+		newStatus.CurrentStepIndex = replicasetutil.ResetCurrentStepIndex(c.rollout)
+		if c.newRS != nil && c.rollout.Status.StableRS == replicasetutil.GetPodTemplateHash(c.newRS) {
 			if newStatus.CurrentStepIndex != nil {
 				msg := "Skipping all steps because the newRS is the stableRS."
-				logCtx.Info(msg)
+				c.log.Info(msg)
 				newStatus.CurrentStepIndex = pointer.Int32Ptr(stepCount)
-				c.recorder.Event(r, corev1.EventTypeNormal, "SkipSteps", msg)
+				c.recorder.Event(c.rollout, corev1.EventTypeNormal, "SkipSteps", msg)
 			}
 		}
-		roCtx.PauseContext().ClearPauseConditions()
-		roCtx.PauseContext().RemoveAbort()
-		roCtx.SetRestartedAt()
-		newStatus = c.calculateRolloutConditions(roCtx, newStatus)
+		c.pauseContext.ClearPauseConditions()
+		c.pauseContext.RemoveAbort()
+		c.SetRestartedAt()
+		newStatus = c.calculateRolloutConditions(newStatus)
 		newStatus.Canary.CurrentStepAnalysisRunStatus = nil
 		newStatus.Canary.CurrentBackgroundAnalysisRunStatus = nil
-		return c.persistRolloutStatus(roCtx, &newStatus)
+		return c.persistRolloutStatus(&newStatus)
 	}
 
-	if stableRS == nil {
+	if c.stableRS == nil {
 		msg := fmt.Sprintf("Setting StableRS to CurrentPodHash: StableRS hash: %s", newStatus.CurrentPodHash)
-		logCtx.Info(msg)
+		c.log.Info(msg)
 		newStatus.StableRS = newStatus.CurrentPodHash
 		//TODO(dthomson) Remove in v0.9.0
 		newStatus.Canary.StableRS = newStatus.CurrentPodHash
 		if stepCount > 0 {
 			if stepCount != *currentStepIndex {
-				c.recorder.Event(r, corev1.EventTypeNormal, "SettingStableRS", msg)
+				c.recorder.Event(c.rollout, corev1.EventTypeNormal, "SettingStableRS", msg)
 			}
 			newStatus.CurrentStepIndex = &stepCount
 		}
-		roCtx.PauseContext().ClearPauseConditions()
-		roCtx.PauseContext().RemoveAbort()
-		newStatus = c.calculateRolloutConditions(roCtx, newStatus)
-		return c.persistRolloutStatus(roCtx, &newStatus)
+		c.pauseContext.ClearPauseConditions()
+		c.pauseContext.RemoveAbort()
+		newStatus = c.calculateRolloutConditions(newStatus)
+		return c.persistRolloutStatus(&newStatus)
 	}
 
-	if roCtx.PauseContext().IsAborted() {
+	if c.pauseContext.IsAborted() {
 		if stepCount > int32(0) {
 			if newStatus.StableRS == newStatus.CurrentPodHash {
 				newStatus.CurrentStepIndex = &stepCount
@@ -316,86 +281,82 @@ func (c *Controller) syncRolloutStatusCanary(roCtx *canaryContext) error {
 				newStatus.CurrentStepIndex = pointer.Int32Ptr(0)
 			}
 		}
-		newStatus = c.calculateRolloutConditions(roCtx, newStatus)
-		return c.persistRolloutStatus(roCtx, &newStatus)
+		newStatus = c.calculateRolloutConditions(newStatus)
+		return c.persistRolloutStatus(&newStatus)
 	}
 
 	if currentStepIndex != nil && *currentStepIndex == stepCount {
-		logCtx.Info("Rollout has executed every step")
+		c.log.Info("Rollout has executed every step")
 		newStatus.CurrentStepIndex = &stepCount
-		if newRS != nil && newRS.Status.AvailableReplicas == defaults.GetReplicasOrDefault(r.Spec.Replicas) {
-			logCtx.Info("New RS has successfully progressed")
+		if c.newRS != nil && c.newRS.Status.AvailableReplicas == defaults.GetReplicasOrDefault(c.rollout.Spec.Replicas) {
+			c.log.Info("New RS has successfully progressed")
 			newStatus.StableRS = newStatus.CurrentPodHash
 			//TODO(dthomson) Remove in v0.9.0
 			newStatus.Canary.StableRS = newStatus.CurrentPodHash
 		}
-		roCtx.PauseContext().ClearPauseConditions()
-		newStatus = c.calculateRolloutConditions(roCtx, newStatus)
-		return c.persistRolloutStatus(roCtx, &newStatus)
+		c.pauseContext.ClearPauseConditions()
+		newStatus = c.calculateRolloutConditions(newStatus)
+		return c.persistRolloutStatus(&newStatus)
 	}
 
 	if stepCount == 0 {
-		logCtx.Info("Rollout has no steps")
-		if newRS != nil && newRS.Status.AvailableReplicas == defaults.GetReplicasOrDefault(r.Spec.Replicas) {
-			logCtx.Info("New RS has successfully progressed")
+		c.log.Info("Rollout has no steps")
+		if c.newRS != nil && c.newRS.Status.AvailableReplicas == defaults.GetReplicasOrDefault(c.rollout.Spec.Replicas) {
+			c.log.Info("New RS has successfully progressed")
 			newStatus.StableRS = newStatus.CurrentPodHash
 			//TODO(dthomson) Remove in v0.9.0
 			newStatus.Canary.StableRS = newStatus.CurrentPodHash
 		}
-		newStatus = c.calculateRolloutConditions(roCtx, newStatus)
-		return c.persistRolloutStatus(roCtx, &newStatus)
+		newStatus = c.calculateRolloutConditions(newStatus)
+		return c.persistRolloutStatus(&newStatus)
 	}
 
-	if completedCurrentCanaryStep(roCtx) {
+	if c.completedCurrentCanaryStep() {
 		*currentStepIndex++
 		newStatus.CurrentStepIndex = currentStepIndex
 		newStatus.Canary.CurrentStepAnalysisRun = ""
-		if int(*currentStepIndex) == len(r.Spec.Strategy.Canary.Steps) {
-			c.recorder.Event(r, corev1.EventTypeNormal, "SettingStableRS", "Completed all steps")
+		if int(*currentStepIndex) == len(c.rollout.Spec.Strategy.Canary.Steps) {
+			c.recorder.Event(c.rollout, corev1.EventTypeNormal, "SettingStableRS", "Completed all steps")
 		}
-		logCtx.Infof("Incrementing the Current Step Index to %d", *currentStepIndex)
-		c.recorder.Eventf(r, corev1.EventTypeNormal, "SetStepIndex", "Set Step Index to %d", int(*currentStepIndex))
-		roCtx.PauseContext().RemovePauseCondition(v1alpha1.PauseReasonCanaryPauseStep)
-		newStatus = c.calculateRolloutConditions(roCtx, newStatus)
-		return c.persistRolloutStatus(roCtx, &newStatus)
+		c.log.Infof("Incrementing the Current Step Index to %d", *currentStepIndex)
+		c.recorder.Eventf(c.rollout, corev1.EventTypeNormal, "SetStepIndex", "Set Step Index to %d", int(*currentStepIndex))
+		c.pauseContext.RemovePauseCondition(v1alpha1.PauseReasonCanaryPauseStep)
+		newStatus = c.calculateRolloutConditions(newStatus)
+		return c.persistRolloutStatus(&newStatus)
 	}
 
 	newStatus.CurrentStepIndex = currentStepIndex
-	newStatus = c.calculateRolloutConditions(roCtx, newStatus)
-	return c.persistRolloutStatus(roCtx, &newStatus)
+	newStatus = c.calculateRolloutConditions(newStatus)
+	return c.persistRolloutStatus(&newStatus)
 }
 
-func (c *Controller) reconcileCanaryReplicaSets(roCtx *canaryContext) (bool, error) {
-	logCtx := roCtx.Log()
-	logCtx.Info("Reconciling StableRS")
-	scaledStableRS, err := c.reconcileStableRS(roCtx)
+func (c *rolloutContext) reconcileCanaryReplicaSets() (bool, error) {
+	c.log.Info("Reconciling StableRS")
+	scaledStableRS, err := c.reconcileStableRS()
 	if err != nil {
 		return false, err
 	}
 	if scaledStableRS {
-		logCtx.Infof("Not finished reconciling stableRS")
+		c.log.Infof("Not finished reconciling stableRS")
 		return true, nil
 	}
 
-	newRS := roCtx.NewRS()
-	olderRSs := roCtx.OlderRSs()
-	allRSs := roCtx.AllRSs()
-	scaledNewRS, err := c.reconcileNewReplicaSet(roCtx)
+	scaledNewRS, err := c.reconcileNewReplicaSet()
 	if err != nil {
 		return false, err
 	}
 	if scaledNewRS {
-		logCtx.Infof("Not finished reconciling new ReplicaSet '%s'", newRS.Name)
+		c.log.Infof("Not finished reconciling new ReplicaSet '%s'", c.newRS.Name)
 		return true, nil
 	}
 
-	logCtx.Info("Reconciling old replica sets")
-	scaledDown, err := c.reconcileOldReplicaSetsCanary(allRSs, controller.FilterActiveReplicaSets(olderRSs), roCtx)
+	c.log.Info("Reconciling old replica sets")
+	scaledDown, err := c.reconcileOldReplicaSetsCanary(c.allRSs, controller.FilterActiveReplicaSets(c.olderRSs))
 	if err != nil {
 		return false, err
 	}
 	if scaledDown {
-		logCtx.Info("Not finished reconciling old replica sets")
+		c.log.Info("Not finished reconciling old replica sets")
 		return true, nil
 	}
 	return false, nil

--- a/rollout/context.go
+++ b/rollout/context.go
@@ -7,19 +7,26 @@ import (
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	analysisutil "github.com/argoproj/argo-rollouts/utils/analysis"
-	experimentutil "github.com/argoproj/argo-rollouts/utils/experiment"
-	logutil "github.com/argoproj/argo-rollouts/utils/log"
-	replicasetutil "github.com/argoproj/argo-rollouts/utils/replicaset"
 )
 
 type rolloutContext struct {
-	rollout *v1alpha1.Rollout
-	log     *log.Entry
+	reconcilerBase
 
-	newRS    *appsv1.ReplicaSet
+	log *log.Entry
+	// rollout is the rollout being reconciled
+	rollout *v1alpha1.Rollout
+	// newRS is the "new" ReplicaSet. Also referred to as current, or desired.
+	// newRS will be nil when the pod template spec changes.
+	newRS *appsv1.ReplicaSet
+	// stableRS is the "stable" ReplicaSet which will be scaled up upon an abort.
+	// stableRS will be nil when a Rollout is first deployed.
 	stableRS *appsv1.ReplicaSet
+	// allRSs are all the ReplicaSets associated with the Rollout
+	allRSs []*appsv1.ReplicaSet
+	// olderRSs are "older" ReplicaSets
+	// For canary, this is anything which is not new or stable
+	// For blueGreen, this is anything which is not new
 	olderRSs []*appsv1.ReplicaSet
-	allRSs   []*appsv1.ReplicaSet
 
 	currentArs analysisutil.CurrentAnalysisRuns
 	otherArs   []*v1alpha1.AnalysisRun
@@ -29,41 +36,6 @@ type rolloutContext struct {
 
 	newStatus    v1alpha1.RolloutStatus
 	pauseContext *pauseContext
-
-	reconcilerBase
-}
-
-func newRolloutCtx(r *v1alpha1.Rollout, newRS *appsv1.ReplicaSet, otherRSs []*appsv1.ReplicaSet, exList []*v1alpha1.Experiment, arList []*v1alpha1.AnalysisRun) *rolloutContext {
-	allRSs := append(otherRSs, newRS)
-	stableRS := replicasetutil.GetStableRS(r, newRS, otherRSs)
-	oldRSs := replicasetutil.GetOlderRSs(r, newRS, stableRS, otherRSs)
-
-	currentArs, otherArs := analysisutil.FilterCurrentRolloutAnalysisRuns(arList, r)
-	currentEx := experimentutil.GetCurrentExperiment(r, exList)
-	otherExs := experimentutil.GetOldExperiments(r, exList)
-	logCtx := logutil.WithRollout(r)
-	return &rolloutContext{
-		rollout:  r,
-		log:      logCtx,
-		newRS:    newRS,
-		stableRS: stableRS,
-		olderRSs: oldRSs,
-		allRSs:   allRSs,
-
-		currentArs: currentArs,
-		otherArs:   otherArs,
-
-		currentEx: currentEx,
-		otherExs:  otherExs,
-
-		newStatus: v1alpha1.RolloutStatus{
-			RestartedAt: r.Status.RestartedAt,
-		},
-		pauseContext: &pauseContext{
-			rollout: r,
-			log:     logCtx,
-		},
-	}
 }
 
 func (c *rolloutContext) reconcile() error {
@@ -87,7 +59,7 @@ func (c *rolloutContext) reconcile() error {
 	}
 
 	if getPauseCondition(c.rollout, v1alpha1.PauseReasonInconclusiveAnalysis) != nil || c.rollout.Spec.Paused || isScalingEvent {
-		return c.syncReplicasOnly(c.rollout, c.allRSs, isScalingEvent)
+		return c.syncReplicasOnly(isScalingEvent)
 	}
 
 	if c.rollout.Spec.Strategy.BlueGreen != nil {
@@ -102,228 +74,6 @@ func (c *rolloutContext) SetRestartedAt() {
 	c.newStatus.RestartedAt = c.rollout.Spec.RestartAt
 }
 
-type blueGreenContext struct {
-	rollout *v1alpha1.Rollout
-	log     *log.Entry
-
-	newRS    *appsv1.ReplicaSet
-	stableRS *appsv1.ReplicaSet
-	olderRSs []*appsv1.ReplicaSet
-	allRSs   []*appsv1.ReplicaSet
-
-	currentArs analysisutil.CurrentAnalysisRuns
-	otherArs   []*v1alpha1.AnalysisRun
-
-	newStatus    v1alpha1.RolloutStatus
-	pauseContext *pauseContext
-}
-
-type canaryContext struct {
-	rollout *v1alpha1.Rollout
-	log     *log.Entry
-
-	newRS    *appsv1.ReplicaSet
-	stableRS *appsv1.ReplicaSet
-	olderRSs []*appsv1.ReplicaSet
-	allRSs   []*appsv1.ReplicaSet
-
-	currentArs analysisutil.CurrentAnalysisRuns
-	otherArs   []*v1alpha1.AnalysisRun
-
-	currentEx *v1alpha1.Experiment
-	otherExs  []*v1alpha1.Experiment
-
-	newStatus    v1alpha1.RolloutStatus
-	pauseContext *pauseContext
-}
-
-func newBlueGreenCtx(r *v1alpha1.Rollout, newRS *appsv1.ReplicaSet, olderRSs []*appsv1.ReplicaSet, arList []*v1alpha1.AnalysisRun) *blueGreenContext {
-	allRSs := append(olderRSs, newRS)
-	logCtx := logutil.WithRollout(r)
-	stableRS, _ := replicasetutil.GetReplicaSetByTemplateHash(allRSs, r.Status.BlueGreen.ActiveSelector)
-
-	currentArs, otherArs := analysisutil.FilterCurrentRolloutAnalysisRuns(arList, r)
-	return &blueGreenContext{
-		rollout: r,
-		log:     logCtx,
-
-		newRS:    newRS,
-		stableRS: stableRS,
-		olderRSs: olderRSs,
-		allRSs:   allRSs,
-
-		newStatus: v1alpha1.RolloutStatus{
-			RestartedAt: r.Status.RestartedAt,
-		},
-		pauseContext: &pauseContext{
-			rollout: r,
-			log:     logCtx,
-		},
-
-		currentArs: currentArs,
-		otherArs:   otherArs,
-	}
-}
-
-func (bgCtx *blueGreenContext) Rollout() *v1alpha1.Rollout {
-	return bgCtx.rollout
-}
-
-func (bgCtx *blueGreenContext) Log() *log.Entry {
-	return bgCtx.log
-}
-
-func (bgCtx *blueGreenContext) NewRS() *appsv1.ReplicaSet {
-	return bgCtx.newRS
-}
-
-func (bgCtx *blueGreenContext) StableRS() *appsv1.ReplicaSet {
-	return bgCtx.stableRS
-}
-
-func (bgCtx *blueGreenContext) OlderRSs() []*appsv1.ReplicaSet {
-	return bgCtx.olderRSs
-}
-
-func (bgCtx *blueGreenContext) AllRSs() []*appsv1.ReplicaSet {
-	return bgCtx.allRSs
-}
-
-func (bgCtx *blueGreenContext) CurrentExperiment() *v1alpha1.Experiment {
-	return nil
-}
-func (bgCtx *blueGreenContext) CurrentAnalysisRuns() analysisutil.CurrentAnalysisRuns {
-	return bgCtx.currentArs
-}
-
-func (bgCtx *blueGreenContext) OtherAnalysisRuns() []*v1alpha1.AnalysisRun {
-	return bgCtx.otherArs
-}
-
-func (bgCtx *blueGreenContext) SetCurrentAnalysisRuns(currAr analysisutil.CurrentAnalysisRuns) {
-	bgCtx.currentArs = currAr
-	currPrePromoAr := currAr.BlueGreenPrePromotion
-	if currPrePromoAr != nil && currPrePromoAr.Status.Phase != v1alpha1.AnalysisPhaseSuccessful {
-		bgCtx.newStatus.BlueGreen.PrePromotionAnalysisRun = currPrePromoAr.Name
-		bgCtx.newStatus.BlueGreen.PrePromotionAnalysisRunStatus = &v1alpha1.RolloutAnalysisRunStatus{
-			Name:    currPrePromoAr.Name,
-			Status:  currPrePromoAr.Status.Phase,
-			Message: currPrePromoAr.Status.Message,
-		}
-	}
-	currPostPromoAr := currAr.BlueGreenPostPromotion
-	if currPostPromoAr != nil && currPostPromoAr.Status.Phase != v1alpha1.AnalysisPhaseSuccessful {
-		bgCtx.newStatus.BlueGreen.PostPromotionAnalysisRun = currPostPromoAr.Name
-		bgCtx.newStatus.BlueGreen.PostPromotionAnalysisRunStatus = &v1alpha1.RolloutAnalysisRunStatus{
-			Name:    currPostPromoAr.Name,
-			Status:  currPostPromoAr.Status.Phase,
-			Message: currPostPromoAr.Status.Message,
-		}
-	}
-}
-
-func (bgCtx *blueGreenContext) OtherExperiments() []*v1alpha1.Experiment {
-	return nil
-}
-
-func (bgCtx *blueGreenContext) PauseContext() *pauseContext {
-	return bgCtx.pauseContext
-}
-
-func (bgCtx *blueGreenContext) NewStatus() v1alpha1.RolloutStatus {
-	return bgCtx.newStatus
-}
-
-func (bgCtx *blueGreenContext) SetRestartedAt() {
-	bgCtx.newStatus.RestartedAt = bgCtx.rollout.Spec.RestartAt
-}
-
-func newCanaryCtx(r *v1alpha1.Rollout, newRS *appsv1.ReplicaSet, otherRSs []*appsv1.ReplicaSet, exList []*v1alpha1.Experiment, arList []*v1alpha1.AnalysisRun) *canaryContext {
-	allRSs := append(otherRSs, newRS)
-	stableRS := replicasetutil.GetStableRS(r, newRS, otherRSs)
-	oldRSs := replicasetutil.GetOlderRSs(r, newRS, stableRS, otherRSs)
-
-	currentArs, otherArs := analysisutil.FilterCurrentRolloutAnalysisRuns(arList, r)
-	currentEx := experimentutil.GetCurrentExperiment(r, exList)
-	otherExs := experimentutil.GetOldExperiments(r, exList)
-	logCtx := logutil.WithRollout(r)
-	return &canaryContext{
-		rollout:  r,
-		log:      logCtx,
-		newRS:    newRS,
-		stableRS: stableRS,
-		olderRSs: oldRSs,
-		allRSs:   allRSs,
-
-		currentArs: currentArs,
-		otherArs:   otherArs,
-
-		currentEx: currentEx,
-		otherExs:  otherExs,
-
-		newStatus: v1alpha1.RolloutStatus{
-			RestartedAt: r.Status.RestartedAt,
-		},
-		pauseContext: &pauseContext{
-			rollout: r,
-			log:     logCtx,
-		},
-	}
-}
-
-func (cCtx *canaryContext) Rollout() *v1alpha1.Rollout {
-	return cCtx.rollout
-}
-
-func (cCtx *canaryContext) Log() *log.Entry {
-	return cCtx.log
-}
-
-func (cCtx *canaryContext) NewRS() *appsv1.ReplicaSet {
-	return cCtx.newRS
-}
-
-func (cCtx *canaryContext) StableRS() *appsv1.ReplicaSet {
-	return cCtx.stableRS
-}
-
-func (cCtx *canaryContext) OlderRSs() []*appsv1.ReplicaSet {
-	return cCtx.olderRSs
-}
-
-func (cCtx *canaryContext) AllRSs() []*appsv1.ReplicaSet {
-	return cCtx.allRSs
-}
-
-func (cCtx *canaryContext) SetCurrentAnalysisRuns(currARs analysisutil.CurrentAnalysisRuns) {
-	cCtx.currentArs = currARs
-	currBackgroundAr := currARs.CanaryBackground
-	if currBackgroundAr != nil && currBackgroundAr.Status.Phase != v1alpha1.AnalysisPhaseSuccessful {
-		cCtx.newStatus.Canary.CurrentBackgroundAnalysisRun = currBackgroundAr.Name
-		cCtx.newStatus.Canary.CurrentBackgroundAnalysisRunStatus = &v1alpha1.RolloutAnalysisRunStatus{
-			Name:    currBackgroundAr.Name,
-			Status:  currBackgroundAr.Status.Phase,
-			Message: currBackgroundAr.Status.Message,
-		}
-	}
-	currStepAr := currARs.CanaryStep
-	if currStepAr != nil && currStepAr.Status.Phase != v1alpha1.AnalysisPhaseSuccessful {
-		cCtx.newStatus.Canary.CurrentStepAnalysisRun = currStepAr.Name
-		cCtx.newStatus.Canary.CurrentStepAnalysisRunStatus = &v1alpha1.RolloutAnalysisRunStatus{
-			Name:    currStepAr.Name,
-			Status:  currStepAr.Status.Phase,
-			Message: currStepAr.Status.Message,
-		}
-	}
-}
-
-func (cCtx *canaryContext) CurrentAnalysisRuns() analysisutil.CurrentAnalysisRuns {
-	return cCtx.currentArs
-}
-func (cCtx *canaryContext) OtherAnalysisRuns() []*v1alpha1.AnalysisRun {
-	return cCtx.otherArs
-}
-
 func (c *rolloutContext) SetCurrentExperiment(ex *v1alpha1.Experiment) {
 	c.currentEx = ex
 	c.newStatus.Canary.CurrentExperiment = ex.Name
@@ -334,26 +84,6 @@ func (c *rolloutContext) SetCurrentExperiment(ex *v1alpha1.Experiment) {
 			break
 		}
 	}
-}
-
-func (cCtx *canaryContext) CurrentExperiment() *v1alpha1.Experiment {
-	return cCtx.currentEx
-}
-
-func (cCtx *canaryContext) OtherExperiments() []*v1alpha1.Experiment {
-	return cCtx.otherExs
-}
-
-func (cCtx *canaryContext) PauseContext() *pauseContext {
-	return cCtx.pauseContext
-}
-
-func (cCtx *canaryContext) NewStatus() v1alpha1.RolloutStatus {
-	return cCtx.newStatus
-}
-
-func (cCtx *canaryContext) SetRestartedAt() {
-	cCtx.newStatus.RestartedAt = cCtx.rollout.Spec.RestartAt
 }
 
 func (c *rolloutContext) SetCurrentAnalysisRuns(currARs analysisutil.CurrentAnalysisRuns) {

--- a/rollout/pause.go
+++ b/rollout/pause.go
@@ -123,7 +123,7 @@ func getPauseCondition(rollout *v1alpha1.Rollout, reason v1alpha1.PauseReason) *
 
 // completedPrePromotionAnalysis checks if the Pre Promotion Analysis has completed successfully or the rollout passed
 // the auto promote seconds.
-func completedPrePromotionAnalysis(c *rolloutContext) bool {
+func (c *rolloutContext) completedPrePromotionAnalysis() bool {
 	if c.rollout.Spec.Strategy.BlueGreen == nil || c.rollout.Spec.Strategy.BlueGreen.PrePromotionAnalysis == nil {
 		return true
 	}

--- a/rollout/replicaset.go
+++ b/rollout/replicaset.go
@@ -85,6 +85,7 @@ func (c *rolloutContext) reconcileOldReplicaSets(oldRSs []*appsv1.ReplicaSet) (b
 		// Can't scale down further
 		return false, nil
 	}
+	c.log.Infof("Reconciling old replica sets (count: %d)", oldPodsCount)
 
 	var err error
 	hasScaled := false

--- a/rollout/service.go
+++ b/rollout/service.go
@@ -44,7 +44,7 @@ func generatePatch(service *corev1.Service, newRolloutUniqueLabelValue string, r
 }
 
 // switchSelector switch the selector on an existing service to a new value
-func (c Controller) switchServiceSelector(service *corev1.Service, newRolloutUniqueLabelValue string, r *v1alpha1.Rollout) error {
+func (c rolloutContext) switchServiceSelector(service *corev1.Service, newRolloutUniqueLabelValue string, r *v1alpha1.Rollout) error {
 	if service.Spec.Selector == nil {
 		service.Spec.Selector = make(map[string]string)
 	}
@@ -65,17 +65,14 @@ func (c Controller) switchServiceSelector(service *corev1.Service, newRolloutUni
 	return err
 }
 
-func (c *Controller) reconcilePreviewService(roCtx *blueGreenContext, previewSvc *corev1.Service) error {
-	r := roCtx.Rollout()
-	logCtx := roCtx.Log()
-	newRS := roCtx.NewRS()
+func (c *rolloutContext) reconcilePreviewService(previewSvc *corev1.Service) error {
 	if previewSvc == nil {
 		return nil
 	}
-	logCtx.Infof("Reconciling preview service '%s'", previewSvc.Name)
+	c.log.Infof("Reconciling preview service '%s'", previewSvc.Name)
 
-	newPodHash := newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
-	err := c.switchServiceSelector(previewSvc, newPodHash, r)
+	newPodHash := c.newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	err := c.switchServiceSelector(previewSvc, newPodHash, c.rollout)
 	if err != nil {
 		return err
 	}
@@ -83,28 +80,24 @@ func (c *Controller) reconcilePreviewService(roCtx *blueGreenContext, previewSvc
 	return nil
 }
 
-func (c *Controller) reconcileActiveService(roCtx *blueGreenContext, previewSvc, activeSvc *corev1.Service) error {
-	r := roCtx.Rollout()
-	newRS := roCtx.NewRS()
-	allRSs := roCtx.AllRSs()
-
-	if !replicasetutil.ReadyForPause(r, newRS, allRSs) || !annotations.IsSaturated(r, newRS) {
-		roCtx.log.Infof("New RS '%s' is not fully saturated", newRS.Name)
+func (c *rolloutContext) reconcileActiveService(previewSvc, activeSvc *corev1.Service) error {
+	if !replicasetutil.ReadyForPause(c.rollout, c.newRS, c.allRSs) || !annotations.IsSaturated(c.rollout, c.newRS) {
+		c.log.Infof("New RS '%s' is not fully saturated", c.newRS.Name)
 		return nil
 	}
 
 	newPodHash := activeSvc.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey]
-	if skipPause(roCtx, activeSvc) {
-		newPodHash = newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	if skipPause(c, activeSvc) {
+		newPodHash = c.newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 	}
-	if roCtx.PauseContext().CompletedBlueGreenPause() && completedPrePromotionAnalysis(roCtx) {
-		newPodHash = newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	if c.pauseContext.CompletedBlueGreenPause() && completedPrePromotionAnalysis(c) {
+		newPodHash = c.newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 	}
 
-	if r.Status.Abort {
+	if c.rollout.Status.Abort {
 		currentRevision := int(0)
-		for _, rs := range controller.FilterActiveReplicaSets(roCtx.OlderRSs()) {
-			revision := replicasetutil.GetReplicaSetRevision(r, rs)
+		for _, rs := range controller.FilterActiveReplicaSets(c.olderRSs) {
+			revision := replicasetutil.GetReplicaSetRevision(c.rollout, rs)
 			if revision > currentRevision {
 				newPodHash = rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 				currentRevision = revision
@@ -112,14 +105,14 @@ func (c *Controller) reconcileActiveService(roCtx *blueGreenContext, previewSvc,
 		}
 	}
 
-	err := c.switchServiceSelector(activeSvc, newPodHash, r)
+	err := c.switchServiceSelector(activeSvc, newPodHash, c.rollout)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (c *Controller) getPreviewAndActiveServices(r *v1alpha1.Rollout) (*corev1.Service, *corev1.Service, error) {
+func (c *rolloutContext) getPreviewAndActiveServices(r *v1alpha1.Rollout) (*corev1.Service, *corev1.Service, error) {
 	var previewSvc *corev1.Service
 	var activeSvc *corev1.Service
 	var err error
@@ -137,33 +130,30 @@ func (c *Controller) getPreviewAndActiveServices(r *v1alpha1.Rollout) (*corev1.S
 	return previewSvc, activeSvc, nil
 }
 
-func (c *Controller) reconcileStableAndCanaryService(roCtx *canaryContext) error {
-	r := roCtx.Rollout()
-	newRS := roCtx.NewRS()
-	stableRS := roCtx.StableRS()
-	if r.Spec.Strategy.Canary == nil {
+func (c *rolloutContext) reconcileStableAndCanaryService() error {
+	if c.rollout.Spec.Strategy.Canary == nil {
 		return nil
 	}
-	if r.Spec.Strategy.Canary.StableService != "" && stableRS != nil {
-		svc, err := c.servicesLister.Services(r.Namespace).Get(r.Spec.Strategy.Canary.StableService)
+	if c.rollout.Spec.Strategy.Canary.StableService != "" && c.stableRS != nil {
+		svc, err := c.servicesLister.Services(c.rollout.Namespace).Get(c.rollout.Spec.Strategy.Canary.StableService)
 		if err != nil {
 			return err
 		}
-		if svc.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey] != stableRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] {
-			err = c.switchServiceSelector(svc, stableRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey], r)
+		if svc.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey] != c.stableRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] {
+			err = c.switchServiceSelector(svc, c.stableRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey], c.rollout)
 			if err != nil {
 				return err
 			}
 		}
 
 	}
-	if r.Spec.Strategy.Canary.CanaryService != "" && newRS != nil {
-		svc, err := c.servicesLister.Services(r.Namespace).Get(r.Spec.Strategy.Canary.CanaryService)
+	if c.rollout.Spec.Strategy.Canary.CanaryService != "" && c.newRS != nil {
+		svc, err := c.servicesLister.Services(c.rollout.Namespace).Get(c.rollout.Spec.Strategy.Canary.CanaryService)
 		if err != nil {
 			return err
 		}
-		if svc.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey] != newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] {
-			err = c.switchServiceSelector(svc, newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey], r)
+		if svc.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey] != c.newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] {
+			err = c.switchServiceSelector(svc, c.newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey], c.rollout)
 			if err != nil {
 				return err
 			}

--- a/rollout/service_test.go
+++ b/rollout/service_test.go
@@ -66,7 +66,9 @@ func TestGetPreviewAndActiveServices(t *testing.T) {
 	}
 	c, _, _ := f.newController(noResyncPeriodFunc)
 	t.Run("Get Both", func(t *testing.T) {
-		preview, active, err := c.getPreviewAndActiveServices(rollout)
+		roCtx, err := c.newRolloutContext(rollout)
+		assert.NoError(t, err)
+		preview, active, err := roCtx.getPreviewAndActiveServices()
 		assert.Nil(t, err)
 		assert.Equal(t, expPreview, preview)
 		assert.Equal(t, expActive, active)
@@ -74,14 +76,18 @@ func TestGetPreviewAndActiveServices(t *testing.T) {
 	t.Run("Preview not found", func(t *testing.T) {
 		noPreviewSvcRollout := rollout.DeepCopy()
 		noPreviewSvcRollout.Spec.Strategy.BlueGreen.PreviewService = "not-preview"
-		_, _, err := c.getPreviewAndActiveServices(noPreviewSvcRollout)
+		roCtx, err := c.newRolloutContext(noPreviewSvcRollout)
+		assert.NoError(t, err)
+		_, _, err = roCtx.getPreviewAndActiveServices()
 		assert.NotNil(t, err)
 		assert.True(t, errors.IsNotFound(err))
 	})
 	t.Run("Active not found", func(t *testing.T) {
 		noActiveSvcRollout := rollout.DeepCopy()
 		noActiveSvcRollout.Spec.Strategy.BlueGreen.ActiveService = "not-active"
-		_, _, err := c.getPreviewAndActiveServices(noActiveSvcRollout)
+		roCtx, err := c.newRolloutContext(noActiveSvcRollout)
+		assert.NoError(t, err)
+		_, _, err = roCtx.getPreviewAndActiveServices()
 		assert.NotNil(t, err)
 		assert.True(t, errors.IsNotFound(err))
 	})
@@ -89,7 +95,9 @@ func TestGetPreviewAndActiveServices(t *testing.T) {
 	t.Run("Invalid Spec: No Active Svc", func(t *testing.T) {
 		noActiveSvcRollout := rollout.DeepCopy()
 		noActiveSvcRollout.Spec.Strategy.BlueGreen.ActiveService = ""
-		_, _, err := c.getPreviewAndActiveServices(noActiveSvcRollout)
+		roCtx, err := c.newRolloutContext(noActiveSvcRollout)
+		assert.NoError(t, err)
+		_, _, err = roCtx.getPreviewAndActiveServices()
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "service \"\" not found")
 	})

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -33,32 +33,37 @@ import (
 // 2. Get new RS this rollout targets (whose pod template matches rollout's), and update new RS's revision number to (maxOldV + 1),
 //    only if its revision number is smaller than (maxOldV + 1). If this step failed, we'll update it in the next rollout sync loop.
 // 3. Copy new RS's revision number to rollout (update rollout's revision). If this step failed, we'll update it in the next rollout sync loop.
+// 4. If there's no existing new RS and createIfNotExisted is true, create one with appropriate revision number (maxOldRevision + 1) and replicas.
+//    Note that the pod-template-hash will be added to adopted RSes and pods.
 //
 // Note that currently the rollout controller is using caches to avoid querying the server for reads.
 // This may lead to stale reads of replica sets, thus incorrect  v status.
-func (c *Controller) getAllReplicaSetsAndSyncRevision(rollout *v1alpha1.Rollout, rsList []*appsv1.ReplicaSet, createIfNotExisted bool) (*appsv1.ReplicaSet, []*appsv1.ReplicaSet, error) {
-	allOldRSs := replicasetutil.FindOldReplicaSets(rollout, rsList)
-
+func (c *rolloutContext) getAllReplicaSetsAndSyncRevision(createIfNotExisted bool) error {
 	// Get new replica set with the updated revision number
-	newRS, err := c.getNewReplicaSet(rollout, rsList, allOldRSs, createIfNotExisted)
+	newRS, err := c.syncReplicaSetRevision()
 	if err != nil {
-		return nil, nil, err
+		return err
 	}
-
-	return newRS, allOldRSs, nil
+	if newRS == nil && createIfNotExisted {
+		newRS, err = c.createDesiredReplicaSet()
+		if err != nil {
+			return err
+		}
+	}
+	c.newRS = newRS
+	return nil
 }
 
 // Returns a replica set that matches the intent of the given rollout. Returns nil if the new replica set doesn't exist yet.
 // 1. Get existing new RS (the RS that the given rollout targets, whose pod template is the same as rollout's).
 // 2. If there's existing new RS, update its revision number if it's smaller than (maxOldRevision + 1), where maxOldRevision is the max revision number among all old RSes.
-// 3. If there's no existing new RS and createIfNotExisted is true, create one with appropriate revision number (maxOldRevision + 1) and replicas.
-// Note that the pod-template-hash will be added to adopted RSes and pods.
-func (c *Controller) getNewReplicaSet(rollout *v1alpha1.Rollout, rsList, oldRSs []*appsv1.ReplicaSet, createIfNotExisted bool) (*appsv1.ReplicaSet, error) {
-	logCtx := logutil.WithRollout(rollout)
-	existingNewRS := replicasetutil.FindNewReplicaSet(rollout, rsList)
+func (c *rolloutContext) syncReplicaSetRevision() (*appsv1.ReplicaSet, error) {
+	if c.newRS == nil {
+		return nil, nil
+	}
 
 	// Calculate the max revision number among all old RSes
-	maxOldRevision := replicasetutil.MaxRevision(oldRSs)
+	maxOldRevision := replicasetutil.MaxRevision(c.olderRSs)
 	// Calculate revision number for this new replica set
 	newRevision := strconv.FormatInt(maxOldRevision+1, 10)
 
@@ -66,86 +71,89 @@ func (c *Controller) getNewReplicaSet(rollout *v1alpha1.Rollout, rsList, oldRSs 
 	// annotationsToSkip from the parent rollout, and update revision and desiredReplicas)
 	// and also update the revision annotation in the rollout with the
 	// latest revision.
-	if existingNewRS != nil {
-		rsCopy := existingNewRS.DeepCopy()
+	rsCopy := c.newRS.DeepCopy()
 
-		// Set existing new replica set's annotation
-		annotationsUpdated := annotations.SetNewReplicaSetAnnotations(rollout, rsCopy, newRevision, true)
-		minReadySecondsNeedsUpdate := rsCopy.Spec.MinReadySeconds != rollout.Spec.MinReadySeconds
-		affinityNeedsUpdate := replicasetutil.IfInjectedAntiAffinityRuleNeedsUpdate(rsCopy.Spec.Template.Spec.Affinity, *rollout)
+	// Set existing new replica set's annotation
+	annotationsUpdated := annotations.SetNewReplicaSetAnnotations(c.rollout, rsCopy, newRevision, true)
+	minReadySecondsNeedsUpdate := rsCopy.Spec.MinReadySeconds != c.rollout.Spec.MinReadySeconds
+	affinityNeedsUpdate := replicasetutil.IfInjectedAntiAffinityRuleNeedsUpdate(rsCopy.Spec.Template.Spec.Affinity, *c.rollout)
 
-		if annotationsUpdated || minReadySecondsNeedsUpdate || affinityNeedsUpdate {
-			rsCopy.Spec.MinReadySeconds = rollout.Spec.MinReadySeconds
-			rsCopy.Spec.Template.Spec.Affinity = replicasetutil.GenerateReplicaSetAffinity(*rollout)
-			return c.kubeclientset.AppsV1().ReplicaSets(rsCopy.ObjectMeta.Namespace).Update(rsCopy)
-		}
-
-		// Should use the revision in existingNewRS's annotation, since it set by before
-		needsUpdate := annotations.SetRolloutRevision(rollout, rsCopy.Annotations[annotations.RevisionAnnotation])
-		// If no other Progressing condition has been recorded and we need to estimate the progress
-		// of this rollout then it is likely that old users started caring about progress. In that
-		// case we need to take into account the first time we noticed their new replica set.
-		cond := conditions.GetRolloutCondition(rollout.Status, v1alpha1.RolloutProgressing)
-		if cond == nil {
-			msg := fmt.Sprintf(conditions.FoundNewRSMessage, rsCopy.Name)
-			condition := conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionTrue, conditions.FoundNewRSReason, msg)
-			conditions.SetRolloutCondition(&rollout.Status, *condition)
-			needsUpdate = true
-		}
-
-		if needsUpdate {
-			var err error
-			logCtx.Info("Setting revision annotation after creating a new replicaset")
-			if rollout, err = c.argoprojclientset.ArgoprojV1alpha1().Rollouts(rollout.Namespace).Update(rollout); err != nil {
-				logCtx.WithError(err).Errorf("Error: Setting rollout revision annotation after creating a new replicaset")
-				return nil, err
-			}
-		}
-		return rsCopy, nil
+	if annotationsUpdated || minReadySecondsNeedsUpdate || affinityNeedsUpdate {
+		rsCopy.Spec.MinReadySeconds = c.rollout.Spec.MinReadySeconds
+		rsCopy.Spec.Template.Spec.Affinity = replicasetutil.GenerateReplicaSetAffinity(*c.rollout)
+		return c.kubeclientset.AppsV1().ReplicaSets(rsCopy.ObjectMeta.Namespace).Update(rsCopy)
 	}
 
-	if !createIfNotExisted {
-		return nil, nil
+	// Should use the revision in existingNewRS's annotation, since it set by before
+	needsUpdate := annotations.SetRolloutRevision(c.rollout, rsCopy.Annotations[annotations.RevisionAnnotation])
+	// If no other Progressing condition has been recorded and we need to estimate the progress
+	// of this rollout then it is likely that old users started caring about progress. In that
+	// case we need to take into account the first time we noticed their new replica set.
+	cond := conditions.GetRolloutCondition(c.rollout.Status, v1alpha1.RolloutProgressing)
+	if cond == nil {
+		msg := fmt.Sprintf(conditions.FoundNewRSMessage, rsCopy.Name)
+		condition := conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionTrue, conditions.FoundNewRSReason, msg)
+		conditions.SetRolloutCondition(&c.rollout.Status, *condition)
+		needsUpdate = true
 	}
+
+	if needsUpdate {
+		var err error
+		c.log.Info("Setting revision annotation after creating a new replicaset")
+		rollout, err := c.argoprojclientset.ArgoprojV1alpha1().Rollouts(c.rollout.Namespace).Update(c.rollout)
+		if err != nil {
+			c.log.WithError(err).Error("Error: Setting rollout revision annotation after creating a new replicaset")
+			return nil, err
+		}
+		c.rollout = rollout
+	}
+	return rsCopy, nil
+}
+
+func (c *rolloutContext) createDesiredReplicaSet() (*appsv1.ReplicaSet, error) {
+	// Calculate the max revision number among all old RSes
+	maxOldRevision := replicasetutil.MaxRevision(c.olderRSs)
+	// Calculate revision number for this new replica set
+	newRevision := strconv.FormatInt(maxOldRevision+1, 10)
 
 	// new ReplicaSet does not exist, create one.
-	newRSTemplate := *rollout.Spec.Template.DeepCopy()
+	newRSTemplate := *c.rollout.Spec.Template.DeepCopy()
 	// Add default anti-affinity rule if antiAffinity bool set and RSTemplate meets requirements
-	newRSTemplate.Spec.Affinity = replicasetutil.GenerateReplicaSetAffinity(*rollout)
-	podTemplateSpecHash := controller.ComputeHash(&rollout.Spec.Template, rollout.Status.CollisionCount)
-	newRSTemplate.Labels = labelsutil.CloneAndAddLabel(rollout.Spec.Template.Labels, v1alpha1.DefaultRolloutUniqueLabelKey, podTemplateSpecHash)
+	newRSTemplate.Spec.Affinity = replicasetutil.GenerateReplicaSetAffinity(*c.rollout)
+	podTemplateSpecHash := controller.ComputeHash(&c.rollout.Spec.Template, c.rollout.Status.CollisionCount)
+	newRSTemplate.Labels = labelsutil.CloneAndAddLabel(c.rollout.Spec.Template.Labels, v1alpha1.DefaultRolloutUniqueLabelKey, podTemplateSpecHash)
 	// Add podTemplateHash label to selector.
-	newRSSelector := labelsutil.CloneSelectorAndAddLabel(rollout.Spec.Selector, v1alpha1.DefaultRolloutUniqueLabelKey, podTemplateSpecHash)
+	newRSSelector := labelsutil.CloneSelectorAndAddLabel(c.rollout.Spec.Selector, v1alpha1.DefaultRolloutUniqueLabelKey, podTemplateSpecHash)
 
 	// Create new ReplicaSet
 	newRS := appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            rollout.Name + "-" + podTemplateSpecHash,
-			Namespace:       rollout.Namespace,
-			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(rollout, controllerKind)},
+			Name:            c.rollout.Name + "-" + podTemplateSpecHash,
+			Namespace:       c.rollout.Namespace,
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(c.rollout, controllerKind)},
 			Labels:          newRSTemplate.Labels,
 		},
 		Spec: appsv1.ReplicaSetSpec{
 			Replicas:        new(int32),
-			MinReadySeconds: rollout.Spec.MinReadySeconds,
+			MinReadySeconds: c.rollout.Spec.MinReadySeconds,
 			Selector:        newRSSelector,
 			Template:        newRSTemplate,
 		},
 	}
-	allRSs := append(oldRSs, &newRS)
-	newReplicasCount, err := replicasetutil.NewRSNewReplicas(rollout, allRSs, &newRS)
+	allRSs := append(c.allRSs, &newRS)
+	newReplicasCount, err := replicasetutil.NewRSNewReplicas(c.rollout, allRSs, &newRS)
 	if err != nil {
 		return nil, err
 	}
 
 	*(newRS.Spec.Replicas) = newReplicasCount
 	// Set new replica set's annotation
-	annotations.SetNewReplicaSetAnnotations(rollout, &newRS, newRevision, false)
+	annotations.SetNewReplicaSetAnnotations(c.rollout, &newRS, newRevision, false)
 	// Create the new ReplicaSet. If it already exists, then we need to check for possible
 	// hash collisions. If there is any other error, we need to report it in the status of
 	// the Rollout.
 	alreadyExists := false
-	createdRS, err := c.kubeclientset.AppsV1().ReplicaSets(rollout.Namespace).Create(&newRS)
+	createdRS, err := c.kubeclientset.AppsV1().ReplicaSets(c.rollout.Namespace).Create(&newRS)
 	switch {
 	// We may end up hitting this due to a slow cache or a fast resync of the Rollout.
 	case errors.IsAlreadyExists(err):
@@ -162,7 +170,7 @@ func (c *Controller) getNewReplicaSet(rollout *v1alpha1.Rollout, rsList, oldRSs 
 		// Otherwise, this is a hash collision and we need to increment the collisionCount field in
 		// the status of the Rollout and requeue to try the creation in the next sync.
 		controllerRef := metav1.GetControllerOf(rs)
-		if controllerRef != nil && controllerRef.UID == rollout.UID && replicasetutil.PodTemplateEqualIgnoreHash(&rs.Spec.Template, &rollout.Spec.Template) {
+		if controllerRef != nil && controllerRef.UID == c.rollout.UID && replicasetutil.PodTemplateEqualIgnoreHash(&rs.Spec.Template, &c.rollout.Spec.Template) {
 			createdRS = rs
 			err = nil
 			break
@@ -170,123 +178,110 @@ func (c *Controller) getNewReplicaSet(rollout *v1alpha1.Rollout, rsList, oldRSs 
 
 		// Matching ReplicaSet is not equal - increment the collisionCount in the RolloutStatus
 		// and requeue the Rollout.
-		if rollout.Status.CollisionCount == nil {
-			rollout.Status.CollisionCount = new(int32)
+		if c.rollout.Status.CollisionCount == nil {
+			c.rollout.Status.CollisionCount = new(int32)
 		}
-		preCollisionCount := *rollout.Status.CollisionCount
-		*rollout.Status.CollisionCount++
+		preCollisionCount := *c.rollout.Status.CollisionCount
+		*c.rollout.Status.CollisionCount++
 		// Update the collisionCount for the Rollout and let it requeue by returning the original
 		// error.
-		_, roErr := c.argoprojclientset.ArgoprojV1alpha1().Rollouts(rollout.Namespace).Update(rollout)
+		_, roErr := c.argoprojclientset.ArgoprojV1alpha1().Rollouts(c.rollout.Namespace).Update(c.rollout)
 		if roErr == nil {
-			logCtx.Warnf("Found a hash collision - bumped collisionCount (%d->%d) to resolve it", preCollisionCount, *rollout.Status.CollisionCount)
+			c.log.Warnf("Found a hash collision - bumped collisionCount (%d->%d) to resolve it", preCollisionCount, *c.rollout.Status.CollisionCount)
 		}
 		return nil, err
 	case err != nil:
 		msg := fmt.Sprintf(conditions.FailedRSCreateMessage, newRS.Name, err)
-		c.recorder.Event(rollout, corev1.EventTypeWarning, conditions.FailedRSCreateReason, msg)
-		newStatus := rollout.Status.DeepCopy()
+		c.recorder.Event(c.rollout, corev1.EventTypeWarning, conditions.FailedRSCreateReason, msg)
+		newStatus := c.rollout.Status.DeepCopy()
 		cond := conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionFalse, conditions.FailedRSCreateReason, msg)
-		patchErr := c.patchCondition(rollout, newStatus, cond)
+		patchErr := c.patchCondition(c.rollout, newStatus, cond)
 		if patchErr != nil {
-			logCtx.Warnf("Error Patching Rollout: %s", patchErr.Error())
+			c.log.Warnf("Error Patching Rollout: %s", patchErr.Error())
 		}
 		return nil, err
 	}
 
 	if !alreadyExists && newReplicasCount > 0 {
-		c.recorder.Eventf(rollout, corev1.EventTypeNormal, "ScalingReplicaSet", "Scaled up replica set %s to %d", createdRS.Name, newReplicasCount)
+		c.recorder.Eventf(c.rollout, corev1.EventTypeNormal, "ScalingReplicaSet", "Scaled up replica set %s to %d", createdRS.Name, newReplicasCount)
 	}
 
-	needsUpdate := annotations.SetRolloutRevision(rollout, newRevision)
+	needsUpdate := annotations.SetRolloutRevision(c.rollout, newRevision)
 	if !alreadyExists {
 		msg := fmt.Sprintf(conditions.NewReplicaSetMessage, createdRS.Name)
 		condition := conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionTrue, conditions.NewReplicaSetReason, msg)
-		conditions.SetRolloutCondition(&rollout.Status, *condition)
+		conditions.SetRolloutCondition(&c.rollout.Status, *condition)
 		needsUpdate = true
 	}
 
 	if needsUpdate {
-		_, err = c.argoprojclientset.ArgoprojV1alpha1().Rollouts(rollout.Namespace).Update(rollout)
+		_, err = c.argoprojclientset.ArgoprojV1alpha1().Rollouts(c.rollout.Namespace).Update(c.rollout)
 	}
 	return createdRS, err
 }
 
 // syncReplicasOnly is responsible for reconciling rollouts on scaling events.
-func (c *Controller) syncReplicasOnly(r *v1alpha1.Rollout, rsList []*appsv1.ReplicaSet, isScaling bool) error {
-	logCtx := logutil.WithRollout(r)
-	logCtx.Infof("Syncing replicas only (userPaused %v, isScaling: %v)", r.Spec.Paused, isScaling)
-	newRS, oldRSs, err := c.getAllReplicaSetsAndSyncRevision(r, rsList, false)
-	if err != nil {
-		return err
-	}
-
-	arList, err := c.getAnalysisRunsForRollout(r)
+func (c *rolloutContext) syncReplicasOnly(r *v1alpha1.Rollout, rsList []*appsv1.ReplicaSet, isScaling bool) error {
+	c.log.Infof("Syncing replicas only (userPaused %v, isScaling: %v)", r.Spec.Paused, isScaling)
+	err := c.getAllReplicaSetsAndSyncRevision(false)
 	if err != nil {
 		return err
 	}
 
 	// NOTE: it is possible for newRS to be nil (e.g. when template and replicas changed at same time)
 	if r.Spec.Strategy.BlueGreen != nil {
-		roCtx := newBlueGreenCtx(r, newRS, oldRSs, arList)
 		previewSvc, activeSvc, err := c.getPreviewAndActiveServices(r)
 		// Keep existing analysis runs if the rollout is paused
-		roCtx.SetCurrentAnalysisRuns(roCtx.CurrentAnalysisRuns())
+		c.SetCurrentAnalysisRuns(c.currentArs)
 		if err != nil {
 			return nil
 		}
-		err = c.podRestarter.Reconcile(roCtx)
+		err = c.podRestarter.Reconcile(c)
 		if err != nil {
 			return err
 		}
-		if err := c.reconcileBlueGreenReplicaSets(roCtx, activeSvc); err != nil {
+		if err := c.reconcileBlueGreenReplicaSets(activeSvc); err != nil {
 			// If we get an error while trying to scale, the rollout will be requeued
 			// so we can abort this resync
 			return err
 		}
-		return c.syncRolloutStatusBlueGreen(previewSvc, activeSvc, roCtx)
+		return c.syncRolloutStatusBlueGreen(previewSvc, activeSvc)
 	}
 	// The controller wants to use the rolloutCanary method to reconcile the rolllout if the rollout is not paused.
 	// If there are no scaling events, the rollout should only sync its status
 	if r.Spec.Strategy.Canary != nil {
-		exList, err := c.getExperimentsForRollout(r)
-		if err != nil {
-			return err
-		}
-
-		roCtx := newCanaryCtx(r, newRS, oldRSs, exList, arList)
-		err = c.podRestarter.Reconcile(roCtx)
+		err = c.podRestarter.Reconcile(c)
 		if err != nil {
 			return err
 		}
 
 		if isScaling {
-			if _, err := c.reconcileCanaryReplicaSets(roCtx); err != nil {
+			if _, err := c.reconcileCanaryReplicaSets(); err != nil {
 				// If we get an error while trying to scale, the rollout will be requeued
 				// so we can abort this resync
 				return err
 			}
 		}
 		// Reconciling AnalysisRuns to manage Background AnalysisRun if necessary
-		err = c.reconcileAnalysisRuns(roCtx)
+		err = c.reconcileAnalysisRuns()
 		if err != nil {
 			return err
 		}
 
 		// reconcileCanaryPause will ensure we will requeue this rollout at the appropriate time
 		// if we are at a pause step with a duration.
-		c.reconcileCanaryPause(roCtx)
-		err = c.reconcileStableAndCanaryService(roCtx)
+		c.reconcileCanaryPause()
+		err = c.reconcileStableAndCanaryService()
 		if err != nil {
 			return err
 		}
 
-		err = c.reconcileTrafficRouting(roCtx)
+		err = c.reconcileTrafficRouting()
 		if err != nil {
 			return err
 		}
 
-		return c.syncRolloutStatusCanary(roCtx)
+		return c.syncRolloutStatusCanary()
 	}
 	return fmt.Errorf("no rollout strategy provided")
 }
@@ -295,29 +290,27 @@ func (c *Controller) syncReplicasOnly(r *v1alpha1.Rollout, rsList []*appsv1.Repl
 // by looking at the desired-replicas annotation in the active replica sets of the rollout.
 //
 // rsList should come from getReplicaSetsForRollout(r).
-func (c *Controller) isScalingEvent(rollout *v1alpha1.Rollout, rsList []*appsv1.ReplicaSet) (bool, error) {
-	newRS, previousRSs, err := c.getAllReplicaSetsAndSyncRevision(rollout, rsList, false)
+func (c *rolloutContext) isScalingEvent() (bool, error) {
+	err := c.getAllReplicaSetsAndSyncRevision(false)
 	if err != nil {
 		return false, err
 	}
 
-	allRSs := append(previousRSs, newRS)
-
-	for _, rs := range controller.FilterActiveReplicaSets(allRSs) {
+	for _, rs := range controller.FilterActiveReplicaSets(c.allRSs) {
 		desired, ok := annotations.GetDesiredReplicasAnnotation(rs)
 		if !ok {
 			continue
 		}
-		if desired != defaults.GetReplicasOrDefault(rollout.Spec.Replicas) {
+		if desired != defaults.GetReplicasOrDefault(c.rollout.Spec.Replicas) {
 			return true, nil
 		}
 	}
 	return false, nil
 }
 
-func (c *Controller) scaleReplicaSetAndRecordEvent(rs *appsv1.ReplicaSet, newScale int32, rollout *v1alpha1.Rollout) (bool, *appsv1.ReplicaSet, error) {
+func (c *rolloutContext) scaleReplicaSetAndRecordEvent(rs *appsv1.ReplicaSet, newScale int32) (bool, *appsv1.ReplicaSet, error) {
 	// No need to scale
-	if *(rs.Spec.Replicas) == newScale && !annotations.ReplicasAnnotationsNeedUpdate(rs, defaults.GetReplicasOrDefault(rollout.Spec.Replicas)) {
+	if *(rs.Spec.Replicas) == newScale && !annotations.ReplicasAnnotationsNeedUpdate(rs, defaults.GetReplicasOrDefault(c.rollout.Spec.Replicas)) {
 		return false, rs, nil
 	}
 	var scalingOperation string
@@ -326,11 +319,11 @@ func (c *Controller) scaleReplicaSetAndRecordEvent(rs *appsv1.ReplicaSet, newSca
 	} else {
 		scalingOperation = "down"
 	}
-	scaled, newRS, err := c.scaleReplicaSet(rs, newScale, rollout, scalingOperation)
+	scaled, newRS, err := c.scaleReplicaSet(rs, newScale, c.rollout, scalingOperation)
 	return scaled, newRS, err
 }
 
-func (c *Controller) scaleReplicaSet(rs *appsv1.ReplicaSet, newScale int32, rollout *v1alpha1.Rollout, scalingOperation string) (bool, *appsv1.ReplicaSet, error) {
+func (c *rolloutContext) scaleReplicaSet(rs *appsv1.ReplicaSet, newScale int32, rollout *v1alpha1.Rollout, scalingOperation string) (bool, *appsv1.ReplicaSet, error) {
 
 	sizeNeedsUpdate := *(rs.Spec.Replicas) != newScale
 	fullScaleDown := newScale == int32(0)
@@ -356,47 +349,42 @@ func (c *Controller) scaleReplicaSet(rs *appsv1.ReplicaSet, newScale int32, roll
 }
 
 // calculateStatus calculates the common fields for all rollouts by looking into the provided replica sets.
-func (c *Controller) calculateBaseStatus(roCtx rolloutContext) v1alpha1.RolloutStatus {
-	rollout := roCtx.Rollout()
-	newRS := roCtx.NewRS()
-	allRSs := roCtx.AllRSs()
-	prevStatus := rollout.Status
+func (c *rolloutContext) calculateBaseStatus() v1alpha1.RolloutStatus {
+	prevStatus := c.rollout.Status
 
 	prevCond := conditions.GetRolloutCondition(prevStatus, v1alpha1.InvalidSpec)
-	err := c.getRolloutValidationErrors(rollout)
+	err := c.getRolloutValidationErrors()
 	if err == nil && prevCond != nil {
 		conditions.RemoveRolloutCondition(&prevStatus, v1alpha1.InvalidSpec)
 	}
 
 	var currentPodHash string
-	if newRS == nil {
+	if c.newRS == nil {
 		// newRS potentially might be nil when called by Controller::syncReplicasOnly(). For this
 		// to happen, the user would have had to simultaneously change the number of replicas, and
 		// the pod template spec at the same time.
-		currentPodHash = controller.ComputeHash(&rollout.Spec.Template, rollout.Status.CollisionCount)
-		logutil.WithRollout(rollout).Warnf("Assuming %s for new replicaset pod hash", currentPodHash)
+		currentPodHash = controller.ComputeHash(&c.rollout.Spec.Template, c.rollout.Status.CollisionCount)
+		logutil.WithRollout(c.rollout).Warnf("Assuming %s for new replicaset pod hash", currentPodHash)
 	} else {
-		currentPodHash = newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+		currentPodHash = c.newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 	}
 
-	newStatus := roCtx.NewStatus()
+	newStatus := c.newStatus
 	newStatus.CurrentPodHash = currentPodHash
-	newStatus.Replicas = replicasetutil.GetActualReplicaCountForReplicaSets(allRSs)
-	newStatus.UpdatedReplicas = replicasetutil.GetActualReplicaCountForReplicaSets([]*appsv1.ReplicaSet{newRS})
-	newStatus.ReadyReplicas = replicasetutil.GetReadyReplicaCountForReplicaSets(allRSs)
-	newStatus.CollisionCount = rollout.Status.CollisionCount
+	newStatus.Replicas = replicasetutil.GetActualReplicaCountForReplicaSets(c.allRSs)
+	newStatus.UpdatedReplicas = replicasetutil.GetActualReplicaCountForReplicaSets([]*appsv1.ReplicaSet{c.newRS})
+	newStatus.ReadyReplicas = replicasetutil.GetReadyReplicaCountForReplicaSets(c.allRSs)
+	newStatus.CollisionCount = c.rollout.Status.CollisionCount
 	newStatus.Conditions = prevStatus.Conditions
-	newStatus.RestartedAt = roCtx.NewStatus().RestartedAt
+	newStatus.RestartedAt = c.newStatus.RestartedAt
 	return newStatus
 }
 
 // cleanupRollout is responsible for cleaning up a rollout ie. retains all but the latest N old replica sets
 // where N=r.Spec.RevisionHistoryLimit. Old replica sets are older versions of the podtemplate of a rollout kept
 // around by default 1) for historical reasons.
-func (c *Controller) cleanupRollouts(oldRSs []*appsv1.ReplicaSet, roCtx rolloutContext) error {
-	rollout := roCtx.Rollout()
-	logCtx := roCtx.Log()
-	revHistoryLimit := defaults.GetRevisionHistoryLimitOrDefault(rollout)
+func (c *rolloutContext) cleanupRollouts(oldRSs []*appsv1.ReplicaSet) error {
+	revHistoryLimit := defaults.GetRevisionHistoryLimitOrDefault(c.rollout)
 
 	// Avoid deleting replica set with deletion timestamp set
 	aliveFilter := func(rs *appsv1.ReplicaSet) bool {
@@ -410,16 +398,16 @@ func (c *Controller) cleanupRollouts(oldRSs []*appsv1.ReplicaSet, roCtx rolloutC
 	}
 
 	sort.Sort(controller.ReplicaSetsByCreationTimestamp(cleanableRSes))
-	podHashToArList := analysisutil.SortAnalysisRunByPodHash(roCtx.OtherAnalysisRuns())
-	podHashToExList := experimentutil.SortExperimentsByPodHash(roCtx.OtherExperiments())
-	logCtx.Info("Looking to cleanup old replica sets")
+	podHashToArList := analysisutil.SortAnalysisRunByPodHash(c.otherArs)
+	podHashToExList := experimentutil.SortExperimentsByPodHash(c.otherExs)
+	c.log.Info("Looking to cleanup old replica sets")
 	for i := int32(0); i < diff; i++ {
 		rs := cleanableRSes[i]
 		// Avoid delete replica set with non-zero replica counts
 		if rs.Status.Replicas != 0 || *(rs.Spec.Replicas) != 0 || rs.Generation > rs.Status.ObservedGeneration || rs.DeletionTimestamp != nil {
 			continue
 		}
-		logCtx.Infof("Trying to cleanup replica set %q", rs.Name)
+		c.log.Infof("Trying to cleanup replica set %q", rs.Name)
 		if err := c.kubeclientset.AppsV1().ReplicaSets(rs.Namespace).Delete(rs.Name, nil); err != nil && !errors.IsNotFound(err) {
 			// Return error instead of aggregating and continuing DELETEs on the theory
 			// that we may be overloading the api server.
@@ -427,15 +415,15 @@ func (c *Controller) cleanupRollouts(oldRSs []*appsv1.ReplicaSet, roCtx rolloutC
 		}
 		if podHash, ok := rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]; ok {
 			if ars, ok := podHashToArList[podHash]; ok {
-				logCtx.Infof("Cleaning up associated analysis runs with ReplicaSet '%s'", rs.Name)
-				err := c.deleteAnalysisRuns(roCtx, ars)
+				c.log.Infof("Cleaning up associated analysis runs with ReplicaSet '%s'", rs.Name)
+				err := c.deleteAnalysisRuns(ars)
 				if err != nil {
 					return err
 				}
 			}
 			if exs, ok := podHashToExList[podHash]; ok {
-				logCtx.Infof("Cleaning up associated experiments with ReplicaSet '%s'", rs.Name)
-				err := c.deleteExperiments(roCtx, exs)
+				c.log.Infof("Cleaning up associated experiments with ReplicaSet '%s'", rs.Name)
+				err := c.deleteExperiments(exs)
 				if err != nil {
 					return err
 				}
@@ -449,15 +437,15 @@ func (c *Controller) cleanupRollouts(oldRSs []*appsv1.ReplicaSet, roCtx rolloutC
 // checkPausedConditions checks if the given rollout is paused or not and adds an appropriate condition.
 // These conditions are needed so that we won't accidentally report lack of progress for resumed rollouts
 // that were paused for longer than progressDeadlineSeconds.
-func (c *Controller) checkPausedConditions(r *v1alpha1.Rollout) error {
-	cond := conditions.GetRolloutCondition(r.Status, v1alpha1.RolloutProgressing)
+func (c *rolloutContext) checkPausedConditions() error {
+	cond := conditions.GetRolloutCondition(c.rollout.Status, v1alpha1.RolloutProgressing)
 	if cond != nil && cond.Reason == conditions.TimedOutReason {
 		// If we have reported lack of progress, do not overwrite it with a paused condition.
 		return nil
 	}
 	pausedCondExists := cond != nil && cond.Reason == conditions.PausedRolloutReason
 
-	isPaused := len(r.Status.PauseConditions) > 0 || r.Spec.Paused
+	isPaused := len(c.rollout.Status.PauseConditions) > 0 || c.rollout.Spec.Paused
 	var updatedConditon *v1alpha1.RolloutCondition
 	if isPaused && !pausedCondExists {
 		updatedConditon = conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionUnknown, conditions.PausedRolloutReason, conditions.PausedRolloutMessage)
@@ -466,7 +454,7 @@ func (c *Controller) checkPausedConditions(r *v1alpha1.Rollout) error {
 	}
 
 	abortCondExists := cond != nil && cond.Reason == conditions.RolloutAbortedReason
-	if !r.Status.Abort && abortCondExists {
+	if !c.rollout.Status.Abort && abortCondExists {
 		updatedConditon = conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionUnknown, conditions.RolloutRetryReason, conditions.RolloutRetryMessage)
 	}
 
@@ -474,12 +462,12 @@ func (c *Controller) checkPausedConditions(r *v1alpha1.Rollout) error {
 		return nil
 	}
 
-	newStatus := r.Status.DeepCopy()
-	err := c.patchCondition(r, newStatus, updatedConditon)
+	newStatus := c.rollout.Status.DeepCopy()
+	err := c.patchCondition(c.rollout, newStatus, updatedConditon)
 	return err
 }
 
-func (c *Controller) patchCondition(r *v1alpha1.Rollout, newStatus *v1alpha1.RolloutStatus, condition *v1alpha1.RolloutCondition) error {
+func (c *rolloutContext) patchCondition(r *v1alpha1.Rollout, newStatus *v1alpha1.RolloutStatus, condition *v1alpha1.RolloutCondition) error {
 	conditions.SetRolloutCondition(newStatus, *condition)
 	newStatus.ObservedGeneration = conditions.ComputeGenerationHash(r.Spec)
 
@@ -516,45 +504,42 @@ func isIndefiniteStep(r *v1alpha1.Rollout) bool {
 	return currentStep != nil && (currentStep.Experiment != nil || currentStep.Analysis != nil)
 }
 
-func (c *Controller) calculateRolloutConditions(roCtx rolloutContext, newStatus v1alpha1.RolloutStatus) v1alpha1.RolloutStatus {
-	r := roCtx.Rollout()
-	allRSs := roCtx.AllRSs()
-	newRS := roCtx.NewRS()
-	if len(r.Status.PauseConditions) > 0 || r.Spec.Paused {
+func (c *rolloutContext) calculateRolloutConditions(newStatus v1alpha1.RolloutStatus) v1alpha1.RolloutStatus {
+	if len(c.rollout.Status.PauseConditions) > 0 || c.rollout.Spec.Paused {
 		return newStatus
 	}
 
 	// If there is only one replica set that is active then that means we are not running
 	// a new rollout and this is a resync where we don't need to estimate any progress.
 	// In such a case, we should simply not estimate any progress for this rollout.
-	currentCond := conditions.GetRolloutCondition(r.Status, v1alpha1.RolloutProgressing)
+	currentCond := conditions.GetRolloutCondition(c.rollout.Status, v1alpha1.RolloutProgressing)
 	isCompleteRollout := newStatus.Replicas == newStatus.AvailableReplicas && currentCond != nil && currentCond.Reason == conditions.NewRSAvailableReason
 	// Check for progress only if the latest rollout hasn't completed yet.
 	if !isCompleteRollout {
 		switch {
-		case roCtx.PauseContext().IsAborted():
+		case c.pauseContext.IsAborted():
 			var condition *v1alpha1.RolloutCondition
-			if roCtx.PauseContext().abortMessage != "" {
-				condition = conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionFalse, conditions.RolloutAbortedReason, roCtx.PauseContext().abortMessage)
+			if c.pauseContext.abortMessage != "" {
+				condition = conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionFalse, conditions.RolloutAbortedReason, c.pauseContext.abortMessage)
 			} else {
 				condition = conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionFalse, conditions.RolloutAbortedReason, conditions.RolloutAbortedMessage)
 			}
 			conditions.SetRolloutCondition(&newStatus, *condition)
-		case conditions.RolloutComplete(r, &newStatus):
+		case conditions.RolloutComplete(c.rollout, &newStatus):
 			// Update the rollout conditions with a message for the new replica set that
 			// was successfully deployed. If the condition already exists, we ignore this update.
-			msg := fmt.Sprintf(conditions.RolloutCompletedMessage, r.Name)
-			if newRS != nil {
-				msg = fmt.Sprintf(conditions.ReplicaSetCompletedMessage, newRS.Name)
+			msg := fmt.Sprintf(conditions.RolloutCompletedMessage, c.rollout.Name)
+			if c.newRS != nil {
+				msg = fmt.Sprintf(conditions.ReplicaSetCompletedMessage, c.newRS.Name)
 			}
 			condition := conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionTrue, conditions.NewRSAvailableReason, msg)
 			conditions.SetRolloutCondition(&newStatus, *condition)
-		case conditions.RolloutProgressing(r, &newStatus):
+		case conditions.RolloutProgressing(c.rollout, &newStatus):
 			// If there is any progress made, continue by not checking if the rollout failed. This
 			// behavior emulates the rolling updater progressDeadline check.
-			msg := fmt.Sprintf(conditions.RolloutProgressingMessage, r.Name)
-			if newRS != nil {
-				msg = fmt.Sprintf(conditions.ReplicaSetProgressingMessage, newRS.Name)
+			msg := fmt.Sprintf(conditions.RolloutProgressingMessage, c.rollout.Name)
+			if c.newRS != nil {
+				msg = fmt.Sprintf(conditions.ReplicaSetProgressingMessage, c.newRS.Name)
 			}
 			condition := conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionTrue, conditions.ReplicaSetUpdatedReason, msg)
 			// Update the current Progressing condition or add a new one if it doesn't exist.
@@ -571,23 +556,23 @@ func (c *Controller) calculateRolloutConditions(roCtx rolloutContext, newStatus 
 				conditions.RemoveRolloutCondition(&newStatus, v1alpha1.RolloutProgressing)
 			}
 			conditions.SetRolloutCondition(&newStatus, *condition)
-		case !isIndefiniteStep(r) && conditions.RolloutTimedOut(r, &newStatus):
+		case !isIndefiniteStep(c.rollout) && conditions.RolloutTimedOut(c.rollout, &newStatus):
 			// Update the rollout with a timeout condition. If the condition already exists,
 			// we ignore this update.
-			msg := fmt.Sprintf(conditions.RolloutTimeOutMessage, r.Name)
-			if newRS != nil {
-				msg = fmt.Sprintf(conditions.ReplicaSetTimeOutMessage, newRS.Name)
+			msg := fmt.Sprintf(conditions.RolloutTimeOutMessage, c.rollout.Name)
+			if c.newRS != nil {
+				msg = fmt.Sprintf(conditions.ReplicaSetTimeOutMessage, c.newRS.Name)
 			}
 			condition := conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionFalse, conditions.TimedOutReason, msg)
 			conditions.SetRolloutCondition(&newStatus, *condition)
 		}
 	}
 
-	activeRS, _ := replicasetutil.GetReplicaSetByTemplateHash(allRSs, newStatus.BlueGreen.ActiveSelector)
-	if r.Spec.Strategy.BlueGreen != nil && activeRS != nil && annotations.IsSaturated(r, activeRS) {
+	activeRS, _ := replicasetutil.GetReplicaSetByTemplateHash(c.allRSs, newStatus.BlueGreen.ActiveSelector)
+	if c.rollout.Spec.Strategy.BlueGreen != nil && activeRS != nil && annotations.IsSaturated(c.rollout, activeRS) {
 		availability := conditions.NewRolloutCondition(v1alpha1.RolloutAvailable, corev1.ConditionTrue, conditions.AvailableReason, conditions.AvailableMessage)
 		conditions.SetRolloutCondition(&newStatus, *availability)
-	} else if r.Spec.Strategy.Canary != nil && replicasetutil.GetAvailableReplicaCountForReplicaSets(allRSs) >= defaults.GetReplicasOrDefault(r.Spec.Replicas) {
+	} else if c.rollout.Spec.Strategy.Canary != nil && replicasetutil.GetAvailableReplicaCountForReplicaSets(c.allRSs) >= defaults.GetReplicasOrDefault(c.rollout.Spec.Replicas) {
 		availability := conditions.NewRolloutCondition(v1alpha1.RolloutAvailable, corev1.ConditionTrue, conditions.AvailableReason, conditions.AvailableMessage)
 		conditions.SetRolloutCondition(&newStatus, *availability)
 	} else {
@@ -597,7 +582,7 @@ func (c *Controller) calculateRolloutConditions(roCtx rolloutContext, newStatus 
 
 	// Move failure conditions of all replica sets in rollout conditions. For now,
 	// only one failure condition is returned from getReplicaFailures.
-	if replicaFailureCond := c.getReplicaFailures(allRSs, newRS); len(replicaFailureCond) > 0 {
+	if replicaFailureCond := c.getReplicaFailures(c.allRSs, c.newRS); len(replicaFailureCond) > 0 {
 		// There will be only one ReplicaFailure condition on the replica set.
 		conditions.SetRolloutCondition(&newStatus, replicaFailureCond[0])
 	} else {
@@ -607,34 +592,32 @@ func (c *Controller) calculateRolloutConditions(roCtx rolloutContext, newStatus 
 }
 
 // persistRolloutStatus persists updates to rollout status. If no changes were made, it is a no-op
-func (c *Controller) persistRolloutStatus(roCtx rolloutContext, newStatus *v1alpha1.RolloutStatus) error {
-	orig := roCtx.Rollout()
-	roCtx.PauseContext().CalculatePauseStatus(newStatus)
-	newStatus.ObservedGeneration = conditions.ComputeGenerationHash(orig.Spec)
-	logCtx := logutil.WithRollout(orig)
+func (c *rolloutContext) persistRolloutStatus(newStatus *v1alpha1.RolloutStatus) error {
+	c.pauseContext.CalculatePauseStatus(newStatus)
+	newStatus.ObservedGeneration = conditions.ComputeGenerationHash(c.rollout.Spec)
 	patch, modified, err := diff.CreateTwoWayMergePatch(
 		&v1alpha1.Rollout{
-			Status: orig.Status,
+			Status: c.rollout.Status,
 		},
 		&v1alpha1.Rollout{
 			Status: *newStatus,
 		}, v1alpha1.Rollout{})
 	if err != nil {
-		logCtx.Errorf("Error constructing app status patch: %v", err)
+		c.log.Errorf("Error constructing app status patch: %v", err)
 		return err
 	}
 	if !modified {
-		logCtx.Info("No status changes. Skipping patch")
-		c.requeueStuckRollout(orig, *newStatus)
+		c.log.Info("No status changes. Skipping patch")
+		c.requeueStuckRollout(c.rollout, *newStatus)
 		return nil
 	}
-	logCtx.Debugf("Rollout Patch: %s", patch)
-	_, err = c.argoprojclientset.ArgoprojV1alpha1().Rollouts(orig.Namespace).Patch(orig.Name, patchtypes.MergePatchType, patch)
+	c.log.Debugf("Rollout Patch: %s", patch)
+	_, err = c.argoprojclientset.ArgoprojV1alpha1().Rollouts(c.rollout.Namespace).Patch(c.rollout.Name, patchtypes.MergePatchType, patch)
 	if err != nil {
-		logCtx.Warningf("Error updating application: %v", err)
+		c.log.Warningf("Error updating application: %v", err)
 		return err
 	}
-	logCtx.Info("Patch status successfully")
+	c.log.Info("Patch status successfully")
 	return nil
 }
 
@@ -644,7 +627,7 @@ var nowFn = func() time.Time { return time.Now() }
 // requeueStuckRollout checks whether the provided rollout needs to be synced for a progress
 // check. It returns the time after the rollout will be requeued for the progress check, 0 if it
 // will be requeued now, or -1 if it does not need to be requeued.
-func (c *Controller) requeueStuckRollout(r *v1alpha1.Rollout, newStatus v1alpha1.RolloutStatus) time.Duration {
+func (c *rolloutContext) requeueStuckRollout(r *v1alpha1.Rollout, newStatus v1alpha1.RolloutStatus) time.Duration {
 	logctx := logutil.WithRollout(r)
 	currentCond := conditions.GetRolloutCondition(r.Status, v1alpha1.RolloutProgressing)
 	// Can't estimate progress if there is no deadline in the spec or progressing condition in the current status.
@@ -677,7 +660,7 @@ func (c *Controller) requeueStuckRollout(r *v1alpha1.Rollout, newStatus v1alpha1
 	// Make it ratelimited so we stay on the safe side, eventually the Deployment should
 	// transition either to a Complete or to a TimedOut condition.
 	if after < time.Second {
-		logctx.Infof("Queueing up Rollout for a progress check now")
+		c.log.Infof("Queueing up Rollout for a progress check now")
 		c.enqueueRollout(r)
 		return time.Duration(0)
 	}
@@ -690,7 +673,7 @@ func (c *Controller) requeueStuckRollout(r *v1alpha1.Rollout, newStatus v1alpha1
 
 // getReplicaFailures will convert replica failure conditions from replica sets
 // to rollout conditions.
-func (c *Controller) getReplicaFailures(allRSs []*appsv1.ReplicaSet, newRS *appsv1.ReplicaSet) []v1alpha1.RolloutCondition {
+func (c *rolloutContext) getReplicaFailures(allRSs []*appsv1.ReplicaSet, newRS *appsv1.ReplicaSet) []v1alpha1.RolloutCondition {
 	var errorConditions []v1alpha1.RolloutCondition
 	if newRS != nil {
 		for _, c := range newRS.Status.Conditions {

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -19,7 +19,7 @@ type TrafficRoutingReconciler interface {
 
 // NewTrafficRoutingReconciler identifies return the TrafficRouting Plugin that the rollout wants to modify
 func (c *Controller) NewTrafficRoutingReconciler(roCtx rolloutContext) (TrafficRoutingReconciler, error) {
-	rollout := roCtx.Rollout()
+	rollout := roCtx.rollout
 	if rollout.Spec.Strategy.Canary.TrafficRouting == nil {
 		return nil, nil
 	}
@@ -60,47 +60,43 @@ func (c *Controller) NewTrafficRoutingReconciler(roCtx rolloutContext) (TrafficR
 	return nil, nil
 }
 
-func (c *Controller) reconcileTrafficRouting(roCtx *canaryContext) error {
-	rollout := roCtx.Rollout()
-	reconciler, err := c.newTrafficRoutingReconciler(roCtx)
+func (c *rolloutContext) reconcileTrafficRouting() error {
+	reconciler, err := c.newTrafficRoutingReconciler(*c)
 	if err != nil {
 		return err
 	}
 	if reconciler == nil {
 		return nil
 	}
-	roCtx.Log().Infof("Reconciling TrafficRouting with type '%s'", reconciler.Type())
-	newRS := roCtx.NewRS()
-	stableRS := roCtx.StableRS()
-	olderRS := roCtx.OlderRSs()
+	c.log.Infof("Reconciling TrafficRouting with type '%s'", reconciler.Type())
 
-	_, index := replicasetutil.GetCurrentCanaryStep(rollout)
+	_, index := replicasetutil.GetCurrentCanaryStep(c.rollout)
 	desiredWeight := int32(0)
 	if index != nil {
-		atDesiredReplicaCount := replicasetutil.AtDesiredReplicaCountsForCanary(rollout, newRS, stableRS, olderRS)
+		atDesiredReplicaCount := replicasetutil.AtDesiredReplicaCountsForCanary(c.rollout, c.newRS, c.stableRS, c.olderRSs)
 		if !atDesiredReplicaCount {
 			// Use the previous weight since the new RS is not ready for a new weight
 			for i := *index - 1; i >= 0; i-- {
-				step := rollout.Spec.Strategy.Canary.Steps[i]
+				step := c.rollout.Spec.Strategy.Canary.Steps[i]
 				if step.SetWeight != nil {
 					desiredWeight = *step.SetWeight
 					break
 				}
 			}
-		} else if *index != int32(len(rollout.Spec.Strategy.Canary.Steps)) {
+		} else if *index != int32(len(c.rollout.Spec.Strategy.Canary.Steps)) {
 			// This if statement prevents the desiredWeight from being set to 100
 			// when the rollout has progressed through all the steps. The rollout
 			// should send all traffic to the stable service by using a weight of
 			// 0. If the rollout is progressing through the steps, the desired
 			// weight of the traffic routing service should be at the value of the
 			// last setWeight step, which is set by GetCurrentSetWeight.
-			desiredWeight = replicasetutil.GetCurrentSetWeight(rollout)
+			desiredWeight = replicasetutil.GetCurrentSetWeight(c.rollout)
 		}
 	}
 
 	err = reconciler.Reconcile(desiredWeight)
 	if err != nil {
-		c.recorder.Event(rollout, corev1.EventTypeWarning, "TrafficRoutingError", err.Error())
+		c.recorder.Event(c.rollout, corev1.EventTypeWarning, "TrafficRoutingError", err.Error())
 	}
 	return err
 }

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -18,7 +18,7 @@ type TrafficRoutingReconciler interface {
 }
 
 // NewTrafficRoutingReconciler identifies return the TrafficRouting Plugin that the rollout wants to modify
-func (c *Controller) NewTrafficRoutingReconciler(roCtx rolloutContext) (TrafficRoutingReconciler, error) {
+func (c *Controller) NewTrafficRoutingReconciler(roCtx *rolloutContext) (TrafficRoutingReconciler, error) {
 	rollout := roCtx.rollout
 	if rollout.Spec.Strategy.Canary.TrafficRouting == nil {
 		return nil, nil
@@ -61,7 +61,7 @@ func (c *Controller) NewTrafficRoutingReconciler(roCtx rolloutContext) (TrafficR
 }
 
 func (c *rolloutContext) reconcileTrafficRouting() error {
-	reconciler, err := c.newTrafficRoutingReconciler(*c)
+	reconciler, err := c.newTrafficRoutingReconciler(c)
 	if err != nil {
 		return err
 	}

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -216,7 +216,7 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 
 	{
 		r := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
-		roCtx := &canaryContext{
+		roCtx := &rolloutContext{
 			rollout: r,
 			log:     logutil.WithRollout(r),
 		}
@@ -227,7 +227,7 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 	{
 		r := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
 		r.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
-		roCtx := &canaryContext{
+		roCtx := &rolloutContext{
 			rollout: r,
 			log:     logutil.WithRollout(r),
 		}
@@ -241,7 +241,7 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 		r.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 			Istio: &v1alpha1.IstioTrafficRouting{},
 		}
-		roCtx := &canaryContext{
+		roCtx := &rolloutContext{
 			rollout: r,
 			log:     logutil.WithRollout(r),
 		}
@@ -261,7 +261,7 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 		r.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 			Istio: &v1alpha1.IstioTrafficRouting{},
 		}
-		roCtx := &canaryContext{
+		roCtx := &rolloutContext{
 			rollout: r,
 			log:     logutil.WithRollout(r),
 		}
@@ -275,7 +275,7 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 		r.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 			Nginx: &v1alpha1.NginxTrafficRouting{},
 		}
-		roCtx := &canaryContext{
+		roCtx := &rolloutContext{
 			rollout: r,
 			log:     logutil.WithRollout(r),
 		}
@@ -289,7 +289,7 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 		r.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 			ALB: &v1alpha1.ALBTrafficRouting{},
 		}
-		roCtx := &canaryContext{
+		roCtx := &rolloutContext{
 			rollout: r,
 			log:     logutil.WithRollout(r),
 		}
@@ -303,7 +303,7 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 		r.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 			SMI: &v1alpha1.SMITrafficRouting{},
 		}
-		roCtx := &canaryContext{
+		roCtx := &rolloutContext{
 			rollout: r,
 			log:     logutil.WithRollout(r),
 		}
@@ -318,7 +318,7 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 		r.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 			SMI: &v1alpha1.SMITrafficRouting{},
 		}
-		roCtx := &canaryContext{
+		roCtx := &rolloutContext{
 			rollout: r,
 			log:     logutil.WithRollout(r),
 		}

--- a/test/fixtures/e2e_suite.go
+++ b/test/fixtures/e2e_suite.go
@@ -2,6 +2,7 @@ package fixtures
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"strconv"
 	"time"
@@ -27,11 +28,11 @@ import (
 	istioutil "github.com/argoproj/argo-rollouts/utils/istio"
 )
 
-const (
-	DefaultTimeout time.Duration = time.Second * 30
-)
-
 var (
+	// E2EWaitTimeout is the timeout when waiting for a condition to become true
+	E2EWaitTimeout time.Duration = time.Second * 60
+
+	// E2E Label is the
 	E2ELabel = "argo-rollouts-e2e"
 
 	serviceGVR = schema.GroupVersionResource{
@@ -39,7 +40,8 @@ var (
 		Resource: "services",
 	}
 	ingressGVR = schema.GroupVersionResource{
-		Version:  "networking.k8s.io",
+		Group:    "networking.k8s.io",
+		Version:  "v1",
 		Resource: "ingresses",
 	}
 )
@@ -47,6 +49,13 @@ var (
 func init() {
 	if e2elabel, ok := os.LookupEnv("E2E_INSTANCE_ID"); ok {
 		E2ELabel = e2elabel
+	}
+	if e2eWaitTimeout, ok := os.LookupEnv("E2E_WAIT_TIMEOUT"); ok {
+		timeout, err := strconv.Atoi(e2eWaitTimeout)
+		if err != nil {
+			panic(fmt.Sprintf("Invalid wait timeout seconds: %s", e2eWaitTimeout))
+		}
+		E2EWaitTimeout = time.Duration(timeout) * time.Second
 	}
 }
 

--- a/test/fixtures/when.go
+++ b/test/fixtures/when.go
@@ -112,7 +112,7 @@ func (w *When) WaitForRolloutStatus(status string) *When {
 		}
 		return false
 	}
-	return w.WaitForRolloutCondition(checkStatus, fmt.Sprintf("status=%s", status), DefaultTimeout)
+	return w.WaitForRolloutCondition(checkStatus, fmt.Sprintf("status=%s", status), E2EWaitTimeout)
 }
 
 func (w *When) WaitForRolloutCanaryStepIndex(index int32) *When {
@@ -133,7 +133,7 @@ func (w *When) WaitForRolloutCanaryStepIndex(index int32) *When {
 		}
 		return true
 	}
-	return w.WaitForRolloutCondition(checkStatus, fmt.Sprintf("status.currentStepIndex=%d", index), DefaultTimeout)
+	return w.WaitForRolloutCondition(checkStatus, fmt.Sprintf("status.currentStepIndex=%d", index), E2EWaitTimeout)
 }
 
 func (w *When) WaitForRolloutCondition(test func(ro *rov1.Rollout) bool, condition string, timeout time.Duration) *When {

--- a/utils/annotations/annotations.go
+++ b/utils/annotations/annotations.go
@@ -121,7 +121,7 @@ func SetNewReplicaSetAnnotations(rollout *v1alpha1.Rollout, newRS *appsv1.Replic
 	if oldRevisionInt < newRevisionInt {
 		newRS.Annotations[RevisionAnnotation] = newRevision
 		annotationChanged = true
-		logCtx.Infof("Updating replica set '%s' revision to %s", newRS.Name, newRevision)
+		logCtx.Infof("Updating replica set '%s' revision from %d to %d", newRS.Name, oldRevisionInt, newRevisionInt)
 	}
 	// If a revision annotation already existed and this replica set was updated with a new revision
 	// then that means we are rolling back to this replica set. We need to preserve the old revisions


### PR DESCRIPTION
The Rollout Controller struct is currently overloaded. This change does the following:

1. removes all reconciliation logic in the Controller struct, and moves it into the existing rolloutContext object.
2. the rolloutContext object is no longer passed around from method to method, since all reconciliation functions are now member functions of the rolloutContext and can access the rollout fields/objects directly.
3. when a rolloutContext is instantiated, it gathers all objects associated with the rollout from the listers at the point of instantiation, rather than during the reconciliation
4. eliminates canaryCtx and blueGreenCtx objects, since they can be superseded by rolloutContext

There's probably more simplifications that can be done, but was already a huge refactor.
