### PR TITLE
feat(cli): get rollout/experiment print options

### DIFF
--- a/pkg/kubectl-argo-rollouts/cmd/get/get.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/info"
@@ -98,6 +99,7 @@ type GetOptions struct {
 	Watch   bool
 	NoColor bool
 
+	PrintFlags *genericclioptions.PrintFlags
 	options.ArgoRolloutsOptions
 }
 

--- a/pkg/kubectl-argo-rollouts/cmd/get/get_experiment.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get_experiment.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/juju/ansiterm"
 	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/info"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options"
@@ -21,13 +23,18 @@ const (
 	%[1]s get experiment my-experiment
 	
 	# Watch experiment progress
-	%[1]s get experiment my-experiment -w`
+	%[1]s get experiment my-experiment -w
+	
+	# Print status
+	%[1]s get experiment my-experiment -o jsonpath='{.spec.status}'
+	`
 )
 
 // NewCmdGetExperiment returns a new instance of an `rollouts get experiment` command
 func NewCmdGetExperiment(o *options.ArgoRolloutsOptions) *cobra.Command {
 	getOptions := GetOptions{
 		ArgoRolloutsOptions: *o,
+		PrintFlags:          genericclioptions.NewPrintFlags("experiment"),
 	}
 
 	var cmd = &cobra.Command{
@@ -66,6 +73,7 @@ func NewCmdGetExperiment(o *options.ArgoRolloutsOptions) *cobra.Command {
 	}
 	cmd.Flags().BoolVarP(&getOptions.Watch, "watch", "w", false, "Watch live updates to the rollout")
 	cmd.Flags().BoolVar(&getOptions.NoColor, "no-color", false, "Do not colorize output")
+	getOptions.PrintFlags.AddFlags(cmd)
 	return cmd
 }
 
@@ -93,13 +101,23 @@ func (o *GetOptions) WatchExperiment(stopCh <-chan struct{}, expUpdates chan *in
 }
 
 func (o *GetOptions) PrintExperiment(exInfo *info.ExperimentInfo) {
+	if o.PrintFlags.OutputFlagSpecified() {
+		printer, err := o.PrintFlags.ToPrinter()
+		cmdutil.CheckErr(err)
+		printer.PrintObj(exInfo, o.Out)
+	} else {
+		o.PrintExperimentTable(exInfo)
+	}
+}
+
+func (o *GetOptions) PrintExperimentTable(exInfo *info.ExperimentInfo) {
 	fmt.Fprintf(o.Out, tableFormat, "Name:", exInfo.Name)
 	fmt.Fprintf(o.Out, tableFormat, "Namespace:", exInfo.Namespace)
-	fmt.Fprintf(o.Out, tableFormat, "Status:", o.colorize(exInfo.Icon)+" "+exInfo.Status)
-	if exInfo.Message != "" {
-		fmt.Fprintf(o.Out, tableFormat, "Message:", exInfo.Message)
+	fmt.Fprintf(o.Out, tableFormat, "Status:", o.colorize(exInfo.Spec.Icon)+" "+exInfo.Spec.Status)
+	if exInfo.Spec.Message != "" {
+		fmt.Fprintf(o.Out, tableFormat, "Message:", exInfo.Spec.Message)
 	}
-	images := exInfo.Images()
+	images := exInfo.Spec.Images()
 	if len(images) > 0 {
 		fmt.Fprintf(o.Out, tableFormat, "Images:", o.formatImage(images[0]))
 		for i := 1; i < len(images); i++ {
@@ -119,18 +137,18 @@ func (o *GetOptions) PrintExperimentTree(exInfo *info.ExperimentInfo) {
 }
 
 func (o *GetOptions) PrintExperimentInfo(w io.Writer, expInfo info.ExperimentInfo, prefix string, subpfx string) {
-	name := o.colorizeStatus(expInfo.Name, expInfo.Status)
+	name := o.colorizeStatus(expInfo.Name, expInfo.Spec.Status)
 	infoCols := []string{}
-	total := len(expInfo.ReplicaSets) + len(expInfo.AnalysisRuns)
+	total := len(expInfo.Spec.ReplicaSets) + len(expInfo.Spec.AnalysisRuns)
 	curr := 0
-	fmt.Fprintf(w, "%s%s %s\t%s\t%s %s\t%s\t%v\n", prefix, IconExperiment, name, "Experiment", o.colorize(expInfo.Icon), expInfo.Status, expInfo.Age(), strings.Join(infoCols, ","))
+	fmt.Fprintf(w, "%s%s %s\t%s\t%s %s\t%s\t%v\n", prefix, IconExperiment, name, "Experiment", o.colorize(expInfo.Spec.Icon), expInfo.Spec.Status, expInfo.Age(), strings.Join(infoCols, ","))
 
-	for _, rsInfo := range expInfo.ReplicaSets {
+	for _, rsInfo := range expInfo.Spec.ReplicaSets {
 		childPrefix, childSubpfx := getPrefixes(curr == total-1, subpfx)
 		o.PrintReplicaSetInfo(w, rsInfo, childPrefix, childSubpfx)
 		curr++
 	}
-	for _, arInfo := range expInfo.AnalysisRuns {
+	for _, arInfo := range expInfo.Spec.AnalysisRuns {
 		arPrefix, arChildPrefix := getPrefixes(curr == total-1, subpfx)
 		o.PrintAnalysisRunInfo(w, arInfo, arPrefix, arChildPrefix)
 		curr++

--- a/pkg/kubectl-argo-rollouts/cmd/get/get_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get_test.go
@@ -2,17 +2,20 @@ package get
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/ghodss/yaml"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/info"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/info/testdata"
 	options "github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options/fake"
 )
@@ -413,4 +416,100 @@ NAME                                                           KIND         STAT
       └──□ canary-demo-877894d5b-zhh6x                         Pod          ✔ Running      7d   ready:1/1
 `, "\n")
 	assertStdout(t, expectedOut, o.IOStreams)
+}
+
+func TestGetRolloutJsonPathPrinter(t *testing.T) {
+	rolloutObjs := testdata.NewBlueGreenRollout()
+
+	tf, o := options.NewFakeArgoRolloutsOptions(rolloutObjs.AllObjects()...)
+	o.RESTClientGetter = tf.WithNamespace(rolloutObjs.Rollouts[0].Namespace)
+	defer tf.Cleanup()
+	cmd := NewCmdGetRollout(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{rolloutObjs.Rollouts[0].Name, "--output", "jsonpath={.spec.status}"})
+	err := cmd.Execute()
+	assert.NoError(t, err)
+	assertStdout(t, "Paused", o.IOStreams)
+}
+
+func TestGetRolloutYamlPrinter(t *testing.T) {
+	rolloutObjs := testdata.NewBlueGreenRollout()
+
+	tf, o := options.NewFakeArgoRolloutsOptions(rolloutObjs.AllObjects()...)
+	o.RESTClientGetter = tf.WithNamespace(rolloutObjs.Rollouts[0].Namespace)
+	defer tf.Cleanup()
+	cmd := NewCmdGetRollout(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{rolloutObjs.Rollouts[0].Name, "--output", "yaml"})
+	err := cmd.Execute()
+	assert.NoError(t, err)
+	txt := o.Out.(*bytes.Buffer).String()
+	var info info.RolloutInfo
+	err = yaml.Unmarshal([]byte(txt), &info)
+	assert.NoError(t, err)
+}
+
+func TestGetRolloutJsonPrinter(t *testing.T) {
+	rolloutObjs := testdata.NewBlueGreenRollout()
+
+	tf, o := options.NewFakeArgoRolloutsOptions(rolloutObjs.AllObjects()...)
+	o.RESTClientGetter = tf.WithNamespace(rolloutObjs.Rollouts[0].Namespace)
+	defer tf.Cleanup()
+	cmd := NewCmdGetRollout(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{rolloutObjs.Rollouts[0].Name, "--output", "json"})
+	err := cmd.Execute()
+	assert.NoError(t, err)
+	txt := o.Out.(*bytes.Buffer).String()
+	var info info.RolloutInfo
+	err = json.Unmarshal([]byte(txt), &info)
+	assert.NoError(t, err)
+}
+
+func TestGetExperimentJsonPathPrinter(t *testing.T) {
+	rolloutObjs := testdata.NewExperimentAnalysisRollout()
+
+	tf, o := options.NewFakeArgoRolloutsOptions(rolloutObjs.AllObjects()...)
+	o.RESTClientGetter = tf.WithNamespace(rolloutObjs.Rollouts[0].Namespace)
+	defer tf.Cleanup()
+	cmd := NewCmdGetExperiment(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{rolloutObjs.Experiments[0].Name, "--output", "jsonpath={.spec.status}"})
+	err := cmd.Execute()
+	assert.NoError(t, err)
+	assertStdout(t, "Running", o.IOStreams)
+}
+
+func TestGetExperimentYamlPrinter(t *testing.T) {
+	rolloutObjs := testdata.NewExperimentAnalysisRollout()
+
+	tf, o := options.NewFakeArgoRolloutsOptions(rolloutObjs.AllObjects()...)
+	o.RESTClientGetter = tf.WithNamespace(rolloutObjs.Rollouts[0].Namespace)
+	defer tf.Cleanup()
+	cmd := NewCmdGetExperiment(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{rolloutObjs.Experiments[0].Name, "--output", "yaml"})
+	err := cmd.Execute()
+	assert.NoError(t, err)
+	txt := o.Out.(*bytes.Buffer).String()
+	var info info.ExperimentInfo
+	err = yaml.Unmarshal([]byte(txt), &info)
+	assert.NoError(t, err)
+}
+
+func TestGetExperimentJsonPrinter(t *testing.T) {
+	rolloutObjs := testdata.NewExperimentAnalysisRollout()
+
+	tf, o := options.NewFakeArgoRolloutsOptions(rolloutObjs.AllObjects()...)
+	o.RESTClientGetter = tf.WithNamespace(rolloutObjs.Rollouts[0].Namespace)
+	defer tf.Cleanup()
+	cmd := NewCmdGetExperiment(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{rolloutObjs.Experiments[0].Name, "--output", "json"})
+	err := cmd.Execute()
+	assert.NoError(t, err)
+	txt := o.Out.(*bytes.Buffer).String()
+	var info info.ExperimentInfo
+	err = json.Unmarshal([]byte(txt), &info)
+	assert.NoError(t, err)
 }

--- a/pkg/kubectl-argo-rollouts/info/info.go
+++ b/pkg/kubectl-argo-rollouts/info/info.go
@@ -30,15 +30,12 @@ const (
 )
 
 type Metadata struct {
-	Name              string
-	Namespace         string
-	UID               types.UID
-	CreationTimestamp metav1.Time
+	metav1.ObjectMeta
 }
 
 type ImageInfo struct {
-	Image string
-	Tags  []string
+	Image string   `json:"image"`
+	Tags  []string `json:"tags"`
 }
 
 func (m Metadata) Age() string {

--- a/pkg/kubectl-argo-rollouts/info/info_test.go
+++ b/pkg/kubectl-argo-rollouts/info/info_test.go
@@ -72,7 +72,9 @@ func newBlueGreenRollout() *v1alpha1.Rollout {
 
 func TestAge(t *testing.T) {
 	m := Metadata{
-		CreationTimestamp: metav1.NewTime(time.Now().Add(-7 * time.Hour * time.Duration(24))),
+		ObjectMeta: metav1.ObjectMeta{
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-7 * time.Hour * time.Duration(24))),
+		},
 	}
 	assert.Equal(t, "7d", m.Age())
 }
@@ -106,8 +108,8 @@ func TestBlueGreenRolloutInfo(t *testing.T) {
 		assert.Len(t, roInfo.ReplicaSetsByRevision(10), 1)
 		assert.Len(t, roInfo.ReplicaSetsByRevision(8), 1)
 
-		assert.Equal(t, roInfo.ReplicaSets[0].ScaleDownDeadline, "")
-		assert.Equal(t, roInfo.ReplicaSets[0].ScaleDownDelay(), "")
+		assert.Equal(t, roInfo.Spec.ReplicaSets[0].Spec.ScaleDownDeadline, "")
+		assert.Equal(t, roInfo.Spec.ReplicaSets[0].Spec.ScaleDownDelay(), "")
 
 		assert.Equal(t, roInfo.Images(), []ImageInfo{
 			{
@@ -127,9 +129,9 @@ func TestBlueGreenRolloutInfo(t *testing.T) {
 		delayedRs := rolloutObjs.ReplicaSets[0].ObjectMeta.UID
 		roInfo := NewRolloutInfo(rolloutObjs.Rollouts[0], rolloutObjs.ReplicaSets, rolloutObjs.Pods, rolloutObjs.Experiments, rolloutObjs.AnalysisRuns)
 
-		assert.Equal(t, roInfo.ReplicaSets[1].UID, delayedRs)
-		assert.Equal(t, roInfo.ReplicaSets[1].ScaleDownDeadline, inFourHours)
-		assert.Equal(t, roInfo.ReplicaSets[1].ScaleDownDelay(), "3h59m")
+		assert.Equal(t, roInfo.Spec.ReplicaSets[1].UID, delayedRs)
+		assert.Equal(t, roInfo.Spec.ReplicaSets[1].Spec.ScaleDownDeadline, inFourHours)
+		assert.Equal(t, roInfo.Spec.ReplicaSets[1].Spec.ScaleDownDelay(), "3h59m")
 	}
 }
 
@@ -161,7 +163,7 @@ func TestExperimentInfo(t *testing.T) {
 	expInfo := NewExperimentInfo(rolloutObjs.Experiments[0], rolloutObjs.ReplicaSets, rolloutObjs.AnalysisRuns, rolloutObjs.Pods)
 	assert.Equal(t, expInfo.Name, rolloutObjs.Experiments[0].Name)
 
-	assert.Equal(t, expInfo.Images(), []ImageInfo{
+	assert.Equal(t, expInfo.Spec.Images(), []ImageInfo{
 		{
 			Image: "argoproj/rollouts-demo:blue",
 		},


### PR DESCRIPTION
Add common k8s print flags to get rollout/experiments commands.

```
-o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
      --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
```

Example usages:
```
# Output json
kubectl argo rollouts get rollout guestbook -o json

# Print status
kubectl argo rollouts get rollout guestbook -o jsonpath='{.spec.status}'
Healthy

# Print Blue Green preview replica set status
kubectl argo rollouts get rollout guestbook -o jsonpath='{.spec.replicaSets[?(@.spec.preview==true)].spec.status}'
Progressing
```

Refs #596

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).