### PR TITLE
fix: background analysis refs were not verified. requeue InvalidSpec rollouts

### DIFF
--- a/pkg/apis/rollouts/validation/validation.go
+++ b/pkg/apis/rollouts/validation/validation.go
@@ -224,14 +224,12 @@ func ValidateRolloutStrategyCanary(rollout *v1alpha1.Rollout, fldPath *field.Pat
 			}
 		}
 
-		if analysisRunArgs != nil {
-			for _, arg := range analysisRunArgs {
-				if arg.ValueFrom != nil {
-					if arg.ValueFrom.FieldRef != nil {
-						_, err := fieldpath.ExtractFieldPathAsString(rollout, arg.ValueFrom.FieldRef.FieldPath)
-						if err != nil {
-							allErrs = append(allErrs, field.Invalid(stepFldPath.Child("analyses"), analysisRunArgs, InvalidAnalysisArgsMessage))
-						}
+		for _, arg := range analysisRunArgs {
+			if arg.ValueFrom != nil {
+				if arg.ValueFrom.FieldRef != nil {
+					_, err := fieldpath.ExtractFieldPathAsString(rollout, arg.ValueFrom.FieldRef.FieldPath)
+					if err != nil {
+						allErrs = append(allErrs, field.Invalid(stepFldPath.Child("analyses"), analysisRunArgs, InvalidAnalysisArgsMessage))
 					}
 				}
 			}

--- a/pkg/apis/rollouts/validation/validation_references_test.go
+++ b/pkg/apis/rollouts/validation/validation_references_test.go
@@ -84,7 +84,7 @@ func getAnalysisTemplateWithType() AnalysisTemplateWithType {
 				}},
 			},
 		},
-		TemplateType:    CanaryStep,
+		TemplateType:    InlineAnalysis,
 		AnalysisIndex:   0,
 		CanaryStepIndex: 0,
 	}
@@ -160,13 +160,22 @@ func TestValidateAnalysisTemplateWithType(t *testing.T) {
 		assert.Empty(t, allErrs)
 	})
 
-	t.Run("validate analysisTemplate - failure", func(t *testing.T) {
+	t.Run("validate inline analysisTemplate - failure", func(t *testing.T) {
 		template := getAnalysisTemplateWithType()
 		template.AnalysisTemplate.Spec.Metrics[0].Count = 0
 		allErrs := ValidateAnalysisTemplateWithType(template)
 		assert.Len(t, allErrs, 1)
 		expectedError := field.Invalid(GetAnalysisTemplateWithTypeFieldPath(template.TemplateType, template.AnalysisIndex, template.CanaryStepIndex), template.AnalysisTemplate.Name, "AnalysisTemplate analysis-template-name has metric metric-name which runs indefinitely")
 		assert.Equal(t, expectedError.Error(), allErrs[0].Error())
+	})
+
+	// verify background analysis does not care about a metric that runs indefinitely
+	t.Run("validate background analysisTemplate - success", func(t *testing.T) {
+		template := getAnalysisTemplateWithType()
+		template.TemplateType = BackgroundAnalysis
+		template.AnalysisTemplate.Spec.Metrics[0].Count = 0
+		allErrs := ValidateAnalysisTemplateWithType(template)
+		assert.Empty(t, allErrs)
 	})
 }
 
@@ -256,7 +265,7 @@ func TestGetAnalysisTemplateWithTypeFieldPath(t *testing.T) {
 	})
 
 	t.Run("get fieldPath for analysisTemplateType CanaryStep", func(t *testing.T) {
-		fldPath := GetAnalysisTemplateWithTypeFieldPath(CanaryStep, 0, 0)
+		fldPath := GetAnalysisTemplateWithTypeFieldPath(InlineAnalysis, 0, 0)
 		expectedFldPath := field.NewPath("spec", "strategy", "canary", "steps").Index(0).Child("analysis", "templates").Index(0).Child("templateName")
 		assert.Equal(t, expectedFldPath.String(), fldPath.String())
 	})

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -356,7 +356,10 @@ func calculatePatch(ro *v1alpha1.Rollout, patch string) string {
 	newObservedGen := conditions.ComputeGenerationHash(newRO.Spec)
 
 	newPatch := make(map[string]interface{})
-	json.Unmarshal([]byte(patch), &newPatch)
+	err = json.Unmarshal([]byte(patch), &newPatch)
+	if err != nil {
+		panic(err)
+	}
 	newStatus := newPatch["status"].(map[string]interface{})
 	newStatus["observedGeneration"] = newObservedGen
 	newPatch["status"] = newStatus

--- a/test/fixtures/then.go
+++ b/test/fixtures/then.go
@@ -255,3 +255,9 @@ func (t *Then) When() *When {
 		Common: t.Common,
 	}
 }
+
+func (t *Then) Given() *Given {
+	return &Given{
+		Common: t.Common,
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/754, https://github.com/argoproj/argo-rollouts/issues/713

1. When a Rollout has an InvalidSpec, we will requeue the Rollout every ~20 seconds to detect if the situation has fixed itself (e.g. the referenced Service was created).

2. BackgroundAnalysis was not being verified

3. Rename CanaryStep to InlineAnalysis