### PR TITLE
fix(controller): calculate bluegreen available replicas from active ReplicaSet

### DIFF
--- a/rollout/analysis_test.go
+++ b/rollout/analysis_test.go
@@ -1628,7 +1628,7 @@ func TestDoNotCreatePrePromotionAnalysisRunOnNotReadyReplicaSet(t *testing.T) {
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-	r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 2, 4, 2, false, true)
+	r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 2, 2, 4, 2, false, true)
 
 	activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}
 	activeSvc := newService("active", 80, activeSelector, r2)

--- a/rollout/bluegreen_test.go
+++ b/rollout/bluegreen_test.go
@@ -147,7 +147,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 		rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 2, 4, 2, false, true)
+		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 2, 2, 4, 2, false, true)
 
 		activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}
 		activeSvc := newService("active", 80, activeSelector, r2)
@@ -742,6 +742,7 @@ func TestBlueGreenRolloutStatusHPAStatusFieldsActiveSelectorSet(t *testing.T) {
 	expectedPatchWithoutSubs := `{
 		"status":{
 			"HPAReplicas":1,
+			"readyReplicas":1,
 			"availableReplicas":1,
 			"updatedReplicas":1,
 			"replicas":2,
@@ -786,6 +787,7 @@ func TestBlueGreenRolloutStatusHPAStatusFieldsNoActiveSelector(t *testing.T) {
 	expectedPatchWithoutSub := `{
 		"status":{
 			"HPAReplicas":1,
+			"readyReplicas": 1,
 			"availableReplicas": 1,
 			"updatedReplicas":1,
 			"replicas":1,

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -143,6 +143,7 @@ func newReplicaSetWithStatus(r *v1alpha1.Rollout, replicas int, availableReplica
 	rs := newReplicaSet(r, replicas)
 	rs.Status.Replicas = int32(replicas)
 	rs.Status.AvailableReplicas = int32(availableReplicas)
+	rs.Status.ReadyReplicas = int32(availableReplicas)
 	return rs
 }
 
@@ -303,6 +304,7 @@ func updateBaseRolloutStatus(r *v1alpha1.Rollout, availableReplicas, updatedRepl
 	newRollout := r.DeepCopy()
 	newRollout.Status.Replicas = totalReplicas
 	newRollout.Status.AvailableReplicas = availableReplicas
+	newRollout.Status.ReadyReplicas = availableReplicas
 	newRollout.Status.UpdatedReplicas = updatedReplicas
 	newRollout.Status.HPAReplicas = hpaReplicas
 	return newRollout

--- a/test/e2e/analysis_test.go
+++ b/test/e2e/analysis_test.go
@@ -332,6 +332,8 @@ spec:
 		ExpectRevisionPodCount("1", 1).
 		ExpectRevisionPodCount("2", 0).
 		ExpectRevisionPodCount("3", 1).
+		ExpectActiveRevision("1").
+		ExpectPreviewRevision("3").
 		When().
 		PromoteRollout().
 		WaitForRolloutStatus("Healthy").

--- a/test/e2e/functional/rollout-bluegreen.yaml
+++ b/test/e2e/functional/rollout-bluegreen.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bluegreen
+spec:
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app: bluegreen
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: bluegreen
+spec:
+  replicas: 3
+  strategy:
+    blueGreen:
+      activeService: bluegreen
+      scaleDownDelaySeconds: 10
+  selector:
+    matchLabels:
+      app: bluegreen
+  template:
+    metadata:
+      labels:
+        app: bluegreen
+    spec:
+      containers:
+      - name: bluegreen
+        image: nginx:1.19-alpine
+        resources:
+          requests:
+            memory: 16Mi
+            cpu: 1m

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -307,3 +307,22 @@ spec:
 		Then().
 		ExpectCanaryStablePodCount(2, 2)
 }
+
+// TestBlueGreenUpdate
+func (s *FunctionalSuite) TestBlueGreenUpdate() {
+	s.Given().
+		HealthyRollout("@functional/rollout-bluegreen.yaml").
+		When().
+		Then().
+		ExpectReplicaCounts(3, 3, 3, 3, 3). // desired, current, updated, ready, available
+		When().
+		UpdateSpec().
+		WaitForRolloutStatus("Progressing").
+		WaitForActiveRevision("2").
+		Then().
+		ExpectReplicaCounts(3, 6, 3, 3, 3).
+		When().
+		WaitForRolloutStatus("Healthy").
+		Then().
+		ExpectReplicaCounts(3, 3, 3, 3, 3) // current may change after fixing https://github.com/argoproj/argo-rollouts/issues/756
+}

--- a/test/fixtures/common.go
+++ b/test/fixtures/common.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	log "github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -19,6 +20,7 @@ import (
 
 	rov1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	clientset "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned"
+	"github.com/argoproj/argo-rollouts/utils/annotations"
 	unstructuredutil "github.com/argoproj/argo-rollouts/utils/unstructured"
 )
 
@@ -59,6 +61,20 @@ func (c *Common) PrintRollout(ro *rov1.Rollout) {
 	bytes, err := json.Marshal(ro)
 	c.CheckError(err)
 	c.log.Info(string(bytes))
+}
+
+func (c *Common) GetReplicaSetByRevision(revision string) *appsv1.ReplicaSet {
+	selector, err := metav1.LabelSelectorAsSelector(c.Rollout().Spec.Selector)
+	c.CheckError(err)
+	replicasets, err := c.kubeClient.AppsV1().ReplicaSets(c.namespace).List(c.Context, metav1.ListOptions{LabelSelector: selector.String()})
+	c.CheckError(err)
+	for _, rs := range replicasets.Items {
+		if rs.Annotations[annotations.RevisionAnnotation] == revision {
+			return &rs
+		}
+	}
+	c.t.Fatalf("Could not find ReplicaSet with revision: %s", revision)
+	return nil
 }
 
 func (c *Common) GetRolloutAnalysisRuns() rov1.AnalysisRunList {

--- a/test/fixtures/then.go
+++ b/test/fixtures/then.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	rov1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
-	"github.com/argoproj/argo-rollouts/utils/annotations"
+	"github.com/argoproj/argo-rollouts/utils/defaults"
 )
 
 type Then struct {
@@ -26,6 +26,27 @@ func (t *Then) ExpectRollout(expectation string, expectFunc RolloutExpectation) 
 		t.t.FailNow()
 	}
 	t.log.Infof("Rollout expectation '%s' met", expectation)
+	return t
+}
+
+func (t *Then) ExpectReplicaCounts(desired, current, updated, ready, available interface{}) *Then {
+	ro, err := t.rolloutClient.ArgoprojV1alpha1().Rollouts(t.namespace).Get(t.Context, t.rollout.GetName(), metav1.GetOptions{})
+	t.CheckError(err)
+	if desired != nil && desired.(int) != int(defaults.GetReplicasOrDefault(ro.Spec.Replicas)) {
+		t.t.Fatalf("Expected %d desired replicas. Actual: %d", desired, defaults.GetReplicasOrDefault(ro.Spec.Replicas))
+	}
+	if current != nil && current.(int) != int(ro.Status.Replicas) {
+		t.t.Fatalf("Expected %d current replicas. Actual: %d", current, ro.Status.Replicas)
+	}
+	if ready != nil && ready.(int) != int(ro.Status.ReadyReplicas) {
+		t.t.Fatalf("Expected %d ready replicas. Actual: %d", ready, ro.Status.ReadyReplicas)
+	}
+	if updated != nil && updated.(int) != int(ro.Status.UpdatedReplicas) {
+		t.t.Fatalf("Expected %d updated replicas. Actual: %d", updated, ro.Status.UpdatedReplicas)
+	}
+	if available != nil && available.(int) != int(ro.Status.AvailableReplicas) {
+		t.t.Fatalf("Expected %d available replicas. Actual: %d", available, ro.Status.AvailableReplicas)
+	}
 	return t
 }
 
@@ -52,24 +73,10 @@ func (t *Then) ExpectCanaryStablePodCount(canaryCount, stableCount int) *Then {
 }
 
 func (t *Then) ExpectRevisionPodCount(revision string, expectedCount int) *Then {
-	rs := t.getReplicaSetByRevision(revision)
+	rs := t.GetReplicaSetByRevision(revision)
 	description := fmt.Sprintf("revision:%s", revision)
 	hash := rs.Labels[rov1.DefaultRolloutUniqueLabelKey]
 	return t.expectPodCountByHash(description, hash, expectedCount)
-}
-
-func (t *Then) getReplicaSetByRevision(revision string) *appsv1.ReplicaSet {
-	selector, err := metav1.LabelSelectorAsSelector(t.Rollout().Spec.Selector)
-	t.CheckError(err)
-	replicasets, err := t.kubeClient.AppsV1().ReplicaSets(t.namespace).List(t.Context, metav1.ListOptions{LabelSelector: selector.String()})
-	t.CheckError(err)
-	for _, rs := range replicasets.Items {
-		if rs.Annotations[annotations.RevisionAnnotation] == revision {
-			return &rs
-		}
-	}
-	t.t.Fatalf("Could not find ReplicaSet with revision: %s", revision)
-	return nil
 }
 
 func (t *Then) expectPodCountByHash(description, hash string, expectedCount int) *Then {
@@ -173,7 +180,7 @@ func (t *Then) verifyBlueGreenSelectorRevision(which string, revision string) *T
 		}
 		svc, err := t.kubeClient.CoreV1().Services(t.namespace).Get(t.Context, serviceName, metav1.GetOptions{})
 		t.CheckError(err)
-		rs := t.getReplicaSetByRevision(revision)
+		rs := t.GetReplicaSetByRevision(revision)
 		if selector != svc.Spec.Selector[rov1.DefaultRolloutUniqueLabelKey] {
 			return fmt.Errorf("Expectation failed: blueGreen %s selector/service selector mismatch %s != %s", which, selector, svc.Spec.Selector[rov1.DefaultRolloutUniqueLabelKey])
 		}

--- a/test/fixtures/when.go
+++ b/test/fixtures/when.go
@@ -209,6 +209,14 @@ func (w *When) WaitForRolloutReplicas(count int32) *When {
 	return w.WaitForRolloutCondition(checkStatus, fmt.Sprintf("status.replicas=%d", count), E2EWaitTimeout)
 }
 
+func (w *When) WaitForActiveRevision(revision string) *When {
+	rs := w.GetReplicaSetByRevision(revision)
+	checkStatus := func(ro *rov1.Rollout) bool {
+		return ro.Status.BlueGreen.ActiveSelector == rs.Labels[rov1.DefaultRolloutUniqueLabelKey]
+	}
+	return w.WaitForRolloutCondition(checkStatus, fmt.Sprintf("active revision=%s", revision), E2EWaitTimeout)
+}
+
 func (w *When) WaitForRolloutCondition(test func(ro *rov1.Rollout) bool, condition string, timeout time.Duration) *When {
 	start := time.Now()
 	w.log.Infof("Waiting for condition: %s", condition)


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/750

Changes behavior of blue-green replica calculation to derive information from the active replicaset (if available). Otherwise, they are derived from all replicasets.