### PR TITLE
[fix] Adds dependency to generate plugin-docs when serving locally (#707)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ release-docs: plugin-docs
 
 # convenience target to run `mkdocs serve` using a docker container
 .PHONY: serve-docs
-serve-docs:
+serve-docs: plugin-docs
 	docker run --rm -it -p 8000:8000 -v ${CURRENT_DIR}:/docs squidfunk/mkdocs-material serve -a 0.0.0.0:8000
 
 .PHONY: release-precheck


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [x] (n/a) I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] (n/a) My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md). <-- this file is missing (is this step obsolete?)

I'm keeping this as a DRAFT PR because this is _just_ a change I did to run the docs locally (while the site is not fixed, see #707). I understand it's not ideal since it adds extra load on every `make serve-docs`. Feel free to close if you think it's the wrong approach. This is my first time using `mkdocs` or navigating the Argo project repositories so I'm very unfamiliar with the tooling and how it's used here.

This is related to #707 but I don't think it's the fix. I suspect the fix requires extra improvements on the `release-docs` task in the makefile but I'd not sure how to test the contents produced are the expected output.