### PR TITLE
feat: Add undo command in kubectl plugin. Fixes #575

### DIFF
--- a/pkg/kubectl-argo-rollouts/cmd/cmd.go
+++ b/pkg/kubectl-argo-rollouts/cmd/cmd.go
@@ -13,6 +13,7 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/retry"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/set"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/terminate"
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/undo"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/version"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options"
 )
@@ -60,5 +61,6 @@ func NewCmdArgoRollouts(o *options.ArgoRolloutsOptions) *cobra.Command {
 	cmd.AddCommand(retry.NewCmdRetry(o))
 	cmd.AddCommand(terminate.NewCmdTerminate(o))
 	cmd.AddCommand(set.NewCmdSet(o))
+	cmd.AddCommand(undo.NewCmdUndo(o))
 	return cmd
 }

--- a/pkg/kubectl-argo-rollouts/cmd/undo/undo.go
+++ b/pkg/kubectl-argo-rollouts/cmd/undo/undo.go
@@ -1,0 +1,205 @@
+package undo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	clientset "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/typed/rollouts/v1alpha1"
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	appsclient "k8s.io/client-go/kubernetes/typed/apps/v1"
+)
+
+const (
+	revisionAnnotation = "rollout.argoproj.io/revision"
+
+	undoExample = `
+	# Undo a rollout
+	%[1]s undo guestbook
+
+	# Undo a rollout revision 3
+	%[1]s undo guestbook --to-revision=3`
+)
+
+// NewCmdUndo returns a new instance of an `rollouts undo` command
+func NewCmdUndo(o *options.ArgoRolloutsOptions) *cobra.Command {
+	var (
+		toRevision = int64(0)
+	)
+	var cmd = &cobra.Command{
+		Use:          "undo ROLLOUT_NAME",
+		Short:        "Undo a rollout",
+		Long:         "Rollback to the previous rollout.",
+		Example:      o.Example(undoExample),
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return o.UsageErr(c)
+			}
+			name := args[0]
+			rolloutIf := o.RolloutsClientset().ArgoprojV1alpha1().Rollouts(o.Namespace())
+			clientset := o.KubeClientset()
+			result, err := RunUndoRollout(rolloutIf, clientset, name, toRevision)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(o.Out, result)
+			return nil
+		},
+	}
+	cmd.Flags().Int64Var(&toRevision, "to-revision", toRevision, "The revision to rollback to. Default to 0 (last revision).")
+	return cmd
+}
+
+// RunUndoRollout performs the execution of 'rollouts undo' sub command
+func RunUndoRollout(rolloutIf clientset.RolloutInterface, c kubernetes.Interface, name string, toRevision int64) (string, error) {
+	ctx := context.TODO()
+	ro, err := rolloutIf.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	rsForRevision, err := rolloutRevision(ro, c, toRevision)
+	if err != nil {
+		return "", err
+	}
+
+	// Skip if the revision already matches current rollout
+	if equalIgnoreHash(&rsForRevision.Spec.Template, &ro.Spec.Template) {
+		return fmt.Sprintf("skipped rollback (current template already matches revision %d)", toRevision), nil
+	}
+
+	// remove hash label before patching back into the rollout
+	delete(rsForRevision.Spec.Template.Labels, v1alpha1.DefaultRolloutUniqueLabelKey)
+
+	// make patch to restore
+	patchType, patch, err := getRolloutPatch(&rsForRevision.Spec.Template, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed restoring revision %d: %v", toRevision, err)
+	}
+
+	// Restore revision
+	if _, err = rolloutIf.Patch(ctx, name, patchType, patch, metav1.PatchOptions{}); err != nil {
+		return "", fmt.Errorf("failed restoring revision %d: %v", toRevision, err)
+	}
+	return fmt.Sprintf("rollout '%s' undo\n", ro.Name), nil
+}
+
+func rolloutRevision(ro *v1alpha1.Rollout, c kubernetes.Interface, toRevision int64) (*appsv1.ReplicaSet, error){
+	allRSs, err := getAllReplicaSets(ro, c.AppsV1())
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve replica sets from rollout %s: %v", ro.Name, err)
+	}
+	var (
+		latestReplicaSet   *appsv1.ReplicaSet
+		latestRevision     = int64(-1)
+		previousReplicaSet *appsv1.ReplicaSet
+		previousRevision   = int64(-1)
+	)
+	for _, rs := range allRSs {
+		if v, err := revision(rs); err == nil {
+			if toRevision == 0 {
+				if latestRevision < v {
+					// newest one we've seen so far
+					previousRevision = latestRevision
+					previousReplicaSet = latestReplicaSet
+					latestRevision = v
+					latestReplicaSet = rs
+				} else if previousRevision < v {
+					// second newest one we've seen so far
+					previousRevision = v
+					previousReplicaSet = rs
+				}
+			} else if toRevision == v {
+				return rs, nil
+			}
+		}
+	}
+	return previousReplicaSet, nil
+}
+
+func getRolloutPatch(podTemplate *corev1.PodTemplateSpec, annotations map[string]string) (types.PatchType, []byte, error) {
+	patch, err := json.Marshal(map[string]interface{}{
+		"op":    "replace",
+		"path":  "/spec/template",
+		"value": podTemplate,
+	})
+	return types.JSONPatchType, patch, err
+}
+
+func getAllReplicaSets(ro *v1alpha1.Rollout, c appsclient.AppsV1Interface) ([]*appsv1.ReplicaSet, error) {
+	rsList, err := listReplicaSets(ro, rsListFromClient(c))
+	if err != nil {
+		return nil, err
+	}
+	return rsList, nil
+}
+
+func rsListFromClient(c appsclient.AppsV1Interface) rsListFunc {
+	return func(namespace string, options metav1.ListOptions) ([]*appsv1.ReplicaSet, error) {
+		rsList, err := c.ReplicaSets(namespace).List(context.TODO(), options)
+		if err != nil {
+			return nil, err
+		}
+		var ret []*appsv1.ReplicaSet
+		for i := range rsList.Items {
+			ret = append(ret, &rsList.Items[i])
+		}
+		return ret, err
+	}
+}
+
+type rsListFunc func(string, metav1.ListOptions) ([]*appsv1.ReplicaSet, error)
+
+func listReplicaSets(ro *v1alpha1.Rollout, getRSList rsListFunc) ([]*appsv1.ReplicaSet, error) {
+	namespace := ro.Namespace
+	selector, err := metav1.LabelSelectorAsSelector(ro.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+	options := metav1.ListOptions{LabelSelector: selector.String()}
+	all, err := getRSList(namespace, options)
+	if err != nil {
+		return nil, err
+	}
+	// Only include those whose ControllerRef matches the rollout.
+	owned := make([]*appsv1.ReplicaSet, 0, len(all))
+	for _, rs := range all {
+		if metav1.IsControlledBy(rs, ro) {
+			owned = append(owned, rs)
+		}
+	}
+	return owned, nil
+}
+
+func revision(obj runtime.Object) (int64, error) {
+	acc, err := meta.Accessor(obj)
+	if err != nil {
+		return 0, err
+	}
+	v, ok := acc.GetAnnotations()[revisionAnnotation]
+	if !ok {
+		return 0, nil
+	}
+	return strconv.ParseInt(v, 10, 64)
+}
+
+func equalIgnoreHash(template1, template2 *corev1.PodTemplateSpec) bool {
+	t1Copy := template1.DeepCopy()
+	t2Copy := template2.DeepCopy()
+	// Remove hash labels from template.Labels before comparing
+	delete(t1Copy.Labels, v1alpha1.DefaultRolloutUniqueLabelKey)
+	delete(t2Copy.Labels, v1alpha1.DefaultRolloutUniqueLabelKey)
+	return apiequality.Semantic.DeepEqual(t1Copy, t2Copy)
+}

--- a/pkg/kubectl-argo-rollouts/cmd/undo/undo.go
+++ b/pkg/kubectl-argo-rollouts/cmd/undo/undo.go
@@ -96,7 +96,7 @@ func RunUndoRollout(rolloutIf clientset.RolloutInterface, c kubernetes.Interface
 	return fmt.Sprintf("rollout '%s' undo\n", ro.Name), nil
 }
 
-func rolloutRevision(ro *v1alpha1.Rollout, c kubernetes.Interface, toRevision int64) (*appsv1.ReplicaSet, error){
+func rolloutRevision(ro *v1alpha1.Rollout, c kubernetes.Interface, toRevision int64) (*appsv1.ReplicaSet, error) {
 	allRSs, err := getAllReplicaSets(ro, c.AppsV1())
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve replica sets from rollout %s: %v", ro.Name, err)

--- a/pkg/kubectl-argo-rollouts/cmd/undo/undo_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/undo/undo_test.go
@@ -1,0 +1,201 @@
+package undo
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/info/testdata"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubetesting "k8s.io/client-go/testing"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	fakeroclient "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
+	options "github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options/fake"
+)
+
+func TestPromoteCmdUsage(t *testing.T) {
+	tf, o := options.NewFakeArgoRolloutsOptions()
+	defer tf.Cleanup()
+	cmd := NewCmdUndo(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	assert.Error(t, err)
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "Usage:")
+	assert.Contains(t, stderr, "undo ROLLOUT")
+}
+
+func TestUndoCmd(t *testing.T) {
+	rolloutObjs := testdata.NewCanaryRollout()
+	ro := rolloutObjs.Rollouts[0]
+	tf, o := options.NewFakeArgoRolloutsOptions(rolloutObjs.AllObjects()...)
+	o.RESTClientGetter = tf.WithNamespace(ro.Namespace)
+	defer tf.Cleanup()
+	fakeClient := o.RolloutsClient.(*fakeroclient.Clientset)
+	fakeClient.PrependReactor("patch", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		if patchAction, ok := action.(kubetesting.PatchAction); ok {
+			type patch struct {
+				Value corev1.PodTemplateSpec `json:"value"`
+			}
+			patchRo := []patch{}
+			err := json.Unmarshal(patchAction.GetPatch(), &patchRo)
+			if err != nil {
+				panic(err)
+			}
+			ro.Spec.Template = patchRo[0].Value
+		}
+		return true, ro, nil
+	})
+
+	cmd := NewCmdUndo(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{ro.Name})
+
+	err := cmd.Execute()
+	assert.Nil(t, err)
+	var rs *v1.ReplicaSet
+	for _, rs = range rolloutObjs.ReplicaSets {
+		if rs.Name == "canary-demo-877894d5b" {
+			break
+		}
+	}
+	delete(rs.Spec.Template.Labels, v1alpha1.DefaultRolloutUniqueLabelKey)
+	assert.Equal(t, rs.Spec.Template, ro.Spec.Template)
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Equal(t, fmt.Sprintf("rollout '%s' undo\n", ro.Name), stdout)
+	assert.Empty(t, stderr)
+}
+
+func TestUndoCmdToRevision(t *testing.T) {
+	rolloutObjs := testdata.NewCanaryRollout()
+	ro := rolloutObjs.Rollouts[0]
+	tf, o := options.NewFakeArgoRolloutsOptions(rolloutObjs.AllObjects()...)
+	o.RESTClientGetter = tf.WithNamespace(ro.Namespace)
+	defer tf.Cleanup()
+	fakeClient := o.RolloutsClient.(*fakeroclient.Clientset)
+	fakeClient.PrependReactor("patch", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		if patchAction, ok := action.(kubetesting.PatchAction); ok {
+			type patch struct {
+				Value corev1.PodTemplateSpec `json:"value"`
+			}
+			patchRo := []patch{}
+			err := json.Unmarshal(patchAction.GetPatch(), &patchRo)
+			if err != nil {
+				panic(err)
+			}
+			ro.Spec.Template = patchRo[0].Value
+		}
+		return true, ro, nil
+	})
+
+	cmd := NewCmdUndo(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{ro.Name, "--to-revision=29"})
+
+	err := cmd.Execute()
+	assert.Nil(t, err)
+	var rs *v1.ReplicaSet
+	for _, rs = range rolloutObjs.ReplicaSets {
+		if rs.Name == "canary-demo-859c99b45c" {
+			break
+		}
+	}
+	delete(rs.Spec.Template.Labels, v1alpha1.DefaultRolloutUniqueLabelKey)
+	assert.Equal(t, rs.Spec.Template, ro.Spec.Template)
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Equal(t, fmt.Sprintf("rollout '%s' undo\n", ro.Name), stdout)
+	assert.Empty(t, stderr)
+}
+
+func TestUndoCmdToRevisionSkipCurrent(t *testing.T) {
+	rolloutObjs := testdata.NewCanaryRollout()
+	ro := rolloutObjs.Rollouts[0]
+	tf, o := options.NewFakeArgoRolloutsOptions(rolloutObjs.AllObjects()...)
+	o.RESTClientGetter = tf.WithNamespace(ro.Namespace)
+	defer tf.Cleanup()
+
+	cmd := NewCmdUndo(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	revision := "31"
+	cmd.SetArgs([]string{ro.Name, "--to-revision=" + revision})
+
+	err := cmd.Execute()
+	assert.Nil(t, err)
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Equal(t, fmt.Sprintf("skipped rollback (current template already matches revision %s)", revision), stdout)
+	assert.Empty(t, stderr)
+}
+
+func TestUndoCmdToRevisionNotFoundError(t *testing.T) {
+	rolloutObjs := testdata.NewCanaryRollout()
+	ro := rolloutObjs.Rollouts[0]
+	tf, o := options.NewFakeArgoRolloutsOptions(rolloutObjs.AllObjects()...)
+	o.RESTClientGetter = tf.WithNamespace(ro.Namespace)
+	defer tf.Cleanup()
+
+	cmd := NewCmdUndo(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	revision := "1"
+	cmd.SetArgs([]string{ro.Name, "--to-revision=" + revision})
+
+	err := cmd.Execute()
+	assert.Error(t, err)
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Empty(t, stdout)
+	assert.Equal(t, fmt.Sprintf("Error: unable to find specified revision %v in history\n", revision), stderr)
+}
+
+func TestUndoCmdNoRevisionError(t *testing.T) {
+	ro := v1alpha1.Rollout{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "guestbook",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: v1alpha1.RolloutSpec{
+			Strategy: v1alpha1.RolloutStrategy{
+				Canary: &v1alpha1.CanaryStrategy{},
+			},
+		},
+	}
+	tf, o := options.NewFakeArgoRolloutsOptions(&ro)
+	defer tf.Cleanup()
+
+	cmd := NewCmdUndo(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{ro.Name})
+
+	err := cmd.Execute()
+	assert.Error(t, err)
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Empty(t, stdout)
+	assert.Equal(t, fmt.Sprintf("Error: no revision found for rollout %q\n", ro.Name), stderr)
+}
+
+func TestUndoCmdError(t *testing.T) {
+	tf, o := options.NewFakeArgoRolloutsOptions(&v1alpha1.Rollout{})
+	defer tf.Cleanup()
+	cmd := NewCmdUndo(o)
+	o.AddKubectlFlags(cmd)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{"doesnotexist", "-n", "test"})
+	err := cmd.Execute()
+	assert.Error(t, err)
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Empty(t, stdout)
+	assert.Equal(t, "Error: rollouts.argoproj.io \"doesnotexist\" not found\n", stderr)
+}

--- a/pkg/kubectl-argo-rollouts/cmd/undo/undo_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/undo/undo_test.go
@@ -12,14 +12,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	kubetesting "k8s.io/client-go/testing"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
-	fakeroclient "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
 	options "github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options/fake"
 )
 
