### PR TITLE
fix(controller): blue-green with analysis was broken

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -98,26 +98,43 @@ KUBECONFIG=~/.kube/minikube make test-e2e
 (or test regex):
 
 ```shell
-make test-e2e E2E_TEST_OPTIONS="-testify.m ^TestRolloutRestart$" 
+make test-e2e E2E_TEST_OPTIONS="-testify.m ^TestRolloutRestart$"
 ```
 
 3. The e2e tests are designed to run as quickly as possible, eliminating readiness and termination
 delays. However, it is often desired to artificially slow down the tests for debugging purposes,
-as well as to understand what the test is doing. To delay startup and termination of pods, set the `E2E_POD_DELAY` to a integer value in seconds. This environment variable is often coupled with `E2E_TEST_OPTIONS` to debug and slow down a specific test.
+as well as to understand what the test is doing. To delay startup and termination of pods, set the 
+`E2E_POD_DELAY` to a integer value in seconds. This environment variable is often coupled with 
+`E2E_TEST_OPTIONS` to debug and slow down a specific test.
 
 ```shell
 make test-e2e E2E_POD_DELAY=10
 ```
 
-4. The e2e tests leverage a feature of the controller allowing the controller to be sharded with
+4. Increasing the timeout. The E2E tests time out waiting on conditions to be met within 60 seconds.
+If debugging the rollout controller, it may be useful to increase this timeout while say sitting
+at a debugger breakpoint:
+
+```shell
+make test-e2e E2E_WAIT_TIMEOUT=999999
+```
+
+
+5. The e2e tests leverage a feature of the controller allowing the controller to be sharded with
 a user-specific "instance id" label. This allows the tests to operate only on rollouts with the
-specified label, and prevents any other controllers (including the system rollouts controller),
+specified label, and prevents any other controllers (including the system rollout controller),
 from also operating on the same set of rollouts. This value can be changed (from the default of
 `argo-rollouts-e2e`), using the `E2E_INSTANCE_ID` environment variable:
 
 ```shell
 make start-e2e E2E_INSTANCE_ID=foo
 make test-e2e E2E_INSTANCE_ID=foo
+```
+
+Alternatively, the e2e tests can be run against the system controller (i.e. without an instance id):
+
+```shell
+make start-e2e E2E_INSTANCE_ID=''
 ```
 
 ## Running Locally

