### PR TITLE
feat(controller): add support for canary/stable ephemeral metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ lint:
 
 .PHONY: test
 test: test-kustomize
-	go test -failfast -covermode=count -coverprofile=coverage.out ${TEST_TARGET}
+	go test -covermode=count -coverprofile=coverage.out ${TEST_TARGET}
 
 .PHONY: test-kustomize
 test-kustomize:

--- a/docs/features/analysis.md
+++ b/docs/features/analysis.md
@@ -916,6 +916,9 @@ to convert a result value to a numeric type so that mathematical comparison oper
 
 ## Datadog Metrics
 
+!!! important
+    Available since v0.10.0
+
 A [Datadog](https://www.datadoghq.com/) query can be used to obtain measurements for analysis.
 
 ```yaml
@@ -954,6 +957,9 @@ data:
 ```
 
 ## NewRelic Metrics
+
+!!! important
+    Available since v0.10.0
 
 A [New Relic](https://newrelic.com/) query using [NRQL](https://docs.newrelic.com/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language) can be used to obtain measurements for analysis.  
 

--- a/docs/features/canary.md
+++ b/docs/features/canary.md
@@ -45,7 +45,7 @@ spec:
 ```
 
 ## Pause Duration
-Pause duration can be specified with an optional time unit suffix. Valid time units are "s", "m", "h". Defaults to "s" if not specified. Values less than zero are not allowed. 
+Pause duration can be specified with an optional time unit suffix. Valid time units are "s", "m", "h". Defaults to "s" if not specified.
 
 ```yaml
 spec:
@@ -56,7 +56,6 @@ spec:
         - pause: { duration: 10s } # 10 seconds
         - pause: { duration: 10m } # 10 minutes
         - pause: { duration: 10h } # 10 hours
-        - pause: { duration: -10 } # invalid spec!
         - pause: {}                # pause indefinitely
 ```
 
@@ -70,8 +69,50 @@ kubectl argo rollouts promote <rollout>
 ## Mimicking Rolling Update
 If the steps field is omitted, the canary strategy will mimic the rolling update behavior. Similar to the deployment, the canary strategy has the `maxSurge` and `maxUnavailable` fields to configure how the Rollout should progress to the new version.
 
+
+## Ephemeral Metadata
+
+!!! important
+    Available since v0.10.0
+
+One use case is for a Rollout to label or annotate the canary/stable pods with user-defined labels/annotations,
+for *only* the duration which they are the canary or stable set, and for the labels to be updated/removed as soon
+as the ReplicaSet switches roles (e.g. from canary to stable). The use case which this enables, is to allow
+prometheus, wavefront, datadog queries and dashboards to be built, which can rely on a consistent
+labels, rather than the `rollouts-pod-template-hash` which is unpredictable and changing from revision
+to revision.
+
+A Rollout using the canary strategy has the ability to attach ephemeral metadata to the stable or 
+canary Pods using the `stableMetadata` and `canaryMetadata` fields respectively.
+
+```yaml
+spec:
+  strategy:
+    canary:
+      stableMetadata:
+        labels:
+          role: stable
+      canaryMetadata:
+        labels:
+          role: canary
+```
+
+During an update, the Rollout will create the canary ReplicaSet while also merging the metadata
+defined in `canaryMetadata` to the canary ReplicaSet's `spec.template.metadata`. This results in all
+Pods of the ReplicaSet being created with the canary metadata. When the rollout becomes fully
+promoted, the canary ReplicaSet becomes the stable, and is updated to use the labels and annotations
+under `stableMetadata`. The Pods of the ReplicaSet will then be updated *in place* to use the stable
+metadata (without recreating the pods).
+
+!!! important
+    In order for tooling to take advantage of this feature, they would need to recognize the change
+    in labels and/or annotations that happen *after* the Pod has already started. Not all tools may
+    detect this.
+
+
 ## Other Configurable Features
 Here are the optional fields that will modify the behavior of canary strategy:
+
 ```yaml
 spec:
   strategy:

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,6 @@ github.com/blang/semver v3.5.0+incompatible h1:CGxCgetQ64DKk7rdZ++Vfnb1+ogGNnB17
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bombsimon/wsl/v3 v3.1.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
-github.com/bouk/monkey v1.0.0 h1:k6z8fLlPhETfn5l9rlWVE7Q6B23DoaqosTdArvNQRdc=
-github.com/bouk/monkey v1.0.0/go.mod h1:PG/63f4XEUlVyW1ttIeOJmJhhe1+t9EC/je3eTjvFhE=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/caarlos0/ctrlc v1.0.0/go.mod h1:CdXpj4rmq0q/1Eb44M9zi2nKB0QraNKuRGYGrrHhcQw=
 github.com/caddyserver/caddy v1.0.3/go.mod h1:G+ouvOY32gENkJC+jhgl62TyhvqEsFaDiZ4uw0RzP1E=

--- a/manifests/crds/rollout-crd.yaml
+++ b/manifests/crds/rollout-crd.yaml
@@ -260,6 +260,17 @@ spec:
                         requiredDuringSchedulingIgnoredDuringExecution:
                           type: object
                       type: object
+                    canaryMetadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
                     canaryService:
                       type: string
                     maxSurge:
@@ -272,6 +283,17 @@ spec:
                       - type: integer
                       - type: string
                       x-kubernetes-int-or-string: true
+                    stableMetadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
                     stableService:
                       type: string
                     steps:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -11342,6 +11342,17 @@ spec:
                         requiredDuringSchedulingIgnoredDuringExecution:
                           type: object
                       type: object
+                    canaryMetadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
                     canaryService:
                       type: string
                     maxSurge:
@@ -11354,6 +11365,17 @@ spec:
                       - type: integer
                       - type: string
                       x-kubernetes-int-or-string: true
+                    stableMetadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
                     stableService:
                       type: string
                     steps:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -11342,6 +11342,17 @@ spec:
                         requiredDuringSchedulingIgnoredDuringExecution:
                           type: object
                       type: object
+                    canaryMetadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
                     canaryService:
                       type: string
                     maxSurge:
@@ -11354,6 +11365,17 @@ spec:
                       - type: integer
                       - type: string
                       x-kubernetes-int-or-string: true
+                    stableMetadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
                     stableService:
                       type: string
                     steps:

--- a/pkg/apis/rollouts/v1alpha1/openapi_generated.go
+++ b/pkg/apis/rollouts/v1alpha1/openapi_generated.go
@@ -56,6 +56,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.ExperimentList":                                  schema_pkg_apis_rollouts_v1alpha1_ExperimentList(ref),
 		"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.ExperimentSpec":                                  schema_pkg_apis_rollouts_v1alpha1_ExperimentSpec(ref),
 		"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.ExperimentStatus":                                schema_pkg_apis_rollouts_v1alpha1_ExperimentStatus(ref),
+		"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.FieldRef":                                        schema_pkg_apis_rollouts_v1alpha1_FieldRef(ref),
 		"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.IstioTrafficRouting":                             schema_pkg_apis_rollouts_v1alpha1_IstioTrafficRouting(ref),
 		"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.IstioVirtualService":                             schema_pkg_apis_rollouts_v1alpha1_IstioVirtualService(ref),
 		"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.JobMetric":                                       schema_pkg_apis_rollouts_v1alpha1_JobMetric(ref),
@@ -597,9 +598,17 @@ func schema_pkg_apis_rollouts_v1alpha1_ArgumentValueFrom(ref common.ReferenceCal
 							Format:      "",
 						},
 					},
+					"fieldRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FieldRef",
+							Ref:         ref("github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.FieldRef"),
+						},
+					},
 				},
 			},
 		},
