### PR TITLE
feat: writeback rollout updates to informer to prevent stale data

### DIFF
--- a/rollout/context.go
+++ b/rollout/context.go
@@ -15,6 +15,8 @@ type rolloutContext struct {
 	log *log.Entry
 	// rollout is the rollout being reconciled
 	rollout *v1alpha1.Rollout
+	// newRollout is the rollout after reconciliation. used to write back to informer
+	newRollout *v1alpha1.Rollout
 	// newRS is the "new" ReplicaSet. Also referred to as current, or desired.
 	// newRS will be nil when the pod template spec changes.
 	newRS *appsv1.ReplicaSet

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -607,13 +607,13 @@ func (c *rolloutContext) persistRolloutStatus(newStatus *v1alpha1.RolloutStatus)
 		c.requeueStuckRollout(*newStatus)
 		return nil
 	}
-	c.log.Debugf("Rollout Patch: %s", patch)
-	_, err = c.argoprojclientset.ArgoprojV1alpha1().Rollouts(c.rollout.Namespace).Patch(c.rollout.Name, patchtypes.MergePatchType, patch)
+	newRollout, err := c.argoprojclientset.ArgoprojV1alpha1().Rollouts(c.rollout.Namespace).Patch(c.rollout.Name, patchtypes.MergePatchType, patch)
 	if err != nil {
 		c.log.Warningf("Error updating application: %v", err)
 		return err
 	}
-	c.log.Info("Patch status successfully")
+	c.log.Infof("Patched: %s", patch)
+	c.newRollout = newRollout
 	return nil
 }
 


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/720

Currently the rollout controller may operate on stale information in the informer cache. This can easily happen when a rollout is requeued into the workqueue while already in the middle of reconciliation. When this happens, the controller immediately re-reconciles the rollout, but this time operating on a stale version of the rollout in the cache (it is stale because the changes to the rollout saved in first reconciliation, have not yet made the round trip into the cache).

At best, this simply duplicates work. At worst, it causes incorrect behavior (such as re-pausing after an unpause as in #720)

There is a technique which argo workflows uses that writes back the updated resource back into the informer cache. Using this technique, even if a rollout is immediately re-reconciled, it at least has the updates saved in the previous reconciliation.

Before this change, TestCanarySetCanaryScale could reproduce the double-pause problem in #720 quite easily. After this fix, I am unable to reproduce the problem.