--- a/pkg/kubectl-argo-rollouts/cmd/get/get_rollout.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get_rollout.go
@@ -181,7 +181,8 @@ func (o *GetOptions) PrintReplicaSetInfo(w io.Writer, rsInfo info.ReplicaSetInfo
 	if rsInfo.Stable {
 		infoCols = append(infoCols, o.colorize(info.InfoTagStable))
 		name = o.colorizeStatus(name, info.InfoTagStable)
-	} else if rsInfo.Canary {
+	}
+	if rsInfo.Canary {
 		infoCols = append(infoCols, o.colorize(info.InfoTagCanary))
 		name = o.colorizeStatus(name, info.InfoTagCanary)
 	} else if rsInfo.Active {

--- a/pkg/kubectl-argo-rollouts/cmd/get/get_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get_test.go
@@ -119,7 +119,7 @@ Name:            bluegreen-demo
 Namespace:       jesse-test
 Status:          ॥ Paused
 Strategy:        BlueGreen
-Images:          argoproj/rollouts-demo:blue (active)
+Images:          argoproj/rollouts-demo:blue (stable, active)
                  argoproj/rollouts-demo:green (preview)
 Replicas:
   Desired:       3
@@ -136,7 +136,7 @@ NAME                                        KIND        STATUS        AGE  INFO
 │     ├──□ bluegreen-demo-74b948fccb-mkhrl  Pod         ✔ Running     7d   ready:1/1
 │     └──□ bluegreen-demo-74b948fccb-vvj2t  Pod         ✔ Running     7d   ready:1/1
 ├──# revision:10
-│  └──⧉ bluegreen-demo-6cbccd9f99           ReplicaSet  ✔ Healthy     7d   active
+│  └──⧉ bluegreen-demo-6cbccd9f99           ReplicaSet  ✔ Healthy     7d   stable,active
 │     ├──□ bluegreen-demo-6cbccd9f99-gk78v  Pod         ✔ Running     7d   ready:1/1
 │     ├──□ bluegreen-demo-6cbccd9f99-kxj8g  Pod         ✔ Running     7d   ready:1/1
 │     └──□ bluegreen-demo-6cbccd9f99-t2d4f  Pod         ✔ Running     7d   ready:1/1
@@ -166,7 +166,7 @@ Name:            bluegreen-demo
 Namespace:       jesse-test
 Status:          ॥ Paused
 Strategy:        BlueGreen
-Images:          argoproj/rollouts-demo:blue (active)
+Images:          argoproj/rollouts-demo:blue (stable, active)
                  argoproj/rollouts-demo:green
 Replicas:
   Desired:       3
@@ -183,7 +183,7 @@ NAME                                        KIND        STATUS        AGE  INFO
 │     ├──□ bluegreen-demo-74b948fccb-mkhrl  Pod         ✔ Running     7d   ready:1/1
 │     └──□ bluegreen-demo-74b948fccb-vvj2t  Pod         ✔ Running     7d   ready:1/1
 ├──# revision:10
-│  └──⧉ bluegreen-demo-6cbccd9f99           ReplicaSet  ✔ Healthy     7d   active
+│  └──⧉ bluegreen-demo-6cbccd9f99           ReplicaSet  ✔ Healthy     7d   stable,active
 │     ├──□ bluegreen-demo-6cbccd9f99-gk78v  Pod         ✔ Running     7d   ready:1/1
 │     ├──□ bluegreen-demo-6cbccd9f99-kxj8g  Pod         ✔ Running     7d   ready:1/1
 │     └──□ bluegreen-demo-6cbccd9f99-t2d4f  Pod         ✔ Running     7d   ready:1/1
@@ -213,7 +213,7 @@ Name:            bluegreen-demo
 Namespace:       jesse-test
 Status:          ॥ Paused
 Strategy:        BlueGreen
-Images:          argoproj/rollouts-demo:blue (active)
+Images:          argoproj/rollouts-demo:blue (stable, active)
                  argoproj/rollouts-demo:green
 Replicas:
   Desired:       3
@@ -230,7 +230,7 @@ NAME                                        KIND        STATUS        AGE  INFO
 │     ├──□ bluegreen-demo-74b948fccb-mkhrl  Pod         ✔ Running     7d   ready:1/1
 │     └──□ bluegreen-demo-74b948fccb-vvj2t  Pod         ✔ Running     7d   ready:1/1
 ├──# revision:10
-│  └──⧉ bluegreen-demo-6cbccd9f99           ReplicaSet  ✔ Healthy     7d   active
+│  └──⧉ bluegreen-demo-6cbccd9f99           ReplicaSet  ✔ Healthy     7d   stable,active
 │     ├──□ bluegreen-demo-6cbccd9f99-gk78v  Pod         ✔ Running     7d   ready:1/1
 │     ├──□ bluegreen-demo-6cbccd9f99-kxj8g  Pod         ✔ Running     7d   ready:1/1
 │     └──□ bluegreen-demo-6cbccd9f99-t2d4f  Pod         ✔ Running     7d   ready:1/1

--- a/pkg/kubectl-argo-rollouts/info/info_test.go
+++ b/pkg/kubectl-argo-rollouts/info/info_test.go
@@ -111,7 +111,7 @@ func TestBlueGreenRolloutInfo(t *testing.T) {
 		assert.Equal(t, roInfo.Images(), []ImageInfo{
 			{
 				Image: "argoproj/rollouts-demo:blue",
-				Tags:  []string{InfoTagActive},
+				Tags:  []string{InfoTagStable, InfoTagActive},
 			},
 			{
 				Image: "argoproj/rollouts-demo:green",

--- a/pkg/kubectl-argo-rollouts/info/testdata/blue-green/bluegreen-rollout.yaml
+++ b/pkg/kubectl-argo-rollouts/info/testdata/blue-green/bluegreen-rollout.yaml
@@ -71,4 +71,5 @@ status:
   readyReplicas: 6
   replicas: 6
   selector: app=bluegreen-demo,rollouts-pod-template-hash=6cbccd9f99
+  stableRS: 6cbccd9f99
   updatedReplicas: 3

--- a/rollout/analysis_test.go
+++ b/rollout/analysis_test.go
@@ -1768,11 +1768,12 @@ func TestRolloutPrePromotionAnalysisSwitchServiceAfterSuccess(t *testing.T) {
 				"activeSelector": "%s",
 				"prePromotionAnalysisRunStatus":{"status":"Successful"}
 			},
+			"stableRS": "%s",
 			"pauseConditions": null,
 			"controllerPause": null,
 			"selector":"foo=bar,rollouts-pod-template-hash=%s"
 		}
-	}`, rs2PodHash, rs2PodHash)
+	}`, rs2PodHash, rs2PodHash, rs2PodHash)
 	assert.Equal(t, calculatePatch(r2, expectedPatch), patch)
 }
 
@@ -1830,11 +1831,12 @@ func TestRolloutPrePromotionAnalysisHonorAutoPromotionSeconds(t *testing.T) {
 			"blueGreen": {
 				"activeSelector": "%s"
 			},
+			"stableRS": "%s",
 			"pauseConditions": null,
 			"controllerPause": null,
 			"selector":"foo=bar,rollouts-pod-template-hash=%s"
 		}
-	}`, rs2PodHash, rs2PodHash)
+	}`, rs2PodHash, rs2PodHash, rs2PodHash)
 	assert.Equal(t, calculatePatch(r2, expectedPatch), patch)
 }
 