+		Dependencies: []string{
+			"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.FieldRef"},
 	}
 }
 
@@ -926,11 +935,23 @@ func schema_pkg_apis_rollouts_v1alpha1_CanaryStrategy(ref common.ReferenceCallba
 							Ref:         ref("github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.AntiAffinity"),
 						},
 					},
+					"canaryMetadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CanaryMetadata specify labels and annotations which will be attached to the canary pods for the duration which they act as a canary, and will be removed after",
+							Ref:         ref("github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.PodTemplateMetadata"),
+						},
+					},
+					"stableMetadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "StableMetadata specify labels and annotations which will be attached to the stable pods for the duration which they act as a canary, and will be removed after",
+							Ref:         ref("github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.PodTemplateMetadata"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.AntiAffinity", "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.CanaryStep", "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.RolloutAnalysisBackground", "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.RolloutTrafficRouting", "k8s.io/apimachinery/pkg/util/intstr.IntOrString"},
+			"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.AntiAffinity", "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.CanaryStep", "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.PodTemplateMetadata", "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.RolloutAnalysisBackground", "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.RolloutTrafficRouting", "k8s.io/apimachinery/pkg/util/intstr.IntOrString"},
 	}
 }
 
@@ -1443,6 +1464,26 @@ func schema_pkg_apis_rollouts_v1alpha1_ExperimentStatus(ref common.ReferenceCall
 		},
 		Dependencies: []string{
 			"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.ExperimentAnalysisRunStatus", "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.ExperimentCondition", "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.TemplateStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
+	}
+}
+
+func schema_pkg_apis_rollouts_v1alpha1_FieldRef(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"fieldPath": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Required: Path of the field to select in the specified API version",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"fieldPath"},
+			},
+		},
 	}
 }
 
