### PR TITLE
docs: Being a bit more clear on the chance of downtime when migrating Deployment->Rollout

### DIFF
--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -39,6 +39,5 @@ spec:
 ## Other Considerations
 
 When migrating a Deployment which is already serving live production traffic, a Rollout should
-run next to the Deployment before deleting the Deployment. Using this approach, there should be no
-downtime needed during the migration, and it allows for the Rollout to be tested before deleting
-the original Deployment.
+run next to the Deployment before deleting the Deployment. **Not following this approach might result in 
+downtime**. It also allows for the Rollout to be tested before deleting the original Deployment.


### PR DESCRIPTION
I think I'd have benefited of a stronger warning on the chance of downtime when migrating if not following the advice of having the Deployment next to the Rollout for the migration.