### PR TITLE
fix: scaleDownDelayRevisionLimit was off by one

### DIFF
--- a/docs/features/bluegreen.md
+++ b/docs/features/bluegreen.md
@@ -110,8 +110,7 @@ The PreviewReplicaCount will indicate the number of replicas that the new versio
 
 This feature is mainly used to save resources during the testing phase. If the application does not need a fully scaled up application for the tests, this feature can help save some resources.
 
-Defaults to nil
-
+If omitted, preview ReplicaSet stack will be scaled to 100% of the replicas.
 ### scaleDownDelaySeconds
 The ScaleDownDelaySeconds is used to delay scaling down the old ReplicaSet after the active Service is switched to the new ReplicaSet.
 
@@ -120,4 +119,4 @@ Defaults to 30
 ### scaleDownDelayRevisionLimit
 The ScaleDownDelayRevisionLimit limits the number of old active ReplicaSets to keep scaled up while they wait for the scaleDownDelay to pass after being removed from the active service. 
 
-Defaults to nil
+If omitted, all ReplicaSets will be retained for the specified scaleDownDelay

--- a/rollout/bluegreen.go
+++ b/rollout/bluegreen.go
@@ -205,8 +205,8 @@ func (c *rolloutContext) scaleDownOldReplicaSetsForBlueGreen(oldRSs []*appsv1.Re
 			scaleDownAtTime, err := time.Parse(time.RFC3339, scaleDownAtStr)
 			if err != nil {
 				c.log.Warnf("Unable to read scaleDownAt label on rs '%s'", targetRS.Name)
-			} else if c.rollout.Spec.Strategy.BlueGreen.ScaleDownDelayRevisionLimit != nil && annotationedRSs == *c.rollout.Spec.Strategy.BlueGreen.ScaleDownDelayRevisionLimit {
-				c.log.Info("At ScaleDownDelayRevisionLimit and scaling down the rest")
+			} else if c.rollout.Spec.Strategy.BlueGreen.ScaleDownDelayRevisionLimit != nil && annotationedRSs > *c.rollout.Spec.Strategy.BlueGreen.ScaleDownDelayRevisionLimit {
+				c.log.Infof("At ScaleDownDelayRevisionLimit (%d) and scaling down the rest", *c.rollout.Spec.Strategy.BlueGreen.ScaleDownDelayRevisionLimit)
 			} else {
 				now := metav1.Now()
 				scaleDownAt := metav1.NewTime(scaleDownAtTime)

--- a/rollout/bluegreen_test.go
+++ b/rollout/bluegreen_test.go
@@ -1163,7 +1163,7 @@ func TestScaleDownLimit(t *testing.T) {
 	r1 := newBlueGreenRollout("foo", 1, nil, "bar", "")
 	r2 := bumpVersion(r1)
 	r3 := bumpVersion(r2)
-	r3.Spec.Strategy.BlueGreen.ScaleDownDelayRevisionLimit = pointer.Int32Ptr(2)
+	r3.Spec.Strategy.BlueGreen.ScaleDownDelayRevisionLimit = pointer.Int32Ptr(1)
 
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
 	rs2 := newReplicaSetWithStatus(r2, 1, 1)

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -491,3 +491,75 @@ spec:
 		ApplyManifests().
 		WaitForRolloutStatus("Healthy")
 }
+
+// TestBlueGreenScaleDownDelay verifies the scaleDownDelay feature
+func (s *FunctionalSuite) TestBlueGreenScaleDownDelay() {
+	s.Given().
+		RolloutObjects(newService("bluegreen-scaledowndelay-active")).
+		RolloutObjects(`
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: bluegreen-scaledowndelay
+spec:
+  replicas: 1
+  strategy:
+    blueGreen:
+      activeService: bluegreen-scaledowndelay-active
+      scaleDownDelaySeconds: 86400 # one day
+      scaleDownDelayRevisionLimit: 2
+  selector:
+    matchLabels:
+      app: bluegreen-scaledowndelay
+  template:
+    metadata:
+      labels:
+        app: bluegreen-scaledowndelay
+    spec:
+      containers:
+      - name: bluegreen-scaledowndelay
+        image: nginx:1.19-alpine
+        resources:
+          requests:
+            memory: 16Mi
+            cpu: 1m
+`).
+		When().
+		ApplyManifests().
+		WaitForRolloutStatus("Healthy").
+		UpdateSpec().
+		WaitForRolloutStatus("Progressing").
+		WaitForRolloutStatus("Healthy").
+		Then().
+		ExpectRevisionPodCount("2", 1).
+		ExpectRevisionPodCount("1", 1).
+		ExpectReplicaCounts(1, 2, 1, 1, 1). // desired, current, updated, ready, available
+		When().
+		UpdateSpec().
+		WaitForRolloutStatus("Progressing").
+		WaitForRolloutStatus("Healthy").
+		UpdateSpec().
+		WaitForRolloutStatus("Progressing").
+		WaitForRolloutStatus("Healthy").
+		Sleep(time.Second).
+		Then().
+		ExpectRevisionPodCount("4", 1).
+		ExpectRevisionPodCount("3", 1).
+		ExpectRevisionPodCount("2", 1).
+		ExpectRevisionPodCount("1", 0).
+		ExpectReplicaCounts(1, 3, 1, 1, 1).
+		When().
+		// lower scaleDownDelayRevisionLimit to 1 old RS. it should cause revision 2 to ScaleDown
+		PatchSpec(`
+spec:
+  strategy:
+    blueGreen:
+      scaleDownDelayRevisionLimit: 1`).
+		Sleep(time.Second).
+		Then().
+		ExpectRevisionPodCount("4", 1).
+		ExpectRevisionPodCount("3", 1).
+		ExpectRevisionPodCount("2", 0).
+		ExpectRevisionPodCount("1", 0).
+		ExpectReplicaCounts(1, 2, 1, 1, 1)
+}


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/813

We were scaling down old ReplicasSets prematurely (by 1), not honoring scaleDownDelayRevisionLimit

Signed-off-by: Jesse Suen <jesse_suen@intuit.com>
