### PR TITLE
fix: revision annotation was off-by-one for canary rollouts

### DIFF
--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -37,7 +37,7 @@ func (c *rolloutContext) rolloutCanary() error {
 	}
 
 	c.log.Info("Cleaning up old replicasets, experiments, and analysis runs")
-	if err := c.cleanupRollouts(c.olderRSs); err != nil {
+	if err := c.cleanupRollouts(c.otherRSs); err != nil {
 		return err
 	}
 
@@ -86,7 +86,7 @@ func (c *rolloutContext) reconcileStableRS() (bool, error) {
 		c.log.Info("No StableRS exists to reconcile or matches newRS")
 		return false, nil
 	}
-	_, stableRSReplicaCount := replicasetutil.CalculateReplicaCountsForCanary(c.rollout, c.newRS, c.stableRS, c.olderRSs)
+	_, stableRSReplicaCount := replicasetutil.CalculateReplicaCountsForCanary(c.rollout, c.newRS, c.stableRS, c.otherRSs)
 	scaled, _, err := c.scaleReplicaSetAndRecordEvent(c.stableRS, stableRSReplicaCount)
 	return scaled, err
 }
@@ -205,7 +205,7 @@ func (c *rolloutContext) completedCurrentCanaryStep() bool {
 		return c.pauseContext.CompletedPauseStep(*currentStep.Pause)
 	}
 	modifyReplicasStep := currentStep.SetWeight != nil || currentStep.SetCanaryScale != nil
