### PR TITLE
fix: do not create background analysisruns with initial deploy

### DIFF
--- a/rollout/analysis.go
+++ b/rollout/analysis.go
@@ -269,7 +269,7 @@ func (c *rolloutContext) reconcileBackgroundAnalysisRun() (*v1alpha1.AnalysisRun
 	}
 
 	// Do not create a background run if the rollout is completely rolled out, just created, before the starting step
-	if c.rollout.Status.StableRS == c.rollout.Status.CurrentPodHash || c.rollout.Status.CurrentPodHash == "" || replicasetutil.BeforeStartingStep(c.rollout) {
+	if c.rollout.Status.StableRS == c.rollout.Status.CurrentPodHash || c.rollout.Status.StableRS == "" || c.rollout.Status.CurrentPodHash == "" || replicasetutil.BeforeStartingStep(c.rollout) {
 		return nil, nil
 	}
 

--- a/test/e2e/functional/analysistemplate-echo-job.yaml
+++ b/test/e2e/functional/analysistemplate-echo-job.yaml
@@ -1,0 +1,18 @@
+kind: AnalysisTemplate
+apiVersion: argoproj.io/v1alpha1
+metadata:
+  name: echo-job
+spec:
+  metrics:
+  - name: echo-job
+    provider:
+      job:
+        spec:
+          template:
+            spec:
+              containers:
+              - name: sleep
+                image: alpine:3.12
+                command: [echo, done]
+              restartPolicy: Never
+          backoffLimit: 0

--- a/test/e2e/functional/analysistemplate-web-background.yaml
+++ b/test/e2e/functional/analysistemplate-web-background.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   metrics:
   - name: web
-    interval: 20s
+    interval: 5s
     successCondition: result.major == '1'
     provider:
       web:

--- a/test/e2e/functional/rollout-inline-analysis.yaml
+++ b/test/e2e/functional/rollout-inline-analysis.yaml
@@ -1,23 +1,29 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
-  name: rollout-background-analysis
+  name: rollout-inline-analysis
 spec:
   strategy:
     canary:
-      analysis:
-        templates:
-        - templateName: web-background
       steps:
       - setWeight: 10
+      - analysis:
+          templates:
+          - templateName: echo-job
       - pause: {}
+      - analysis:
+          templates:
+          - templateName: echo-job
+      - analysis:
+          templates:
+          - templateName: echo-job
   selector:
     matchLabels:
-      app: rollout-background-analysis
+      app: rollout-inline-analysis
   template:
     metadata:
       labels:
-        app: rollout-background-analysis
+        app: rollout-inline-analysis
     spec:
       containers:
       - name: rollouts-demo


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/714

The check for detecting an initial deploy and conditionally creating a background analysisrun was incomplete. It did not catch a scenario where `Rollout.Status.StableRS == ""`. Not sure why this is true in v0.9. but not v0.8

This is stacked ontop of another PR so only look at https://github.com/argoproj/argo-rollouts/pull/722/commits/9d1424e117b1a8a400cad885c76760f200b96235