### PR TITLE
test: add e2e test for previewReplicaCount and bluegreen-to-canary

### DIFF
--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -326,3 +326,54 @@ func (s *FunctionalSuite) TestBlueGreenUpdate() {
 		Then().
 		ExpectReplicaCounts(3, 3, 3, 3, 3) // current may change after fixing https://github.com/argoproj/argo-rollouts/issues/756
 }
+
+// TestBlueGreenPreviewReplicaCount verifies the previewReplicaCount feature
+func (s *FunctionalSuite) TestBlueGreenPreviewReplicaCount() {
+	s.Given().
+		RolloutObjects(newService("bluegreen-preview-replicas-active")).
+		RolloutObjects(newService("bluegreen-preview-replicas-preview")).
+		RolloutObjects(`
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: bluegreen-preview-replicas
+spec:
+  replicas: 2
+  strategy:
+    blueGreen:
+      activeService: bluegreen-preview-replicas-active
+      previewService: bluegreen-preview-replicas-preview
+      previewReplicaCount: 1
+      scaleDownDelaySeconds: 5
+      autoPromotionEnabled: false
+  selector:
+    matchLabels:
+      app: bluegreen-preview-replicas
+  template:
+    metadata:
+      labels:
+        app: bluegreen-preview-replicas
+    spec:
+      containers:
+      - name: bluegreen-preview-replicas
+        image: nginx:1.19-alpine
+        resources:
+          requests:
+            memory: 16Mi
+            cpu: 1m
+`).
+		When().
+		ApplyManifests().
+		WaitForRolloutStatus("Healthy").
+		UpdateSpec().
+		WaitForRolloutStatus("Paused").
+		Then().
+		ExpectRevisionPodCount("2", 1).
+		ExpectRevisionPodCount("1", 2).
+		ExpectReplicaCounts(2, 3, 1, 2, 2). // desired, current, updated, ready, available
+		When().
+		PromoteRollout().
+		WaitForRolloutStatus("Healthy").
+		Then().
+		ExpectReplicaCounts(2, 2, 2, 2, 2) // current may change after fixing https://github.com/argoproj/argo-rollouts/issues/756
+}

--- a/test/fixtures/then.go
+++ b/test/fixtures/then.go
@@ -2,6 +2,7 @@ package fixtures
 
 import (
 	"fmt"
+	"reflect"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -47,6 +48,7 @@ func (t *Then) ExpectReplicaCounts(desired, current, updated, ready, available i
 	if available != nil && available.(int) != int(ro.Status.AvailableReplicas) {
 		t.t.Fatalf("Expected %d available replicas. Actual: %d", available, ro.Status.AvailableReplicas)
 	}
+	t.log.Infof("Replica count expectation met (desired:%v, current:%v, updated:%v, ready:%v, available:%v)", desired, current, updated, ready, available)
 	return t
 }
 
@@ -205,6 +207,16 @@ func (t *Then) verifyBlueGreenSelectorRevision(which string, revision string) *T
 	}
 	t.log.Error(err)
 	t.t.FailNow()
+	return t
+}
+
+func (t *Then) ExpectServiceSelector(service string, selector map[string]string) *Then {
+	svc, err := t.kubeClient.CoreV1().Services(t.namespace).Get(t.Context, service, metav1.GetOptions{})
+	t.CheckError(err)
+	if !reflect.DeepEqual(svc.Spec.Selector, selector) {
+		t.t.Fatalf("Expected %s selector: %v. Actual: %v", service, selector, svc.Spec.Selector)
+	}
+	t.log.Infof("Expectation %s selector: %v met", service, selector)
 	return t
 }
 


### PR DESCRIPTION
Adds two e2e test to:
* verify the bluegreen previewReplicaCount feature
* verify behavior when switching strategies from blue-green to canary