### PR TITLE
fix: scaleDown stableRS for not running

### DIFF
--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -163,10 +163,12 @@ func CalculateReplicaCountsForCanary(rollout *v1alpha1.Rollout, newRS *appsv1.Re
 	minAvailableReplicaCount := rolloutSpecReplica - MaxUnavailable(rollout)
 
 	totalAvailableOlderReplicaCount := GetAvailableReplicaCountForReplicaSets(oldRSs)
-	scaleDownCount := GetReplicasForScaleDown(newRS) + GetReplicasForScaleDown(stableRS) + totalAvailableOlderReplicaCount - minAvailableReplicaCount
+	stableRSReplicasForScaleDown := GetReplicasForScaleDown(stableRS)
+	scaleDownCount := GetReplicasForScaleDown(newRS) + stableRSReplicasForScaleDown + totalAvailableOlderReplicaCount - minAvailableReplicaCount
 
 	if scaleDownCount <= 0 {
 		// Cannot scale down stableRS or newRS without going below min available replica count
+		stableRSReplicaCount = stableRSReplicasForScaleDown
 		return newRSReplicaCount, stableRSReplicaCount
 	}
 


### PR DESCRIPTION

After the program version of crashloopbackoff is deployed for the first time, the number of copies of the old version is not deleted after rolling out the version that can be run