@@ -3247,11 +3288,17 @@ func schema_pkg_apis_rollouts_v1alpha1_ValueFrom(ref common.ReferenceCallback) c
 							Ref:         ref("github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.SecretKeyRef"),
 						},
 					},
+					"fieldRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FieldRef is a reference to the fields in metadata which we are referencing. This field is one of the fields with valueFrom",
+							Ref:         ref("github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.FieldRef"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.SecretKeyRef"},
+			"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.FieldRef", "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1.SecretKeyRef"},
 	}
 }
 

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -190,6 +190,12 @@ type CanaryStrategy struct {
 	// AntiAffinity enables anti-affinity rules for Canary deployment
 	// +optional
 	AntiAffinity *AntiAffinity `json:"antiAffinity,omitempty"`
+	// CanaryMetadata specify labels and annotations which will be attached to the canary pods for
+	// the duration which they act as a canary, and will be removed after
+	CanaryMetadata *PodTemplateMetadata `json:"canaryMetadata,omitempty"`
+	// StableMetadata specify labels and annotations which will be attached to the stable pods for
+	// the duration which they act as a canary, and will be removed after
+	StableMetadata *PodTemplateMetadata `json:"stableMetadata,omitempty"`
 }
 
 // ALBTrafficRouting configuration for ALB ingress controller to control traffic routing

