### PR TITLE
fix(controller): controller did not honor maxUnavailable during abort

### DIFF
--- a/test/e2e/analysis_test.go
+++ b/test/e2e/analysis_test.go
@@ -155,10 +155,11 @@ spec:
 		Sleep(2*time.Second). // promoting too fast causes test to flake
 		PromoteRollout().
 		WaitForActiveRevision("2").
-		Sleep(time.Second). // analysis is created on later reconciliations after service cutover
+		Sleep(2*time.Second). // analysis is created on later reconciliations after service cutover
 		Then().
 		ExpectAnalysisRunCount(2).
 		ExpectReplicaCounts(1, 2, 1, 1, 1).
+		ExpectRolloutStatus("Progressing").
 		When().
 		WaitForRolloutStatus("Healthy").
 		Then().

--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 
@@ -16,6 +17,11 @@ type CanarySuite struct {
 
 func TestCanarySuite(t *testing.T) {
 	suite.Run(t, new(CanarySuite))
+}
+
+func (s *CanarySuite) SetupSuite() {
+	s.E2ESuite.SetupSuite()
+	s.ApplyManifests("@functional/analysistemplate-sleep-job.yaml")
 }
 
 func (s *CanarySuite) TestCanarySetCanaryScale() {
@@ -103,7 +109,7 @@ func (s *FunctionalSuite) TestRolloutScalingWhenPaused() {
 }
 
 // TestRolloutScalingDuringUpdate verifies behavior when scaling a rollout up/down in middle of update
-func (s *FunctionalSuite) TestRolloutScalingDuringUpdate() {
+func (s *CanarySuite) TestRolloutScalingDuringUpdate() {
 	s.Given().
 		HealthyRollout(`
 apiVersion: argoproj.io/v1alpha1
@@ -152,4 +158,75 @@ spec:
 		When().
 		ScaleRollout(4)
 	// WaitForRolloutReplicas(4) // this doesn't work yet (bug)
+}
+
+// TestReduceWeightAndHonorMaxUnavailable verifies we honor maxUnavailable when decreasing weight or aborting
+func (s *CanarySuite) TestReduceWeightAndHonorMaxUnavailable() {
+	s.Given().
+		HealthyRollout(`
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: reduceweight-maxunavailable
+spec:
+  replicas: 3
+  strategy:
+    canary:
+      maxSurge: 2
+      maxUnavailable: 0
+      steps:
+      - setWeight: 100
+      - pause: {}
+      - setWeight: 0
+      - pause: {}
+      - setWeight: 100
+      - analysis:
+          templates:
+          - templateName: sleep-job
+          args:
+          - name: exit-code
+            value: "1"
+  selector:
+    matchLabels:
+      app: reduceweight-maxunavailable
+  template:
+    metadata:
+      labels:
+        app: reduceweight-maxunavailable
+    spec:
+      containers:
+      - name: reduceweight-maxunavailable
+        image: nginx:1.19-alpine
+        # slow down the start/stop of pods so our pod count checks will not flake
+        lifecycle:
+          postStart:
+            exec:
+              command: [sleep, "5"]
+          preStop:
+            exec:
+              command: [sleep, "5"]
+        resources:
+          requests:
+            memory: 16Mi
+            cpu: 1m`).
+		When().
+		UpdateSpec().
+		WaitForRolloutStatus("Paused").
+		Then().
+		ExpectCanaryStablePodCount(3, 0).
+		When().
+		PromoteRollout().
+		Sleep(2*time.Second).
+		Then().
+		// verify we don't scale down immediately after and honor maxSurge/maxUnavailable
+		ExpectCanaryStablePodCount(3, 2).
+		When().
+		WaitForRolloutCanaryStepIndex(3).
+		PromoteRollout().
+		WaitForRolloutStatus("Degraded").
+		Sleep(2*time.Second).
+		Then().
+		ExpectAnalysisRunCount(1).
+		// verify we don't scale down immediately after and honor maxSurge/maxUnavailable
+		ExpectCanaryStablePodCount(3, 2)
 }

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 	appsv1 "k8s.io/api/apps/v1"
@@ -48,6 +49,7 @@ func (s *FunctionalSuite) TestRolloutRestart() {
 	s.Given().
 		HealthyRollout(`@functional/rollout-basic.yaml`).
 		When().
+		Sleep(time.Second). // need to sleep so that clock will advanced past pod creationTimestamp
 		RestartRollout().
 		WaitForRolloutStatus("Progressing").
 		WaitForRolloutStatus("Healthy")
@@ -408,7 +410,6 @@ spec:
           requests:
             memory: 16Mi
             cpu: 1m
-
 `).
 		When().
 		UpdateSpec(`

--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -167,7 +167,11 @@ func CalculateReplicaCountsForCanary(rollout *v1alpha1.Rollout, newRS *appsv1.Re
 	}
 
 	minAvailableReplicaCount := rolloutSpecReplica - MaxUnavailable(rollout)
-	replicasToScaleDown := GetReplicasForScaleDown(newRS, false) + GetReplicasForScaleDown(stableRS, true)
+	// isIncreasing indicates if we are supposed to be increasing our canary replica count.
+	// If so, we can ignore pod availability of the stableRS. Otherwise, if we are reducing our
+	// weight (e.g. we are aborting), then we can ignore pod availability of the canaryRS.
+	isIncreasing := newRS == nil || desiredNewRSReplicaCount >= *newRS.Spec.Replicas
+	replicasToScaleDown := GetReplicasForScaleDown(newRS, !isIncreasing) + GetReplicasForScaleDown(stableRS, isIncreasing)
 
 	if replicasToScaleDown <= minAvailableReplicaCount {
 		// Cannot scale down stableRS or newRS without going below min available replica count
@@ -229,9 +233,15 @@ func CheckStableRSExists(newRS, stableRS *appsv1.ReplicaSet) bool {
 	return true
 }
 
-// GetReplicasForScaleDown returns the number of replicas to consider for scaling down.
-// isStableRS indicates if the supplied ReplicaSet is the stableRS
-func GetReplicasForScaleDown(rs *appsv1.ReplicaSet, isStableRS bool) int32 {
+// GetReplicasForScaleDown returns the total number of replicas to consider for scaling down the
+// given ReplicaSet. ignoreAvailability indicates if we are allowed to ignore availability
+// of pods during the calculation, in which case we return just the desired replicas.
+// The purpose of ignoring availability is to handle the case when the ReplicaSet which we are
+// considering for scaledown might be scaled up, but its pods may be unavailable (e.g. because of
+// a CrashloopBackoff). In this case we need to return the spec.Replicas so that the controller will
+// still consider scaling down this ReplicaSet. Without this, a rollout could become stuck not
+// scaling down the stable, in order to make room for more canaries.
+func GetReplicasForScaleDown(rs *appsv1.ReplicaSet, ignoreAvailability bool) int32 {
 	if rs == nil {
 		return int32(0)
 	}
@@ -243,11 +253,7 @@ func GetReplicasForScaleDown(rs *appsv1.ReplicaSet, isStableRS bool) int32 {
 		// violate the min available.
 		return *rs.Spec.Replicas
 	}
-	if isStableRS && rs.Status.AvailableReplicas < *rs.Spec.Replicas {
-		// The stable ReplicaSet might be scaled up, but its pods may be unavailable.
-		// In this case we need to return the spec.Replicas so that the controller will still
-		// consider scaling down this ReplicaSet. Without this, a rollout update could become stuck
-		// not scaling down the stable, in order to make room for more canaries.
+	if ignoreAvailability {
 		return *rs.Spec.Replicas
 	}
 	return rs.Status.AvailableReplicas

--- a/utils/replicaset/canary_test.go
+++ b/utils/replicaset/canary_test.go
@@ -484,6 +484,57 @@ func TestCalculateReplicaCountsForCanary(t *testing.T) {
 			expectedStableReplicaCount: 3, // should only scale down by 1 to honor maxUnavailable: 0
 			expectedCanaryReplicaCount: 1,
 		},
+		{
+			// verify we honor maxUnavailable when aborting or reducing weight
+			name:                "honor maxUnavailable when aborting or reducing weight part 1",
+			rolloutSpecReplicas: 4,
+			setWeight:           0,
+			maxSurge:            intstr.FromInt(1),
+			maxUnavailable:      intstr.FromInt(0),
+
+			stableSpecReplica:      0,
+			stableAvailableReplica: 0,
+
+			canarySpecReplica:      4,
+			canaryAvailableReplica: 4,
+
+			expectedStableReplicaCount: 1,
+			expectedCanaryReplicaCount: 4, // should not bring down canary until we surge stable
+		},
+		{
+			// verify we honor maxUnavailable when aborting or reducing weight (after surging stable)
+			name:                "honor maxUnavailable when aborting or reducing weight part 2",
+			rolloutSpecReplicas: 4,
+			setWeight:           0,
+			maxSurge:            intstr.FromInt(1),
+			maxUnavailable:      intstr.FromInt(0),
+
+			stableSpecReplica:      1,
+			stableAvailableReplica: 0,
+
+			canarySpecReplica:      4,
+			canaryAvailableReplica: 4,
+
+			expectedStableReplicaCount: 1, // should not adjust counts at all since stable not available
+			expectedCanaryReplicaCount: 4,
+		},
+		{
+			// verify we honor maxUnavailable when aborting or reducing weight (after stable surge availability)
+			name:                "honor maxUnavailable when aborting or reducing weight part 3",
+			rolloutSpecReplicas: 4,
+			setWeight:           0,
+			maxSurge:            intstr.FromInt(1),
+			maxUnavailable:      intstr.FromInt(0),
+
+			stableSpecReplica:      1,
+			stableAvailableReplica: 1,
+
+			canarySpecReplica:      4,
+			canaryAvailableReplica: 4,
+
+			expectedStableReplicaCount: 1,
+			expectedCanaryReplicaCount: 3, // should only reduce by 1 to honor maxUnavailable
+		},
 	}
 	for i := range tests {
 		test := tests[i]


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/777

The calculation change made in https://github.com/argoproj/argo-rollouts/pull/739, only accounted for the case when we were scaling up the canary, but not when we were scaling down the canary (e.g. in the case of abort). This caused a regression where we did not honor maxUnavailable during an abort.

