### PR TITLE
fix: blue-green scaleDownDelay was delaying Healthy status

### DIFF
--- a/pkg/kubectl-argo-rollouts/cmd/get/get_rollout.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get_rollout.go
@@ -109,6 +109,9 @@ func (o *GetOptions) PrintRollout(roInfo *info.RolloutInfo) {
 	fmt.Fprintf(o.Out, tableFormat, "Name:", roInfo.Name)
 	fmt.Fprintf(o.Out, tableFormat, "Namespace:", roInfo.Namespace)
 	fmt.Fprintf(o.Out, tableFormat, "Status:", o.colorize(roInfo.Icon)+" "+roInfo.Status)
+	if roInfo.Message != "" {
+		fmt.Fprintf(o.Out, tableFormat, "Message:", roInfo.Message)
+	}
 	fmt.Fprintf(o.Out, tableFormat, "Strategy:", roInfo.Strategy)
 	if roInfo.Strategy == "Canary" {
 		fmt.Fprintf(o.Out, tableFormat, "  Step:", roInfo.Step)
@@ -129,12 +132,6 @@ func (o *GetOptions) PrintRollout(roInfo *info.RolloutInfo) {
 	fmt.Fprintf(o.Out, tableFormat, "  Ready:", roInfo.Ready)
 	fmt.Fprintf(o.Out, tableFormat, "  Available:", roInfo.Available)
 
-	if len(roInfo.ErrorConditions) > 0 {
-		fmt.Fprintf(o.Out, "Errors:\n")
-		for _, msg := range roInfo.ErrorConditions {
-			fmt.Fprintf(o.Out, "* %s\n", msg)
-		}
-	}
 	fmt.Fprintf(o.Out, "\n")
 	o.PrintRolloutTree(roInfo)
 }

--- a/pkg/kubectl-argo-rollouts/cmd/get/get_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get_test.go
@@ -256,6 +256,7 @@ func TestGetCanaryRollout(t *testing.T) {
 Name:            canary-demo
 Namespace:       jesse-test
 Status:          ✖ Degraded
+Message:         ProgressDeadlineExceeded: ReplicaSet "canary-demo-65fb5ffc84" has timed out progressing.
 Strategy:        Canary
   Step:          0/8
   SetWeight:     20
@@ -303,6 +304,7 @@ func TestExperimentRollout(t *testing.T) {
 Name:            rollout-experiment-analysis
 Namespace:       jesse-test
 Status:          ✖ Degraded
+Message:         ProgressDeadlineExceeded: ReplicaSet "rollout-experiment-analysis-6f646bf7b7" has timed out progressing.
 Strategy:        Canary
   Step:          1/2
   SetWeight:     25
@@ -382,6 +384,7 @@ func TestGetRolloutWithExperimentJob(t *testing.T) {
 Name:            canary-demo
 Namespace:       jesse-test
 Status:          ◌ Progressing
+Message:         more replicas need to be updated
 Strategy:        Canary
   Step:          0/1
   SetWeight:     0
@@ -429,7 +432,8 @@ func TestGetInvalidRollout(t *testing.T) {
 	expectedOut := strings.TrimPrefix(`
 Name:            rollout-invalid
 Namespace:       default
-Status:          ⚠ InvalidSpec
+Status:          ✖ Degraded
+Message:         InvalidSpec: The Rollout "rollout-invalid" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"app":"doesnt-match"}: `+"`selector`"+` does not match template `+"`labels`"+`
 Strategy:        Canary
   Step:
   SetWeight:     100
@@ -440,11 +444,9 @@ Replicas:
   Updated:       0
   Ready:         0
   Available:     0
-Errors:
-* The Rollout "rollout-invalid" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"app":"doesnt-match"}: `+"`selector`"+` does not match template `+"`labels`"+`
 
-NAME               KIND     STATUS         AGE  INFO
-⟳ rollout-invalid  Rollout  ⚠ InvalidSpec  7d
+NAME               KIND     STATUS      AGE  INFO
+⟳ rollout-invalid  Rollout  ✖ Degraded  7d
 `, "\n")
 	assertStdout(t, expectedOut, o.IOStreams)
 }
@@ -464,6 +466,7 @@ func TestGetAbortedRollout(t *testing.T) {
 Name:            rollout-background-analysis
 Namespace:       default
 Status:          ✖ Degraded
+Message:         RolloutAborted: metric "web" assessed Failed due to failed (1) > failureLimit (0)
 Strategy:        Canary
   Step:          0/2
   SetWeight:     0
@@ -475,8 +478,6 @@ Replicas:
   Updated:       0
   Ready:         1
   Available:     1
-Errors:
-* metric "web" assessed Failed due to failed (1) > failureLimit (0)
 
 NAME                                                     KIND         STATUS        AGE  INFO
 ⟳ rollout-background-analysis                            Rollout      ✖ Degraded    7d

--- a/pkg/kubectl-argo-rollouts/cmd/list/rollloutinfo.go
+++ b/pkg/kubectl-argo-rollouts/cmd/list/rollloutinfo.go
@@ -63,7 +63,7 @@ func newRolloutInfo(ro v1alpha1.Rollout) rolloutInfo {
 	} else if ro.Spec.Strategy.BlueGreen != nil {
 		ri.strategy = "BlueGreen"
 	}
-	ri.status = info.RolloutStatusString(&ro)
+	ri.status, _ = info.RolloutStatusString(&ro)
 
 	ri.desired = 1
 	if ro.Spec.Replicas != nil {

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -324,7 +324,7 @@ func (s *FunctionalSuite) TestBlueGreenUpdate() {
 		When().
 		WaitForRolloutStatus("Healthy").
 		Then().
-		ExpectReplicaCounts(3, 3, 3, 3, 3) // current may change after fixing https://github.com/argoproj/argo-rollouts/issues/756
+		ExpectReplicaCounts(3, 6, 3, 3, 3)
 }
 
 // TestBlueGreenPreviewReplicaCount verifies the previewReplicaCount feature
@@ -375,7 +375,7 @@ spec:
 		PromoteRollout().
 		WaitForRolloutStatus("Healthy").
 		Then().
-		ExpectReplicaCounts(2, 2, 2, 2, 2) // current may change after fixing https://github.com/argoproj/argo-rollouts/issues/756
+		ExpectReplicaCounts(2, 4, 2, 2, 2)
 }
 
 // TestBlueGreenToCanary tests behavior when migrating from bluegreen to canary

--- a/test/fixtures/when.go
+++ b/test/fixtures/when.go
@@ -166,10 +166,8 @@ func (w *When) PatchSpec(patch string) *When {
 
 func (w *When) WaitForRolloutStatus(status string) *When {
 	checkStatus := func(ro *rov1.Rollout) bool {
-		if info.RolloutStatusString(ro) == status {
-			return true
-		}
-		return false
+		s, _ := info.RolloutStatusString(ro)
+		return s == status
 	}
 	return w.WaitForRolloutCondition(checkStatus, fmt.Sprintf("status=%s", status), E2EWaitTimeout)
 }
@@ -188,7 +186,8 @@ func (w *When) WaitForRolloutCanaryStepIndex(index int32) *When {
 			//      WaitForRolloutCanaryStepIndex(N).
 			//      WaitForRolloutStatus("Paused").
 			// which would be annoying.
-			return info.RolloutStatusString(ro) == "Paused"
+			status, _ := info.RolloutStatusString(ro)
+			return status == "Paused"
 		}
 		return true
 	}


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/756

Unlike canary, in the case of blue-green, the plugin should **_not_** consider a Rollout as still Progressing if it has more Status.Replicas than Status.UpdatedReplicas. This is because the blue-green has a scaleDownDelay, where it can leave old replicasets scaled up for a long time. These scaled up replicasets do not impact the service (unlike canary) because they are not reachable from the active service. This logic is already in Argo CD Rollout health check, but not in the plugin.

Also, this PR changes the output of the plugin such that messages and errors show up in a new "messages" row, in a consistent manner like Argo CD. See below examples:

```
Name:            canary-demo
Namespace:       jesse-test
Status:          ◌ Progressing
Message:         more replicas need to be updated
```

```
Name:            rollout-invalid
Namespace:       default
Status:          ✖ Degraded
Message:         InvalidSpec: The Rollout "rollout-invalid" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"app":"doesnt-match"}: `+"`selector`"+` does not match template `+"`labels`"+`
Strategy:        Canary
```