--- a/pkg/apis/rollouts/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/rollouts/v1alpha1/zz_generated.deepcopy.go
@@ -537,6 +537,16 @@ func (in *CanaryStrategy) DeepCopyInto(out *CanaryStrategy) {
 		*out = new(AntiAffinity)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.CanaryMetadata != nil {
+		in, out := &in.CanaryMetadata, &out.CanaryMetadata
+		*out = new(PodTemplateMetadata)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.StableMetadata != nil {
+		in, out := &in.StableMetadata, &out.StableMetadata
+		*out = new(PodTemplateMetadata)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
@@ -1364,4 +1365,111 @@ func TestHandleCanaryAbort(t *testing.T) {
 		newConditions := generateConditionsPatch(true, conditions.RolloutAbortedReason, r1, false, "")
 		assert.Equal(t, calculatePatch(r1, fmt.Sprintf(expectedPatch, newConditions)), patch)
 	})
+}
+
+// TestSyncEphemeralMetadataInitialRevision verifies when we create a revision 1 ReplicaSet
+// (with no previous revisions), that the ReplicaSet will get the stable metadata.
+func TestSyncEphemeralMetadataInitialRevision(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	r1 := newCanaryRollout("foo", 1, nil, nil, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(1))
+	r1.Spec.Strategy.Canary.CanaryMetadata = &v1alpha1.PodTemplateMetadata{
+		Labels: map[string]string{
+			"role": "canary",
+		},
+	}
+	r1.Spec.Strategy.Canary.StableMetadata = &v1alpha1.PodTemplateMetadata{
+		Labels: map[string]string{
+			"role": "stable",
+		},
+	}
+	rs1 := newReplicaSetWithStatus(r1, 3, 3)
+	f.rolloutLister = append(f.rolloutLister, r1)
+	f.objects = append(f.objects, r1)
+
+	f.expectUpdateRolloutAction(r1)
+	idx := f.expectCreateReplicaSetAction(rs1)
+	_ = f.expectPatchRolloutAction(r1)
+	f.run(getKey(r1, t))
+	createdRS1 := f.getCreatedReplicaSet(idx)
+	expectedLabels := map[string]string{
+		"foo":                        "bar",
+		"role":                       "stable",
+		"rollouts-pod-template-hash": r1.Status.CurrentPodHash,
+	}
+	assert.Equal(t, expectedLabels, createdRS1.Spec.Template.Labels)
+}
+
+// TestSyncEphemeralMetadataSecondRevision verifies when we deploy a canary ReplicaSet, the canary
+// contains the canary ephemeral metadata.  Also verifies we patch existing pods of the ReplicaSet
+// with the metadata
+func TestSyncEphemeralMetadataSecondRevision(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	r1 := newCanaryRollout("foo", 1, nil, nil, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(1))
+	r1.Annotations[annotations.RevisionAnnotation] = "1"
+	r1.Spec.Strategy.Canary.CanaryMetadata = &v1alpha1.PodTemplateMetadata{
+		Labels: map[string]string{
+			"role": "canary",
+		},
+	}
+	r1.Spec.Strategy.Canary.StableMetadata = &v1alpha1.PodTemplateMetadata{
+		Labels: map[string]string{
+			"role": "stable",
+		},
+	}
+	rs1 := newReplicaSetWithStatus(r1, 3, 3)
+	r2 := bumpVersion(r1)
+	r2.Status.StableRS = r1.Status.CurrentPodHash
+	r2.Status.Canary.StableRS = r1.Status.CurrentPodHash
+	rs2 := newReplicaSetWithStatus(r2, 3, 3)
+	rsGVK := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"}
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo-abc123",
+			Namespace: r1.Namespace,
+			Labels: map[string]string{
+				"foo":                        "bar",
+				"rollouts-pod-template-hash": r1.Status.CurrentPodHash,
+			},
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(rs1, rsGVK)},
+		},
+	}
+
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2)
+	f.kubeobjects = append(f.kubeobjects, rs1, &pod)
+	f.replicaSetLister = append(f.replicaSetLister, rs1)
+
+	f.expectUpdateRolloutAction(r2)               // Update Rollout revision to 2
+	rs2idx := f.expectCreateReplicaSetAction(rs2) // Create revision 2 ReplicaSet
+	f.expectListPodAction(r1.Namespace)           // list pods to patch ephemeral data on revision 1 ReplicaSets pods
+	podIdx := f.expectUpdatePodAction(&pod)       // Update pod with ephemeral data
+	rs1idx := f.expectUpdateReplicaSetAction(rs1) // update stable replicaset with stable metadata
+	f.expectUpdateReplicaSetAction(rs1)           // scale revision 1 ReplicaSet down
+	f.expectPatchRolloutAction(r2)                // Patch Rollout status
+
+	f.run(getKey(r2, t))
+	// revision 2 replicaset should been updated to use canary metadata
+	createdRS2 := f.getCreatedReplicaSet(rs2idx)
+	expectedCanaryLabels := map[string]string{
+		"foo":                        "bar",
+		"role":                       "canary",
+		"rollouts-pod-template-hash": r2.Status.CurrentPodHash,
+	}
+	assert.Equal(t, expectedCanaryLabels, createdRS2.Spec.Template.Labels)
+
+	// revision 1 replicaset should been updated to use stable metadata
+	updatedRS1 := f.getCreatedReplicaSet(rs1idx)
+	expectedStableLabels := map[string]string{
+		"foo":                        "bar",
+		"role":                       "stable",
+		"rollouts-pod-template-hash": r1.Status.CurrentPodHash,
+	}
+	assert.Equal(t, expectedStableLabels, updatedRS1.Spec.Template.Labels)
+	// also it's pods
+	updatedPod := f.getUpdatedPod(podIdx)
+	assert.Equal(t, expectedStableLabels, updatedPod.Labels)
 }

