### PR TITLE
chore: Set preserveUnknownFields: false to prevent mistake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ all: controller image
 codegen: mocks
 	./hack/update-codegen.sh
 	./hack/update-openapigen.sh
-	PATH=$$DIST_DIR:$$PATH go run ./hack/gen-crd-spec/main.go
+	PATH=${DIST_DIR}:$$PATH go run ./hack/gen-crd-spec/main.go
 
 .PHONY: controller
 controller: clean-debug

--- a/hack/gen-crd-spec/main.go
+++ b/hack/gen-crd-spec/main.go
@@ -57,6 +57,7 @@ func NewCustomResourceDefinition() []*extensionsobj.CustomResourceDefinition {
 		"controller-gen",
 		"paths=./pkg/apis/rollouts/...",
 		"crd:trivialVersions=true",
+		"crd:preserveUnknownFields=false",
 		"output:crd:stdout",
 	).Output()
 	if err != nil {

--- a/hack/gen-crd-spec/main.go
+++ b/hack/gen-crd-spec/main.go
@@ -72,6 +72,11 @@ func NewCustomResourceDefinition() []*extensionsobj.CustomResourceDefinition {
 	// clean up stuff left by controller-gen
 	deleteFile("config/webhook/manifests.yaml")
 	deleteFile("config/webhook")
+	deleteFile("config/argoproj.io_analysisruns.yaml")
+	deleteFile("config/argoproj.io_analysistemplates.yaml")
+	deleteFile("config/argoproj.io_clusteranalysistemplates.yaml")
+	deleteFile("config/argoproj.io_experiments.yaml")
+	deleteFile("config/argoproj.io_rollouts.yaml")
 	deleteFile("config")
 
 	crds := []*extensionsobj.CustomResourceDefinition{}

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -1,3 +1,5 @@
+#! /usr/bin/env bash
+
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/manifests/crds/analysis-run-crd.yaml
+++ b/manifests/crds/analysis-run-crd.yaml
@@ -18,6 +18,7 @@ spec:
     shortNames:
     - ar
     singular: analysisrun
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/manifests/crds/analysis-template-crd.yaml
+++ b/manifests/crds/analysis-template-crd.yaml
@@ -13,6 +13,7 @@ spec:
     shortNames:
     - at
     singular: analysistemplate
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/manifests/crds/cluster-analysis-template-crd.yaml
+++ b/manifests/crds/cluster-analysis-template-crd.yaml
@@ -13,6 +13,7 @@ spec:
     shortNames:
     - cat
     singular: clusteranalysistemplate
+  preserveUnknownFields: false
   scope: Cluster
   validation:
     openAPIV3Schema:

--- a/manifests/crds/experiment-crd.yaml
+++ b/manifests/crds/experiment-crd.yaml
@@ -18,6 +18,7 @@ spec:
     shortNames:
     - exp
     singular: experiment
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/manifests/crds/rollout-crd.yaml
+++ b/manifests/crds/rollout-crd.yaml
@@ -30,6 +30,7 @@ spec:
     shortNames:
     - ro
     singular: rollout
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     scale:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -19,6 +19,7 @@ spec:
     shortNames:
     - ar
     singular: analysisrun
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:
@@ -2824,6 +2825,7 @@ spec:
     shortNames:
     - at
     singular: analysistemplate
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -5556,6 +5558,7 @@ spec:
     shortNames:
     - cat
     singular: clusteranalysistemplate
+  preserveUnknownFields: false
   scope: Cluster
   validation:
     openAPIV3Schema:
@@ -8293,6 +8296,7 @@ spec:
     shortNames:
     - exp
     singular: experiment
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:
@@ -10964,13 +10968,11 @@ spec:
     name: Current
     type: integer
   - JSONPath: .status.updatedReplicas
-    description: Total number of non-terminated pods targeted by this rollout that
-      have the desired template spec
+    description: Total number of non-terminated pods targeted by this rollout that have the desired template spec
     name: Up-to-date
     type: integer
   - JSONPath: .status.availableReplicas
-    description: Total number of available pods (ready for at least minReadySeconds)
-      targeted by this rollout
+    description: Total number of available pods (ready for at least minReadySeconds) targeted by this rollout
     name: Available
     type: integer
   group: argoproj.io
@@ -10981,6 +10983,7 @@ spec:
     shortNames:
     - ro
     singular: rollout
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     scale:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -19,6 +19,7 @@ spec:
     shortNames:
     - ar
     singular: analysisrun
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:
@@ -2824,6 +2825,7 @@ spec:
     shortNames:
     - at
     singular: analysistemplate
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -5556,6 +5558,7 @@ spec:
     shortNames:
     - cat
     singular: clusteranalysistemplate
+  preserveUnknownFields: false
   scope: Cluster
   validation:
     openAPIV3Schema:
@@ -8293,6 +8296,7 @@ spec:
     shortNames:
     - exp
     singular: experiment
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:
@@ -10964,13 +10968,11 @@ spec:
     name: Current
     type: integer
   - JSONPath: .status.updatedReplicas
-    description: Total number of non-terminated pods targeted by this rollout that
-      have the desired template spec
+    description: Total number of non-terminated pods targeted by this rollout that have the desired template spec
     name: Up-to-date
     type: integer
   - JSONPath: .status.availableReplicas
-    description: Total number of available pods (ready for at least minReadySeconds)
-      targeted by this rollout
+    description: Total number of available pods (ready for at least minReadySeconds) targeted by this rollout
     name: Available
     type: integer
   group: argoproj.io
@@ -10981,6 +10983,7 @@ spec:
     shortNames:
     - ro
     singular: rollout
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     scale:


### PR DESCRIPTION
Setting `preserveUnknownFields: false` makes validation strict and can prevent nesting mistake like the following:

```yaml
strategy:
  # <= canary is missing!
  steps: [...]
```

https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
  * I think this is a chore
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).