-	if modifyReplicasStep && replicasetutil.AtDesiredReplicaCountsForCanary(c.rollout, c.newRS, c.stableRS, c.olderRSs) {
+	if modifyReplicasStep && replicasetutil.AtDesiredReplicaCountsForCanary(c.rollout, c.newRS, c.stableRS, c.otherRSs) {
 		c.log.Info("Rollout has reached the desired state for the correct weight")
 		return true
 	}
@@ -350,7 +350,7 @@ func (c *rolloutContext) reconcileCanaryReplicaSets() (bool, error) {
 	}
 
 	c.log.Info("Reconciling old replica sets")
-	scaledDown, err := c.reconcileOldReplicaSetsCanary(c.allRSs, controller.FilterActiveReplicaSets(c.olderRSs))
+	scaledDown, err := c.reconcileOldReplicaSetsCanary(c.allRSs, controller.FilterActiveReplicaSets(c.otherRSs))
 	if err != nil {
 		return false, err
 	}

--- a/rollout/context.go
+++ b/rollout/context.go
@@ -23,10 +23,10 @@ type rolloutContext struct {
 	stableRS *appsv1.ReplicaSet
 	// allRSs are all the ReplicaSets associated with the Rollout
 	allRSs []*appsv1.ReplicaSet
-	// olderRSs are "older" ReplicaSets
-	// For canary, this is anything which is not new or stable
-	// For blueGreen, this is anything which is not new
+	// olderRSs are "older" ReplicaSets -- anything which is not the new. includes stableRS
 	olderRSs []*appsv1.ReplicaSet
+	// otherRSs are ReplicaSets which are neither new or stable (allRSs - newRS - stableRS)
+	otherRSs []*appsv1.ReplicaSet
 
 	currentArs analysisutil.CurrentAnalysisRuns
 	otherArs   []*v1alpha1.AnalysisRun

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -9,13 +9,6 @@ import (
 	"testing"
 	"time"
 
-	istioutil "github.com/argoproj/argo-rollouts/utils/istio"
-
-	"k8s.io/client-go/dynamic/dynamicinformer"
-
-	"k8s.io/apimachinery/pkg/util/validation/field"
-	dynamicfake "k8s.io/client-go/dynamic/fake"
-
 	"github.com/bouk/monkey"
 	"github.com/ghodss/yaml"
 	log "github.com/sirupsen/logrus"
@@ -31,6 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	kubeinformers "k8s.io/client-go/informers"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
@@ -49,6 +45,7 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/annotations"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
+	istioutil "github.com/argoproj/argo-rollouts/utils/istio"
 )
 
 var (

--- a/rollout/service.go
+++ b/rollout/service.go
@@ -95,7 +95,7 @@ func (c *rolloutContext) reconcileActiveService(previewSvc, activeSvc *corev1.Se
 
 	if c.rollout.Status.Abort {
 		currentRevision := int(0)
-		for _, rs := range controller.FilterActiveReplicaSets(c.olderRSs) {
+		for _, rs := range controller.FilterActiveReplicaSets(c.otherRSs) {
 			revision := replicasetutil.GetReplicaSetRevision(c.rollout, rs)
 			if revision > currentRevision {
 				newPodHash = rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -83,7 +83,7 @@ func (c *rolloutContext) syncReplicaSetRevision() (*appsv1.ReplicaSet, error) {
 	// Should use the revision in existingNewRS's annotation, since it set by before
 	revisionNeedsUpdate := annotations.SetRolloutRevision(c.rollout, rsCopy.Annotations[annotations.RevisionAnnotation])
 	if revisionNeedsUpdate {
-		c.log.Info("Updating rollout revision annotation")
+		c.log.Infof("Updating rollout revision annotation to %s", rsCopy.Annotations[annotations.RevisionAnnotation])
 	}
 	// If no other Progressing condition has been recorded and we need to estimate the progress
 	// of this rollout then it is likely that old users started caring about progress. In that

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -73,7 +73,7 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 	_, index := replicasetutil.GetCurrentCanaryStep(c.rollout)
 	desiredWeight := int32(0)
 	if index != nil {
-		atDesiredReplicaCount := replicasetutil.AtDesiredReplicaCountsForCanary(c.rollout, c.newRS, c.stableRS, c.olderRSs)
+		atDesiredReplicaCount := replicasetutil.AtDesiredReplicaCountsForCanary(c.rollout, c.newRS, c.stableRS, c.otherRSs)
 		if !atDesiredReplicaCount {
 			// Use the previous weight since the new RS is not ready for a new weight
 			for i := *index - 1; i >= 0; i-- {

--- a/test/fixtures/common.go
+++ b/test/fixtures/common.go
@@ -2,7 +2,6 @@ package fixtures
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -50,8 +49,7 @@ func (c *Common) PrintRollout(ro *rov1.Rollout) {
 }
 
 func (c *Common) GetRolloutAnalysisRuns() rov1.AnalysisRunList {
-	e2eLabel := fmt.Sprintf("%s=%s", rov1.LabelKeyControllerInstanceID, E2ELabel)
-	aruns, err := c.rolloutClient.ArgoprojV1alpha1().AnalysisRuns(c.namespace).List(metav1.ListOptions{LabelSelector: e2eLabel})
+	aruns, err := c.rolloutClient.ArgoprojV1alpha1().AnalysisRuns(c.namespace).List(metav1.ListOptions{})
 	c.CheckError(err)
 	// filter analysis runs by ones owned by rollout to allow test parallellism
 	var newAruns rov1.AnalysisRunList

--- a/test/fixtures/e2e_suite.go
+++ b/test/fixtures/e2e_suite.go
@@ -43,7 +43,10 @@ const (
 var (
 	E2EWaitTimeout time.Duration = time.Second * 60
 
-	E2ELabel = "argo-rollouts-e2e"
+	// All e2e tests will be labeled with this instance-id (unless E2E_INSTANCE_ID="")
+	E2ELabelValueInstanceID = "argo-rollouts-e2e"
+	// All e2e tests will be labeled with their test name
+	E2ELabelKeyTestName = "e2e-test-name"
 
 	serviceGVR = schema.GroupVersionResource{
 		Version:  "v1",
@@ -57,8 +60,8 @@ var (
 )
 
 func init() {
-	if e2elabel, ok := os.LookupEnv(EnvVarE2EInstanceID); ok {
-		E2ELabel = e2elabel
+	if instanceID, ok := os.LookupEnv(EnvVarE2EInstanceID); ok {
+		E2ELabelValueInstanceID = instanceID
 	}
 	if e2eWaitTimeout, ok := os.LookupEnv(EnvVarE2EWaitTimeout); ok {
 		timeout, err := strconv.Atoi(e2eWaitTimeout)
@@ -113,17 +116,17 @@ func (s *E2ESuite) TearDownSuite() {
 		s.log.Info("skipping resource cleanup")
 		return
 	}
-	s.DeleteResources(E2ELabel)
+	s.DeleteResources()
 }
 
 func (s *E2ESuite) BeforeTest(suiteName, testName string) {
-	s.DeleteResources(E2ELabel)
+	s.DeleteResources()
 }
 
 func (s *E2ESuite) AfterTest(_, _ string) {
 }
 
-func (s *E2ESuite) DeleteResources(label string) {
+func (s *E2ESuite) DeleteResources() {
 	resources := []schema.GroupVersionResource{
 		rov1.RolloutGVR,
 		rov1.AnalysisRunGVR,
@@ -134,7 +137,7 @@ func (s *E2ESuite) DeleteResources(label string) {
 		ingressGVR,
 		istioutil.GetIstioGVR("v1alpha3"),
 	}
-	req, err := labels.NewRequirement(rov1.LabelKeyControllerInstanceID, selection.Equals, []string{E2ELabel})
+	req, err := labels.NewRequirement(E2ELabelKeyTestName, selection.Exists, []string{})
 	s.CheckError(err)
 
 	foregroundDelete := metav1.DeletePropagationForeground
@@ -145,9 +148,9 @@ func (s *E2ESuite) DeleteResources(label string) {
 		var err error
 		var lst *unstructured.UnstructuredList
 		if gvr == rov1.ClusterAnalysisTemplateGVR {
-			lst, err = s.dynamicClient.Resource(gvr).List(metav1.ListOptions{LabelSelector: req.String()})
+			lst, err = s.dynamicClient.Resource(gvr).List(listOpts)
 		} else {
-			lst, err = s.dynamicClient.Resource(gvr).Namespace(s.namespace).List(metav1.ListOptions{LabelSelector: req.String()})
+			lst, err = s.dynamicClient.Resource(gvr).Namespace(s.namespace).List(listOpts)
 		}
 		if err != nil && !k8serrors.IsNotFound(err) {
 			s.CheckError(err)
@@ -158,7 +161,7 @@ func (s *E2ESuite) DeleteResources(label string) {
 		return lst.Items
 	}
 
-	// Delete all resources with test instance id
+	// Delete all resources with test label
 	resourcesRemaining := resources[:0]
 	for _, gvr := range resources {
 		switch gvr {

--- a/test/fixtures/given.go
+++ b/test/fixtures/given.go
@@ -38,7 +38,10 @@ func (g *Given) RolloutObjects(text string) *Given {
 		if labels == nil {
 			labels = make(map[string]string)
 		}
-		labels[rov1.LabelKeyControllerInstanceID] = E2ELabel
+		if E2ELabelValueInstanceID != "" {
+			labels[rov1.LabelKeyControllerInstanceID] = E2ELabelValueInstanceID
+		}
+		labels[E2ELabelKeyTestName] = g.t.Name()
 		obj.SetLabels(labels)
 
 		if obj.GetKind() == "Rollout" {

--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -328,9 +328,9 @@ func UseSetCanaryScale(rollout *v1alpha1.Rollout) *v1alpha1.SetCanaryScale {
 	return nil
 }
 
-// GetOlderRSs the function goes through a list of ReplicaSets and returns a list of RS that are not the new or stable RS
-func GetOlderRSs(rollout *v1alpha1.Rollout, newRS, stableRS *appsv1.ReplicaSet, allRSs []*appsv1.ReplicaSet) []*appsv1.ReplicaSet {
-	olderRSs := []*appsv1.ReplicaSet{}
+// GetOtherRSs the function goes through a list of ReplicaSets and returns a list of RS that are not the new or stable RS
+func GetOtherRSs(rollout *v1alpha1.Rollout, newRS, stableRS *appsv1.ReplicaSet, allRSs []*appsv1.ReplicaSet) []*appsv1.ReplicaSet {
+	otherRSs := []*appsv1.ReplicaSet{}
 	for _, rs := range allRSs {
 		if rs != nil {
 			if stableRS != nil && rs.Name == stableRS.Name {
@@ -339,10 +339,10 @@ func GetOlderRSs(rollout *v1alpha1.Rollout, newRS, stableRS *appsv1.ReplicaSet, 
 			if newRS != nil && rs.Name == newRS.Name {
 				continue
 			}
-			olderRSs = append(olderRSs, rs)
+			otherRSs = append(otherRSs, rs)
 		}
 	}
-	return olderRSs
+	return otherRSs
 }
 
 // GetStableRS finds the stable RS using the RS's RolloutUniqueLabelKey and the stored StableRS in the rollout status

--- a/utils/replicaset/canary_test.go
+++ b/utils/replicaset/canary_test.go
@@ -486,7 +486,7 @@ func TestCalculateReplicaCountsForCanaryStableRSdEdgeCases(t *testing.T) {
 	assert.Equal(t, int32(0), stableRSReplicaCount)
 }
 
-func TestGetOlderRSs(t *testing.T) {
+func TestGetOtherRSs(t *testing.T) {
 	rs := func(podHash string) appsv1.ReplicaSet {
 		return appsv1.ReplicaSet{
 			ObjectMeta: metav1.ObjectMeta{
@@ -497,15 +497,15 @@ func TestGetOlderRSs(t *testing.T) {
 	rollout := &v1alpha1.Rollout{}
 	rs1 := rs("1")
 	rs2 := rs("2")
-	handleNil := GetOlderRSs(rollout, nil, nil, []*appsv1.ReplicaSet{&rs1})
+	handleNil := GetOtherRSs(rollout, nil, nil, []*appsv1.ReplicaSet{&rs1})
 	assert.Len(t, handleNil, 1)
 	assert.Equal(t, *handleNil[0], rs1)
 
-	handleExistingNewRS := GetOlderRSs(rollout, &rs1, nil, []*appsv1.ReplicaSet{&rs1, &rs2})
+	handleExistingNewRS := GetOtherRSs(rollout, &rs1, nil, []*appsv1.ReplicaSet{&rs1, &rs2})
 	assert.Len(t, handleExistingNewRS, 1)
 	assert.Equal(t, *handleExistingNewRS[0], rs2)
 
-	handleExistingStableRS := GetOlderRSs(rollout, nil, &rs1, []*appsv1.ReplicaSet{&rs1, &rs2})
+	handleExistingStableRS := GetOtherRSs(rollout, nil, &rs1, []*appsv1.ReplicaSet{&rs1, &rs2})
 	assert.Len(t, handleExistingStableRS, 1)
 	assert.Equal(t, *handleExistingStableRS[0], rs2)
 

--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -248,8 +248,8 @@ func NewRSNewReplicas(rollout *v1alpha1.Rollout, allRSs []*appsv1.ReplicaSet, ne
 	}
 	if rollout.Spec.Strategy.Canary != nil {
 		stableRS := GetStableRS(rollout, newRS, allRSs)
-		olderRSs := GetOlderRSs(rollout, newRS, stableRS, allRSs)
-		newRSReplicaCount, _ := CalculateReplicaCountsForCanary(rollout, newRS, stableRS, olderRSs)
+		otherRSs := GetOtherRSs(rollout, newRS, stableRS, allRSs)
+		newRSReplicaCount, _ := CalculateReplicaCountsForCanary(rollout, newRS, stableRS, otherRSs)
 		return newRSReplicaCount, nil
 	}
 	return 0, fmt.Errorf("no rollout strategy provided")


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/721

The refactor to the rolloutContext introduced a problem with canary rollouts where the revision annotated on the ReplicaSet and Rollout was under by one. This is because it calculated the revision number by the count of older RSs, which was not calculated correctly during the refactor.

This change also makes it possible for E2E tests to run without an instanceID, so that they may run against a normally installed cluster controller.

NOTE: this PR is layered ontop of 9d1424e so only look at last commit