--- a/rollout/bluegreen_test.go
+++ b/rollout/bluegreen_test.go
@@ -405,12 +405,13 @@ func TestBlueGreenHandlePause(t *testing.T) {
 				"blueGreen": {
 					"activeSelector": "%s"
 				},
+				"stableRS": "%s",
 				"pauseConditions": null,
 				"controllerPause": null,
 				"selector": "foo=bar,rollouts-pod-template-hash=%s"
 			}
 		}`
-		expectedPatch := calculatePatch(r2, fmt.Sprintf(expectedPatchWithoutSubs, rs2PodHash, rs2PodHash))
+		expectedPatch := calculatePatch(r2, fmt.Sprintf(expectedPatchWithoutSubs, rs2PodHash, rs2PodHash, rs2PodHash))
 		f.expectPatchServiceAction(activeSvc, rs2PodHash)
 		f.expectPatchReplicaSetAction(rs1)
 		patchRolloutIndex := f.expectPatchRolloutActionWithPatch(r2, expectedPatch)
@@ -498,11 +499,12 @@ func TestBlueGreenHandlePause(t *testing.T) {
 				"blueGreen": {
 					"activeSelector": "%s"
 				},
+				"stableRS": "%s",
 				"conditions": %s,
 				"selector": "%s"
 			}
 		}`
-		expectedPatch := calculatePatch(r2, fmt.Sprintf(expectedPatchWithoutSubs, rs2PodHash, generatedConditions, newSelector))
+		expectedPatch := calculatePatch(r2, fmt.Sprintf(expectedPatchWithoutSubs, rs2PodHash, rs2PodHash, generatedConditions, newSelector))
 		patchIndex := f.expectPatchRolloutActionWithPatch(r2, expectedPatch)
 		f.run(getKey(r2, t))
 		f.verifyPatchedService(servicePatchIndex, rs2PodHash, "")