--- a/rollout/context.go
+++ b/rollout/context.go
@@ -23,11 +23,12 @@ type rolloutContext struct {
 	// newRS will be nil when the pod template spec changes.
 	newRS *appsv1.ReplicaSet
 	// stableRS is the "stable" ReplicaSet which will be scaled up upon an abort.
-	// stableRS will be nil when a Rollout is first deployed.
+	// stableRS will be nil when a Rollout is first deployed, and will be equal to newRS when fully promoted
 	stableRS *appsv1.ReplicaSet
 	// allRSs are all the ReplicaSets associated with the Rollout
 	allRSs []*appsv1.ReplicaSet
-	// olderRSs are "older" ReplicaSets -- anything which is not the new. includes stableRS
+	// olderRSs are "older" ReplicaSets -- anything which is not the new
+	// this includes the stableRS (when in the middle of an update)
 	olderRSs []*appsv1.ReplicaSet
 	// otherRSs are ReplicaSets which are neither new or stable (allRSs - newRS - stableRS)
 	otherRSs []*appsv1.ReplicaSet

--- a/test/e2e/functional/ephemeral-labels.yaml
+++ b/test/e2e/functional/ephemeral-labels.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: ephemeral-label
+spec:
+  replicas: 2
+  strategy:
+    canary:
+      stableMetadata:
+        labels:
+          role: stable
+      canaryMetadata:
+        labels:
+          role: canary
+      steps:
+      - setWeight: 50
+      - pause: {}
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: ephemeral-label
+  template:
+    metadata:
+      labels:
+        app: ephemeral-label
+    spec:
+      containers:
+      - name: ephemeral-label
+        image: argoproj/rollouts-demo:blue
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        resources:
+          requests:
+            memory: 32Mi
+            cpu: 5m

--- a/test/fixtures/then.go
+++ b/test/fixtures/then.go
@@ -69,6 +69,7 @@ func (t *Then) ExpectReplicaCounts(desired, current, updated, ready, available i
 type PodExpectation func(*corev1.PodList) bool
 
 func (t *Then) ExpectPods(expectation string, expectFunc PodExpectation) *Then {
+	t.t.Helper()
 	selector, err := metav1.LabelSelectorAsSelector(t.Rollout().Spec.Selector)
 	t.CheckError(err)
 	pods, err := t.kubeClient.CoreV1().Pods(t.namespace).List(t.Context, metav1.ListOptions{LabelSelector: selector.String()})
@@ -81,7 +82,19 @@ func (t *Then) ExpectPods(expectation string, expectFunc PodExpectation) *Then {
 	return t
 }
 
+func (t *Then) ExpectRevisionPods(expectation string, revision string, expectFunc PodExpectation) *Then {
+	t.t.Helper()
+	pods := t.GetPodsByRevision(revision)
+	if !expectFunc(pods) {
+		t.log.Errorf("Pod expectation '%s' failed", expectation)
+		t.t.FailNow()
+	}
+	t.log.Infof("Pod expectation '%s' met", expectation)
+	return t
+}
+
 func (t *Then) ExpectCanaryStablePodCount(canaryCount, stableCount int) *Then {
+	t.t.Helper()
 	ro, err := t.rolloutClient.ArgoprojV1alpha1().Rollouts(t.namespace).Get(t.Context, t.rollout.GetName(), metav1.GetOptions{})
 	t.CheckError(err)
 	return t.expectPodCountByHash("canary", ro.Status.CurrentPodHash, canaryCount).
@@ -89,6 +102,7 @@ func (t *Then) ExpectCanaryStablePodCount(canaryCount, stableCount int) *Then {
 }
 
 func (t *Then) ExpectRevisionPodCount(revision string, expectedCount int) *Then {
+	t.t.Helper()
 	rs := t.GetReplicaSetByRevision(revision)
 	description := fmt.Sprintf("revision:%s", revision)
 	hash := rs.Labels[rov1.DefaultRolloutUniqueLabelKey]
@@ -120,6 +134,7 @@ func (t *Then) expectPodCountByHash(description, hash string, expectedCount int)
 type ReplicaSetExpectation func(*appsv1.ReplicaSetList) bool
 
 func (t *Then) ExpectReplicaSets(expectation string, expectFunc ReplicaSetExpectation) *Then {
+	t.t.Helper()
 	selector, err := metav1.LabelSelectorAsSelector(t.Rollout().Spec.Selector)
 	t.CheckError(err)
 	replicasets, err := t.kubeClient.AppsV1().ReplicaSets(t.namespace).List(t.Context, metav1.ListOptions{LabelSelector: selector.String()})
@@ -136,6 +151,7 @@ type AnalysisRunListExpectation func(*rov1.AnalysisRunList) bool
 type AnalysisRunExpectation func(*rov1.AnalysisRun) bool
 
 func (t *Then) ExpectAnalysisRuns(expectation string, expectFunc AnalysisRunListExpectation) *Then {
+	t.t.Helper()
 	aruns := t.GetRolloutAnalysisRuns()
 	if !expectFunc(&aruns) {
 		t.log.Errorf("AnalysisRun expectation '%s' failed", expectation)
@@ -146,12 +162,14 @@ func (t *Then) ExpectAnalysisRuns(expectation string, expectFunc AnalysisRunList
 }
 
 func (t *Then) ExpectAnalysisRunCount(expectedCount int) *Then {
+	t.t.Helper()
 	return t.ExpectAnalysisRuns(fmt.Sprintf("analysisrun count == %d", expectedCount), func(aruns *rov1.AnalysisRunList) bool {
 		return len(aruns.Items) == expectedCount
 	})
 }
 
 func (t *Then) ExpectBackgroundAnalysisRun(expectation string, expectFunc AnalysisRunExpectation) *Then {
+	t.t.Helper()
 	bgArun := t.GetBackgroundAnalysisRun()
 	if !expectFunc(bgArun) {
 		t.log.Errorf("Background AnalysisRun expectation '%s' failed", expectation)
@@ -162,6 +180,7 @@ func (t *Then) ExpectBackgroundAnalysisRun(expectation string, expectFunc Analys
 }
 
 func (t *Then) ExpectBackgroundAnalysisRunPhase(phase string) *Then {
+	t.t.Helper()
 	return t.ExpectBackgroundAnalysisRun(fmt.Sprintf("background analysis phase == %s", phase),
 		func(run *rov1.AnalysisRun) bool {
 			return string(run.Status.Phase) == phase
@@ -171,6 +190,7 @@ func (t *Then) ExpectBackgroundAnalysisRunPhase(phase string) *Then {
 
 // ExpectStableRevision verifies the ReplicaSet with the specified revision is marked stable
 func (t *Then) ExpectStableRevision(revision string) *Then {
+	t.t.Helper()
 	verifyRevision := func() error {
 		ro, err := t.rolloutClient.ArgoprojV1alpha1().Rollouts(t.namespace).Get(t.Context, t.rollout.GetName(), metav1.GetOptions{})
 		t.CheckError(err)
@@ -187,11 +207,13 @@ func (t *Then) ExpectStableRevision(revision string) *Then {
 
 // ExpectPreviewRevision verifies the preview service selector is pointing to the specified revision
 func (t *Then) ExpectPreviewRevision(revision string) *Then {
+	t.t.Helper()
 	return t.verifyBlueGreenSelectorRevision("preview", revision)
 }
 
 // ExpectActiveRevision verifies the active service selector is pointing to the specified revision
 func (t *Then) ExpectActiveRevision(revision string) *Then {
+	t.t.Helper()
 	return t.verifyBlueGreenSelectorRevision("active", revision)
 }
 
@@ -241,6 +263,7 @@ func (t *Then) verifyBlueGreenSelectorRevision(which string, revision string) *T
 }
 
 func (t *Then) ExpectServiceSelector(service string, selector map[string]string) *Then {
+	t.t.Helper()
 	svc, err := t.kubeClient.CoreV1().Services(t.namespace).Get(t.Context, service, metav1.GetOptions{})
 	t.CheckError(err)
 	if !reflect.DeepEqual(svc.Spec.Selector, selector) {

--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -1,12 +1,19 @@
 package replicaset
 
 import (
+	"encoding/json"
 	"math"
 
 	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// EphemeralMetadataAnnotation denotes pod metadata which are ephemerally injected to canary/stable pods
+	EphemeralMetadataAnnotation = "rollout.argoproj.io/ephemeral-metadata"
 )
 
 // AtDesiredReplicaCountsForCanary indicates if the rollout is at the desired state for the current step
@@ -392,4 +399,79 @@ func GetCurrentExperimentStep(r *v1alpha1.Rollout) *v1alpha1.RolloutExperimentSt
 		}
 	}
 	return nil
+}
+
+// removeInjectedPodMetadata removes injected pod metadata from the replicaset
+func removeInjectedPodMetadata(rs *appsv1.ReplicaSet, podMetadata *v1alpha1.PodTemplateMetadata) {
+	if rs.Spec.Template.Annotations != nil {
+		for key := range podMetadata.Annotations {
+			delete(rs.Spec.Template.Annotations, key)
+		}
+	}
+	if rs.Spec.Template.Labels != nil {
+		for key := range podMetadata.Labels {
+			delete(rs.Spec.Template.Labels, key)
+		}
+	}
+	delete(rs.Annotations, EphemeralMetadataAnnotation)
+}
+
+// UpdateEphemeralPodMetadata updates the supplied pod metadata to the replicaset, removing previous
+// existing metadata if it had changed. A podMetadata value of nil indicates canary/stable
+// meta should be removed
+func UpdateEphemeralPodMetadata(rs *appsv1.ReplicaSet, podMetadata *v1alpha1.PodTemplateMetadata) (*appsv1.ReplicaSet, bool) {
+	var metadataStr string
+	if podMetadata != nil {
+		metadataBytes, _ := json.Marshal(podMetadata)
+		metadataStr = string(metadataBytes)
+	}
+
+	var existingPodMetadataStr string
+	var existingPodMetadata *v1alpha1.PodTemplateMetadata
+	if rs.Annotations != nil {
+		var ok bool
+		if existingPodMetadataStr, ok = rs.Annotations[EphemeralMetadataAnnotation]; ok {
+			err := json.Unmarshal([]byte(existingPodMetadataStr), &existingPodMetadata)
+			if err != nil {
+				log.Warnf("Failed to determine existing ephemeral metadata from annotation: %s", existingPodMetadataStr)
+				existingPodMetadata = nil
+				existingPodMetadataStr = ""
+			}
+		}
+	}
+	if existingPodMetadataStr == metadataStr {
+		return rs, false
+	}
+
+	rs = rs.DeepCopy()
+	if existingPodMetadata != nil {
+		// remove existing metadata
+		removeInjectedPodMetadata(rs, existingPodMetadata)
+	}
+
+	// Add new ephemeral metadata to ReplicaSet
+	if podMetadata != nil {
+		if len(podMetadata.Annotations) > 0 {
+			if rs.Spec.Template.Annotations == nil {
+				rs.Spec.Template.Annotations = make(map[string]string)
+			}
+			for k, v := range podMetadata.Annotations {
+				rs.Spec.Template.Annotations[k] = v
+			}
+		}
+		if len(podMetadata.Labels) > 0 {
+			if rs.Spec.Template.Labels == nil {
+				rs.Spec.Template.Labels = make(map[string]string)
+			}
+			for k, v := range podMetadata.Labels {
+				rs.Spec.Template.Labels[k] = v
+			}
+		}
+		// remember what we injected by annotating it
+		if rs.Annotations == nil {
+			rs.Annotations = make(map[string]string)
+		}
+		rs.Annotations[EphemeralMetadataAnnotation] = metadataStr
+	}
+	return rs, true
 }

--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -1,6 +1,7 @@
 package replicaset
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strconv"
@@ -13,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
 	corev1defaults "k8s.io/kubernetes/pkg/apis/core/v1"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/utils/pointer"
@@ -48,8 +50,10 @@ func FindNewReplicaSet(rollout *v1alpha1.Rollout, rsList []*appsv1.ReplicaSet) *
 	// When this (rare) situation arises, we do not want to return nil, since nil is considered a
 	// PodTemplate change, which in turn would triggers an unexpected redeploy of the replicaset.
 	for _, rs := range rsList {
+		// Remove injected canary/stable metadata from spec.template.metadata before comparing
+		rsCopy, _ := UpdateEphemeralPodMetadata(rs, nil)
 		// Remove anti-affinity from template.Spec.Affinity before comparing
-		live := rs.Spec.Template.DeepCopy()
+		live := &rsCopy.Spec.Template
 		live.Spec.Affinity = RemoveInjectedAntiAffinityRule(live.Spec.Affinity, *rollout)
 
 		desired := rollout.Spec.Template.DeepCopy()
@@ -549,4 +553,22 @@ func HasScaleDownDeadline(rs *appsv1.ReplicaSet) bool {
 		return false
 	}
 	return rs.Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey] != ""
+}
+
+// GetPodsOwnedByReplicaSet returns a list of pods owned by the given replicaset
+func GetPodsOwnedByReplicaSet(ctx context.Context, client kubernetes.Interface, rs *appsv1.ReplicaSet) ([]*corev1.Pod, error) {
+	pods, err := client.CoreV1().Pods(rs.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: metav1.FormatLabelSelector(rs.Spec.Selector),
+	})
+	if err != nil {
+		return nil, err
+	}
+	var podOwnedByRS []*corev1.Pod
+	for i := range pods.Items {
+		pod := pods.Items[i]
+		if metav1.IsControlledBy(&pod, rs) {
+			podOwnedByRS = append(podOwnedByRS, &pod)
+		}
+	}
+	return podOwnedByRS, nil
 }


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/455

Adds support for setting ephemeral metadata (annotations/labels) which get updated on the Pods/ReplicaSets during an update. Example syntax:

```yaml
spec:
  strategy:
    canary:
      stableMetadata:
        labels:
          role: stable
      canaryMetadata:
        labels:
          role: canary
      steps:
      - setWeight: 50
      - pause: {}
```


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).