### PR TITLE
feat: plugin now surfaces InvalidSpec errors and failed analysisrun messages

### DIFF
--- a/pkg/kubectl-argo-rollouts/cmd/get/get_rollout.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get_rollout.go
@@ -129,6 +129,12 @@ func (o *GetOptions) PrintRollout(roInfo *info.RolloutInfo) {
 	fmt.Fprintf(o.Out, tableFormat, "  Ready:", roInfo.Ready)
 	fmt.Fprintf(o.Out, tableFormat, "  Available:", roInfo.Available)
 
+	if len(roInfo.ErrorConditions) > 0 {
+		fmt.Fprintf(o.Out, "Errors:\n")
+		for _, msg := range roInfo.ErrorConditions {
+			fmt.Fprintf(o.Out, "* %s\n", msg)
+		}
+	}
 	fmt.Fprintf(o.Out, "\n")
 	o.PrintRolloutTree(roInfo)
 }

--- a/pkg/kubectl-argo-rollouts/info/info_test.go
+++ b/pkg/kubectl-argo-rollouts/info/info_test.go
@@ -181,11 +181,16 @@ func TestRolloutStatusDegraded(t *testing.T) {
 }
 
 func TestRolloutStatusInvalidSpec(t *testing.T) {
-	ro := newCanaryRollout()
-	ro.Status.Conditions = append(ro.Status.Conditions, v1alpha1.RolloutCondition{
-		Type: v1alpha1.InvalidSpec,
-	})
-	assert.Equal(t, string(v1alpha1.InvalidSpec), RolloutStatusString(ro))
+	rolloutObjs := testdata.NewInvalidRollout()
+	roInfo := NewRolloutInfo(rolloutObjs.Rollouts[0], rolloutObjs.ReplicaSets, rolloutObjs.Pods, rolloutObjs.Experiments, rolloutObjs.AnalysisRuns)
+	assert.Equal(t, []string{"The Rollout \"rollout-invalid\" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{\"app\":\"doesnt-match\"}: `selector` does not match template `labels`"}, roInfo.ErrorConditions)
+	assert.Equal(t, string(v1alpha1.InvalidSpec), RolloutStatusString(rolloutObjs.Rollouts[0]))
+}
+
+func TestRolloutAborted(t *testing.T) {
+	rolloutObjs := testdata.NewAbortedRollout()
+	roInfo := NewRolloutInfo(rolloutObjs.Rollouts[0], rolloutObjs.ReplicaSets, rolloutObjs.Pods, rolloutObjs.Experiments, rolloutObjs.AnalysisRuns)
+	assert.Equal(t, []string{`metric "web" assessed Failed due to failed (1) > failureLimit (0)`}, roInfo.ErrorConditions)
 }
 
 func TestRolloutStatusPaused(t *testing.T) {

--- a/pkg/kubectl-argo-rollouts/info/testdata/rollout-aborted/analysisrun.yaml
+++ b/pkg/kubectl-argo-rollouts/info/testdata/rollout-aborted/analysisrun.yaml
@@ -1,0 +1,45 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisRun
+metadata:
+  annotations:
+    rollout.argoproj.io/revision: "2"
+  creationTimestamp: "2020-09-22T09:10:04Z"
+  generation: 2
+  labels:
+    rollout-type: Background
+    rollouts-pod-template-hash: db976bc44
+  name: rollout-background-analysis-db976bc44-2
+  namespace: default
+  ownerReferences:
+  - apiVersion: argoproj.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Rollout
+    name: rollout-background-analysis
+    uid: aeddde25-f8bd-4a68-a4a1-523a559bdb83
+  resourceVersion: "877974"
+  selfLink: /apis/argoproj.io/v1alpha1/namespaces/default/analysisruns/rollout-background-analysis-db976bc44-2
+  uid: f453c075-5964-4330-bb30-6bedad22d08b
+spec:
+  metrics:
+  - interval: 5s
+    name: web
+    provider:
+      web:
+        jsonPath: '{$.completed}'
+        url: https://jsonplaceholder.typicode.com/todos/1
+    successCondition: result == "true"
+status:
+  message: metric "web" assessed Failed due to failed (1) > failureLimit (0)
+  metricResults:
+  - count: 1
+    failed: 1
+    measurements:
+    - finishedAt: "2020-09-22T09:10:04Z"
+      phase: Failed
+      startedAt: "2020-09-22T09:10:04Z"
+      value: "false"
+    name: web
+    phase: Failed
+  phase: Failed
+  startedAt: "2020-09-22T09:10:04Z"

--- a/pkg/kubectl-argo-rollouts/info/testdata/rollout-aborted/pod1.yaml
+++ b/pkg/kubectl-argo-rollouts/info/testdata/rollout-aborted/pod1.yaml
@@ -1,0 +1,103 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2020-09-22T09:09:46Z"
+  generateName: rollout-background-analysis-7d84d44bb8-
+  labels:
+    app: rollout-background-analysis
+    rollouts-pod-template-hash: 7d84d44bb8
+  name: rollout-background-analysis-7d84d44bb8-z5wps
+  namespace: default
+  ownerReferences:
+  - apiVersion: apps/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: ReplicaSet
+    name: rollout-background-analysis-7d84d44bb8
+    uid: 6f122e62-48fc-4f51-9629-24367b2460fb
+  resourceVersion: "877904"
+  selfLink: /api/v1/namespaces/default/pods/rollout-background-analysis-7d84d44bb8-z5wps
+  uid: b8b2d6d6-4c15-4e49-ab78-78c40e285ff6
+spec:
+  containers:
+  - args:
+    - --termination-delay
+    - "0"
+    image: argoproj/rollouts-demo:blue
+    imagePullPolicy: IfNotPresent
+    name: rollouts-demo
+    ports:
+    - containerPort: 8080
+      name: http
+      protocol: TCP
+    resources:
+      requests:
+        cpu: 5m
+        memory: 32Mi
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-d8v2q
+      readOnly: true
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  nodeName: minikube
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+    tolerationSeconds: 300
+  volumes:
+  - name: default-token-d8v2q
+    secret:
+      defaultMode: 420
+      secretName: default-token-d8v2q
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2020-09-22T09:09:46Z"
+    status: "True"
+    type: Initialized
+  - lastProbeTime: null
+    lastTransitionTime: "2020-09-22T09:09:47Z"
+    status: "True"
+    type: Ready
+  - lastProbeTime: null
+    lastTransitionTime: "2020-09-22T09:09:47Z"
+    status: "True"
+    type: ContainersReady
+  - lastProbeTime: null
+    lastTransitionTime: "2020-09-22T09:09:46Z"
+    status: "True"
+    type: PodScheduled
+  containerStatuses:
+  - containerID: docker://adb92f1611b818df8aa6e33633e2c3336ebe7c16ed7d57993c4fd667fdeacbea
+    image: argoproj/rollouts-demo:blue
+    imageID: docker-pullable://argoproj/rollouts-demo@sha256:abe71372b176947a10b27d12559a7e33057d70301fed78ea8bc9551d1503aef9
+    lastState: {}
+    name: rollouts-demo
+    ready: true
+    restartCount: 0
+    started: true
+    state:
+      running:
+        startedAt: "2020-09-22T09:09:47Z"
+  hostIP: 192.168.64.3
+  phase: Running
+  podIP: 172.17.0.9
+  podIPs:
+  - ip: 172.17.0.9
+  qosClass: Burstable
+  startTime: "2020-09-22T09:09:46Z"

--- a/pkg/kubectl-argo-rollouts/info/testdata/rollout-aborted/rollout.yaml
+++ b/pkg/kubectl-argo-rollouts/info/testdata/rollout-aborted/rollout.yaml
@@ -1,0 +1,79 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  annotations:
+    rollout.argoproj.io/revision: "2"
+  creationTimestamp: "2020-09-22T09:09:46Z"
+  generation: 15
+  name: rollout-background-analysis
+  namespace: default
+  resourceVersion: "877993"
+  selfLink: /apis/argoproj.io/v1alpha1/namespaces/default/rollouts/rollout-background-analysis
+  uid: aeddde25-f8bd-4a68-a4a1-523a559bdb83
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rollout-background-analysis
+  strategy:
+    canary:
+      analysis:
+        templates:
+        - templateName: web-background
+      steps:
+      - setWeight: 10
+      - pause: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: rollout-background-analysis
+    spec:
+      containers:
+      - args:
+        - --termination-delay
+        - "0"
+        image: argoproj/rollouts-demo:yellow
+        name: rollouts-demo
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 5m
+            memory: 32Mi
+status:
+  HPAReplicas: 1
+  abort: true
+  abortedAt: "2020-09-22T09:10:05Z"
+  availableReplicas: 1
+  blueGreen: {}
+  canary:
+    currentBackgroundAnalysisRun: rollout-background-analysis-db976bc44-2
+    currentBackgroundAnalysisRunStatus:
+      message: metric "web" assessed Failed due to failed (1) > failureLimit (0)
+      name: rollout-background-analysis-db976bc44-2
+      status: Failed
+    stableRS: 7d84d44bb8
+  conditions:
+  - lastTransitionTime: "2020-09-22T09:09:47Z"
+    lastUpdateTime: "2020-09-22T09:09:47Z"
+    message: Rollout has minimum availability
+    reason: AvailableReason
+    status: "True"
+    type: Available
+  - lastTransitionTime: "2020-09-22T09:10:04Z"
+    lastUpdateTime: "2020-09-22T09:10:04Z"
+    message: metric "web" assessed Failed due to failed (1) > failureLimit (0)
+    reason: RolloutAborted
+    status: "False"
+    type: Progressing
+  currentPodHash: db976bc44
+  currentStepHash: 849b756fd4
+  currentStepIndex: 0
+  observedGeneration: 7d77fd9646
+  readyReplicas: 1
+  replicas: 1
+  selector: app=rollout-background-analysis
+  stableRS: 7d84d44bb8

--- a/pkg/kubectl-argo-rollouts/info/testdata/rollout-aborted/rs1.yaml
+++ b/pkg/kubectl-argo-rollouts/info/testdata/rollout-aborted/rs1.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  annotations:
+    rollout.argoproj.io/desired-replicas: "1"
+    rollout.argoproj.io/revision: "2"
+  creationTimestamp: "2020-09-22T09:10:04Z"
+  generation: 2
+  labels:
+    app: rollout-background-analysis
+    rollouts-pod-template-hash: db976bc44
+  name: rollout-background-analysis-db976bc44
+  namespace: default
+  ownerReferences:
+  - apiVersion: argoproj.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Rollout
+    name: rollout-background-analysis
+    uid: aeddde25-f8bd-4a68-a4a1-523a559bdb83
+  resourceVersion: "877992"
+  selfLink: /apis/apps/v1/namespaces/default/replicasets/rollout-background-analysis-db976bc44
+  uid: c562ef93-0413-4249-a2d1-4f6f18362a1c
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: rollout-background-analysis
+      rollouts-pod-template-hash: db976bc44
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: rollout-background-analysis
+        rollouts-pod-template-hash: db976bc44
+    spec:
+      containers:
+      - args:
+        - --termination-delay
+        - "0"
+        image: argoproj/rollouts-demo:yellow
+        imagePullPolicy: IfNotPresent
+        name: rollouts-demo
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 5m
+            memory: 32Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  observedGeneration: 2
+  replicas: 0

--- a/pkg/kubectl-argo-rollouts/info/testdata/rollout-aborted/rs2.yaml
+++ b/pkg/kubectl-argo-rollouts/info/testdata/rollout-aborted/rs2.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  annotations:
+    rollout.argoproj.io/desired-replicas: "1"
+    rollout.argoproj.io/revision: "1"
+  creationTimestamp: "2020-09-22T09:09:46Z"
+  generation: 1
+  labels:
+    app: rollout-background-analysis
+    rollouts-pod-template-hash: 7d84d44bb8
+  name: rollout-background-analysis-7d84d44bb8
+  namespace: default
+  ownerReferences:
+  - apiVersion: argoproj.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Rollout
+    name: rollout-background-analysis
+    uid: aeddde25-f8bd-4a68-a4a1-523a559bdb83
+  resourceVersion: "877905"
+  selfLink: /apis/apps/v1/namespaces/default/replicasets/rollout-background-analysis-7d84d44bb8
+  uid: 6f122e62-48fc-4f51-9629-24367b2460fb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rollout-background-analysis
+      rollouts-pod-template-hash: 7d84d44bb8
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: rollout-background-analysis
+        rollouts-pod-template-hash: 7d84d44bb8
+    spec:
+      containers:
+      - args:
+        - --termination-delay
+        - "0"
+        image: argoproj/rollouts-demo:blue
+        imagePullPolicy: IfNotPresent
+        name: rollouts-demo
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 5m
+            memory: 32Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 1
+  fullyLabeledReplicas: 1
+  observedGeneration: 1
+  readyReplicas: 1
+  replicas: 1

--- a/pkg/kubectl-argo-rollouts/info/testdata/rollout-invalid/rollout-invalid.yaml
+++ b/pkg/kubectl-argo-rollouts/info/testdata/rollout-invalid/rollout-invalid.yaml
@@ -1,0 +1,46 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  creationTimestamp: "2020-09-22T07:48:29Z"
+  generation: 3
+  name: rollout-invalid
+  namespace: default
+  resourceVersion: "864018"
+  selfLink: /apis/argoproj.io/v1alpha1/namespaces/default/rollouts/rollout-invalid
+  uid: e4bab69c-dac6-49e9-8f5e-36909c596ce6
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: basic
+  strategy:
+    canary: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: doesnt-match
+    spec:
+      containers:
+      - image: argoproj/rollouts-demo:blue
+        name: rollouts-demo
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 1m
+            memory: 16Mi
+status:
+  blueGreen: {}
+  canary: {}
+  conditions:
+  - lastTransitionTime: "2020-09-22T07:48:42Z"
+    lastUpdateTime: "2020-09-22T07:48:42Z"
+    message: 'The Rollout "rollout-invalid" is invalid: spec.template.metadata.labels:
+      Invalid value: map[string]string{"app":"doesnt-match"}: `selector` does not
+      match template `labels`'
+    reason: InvalidSpec
+    status: "True"
+    type: InvalidSpec
+  observedGeneration: 67655ff475

--- a/pkg/kubectl-argo-rollouts/info/testdata/testdata.go
+++ b/pkg/kubectl-argo-rollouts/info/testdata/testdata.go
@@ -67,6 +67,14 @@ func NewExperimentAnalysisJobRollout() *RolloutObjects {
 	return discoverObjects(testDir + "/experiment-step")
 }
 
+func NewInvalidRollout() *RolloutObjects {
+	return discoverObjects(testDir + "/rollout-invalid")
+}
+
+func NewAbortedRollout() *RolloutObjects {
+	return discoverObjects(testDir + "/rollout-aborted")
+}
+
 func discoverObjects(path string) *RolloutObjects {
 	files, err := ioutil.ReadDir(path)
 	if err != nil {


### PR DESCRIPTION
The plugin will now show Errors such as InvalidSpec reason or when analysis fails. Examples:

```
Name:            rollout-invalid
Namespace:       default
Status:          ⚠ InvalidSpec
Strategy:        Canary
  Step:
  SetWeight:     100
  ActualWeight:  100
Replicas:
  Desired:       1
  Current:       0
  Updated:       0
  Ready:         0
  Available:     0
Errors:
* The Rollout "rollout-invalid" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"app":"doesnt-match"}: `+"`selector`"+` does not match template `+"`labels`"+`

NAME               KIND     STATUS         AGE  INFO
⟳ rollout-invalid  Rollout  ⚠ InvalidSpec  7d
```

```
Name:            rollout-background-analysis
Namespace:       default
Status:          ✖ Degraded
Strategy:        Canary
  Step:          0/2
  SetWeight:     0
  ActualWeight:  0
Images:          argoproj/rollouts-demo:blue (stable)
Replicas:
  Desired:       1
  Current:       1
  Updated:       0
  Ready:         1
  Available:     1
Errors:
* metric "web" assessed Failed due to failed (1) > failureLimit (0)

NAME                                                     KIND         STATUS        AGE    INFO
⟳ rollout-background-analysis                            Rollout      ✖ Degraded    4m51s
├──# revision:2
│  ├──⧉ rollout-background-analysis-db976bc44            ReplicaSet   • ScaledDown  4m33s  canary
│  └──α rollout-background-analysis-db976bc44-2          AnalysisRun  ✖ Failed      4m33s  ✖ 1
└──# revision:1
   └──⧉ rollout-background-analysis-7d84d44bb8           ReplicaSet   ✔ Healthy     4m51s  stable
      └──□ rollout-background-analysis-7d84d44bb8-z5wps  Pod          ✔ Running     4m51s  ready:1/1
```