### PR TITLE
feat: web metrics preserve data types, allow insecure tls, and make jsonPath optional

### DIFF
--- a/manifests/crds/analysis-run-crd.yaml
+++ b/manifests/crds/analysis-run-crd.yaml
@@ -2707,6 +2707,8 @@ spec:
                               - value
                               type: object
                             type: array
+                          insecure:
+                            type: boolean
                           jsonPath:
                             type: string
                           timeoutSeconds:
@@ -2714,7 +2716,6 @@ spec:
                           url:
                             type: string
                         required:
-                        - jsonPath
                         - url
                         type: object
                     type: object

--- a/manifests/crds/analysis-template-crd.yaml
+++ b/manifests/crds/analysis-template-crd.yaml
@@ -2701,6 +2701,8 @@ spec:
                               - value
                               type: object
                             type: array
+                          insecure:
+                            type: boolean
                           jsonPath:
                             type: string
                           timeoutSeconds:
@@ -2708,7 +2710,6 @@ spec:
                           url:
                             type: string
                         required:
-                        - jsonPath
                         - url
                         type: object
                     type: object

--- a/manifests/crds/cluster-analysis-template-crd.yaml
+++ b/manifests/crds/cluster-analysis-template-crd.yaml
@@ -2701,6 +2701,8 @@ spec:
                               - value
                               type: object
                             type: array
+                          insecure:
+                            type: boolean
                           jsonPath:
                             type: string
                           timeoutSeconds:
@@ -2708,7 +2710,6 @@ spec:
                           url:
                             type: string
                         required:
-                        - jsonPath
                         - url
                         type: object
                     type: object

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: analysisruns.argoproj.io
 spec:
   additionalPrinterColumns:
@@ -2715,7 +2715,6 @@ spec:
                           url:
                             type: string
                         required:
-                        - jsonPath
                         - url
                         type: object
                     type: object
@@ -2814,7 +2813,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: analysistemplates.argoproj.io
 spec:
   group: argoproj.io
@@ -5520,7 +5519,6 @@ spec:
                           url:
                             type: string
                         required:
-                        - jsonPath
                         - url
                         type: object
                     type: object
@@ -5547,7 +5545,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: clusteranalysistemplates.argoproj.io
 spec:
   group: argoproj.io
@@ -8253,7 +8251,6 @@ spec:
                           url:
                             type: string
                         required:
-                        - jsonPath
                         - url
                         type: object
                     type: object
@@ -8280,7 +8277,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: experiments.argoproj.io
 spec:
   additionalPrinterColumns:
@@ -10955,7 +10952,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: rollouts.argoproj.io
 spec:
   additionalPrinterColumns:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: analysisruns.argoproj.io
 spec:
   additionalPrinterColumns:
@@ -2715,7 +2715,6 @@ spec:
                           url:
                             type: string
                         required:
-                        - jsonPath
                         - url
                         type: object
                     type: object
@@ -2814,7 +2813,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: analysistemplates.argoproj.io
 spec:
   group: argoproj.io
@@ -5520,7 +5519,6 @@ spec:
                           url:
                             type: string
                         required:
-                        - jsonPath
                         - url
                         type: object
                     type: object
@@ -5547,7 +5545,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: clusteranalysistemplates.argoproj.io
 spec:
   group: argoproj.io
@@ -8253,7 +8251,6 @@ spec:
                           url:
                             type: string
                         required:
-                        - jsonPath
                         - url
                         type: object
                     type: object
@@ -8280,7 +8277,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: experiments.argoproj.io
 spec:
   additionalPrinterColumns:
@@ -10955,7 +10952,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: rollouts.argoproj.io
 spec:
   additionalPrinterColumns:

--- a/pkg/apis/rollouts/v1alpha1/analysis_types.go
+++ b/pkg/apis/rollouts/v1alpha1/analysis_types.go
@@ -124,8 +124,10 @@ func (m *Metric) EffectiveCount() *int32 {
 type MetricProvider struct {
 	// Prometheus specifies the prometheus metric to query
 	Prometheus *PrometheusMetric `json:"prometheus,omitempty"`
-	Kayenta    *KayentaMetric    `json:"kayenta,omitempty"`
-	Web        *WebMetric        `json:"web,omitempty"`
+	// Kayenta specifies a Kayenta metric
+	Kayenta *KayentaMetric `json:"kayenta,omitempty"`
+	// Web specifies a generic HTTP web metric
+	Web *WebMetric `json:"web,omitempty"`
 	// Wavefront specifies the wavefront metric to query
 	Wavefront *WavefrontMetric `json:"wavefront,omitempty"`
 	// Job specifies the job metric run
@@ -330,12 +332,18 @@ type ScopeDetail struct {
 }
 
 type WebMetric struct {
+	// URL is the address of the web metric
 	URL string `json:"url"`
 	// +patchMergeKey=key
 	// +patchStrategy=merge
-	Headers        []WebMetricHeader `json:"headers,omitempty" patchStrategy:"merge" patchMergeKey:"key"`
-	TimeoutSeconds int               `json:"timeoutSeconds,omitempty"`
-	JSONPath       string            `json:"jsonPath"`
+	// Headers are optional HTTP headers to use in the request
+	Headers []WebMetricHeader `json:"headers,omitempty" patchStrategy:"merge" patchMergeKey:"key"`
+	// TimeoutSeconds is the timeout for the request in seconds (default: 10)
+	TimeoutSeconds int `json:"timeoutSeconds,omitempty"`
+	// JSONPath is a JSON Path to use as the result variable (default: "{$}")
+	JSONPath string `json:"jsonPath,omitempty"`
+	// Insecure skips host TLS verification
+	Insecure bool `json:"insecure,omitempty"`
 }
 
 type WebMetricHeader struct {

--- a/test/e2e/functional/analysistemplate-web-background.yaml
+++ b/test/e2e/functional/analysistemplate-web-background.yaml
@@ -1,3 +1,4 @@
+# A dummy web metric which uses the kubernetes version endpoint as a metric provider
 apiVersion: argoproj.io/v1alpha1
 kind: AnalysisTemplate
 metadata:
@@ -9,5 +10,5 @@ spec:
     successCondition: result.major == '1'
     provider:
       web:
-        url: http://kubernetes.default.svc/version
-        jsonPath: "{$.}" 
+        url: https://kubernetes.default.svc/version
+        insecure: true

--- a/test/fixtures/given.go
+++ b/test/fixtures/given.go
@@ -1,7 +1,6 @@
 package fixtures
 
 import (
-	"fmt"
 	"io/ioutil"
 	"strconv"
 	"strings"
@@ -28,8 +27,7 @@ func (g *Given) RolloutObjects(text string) *Given {
 	// Some E2E AnalysisTemplates use http://kubernetes.default.svc/version as a fake metric provider.
 	// This doesn't work outside the cluster, so the following replaces it with the host from the
 	// rest config.
-	newKubernetesURL := fmt.Sprintf("%s/version", g.kubernetesHost)
-	yamlString := strings.ReplaceAll(string(yamlBytes), "http://kubernetes.default.svc/version", newKubernetesURL)
+	yamlString := strings.ReplaceAll(string(yamlBytes), "https://kubernetes.default.svc", g.kubernetesHost)
 
 	objs, err := unstructuredutil.SplitYAML(yamlString)
 	g.CheckError(err)

--- a/utils/evaluate/evaluate.go
+++ b/utils/evaluate/evaluate.go
@@ -2,6 +2,7 @@ package evaluate
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 
 	"github.com/antonmedv/expr"
@@ -85,18 +86,74 @@ func EvalCondition(resultValue interface{}, condition string) (bool, error) {
 	return output.(bool), err
 }
 
-func asInt(in string) int64 {
-	inAsInt, err := strconv.ParseInt(in, 10, 64)
-	if err == nil {
-		return inAsInt
+func asInt(in interface{}) int64 {
+	switch i := in.(type) {
+	case float64:
+		return int64(i)
+	case float32:
+		return int64(i)
+	case int64:
+		return i
+	case int32:
+		return int64(i)
+	case int16:
+		return int64(i)
+	case int8:
+		return int64(i)
+	case int:
+		return int64(i)
+	case uint64:
+		return int64(i)
+	case uint32:
+		return int64(i)
+	case uint16:
+		return int64(i)
+	case uint8:
+		return int64(i)
+	case uint:
+		return int64(i)
+	case string:
+		inAsInt, err := strconv.ParseInt(i, 10, 64)
+		if err == nil {
+			return inAsInt
+		}
+		panic(err)
 	}
-	panic(err)
+	panic(fmt.Sprintf("asInt() not supported on %v %v", reflect.TypeOf(in), in))
 }
 
-func asFloat(in string) float64 {
-	inAsFloat, err := strconv.ParseFloat(in, 64)
-	if err == nil {
-		return inAsFloat
+func asFloat(in interface{}) float64 {
+	switch i := in.(type) {
+	case float64:
+		return i
+	case float32:
+		return float64(i)
+	case int64:
+		return float64(i)
+	case int32:
+		return float64(i)
+	case int16:
+		return float64(i)
+	case int8:
+		return float64(i)
+	case int:
+		return float64(i)
+	case uint64:
+		return float64(i)
+	case uint32:
+		return float64(i)
+	case uint16:
+		return float64(i)
+	case uint8:
+		return float64(i)
+	case uint:
+		return float64(i)
+	case string:
+		inAsFloat, err := strconv.ParseFloat(i, 64)
+		if err == nil {
+			return inAsFloat
+		}
+		panic(err)
 	}
-	panic(err)
+	panic(fmt.Sprintf("asFloat() not supported on %v %v", reflect.TypeOf(in), in))
 }


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/728, https://github.com/argoproj/argo-rollouts/issues/718, https://github.com/argoproj/argo-rollouts/issues/717

1. When using jsonPath, the web metric always converted the result into a string. This is why the `asFloat` and `asInt` helpers were introduced, in to convert these strings into numbers so that mathematical comparison could be performed. This change preserves the original types so that `asFloat` and `asInt` are no longer necessary (as long as the original data types are numeric).

2. Previously, `jsonPath` was a required field. This change allows `jsonPath` to be omitted, in which case the entire body is the payload.

3. Added an `insecure: true` field that allows the web metric to disable TLS host verification when making HTTP requests.