-func TestPromoteCmdUsage(t *testing.T) {
+func TestUndoCmdUsage(t *testing.T) {
 	tf, o := options.NewFakeArgoRolloutsOptions()
 	defer tf.Cleanup()
 	cmd := NewCmdUndo(o)
@@ -40,7 +40,7 @@ func TestUndoCmd(t *testing.T) {
 	tf, o := options.NewFakeArgoRolloutsOptions(rolloutObjs.AllObjects()...)
 	o.RESTClientGetter = tf.WithNamespace(ro.Namespace)
 	defer tf.Cleanup()
-	fakeClient := o.RolloutsClient.(*fakeroclient.Clientset)
+	fakeClient := o.DynamicClient.(*dynamicfake.FakeDynamicClient)
 	fakeClient.PrependReactor("patch", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 		if patchAction, ok := action.(kubetesting.PatchAction); ok {
 			type patch struct {
@@ -82,7 +82,7 @@ func TestUndoCmdToRevision(t *testing.T) {
 	tf, o := options.NewFakeArgoRolloutsOptions(rolloutObjs.AllObjects()...)
 	o.RESTClientGetter = tf.WithNamespace(ro.Namespace)
 	defer tf.Cleanup()
-	fakeClient := o.RolloutsClient.(*fakeroclient.Clientset)
+	fakeClient := o.DynamicClient.(*dynamicfake.FakeDynamicClient)
 	fakeClient.PrependReactor("patch", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 		if patchAction, ok := action.(kubetesting.PatchAction); ok {
 			type patch struct {


### PR DESCRIPTION
I created `kubectl argo rollouts undo` command in the same way as `kubectl rollout undo` command.
I referred to the following program.
https://github.com/kubernetes/kubectl/blob/master/pkg/polymorphichelpers/rollback.go

Refs #575 

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).