@@ -654,13 +656,14 @@ func TestBlueGreenHandlePause(t *testing.T) {
 				"blueGreen": {
 					"activeSelector": "%s"
 				},
+				"stableRS": "%s",
 				"controllerPause":null,
 				"conditions": %s,
 				"selector": "%s"
 			}
 		}`
 		newSelector := metav1.FormatLabelSelector(rs2.Spec.Selector)
-		expected2ndPatch := calculatePatch(r2, fmt.Sprintf(expected2ndPatchWithoutSubs, rs2PodHash, generatedConditions, newSelector))
+		expected2ndPatch := calculatePatch(r2, fmt.Sprintf(expected2ndPatchWithoutSubs, rs2PodHash, rs2PodHash, generatedConditions, newSelector))
 		rollout2ndPatch := f.getPatchedRollout(patchRolloutIndex)
 		assert.Equal(t, expected2ndPatch, rollout2ndPatch)
 	})
@@ -701,13 +704,14 @@ func TestBlueGreenAddScaleDownDelayToPreviousActiveReplicaSet(t *testing.T) {
 			"blueGreen": {
 				"activeSelector": "%s"
 			},
+			"stableRS": "%s",
 			"conditions": %s,
 			"selector": "%s"
 		}
 	}`
 	newSelector := metav1.FormatLabelSelector(rs2.Spec.Selector)
 	expectedCondition := generateConditionsPatch(true, conditions.ReplicaSetUpdatedReason, rs2, true, "")
-	expectedPatch := calculatePatch(r2, fmt.Sprintf(expectedPatchWithoutSubs, rs2PodHash, expectedCondition, newSelector))
+	expectedPatch := calculatePatch(r2, fmt.Sprintf(expectedPatchWithoutSubs, rs2PodHash, rs2PodHash, expectedCondition, newSelector))
 	assert.Equal(t, expectedPatch, patch)
 }
 

