### PR TITLE
fix: rollout kustomize transform analysis ref should use templateName instead of name

### DIFF
--- a/docs/features/kustomize/rollout-transform.yaml
+++ b/docs/features/kustomize/rollout-transform.yaml
@@ -149,19 +149,19 @@ nameReference:
 - kind: AnalysisTemplate
   group: argoproj.io
   fieldSpecs:
-  - path: spec/strategy/blueGreen/prePromotionAnalysis/templates/name
+  - path: spec/strategy/blueGreen/prePromotionAnalysis/templates/templateName
     kind: Rollout
-  - path: spec/strategy/blueGreen/postPromotionAnalysis/templates/name
+  - path: spec/strategy/blueGreen/postPromotionAnalysis/templates/templateName
     kind: Rollout
-  - path: spec/strategy/canary/analysis/templates/name
+  - path: spec/strategy/canary/analysis/templates/templateName
     kind: Rollout
-  - path: spec/strategy/canary/steps/analysis/templates/name
+  - path: spec/strategy/canary/steps/analysis/templates/templateName
     kind: Rollout
   - path: spec/strategy/canary/steps/experiment/analyses/templateName
     kind: Rollout
   - path: spec/analyses/templateName
     kind: Experiment
-    # NOTE: templateName is deprecated in the below fields, in favor of templates[].name
+    # NOTE: templateName is deprecated in the below fields, in favor of templates[].templateName
   - path: spec/strategy/blueGreen/prePromotionAnalysis/templateName   
     kind: Rollout
   - path: spec/strategy/blueGreen/postPromotionAnalysis/templateName

--- a/test/kustomize/rollout/expected.yaml
+++ b/test/kustomize/rollout/expected.yaml
@@ -149,7 +149,7 @@ spec:
     canary:
       analysis:
         templates:
-        - name: my-random-fail
+        - templateName: my-random-fail
       canaryService: my-guestbook-canary-svc
       stableService: my-guestbook-stable-svc
       steps:
@@ -162,7 +162,7 @@ spec:
             specRef: canary
       - analysis:
           templates:
-          - name: my-random-fail
+          - templateName: my-random-fail
       trafficRouting:
         alb:
           ingress: my-networking-ingress

--- a/test/kustomize/rollout/rollout.yaml
+++ b/test/kustomize/rollout/rollout.yaml
@@ -67,7 +67,7 @@ spec:
           ingress: networking-ingress
       analysis:
         templates:
-        - name: random-fail
+        - templateName: random-fail
       steps:
       - experiment:
           templates:
@@ -78,7 +78,7 @@ spec:
             templateName: random-fail
       - analysis:
           templates:
-          - name: random-fail
+          - templateName: random-fail
 
 ---
 apiVersion: argoproj.io/v1alpha1


### PR DESCRIPTION
The rollout-transform was incorrect and didn't match our type definitions. AnalysisTemplates reference use the field `templateName:` and not `name:`