### PR TITLE
feat: Implement kubectl argo rollouts lint

### DIFF
--- a/pkg/kubectl-argo-rollouts/cmd/cmd.go
+++ b/pkg/kubectl-argo-rollouts/cmd/cmd.go
@@ -6,6 +6,7 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/abort"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/create"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/get"
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/lint"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/list"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/pause"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/promote"
@@ -28,7 +29,7 @@ const (
 
   # Promote the guestbook rollout
   %[1]s promote guestbook
-  
+
   # Abort the guestbook rollout
   %[1]s abort guestbook
 
@@ -52,6 +53,7 @@ func NewCmdArgoRollouts(o *options.ArgoRolloutsOptions) *cobra.Command {
 	o.AddKubectlFlags(cmd)
 	cmd.AddCommand(create.NewCmdCreate(o))
 	cmd.AddCommand(get.NewCmdGet(o))
+	cmd.AddCommand(lint.NewCmdLint(o))
 	cmd.AddCommand(list.NewCmdList(o))
 	cmd.AddCommand(pause.NewCmdPause(o))
 	cmd.AddCommand(promote.NewCmdPromote(o))

--- a/pkg/kubectl-argo-rollouts/cmd/lint/lint.go
+++ b/pkg/kubectl-argo-rollouts/cmd/lint/lint.go
@@ -16,7 +16,6 @@ import (
 )
 
 type LintOptions struct {
-	NoColor bool
 	options.ArgoRolloutsOptions
 	File string
 }
@@ -52,7 +51,6 @@ func NewCmdLint(o *options.ArgoRolloutsOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&lintOptions.File, "filename", "f", "", "File to lint")
-	cmd.Flags().BoolVar(&lintOptions.NoColor, "no-color", false, "Do not colorize output")
 	return cmd
 }
 

--- a/pkg/kubectl-argo-rollouts/cmd/lint/lint.go
+++ b/pkg/kubectl-argo-rollouts/cmd/lint/lint.go
@@ -1,0 +1,102 @@
+package lint
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"unicode"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts"
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/validation"
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options"
+	"github.com/ghodss/yaml"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type LintOptions struct {
+	NoColor bool
+	options.ArgoRolloutsOptions
+	File string
+}
+
+const (
+	lintExample = `
+	# Lint a rollout
+	%[1]s lint -f my-rollout.yaml`
+)
+
+// NewCmdLint returns a new instance of a `rollouts lint` command
+func NewCmdLint(o *options.ArgoRolloutsOptions) *cobra.Command {
+	lintOptions := LintOptions{
+		ArgoRolloutsOptions: *o,
+	}
+	var cmd = &cobra.Command{
+		Use:          "lint",
+		Short:        "Lint and validate a Rollout",
+		Long:         "This command lints and validates a new Rollout resource from a file.",
+		Example:      o.Example(lintExample),
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if lintOptions.File == "" {
+				return o.UsageErr(c)
+			}
+
+			err := lintOptions.lintResource(lintOptions.File)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&lintOptions.File, "filename", "f", "", "File to lint")
+	cmd.Flags().BoolVar(&lintOptions.NoColor, "no-color", false, "Do not colorize output")
+	return cmd
+}
+
+// isJSON detects if the byte array looks like json, based on the first non-whitespace character
+func isJSON(fileBytes []byte) bool {
+	for _, b := range fileBytes {
+		if !unicode.IsSpace(rune(b)) {
+			return b == '{'
+		}
+	}
+	return false
+}
+
+func unmarshal(fileBytes []byte, obj interface{}) error {
+	if isJSON(fileBytes) {
+		decoder := json.NewDecoder(bytes.NewReader(fileBytes))
+		decoder.DisallowUnknownFields()
+		return decoder.Decode(&obj)
+	}
+	return yaml.UnmarshalStrict(fileBytes, &obj, yaml.DisallowUnknownFields)
+}
+
+func (l *LintOptions) lintResource(path string) error {
+	fileBytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	var un unstructured.Unstructured
+	err = unmarshal(fileBytes, &un)
+	if err != nil {
+		return err
+	}
+	gvk := un.GroupVersionKind()
+	switch {
+	case gvk.Group == rollouts.Group && gvk.Kind == rollouts.RolloutKind:
+		var ro v1alpha1.Rollout
+		err = unmarshal(fileBytes, &ro)
+		if err != nil {
+			return err
+		}
+		errs := validation.ValidateRollout(&ro)
+		if 0 < len(errs) {
+			return errs[0]
+		}
+	}
+	return nil
+}

--- a/pkg/kubectl-argo-rollouts/cmd/lint/lint_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/lint/lint_test.go
@@ -1,0 +1,39 @@
+package lint
+
+import (
+	"bytes"
+	"testing"
+
+	options "github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options/fake"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLintValidRollout(t *testing.T) {
+	tf, o := options.NewFakeArgoRolloutsOptions()
+	defer tf.Cleanup()
+
+	cmd := NewCmdLint(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{"-f", "testdata/valid.yml"})
+	err := cmd.Execute()
+	assert.NoError(t, err)
+
+	stdout := o.Out.(*bytes.Buffer).String()
+	assert.Empty(t, stdout)
+}
+
+func TestLintInvalidRollout(t *testing.T) {
+	tf, o := options.NewFakeArgoRolloutsOptions()
+	defer tf.Cleanup()
+
+	cmd := NewCmdLint(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{"-f", "testdata/invalid.yml"})
+	err := cmd.Execute()
+	assert.Error(t, err)
+
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Empty(t, stdout)
+	assert.Equal(t, "Error: spec.strategy.maxSurge: Invalid value: intstr.IntOrString{Type:0, IntVal:0, StrVal:\"\"}: MaxSurge and MaxUnavailable both can not be zero\n", stderr)
+}

--- a/pkg/kubectl-argo-rollouts/cmd/lint/testdata/invalid.yml
+++ b/pkg/kubectl-argo-rollouts/cmd/lint/testdata/invalid.yml
@@ -1,0 +1,40 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: invalid-rollout
+spec:
+  revisionHistoryLimit: 1
+  replicas: 1
+  strategy:
+    canary:
+      maxUnavailable: 0
+      maxSurge: 0
+      analysis:
+        templates:
+          - templateName: integrationtests
+      steps:
+        - setWeight: 10
+        - setWeight: 20
+        - setWeight: 40
+        - setWeight: 80
+  selector:
+    matchLabels:
+      app: invalid-rollout
+  template:
+    metadata:
+      labels:
+        app: invalid-rollout
+    spec:
+      containers:
+        - name: invalid-rollout
+          image: invalid-rollout:0.0.0
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 8080
+            periodSeconds: 5

--- a/pkg/kubectl-argo-rollouts/cmd/lint/testdata/valid.yml
+++ b/pkg/kubectl-argo-rollouts/cmd/lint/testdata/valid.yml
@@ -1,0 +1,40 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: valid-rollout
+spec:
+  revisionHistoryLimit: 1
+  replicas: 10
+  strategy:
+    canary:
+      maxUnavailable: 0
+      maxSurge: 1
+      analysis:
+        templates:
+          - templateName: integrationtests
+      steps:
+        - setWeight: 10
+        - setWeight: 20
+        - setWeight: 40
+        - setWeight: 80
+  selector:
+    matchLabels:
+      app: valid-rollout
+  template:
+    metadata:
+      labels:
+        app: valid-rollout
+    spec:
+      containers:
+        - name: valid-rollout
+          image: valid-rollout:0.0.0
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 8080
+            periodSeconds: 5


### PR DESCRIPTION
This allows a user to lint the rollout objects via the CLI, in order to
catch mistakes before applying or committing to a git repo.

I didn't write any unit tests for this because there are already comprehensive unit tests for the actual validation libraries. I didn't think unit tests for wrapping the validation libraries in a cobra cmd were necessary. If my assumption was wrong, please let me know!

Closes #695

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [X] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [X] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).