--- a/rollout/pause.go
+++ b/rollout/pause.go
@@ -56,16 +56,21 @@ func (pCtx *pauseContext) ClearPauseConditions() {
 }
 
 func (pCtx *pauseContext) CalculatePauseStatus(newStatus *v1alpha1.RolloutStatus) {
+	now := metav1.Now()
+	// if we are already aborted, preserve the original timestamp, otherwise we'll cause a
+	// reconciliation hot-loop.
+	newAbortedAt := pCtx.rollout.Status.AbortedAt
+	if newAbortedAt == nil {
+		newAbortedAt = &now
+	}
 	if pCtx.addAbort {
 		newStatus.Abort = true
-		now := metav1.Now()
-		newStatus.AbortedAt = &now
+		newStatus.AbortedAt = newAbortedAt
 		return
 	}
 	if !pCtx.removeAbort && pCtx.rollout.Status.Abort {
 		newStatus.Abort = true
-		now := metav1.Now()
-		newStatus.AbortedAt = &now
+		newStatus.AbortedAt = newAbortedAt
 		return
 	}
 	newStatus.Abort = false
@@ -90,7 +95,6 @@ func (pCtx *pauseContext) CalculatePauseStatus(newStatus *v1alpha1.RolloutStatus
 		pauseAlreadyExists[cond.Reason] = true
 	}
 
-	now := metav1.Now()
 	for i := range pCtx.addPauseReasons {
 		reason := pCtx.addPauseReasons[i]
 		if exists := pauseAlreadyExists[reason]; !exists {

--- a/test/fixtures/when.go
+++ b/test/fixtures/when.go
@@ -27,11 +27,17 @@ type When struct {
 	Common
 }
 
-func (w *When) ApplyManifests() *When {
-	if w.rollout == nil {
-		w.t.Fatal("No rollout to create")
+func (w *When) ApplyManifests(yaml ...string) *When {
+	var objects []*unstructured.Unstructured
+	if len(yaml) == 0 {
+		if w.rollout == nil {
+			w.t.Fatal("No rollout to create")
+		}
+		objects = w.objects
+	} else {
+		objects = w.parseTextToObjects(yaml[0])
 	}
-	for _, obj := range w.objects {
+	for _, obj := range objects {
 		if obj.GetKind() == "Rollout" && E2EPodDelay > 0 {
 			w.injectDelays(obj)
 		}

--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -542,3 +542,11 @@ func IsStillReferenced(status v1alpha1.RolloutStatus, rs *appsv1.ReplicaSet) boo
 	}
 	return false
 }
+
+// HasScaleDownDeadline returns whether or not the given ReplicaSet is annotated with a scale-down delay
+func HasScaleDownDeadline(rs *appsv1.ReplicaSet) bool {
+	if rs == nil || rs.Annotations == nil {
+		return false
+	}
+	return rs.Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey] != ""
+}

--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -531,3 +531,14 @@ func (o ReplicaSetsByRevisionNumber) Less(i, j int) bool {
 	}
 	return iRevision < jRevision
 }
+
+// IsStillReferenced returns if the given ReplicaSet is still being referenced by any of
+// the current, stable, blue-green active references. Used to determine if the ReplicaSet can
+// safely be scaled to zero, or deleted.
+func IsStillReferenced(status v1alpha1.RolloutStatus, rs *appsv1.ReplicaSet) bool {
+	hash := GetPodTemplateHash(rs)
+	if hash != "" && (hash == status.StableRS || hash == status.CurrentPodHash || hash == status.BlueGreen.ActiveSelector) {
+		return true
+	}
+	return false
+}

--- a/utils/service/service.go
+++ b/utils/service/service.go
@@ -8,15 +8,11 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 )
 
-func GetRolloutSelectorLabel(svc *corev1.Service) (string, bool) {
-	if svc == nil {
-		return "", false
+func GetRolloutSelectorLabel(svc *corev1.Service) string {
+	if svc == nil || svc.Spec.Selector == nil {
+		return ""
 	}
-	if svc.Spec.Selector == nil {
-		return "", false
-	}
-	currentSelectorValue, ok := svc.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey]
-	return currentSelectorValue, ok
+	return svc.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey]
 }
 
 // GetRolloutServiceKeys returns services keys (namespace/serviceName) which are referenced by specified rollout

--- a/utils/service/service_test.go
+++ b/utils/service/service_test.go
@@ -11,14 +11,12 @@ import (
 )
 
 func TestGetRolloutSelectorLabel(t *testing.T) {
-	selector, ok := GetRolloutSelectorLabel(nil)
+	selector := GetRolloutSelectorLabel(nil)
 	assert.Empty(t, selector)
-	assert.False(t, ok)
 
 	svc := &corev1.Service{}
-	selector, ok = GetRolloutSelectorLabel(svc)
+	selector = GetRolloutSelectorLabel(svc)
 	assert.Empty(t, selector)
-	assert.False(t, ok)
 
 	testSelectorValue := "abcdef"
 	svc = &corev1.Service{
@@ -28,10 +26,8 @@ func TestGetRolloutSelectorLabel(t *testing.T) {
 			},
 		},
 	}
-	selector, ok = GetRolloutSelectorLabel(svc)
+	selector = GetRolloutSelectorLabel(svc)
 	assert.Equal(t, selector, testSelectorValue)
-	assert.True(t, ok)
-
 }
 
 func TestGetRolloutServiceKeysForCanary(t *testing.T) {


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/774

The major change here is that we were using status.activeRS == currentPodHash to determine if rollout was fully promoted. However this is no longer true, because we now use status.stableRS == currentPodHash. 

fix: postPromotionAnalysis was broken
fix: blue-green fast-tracked rollbacks would still start analysis templates
fix: prePromotionAnalysis with previewReplicaCount did not start prePromotionAnalysis
feat(plugin): indicate the stable ReplicaSet for blue-green rollouts in plugin