### PR TITLE
feat(controller): add full rollout promotion (skip analysis, pause, steps)

### DIFF
--- a/analysis/controller_test.go
+++ b/analysis/controller_test.go
@@ -174,7 +174,7 @@ func (f *fixture) runController(analysisRunName string, startInformers bool, exp
 	}
 
 	if len(f.actions) > len(actions) {
-		f.t.Errorf("%d additional expected actions:%+v", len(f.actions)-len(actions), f.actions[len(actions):])
+		f.t.Errorf("%d expected actions did not occur:%+v", len(f.actions)-len(actions), f.actions[len(actions):])
 	}
 
 	// k8sActions := filterInformerActions(f.kubeclient.Actions())
@@ -189,7 +189,7 @@ func (f *fixture) runController(analysisRunName string, startInformers bool, exp
 	// }
 
 	// if len(f.kubeactions) > len(k8sActions) {
-	// 	f.t.Errorf("%d additional expected actions:%+v", len(f.kubeactions)-len(k8sActions), f.kubeactions[len(k8sActions):])
+	// 	f.t.Errorf("%d expected actions did not occur:%+v", len(f.kubeactions)-len(k8sActions), f.kubeactions[len(k8sActions):])
 	// }
 	return c
 }

--- a/experiments/controller_test.go
+++ b/experiments/controller_test.go
@@ -422,7 +422,7 @@ func (f *fixture) runController(experimentName string, startInformers bool, expe
 	}
 
 	if len(f.actions) > len(actions) {
-		f.t.Errorf("%d additional expected actions:%+v", len(f.actions)-len(actions), f.actions[len(actions):])
+		f.t.Errorf("%d expected actions did not occur:%+v", len(f.actions)-len(actions), f.actions[len(actions):])
 	}
 
 	k8sActions := filterInformerActions(f.kubeclient.Actions())
@@ -438,7 +438,7 @@ func (f *fixture) runController(experimentName string, startInformers bool, expe
 	}
 
 	if len(f.kubeactions) > len(k8sActions) {
-		f.t.Errorf("%d additional expected actions:%+v", len(f.kubeactions)-len(k8sActions), f.kubeactions[len(k8sActions):])
+		f.t.Errorf("%d expected actions did not occur:%+v", len(f.kubeactions)-len(k8sActions), f.kubeactions[len(k8sActions):])
 	}
 	return c
 }

--- a/manifests/crds/rollout-crd.yaml
+++ b/manifests/crds/rollout-crd.yaml
@@ -3114,6 +3114,8 @@ spec:
                 - startTime
                 type: object
               type: array
+            promoteFull:
+              type: boolean
             readyReplicas:
               format: int32
               type: integer

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -14158,6 +14158,8 @@ spec:
                 - startTime
                 type: object
               type: array
+            promoteFull:
+              type: boolean
             readyReplicas:
               format: int32
               type: integer

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -14158,6 +14158,8 @@ spec:
                 - startTime
                 type: object
               type: array
+            promoteFull:
+              type: boolean
             readyReplicas:
               format: int32
               type: integer

--- a/pkg/apis/rollouts/v1alpha1/openapi_generated.go
+++ b/pkg/apis/rollouts/v1alpha1/openapi_generated.go
@@ -2940,6 +2940,13 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutStatus(ref common.ReferenceCallbac
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
+					"promoteFull": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PromoteFull indicates if the rollout should perform a full promotion, skipping analysis and pauses.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -563,6 +563,8 @@ type RolloutStatus struct {
 	StableRS string `json:"stableRS,omitempty"`
 	// RestartedAt indicates last time a Rollout was restarted
 	RestartedAt *metav1.Time `json:"restartedAt,omitempty"`
+	// PromoteFull indicates if the rollout should perform a full promotion, skipping analysis and pauses.
+	PromoteFull bool `json:"promoteFull,omitempty"`
 }
 
 // BlueGreenStatus status fields that only pertain to the blueGreen rollout

--- a/rollout/analysis.go
+++ b/rollout/analysis.go
@@ -68,7 +68,7 @@ func (c *Controller) getAnalysisRunsForRollout(rollout *v1alpha1.Rollout) ([]*v1
 }
 
 func (c *rolloutContext) reconcileAnalysisRuns() error {
-	if c.pauseContext.IsAborted() {
+	if c.pauseContext.IsAborted() || c.rollout.Status.PromoteFull {
 		allArs := append(c.currentArs.ToArray(), c.otherArs...)
 		c.SetCurrentAnalysisRuns(c.currentArs)
 		return c.cancelAnalysisRuns(allArs)

--- a/rollout/analysis_test.go
+++ b/rollout/analysis_test.go
@@ -1354,9 +1354,9 @@ func TestDoNotCreateBackgroundAnalysisRunAfterInconclusiveRun(t *testing.T) {
 	rs2 := newReplicaSetWithStatus(r2, 0, 0)
 	f.kubeobjects = append(f.kubeobjects, rs1, rs2)
 	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
-	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-	r2 = updateCanaryRolloutStatus(r2, rs2PodHash, 1, 0, 1, false)
+	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 1, 0, 1, false)
 	r2.Status.PauseConditions = []v1alpha1.PauseCondition{{
 		Reason:    v1alpha1.PauseReasonInconclusiveAnalysis,
 		StartTime: metav1.Now(),

--- a/rollout/bluegreen.go
+++ b/rollout/bluegreen.go
@@ -120,6 +120,9 @@ func (c *rolloutContext) skipPause(activeSvc *corev1.Service) bool {
 		c.log.Infof("Detected scale down annotation for ReplicaSet '%s' and will skip pause", c.newRS.Name)
 		return true
 	}
+	if c.rollout.Status.PromoteFull {
+		return true
+	}
 
 	// If a rollout has a PrePromotionAnalysis, the controller only skips the pause after the analysis passes
 	if defaults.GetAutoPromotionEnabledOrDefault(c.rollout) && c.completedPrePromotionAnalysis() {
@@ -244,6 +247,12 @@ func (c *rolloutContext) syncRolloutStatusBlueGreen(previewSvc *corev1.Service, 
 		c.SetRestartedAt()
 		newStatus.BlueGreen.PrePromotionAnalysisRunStatus = nil
 		newStatus.BlueGreen.PostPromotionAnalysisRunStatus = nil
+		newStatus.PromoteFull = false
+	}
+
+	if c.rollout.Status.PromoteFull {
+		c.pauseContext.ClearPauseConditions()
+		c.pauseContext.RemoveAbort()
 	}
 
 	previewSelector := serviceutil.GetRolloutSelectorLabel(previewSvc)
@@ -262,6 +271,7 @@ func (c *rolloutContext) syncRolloutStatusBlueGreen(previewSvc *corev1.Service, 
 	if c.shouldUpdateBlueGreenStable(newStatus) {
 		c.log.Infof("Updating stable RS (%s -> %s)", newStatus.StableRS, newStatus.CurrentPodHash)
 		newStatus.StableRS = newStatus.CurrentPodHash
+		newStatus.PromoteFull = false
 
 		// Now that we've marked the current RS as stable, start the scale-down countdown on the previous stable RS
 		previousStableRS, _ := replicasetutil.GetReplicaSetByTemplateHash(c.olderRSs, c.rollout.Status.StableRS)
@@ -310,6 +320,9 @@ func (c *rolloutContext) shouldUpdateBlueGreenStable(newStatus v1alpha1.RolloutS
 	if newStatus.BlueGreen.ActiveSelector != newStatus.CurrentPodHash {
 		// haven't service performed cutover yet
 		return false
+	}
+	if newStatus.PromoteFull {
+		return true
 	}
 	if c.rollout.Spec.Strategy.BlueGreen.PostPromotionAnalysis != nil {
 		// corner case - we fast-track the StableRS to be updated to CurrentPodHash when we are

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -172,7 +172,7 @@ func (c *rolloutContext) scaleDownOldReplicaSetsForCanary(allRSs []*appsv1.Repli
 		// Cannot scale down.
 		return 0, nil
 	}
-	c.log.Infof("Found %d available pods, scaling down old RSes", availablePodCount)
+	c.log.Infof("Found %d available pods, scaling down old RSes (minAvailable: %d, maxScaleDown: %d)", availablePodCount, minAvailable, maxScaleDown)
 
 	sort.Sort(controller.ReplicaSetsByCreationTimestamp(oldRSs))
 

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/utils/pointer"
 
@@ -105,7 +104,7 @@ func TestReconcileCanaryStepsHandleBaseCases(t *testing.T) {
 		reconcilerBase: reconcilerBase{
 			argoprojclientset: &fake,
 			kubeclientset:     &k8sfake,
-			recorder:          &record.FakeRecorder{},
+			recorder:          &FakeEventRecorder{},
 		},
 	}
 	stepResult := roCtx.reconcileCanaryPause()
@@ -120,7 +119,7 @@ func TestReconcileCanaryStepsHandleBaseCases(t *testing.T) {
 		reconcilerBase: reconcilerBase{
 			argoprojclientset: &fake,
 			kubeclientset:     &k8sfake,
-			recorder:          &record.FakeRecorder{},
+			recorder:          &FakeEventRecorder{},
 		},
 	}
 	stepResult = roCtx2.reconcileCanaryPause()
@@ -1167,23 +1166,25 @@ func TestResumeRolloutAfterPauseDuration(t *testing.T) {
 		},
 	}
 	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(1))
+	r2 := bumpVersion(r1)
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
-	r1 = updateCanaryRolloutStatus(r1, rs1PodHash, 1, 1, 1, true)
+	rs2 := newReplicaSetWithStatus(r2, 1, 1)
+	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 1, 1, 1, true)
 	overAMinuteAgo := metav1.Time{Time: time.Now().Add(-61 * time.Second)}
-	r1.Status.ObservedGeneration = strconv.Itoa(int(r1.Generation))
-	r1.Status.PauseConditions = []v1alpha1.PauseCondition{{
+	r2.Status.ObservedGeneration = strconv.Itoa(int(r2.Generation))
+	r2.Status.PauseConditions = []v1alpha1.PauseCondition{{
 		Reason:    v1alpha1.PauseReasonCanaryPauseStep,
 		StartTime: overAMinuteAgo,
 	}}
-	f.kubeobjects = append(f.kubeobjects, rs1)
-	f.replicaSetLister = append(f.replicaSetLister, rs1)
-	f.rolloutLister = append(f.rolloutLister, r1)
-	f.objects = append(f.objects, r1)
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2)
 
-	_ = f.expectPatchRolloutAction(r1)           // this just sets a conditions. ignore for now
-	patchIndex := f.expectPatchRolloutAction(r1) // this patch should resume the rollout
-	f.run(getKey(r1, t))
+	_ = f.expectPatchRolloutAction(r2)           // this just sets a conditions. ignore for now
+	patchIndex := f.expectPatchRolloutAction(r2) // this patch should resume the rollout
+	f.run(getKey(r2, t))
 
 	patch := f.getPatchedRollout(patchIndex)
 	var patchObj map[string]interface{}

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -32,7 +32,6 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	corev1defaults "k8s.io/kubernetes/pkg/apis/core/v1"
 	"k8s.io/kubernetes/pkg/controller"
@@ -60,6 +59,22 @@ const (
 			}
 	}`
 )
+
+type FakeEventRecorder struct {
+	Events chan string
+}
+
+func (f *FakeEventRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+	log.Infof("%s %s %s", eventtype, reason, message)
+}
+
+func (f *FakeEventRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	log.Infof(eventtype+" "+reason+" "+messageFmt, args...)
+}
+
+func (f *FakeEventRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	f.Eventf(object, eventtype, reason, messageFmt, args...)
+}
 
 type fixture struct {
 	t *testing.T
@@ -430,7 +445,7 @@ func (f *fixture) newController(resync resyncFunc) (*Controller, informers.Share
 		ServiceWorkQueue:                serviceWorkqueue,
 		IngressWorkQueue:                ingressWorkqueue,
 		MetricsServer:                   metricsServer,
-		Recorder:                        &record.FakeRecorder{},
+		Recorder:                        &FakeEventRecorder{},
 		DefaultIstioVersion:             "v1alpha3",
 	})
 
@@ -875,6 +890,20 @@ func (f *fixture) getPatchedRollout(index int) string {
 		f.t.Fatalf("Expected Patch action, not %s", action.GetVerb())
 	}
 	return string(patchAction.GetPatch())
+}
+
+func (f *fixture) getPatchedRolloutAsObject(index int) *v1alpha1.Rollout {
+	action := filterInformerActions(f.client.Actions())[index]
+	patchAction, ok := action.(core.PatchAction)
+	if !ok {
+		f.t.Fatalf("Expected Patch action, not %s", action.GetVerb())
+	}
+	ro := v1alpha1.Rollout{}
+	err := json.Unmarshal(patchAction.GetPatch(), &ro)
+	if err != nil {
+		panic(err)
+	}
+	return &ro
 }
 
 func (f *fixture) expectDeleteAnalysisRunAction(ar *v1alpha1.AnalysisRun) int {

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -544,7 +544,7 @@ func (f *fixture) runController(rolloutName string, startInformers bool, expectE
 	}
 
 	if len(f.actions) > len(actions) {
-		f.t.Errorf("%d additional expected actions:%+v", len(f.actions)-len(actions), f.actions[len(actions):])
+		f.t.Errorf("%d expected actions did not happen:%+v", len(f.actions)-len(actions), f.actions[len(actions):])
 	}
 
 	k8sActions := filterInformerActions(f.kubeclient.Actions())
@@ -560,7 +560,7 @@ func (f *fixture) runController(rolloutName string, startInformers bool, expectE
 	}
 
 	if len(f.kubeactions) > len(k8sActions) {
-		f.t.Errorf("%d additional expected actions:%+v", len(f.kubeactions)-len(k8sActions), f.kubeactions[len(k8sActions):])
+		f.t.Errorf("%d expected actions did not happen:%+v", len(f.kubeactions)-len(k8sActions), f.kubeactions[len(k8sActions):])
 	}
 	return c
 }

--- a/rollout/experiment.go
+++ b/rollout/experiment.go
@@ -143,7 +143,7 @@ func (c *Controller) getExperimentsForRollout(rollout *v1alpha1.Rollout) ([]*v1a
 }
 
 func (c *rolloutContext) reconcileExperiments() error {
-	if c.pauseContext.IsAborted() {
+	if c.pauseContext.IsAborted() || c.rollout.Status.PromoteFull {
 		allExs := append(c.otherExs, c.currentEx)
 		return c.cancelExperiments(allExs)
 	}

--- a/rollout/service.go
+++ b/rollout/service.go
@@ -59,7 +59,7 @@ func (c rolloutContext) switchServiceSelector(service *corev1.Service, newRollou
 	if err != nil {
 		return err
 	}
-	msg := fmt.Sprintf("Switched selector for service '%s' to value '%s'", service.Name, newRolloutUniqueLabelValue)
+	msg := fmt.Sprintf("Switched selector for service '%s' from '%s' to '%s'", service.Name, oldPodHash, newRolloutUniqueLabelValue)
 	c.log.Info(msg)
 	c.recorder.Event(r, corev1.EventTypeNormal, "SwitchService", msg)
 	service.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey] = newRolloutUniqueLabelValue

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -364,6 +364,7 @@ func (c *rolloutContext) scaleReplicaSet(rs *appsv1.ReplicaSet, newScale int32, 
 	var err error
 	if sizeNeedsUpdate || annotationsNeedUpdate {
 		rsCopy := rs.DeepCopy()
+		oldScale := defaults.GetReplicasOrDefault(rs.Spec.Replicas)
 		*(rsCopy.Spec.Replicas) = newScale
 		annotations.SetReplicasAnnotations(rsCopy, rolloutReplicas)
 		if fullScaleDown {
@@ -372,7 +373,7 @@ func (c *rolloutContext) scaleReplicaSet(rs *appsv1.ReplicaSet, newScale int32, 
 		rs, err = c.kubeclientset.AppsV1().ReplicaSets(rsCopy.Namespace).Update(ctx, rsCopy, metav1.UpdateOptions{})
 		if err == nil && sizeNeedsUpdate {
 			scaled = true
-			c.recorder.Eventf(rollout, corev1.EventTypeNormal, "ScalingReplicaSet", "Scaled %s replica set %s to %d", scalingOperation, rs.Name, newScale)
+			c.recorder.Eventf(rollout, corev1.EventTypeNormal, "ScalingReplicaSet", "Scaled %s replica set %s from %d to %d", scalingOperation, rs.Name, oldScale, newScale)
 		}
 	}
 	return scaled, rs, err

--- a/rollout/sync_test.go
+++ b/rollout/sync_test.go
@@ -8,10 +8,13 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	testclient "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/pointer"
 
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
 	"github.com/argoproj/argo-rollouts/utils/annotations"
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
@@ -209,4 +212,113 @@ func TestCleanupRollouts(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCanaryPromoteFull verifies skip pause, analysis, steps when promote full is set for a canary rollout
+func TestCanaryPromoteFull(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	// these steps should be ignored
+	steps := []v1alpha1.CanaryStep{
+		{
+			SetWeight: int32Ptr(10),
+		},
+		{
+			Pause: &v1alpha1.RolloutPause{
+				Duration: v1alpha1.DurationFromInt(60),
+			},
+		},
+	}
+
+	at := analysisTemplate("bar")
+	r1 := newCanaryRollout("foo", 10, nil, steps, int32Ptr(0), intstr.FromInt(10), intstr.FromInt(0))
+	r1.Spec.Strategy.Canary.Analysis = &v1alpha1.RolloutAnalysisBackground{
+		RolloutAnalysis: v1alpha1.RolloutAnalysis{
+			Templates: []v1alpha1.RolloutAnalysisTemplate{
+				{
+					TemplateName: at.Name,
+				},
+			},
+		},
+	}
+
+	rs1 := newReplicaSetWithStatus(r1, 10, 10)
+	r1.Status.StableRS = rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	r2 := bumpVersion(r1)
+	r2.Status.PromoteFull = true
+	r2.Annotations[annotations.RevisionAnnotation] = "1"
+	rs2 := newReplicaSetWithStatus(r2, 1, 0)
+
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2, at)
+	f.kubeobjects = append(f.kubeobjects, rs1)
+	f.replicaSetLister = append(f.replicaSetLister, rs1)
+
+	createdRS2Index := f.expectCreateReplicaSetAction(rs2) // create new ReplicaSet (surge to 10)
+	f.expectUpdateRolloutAction(r2)                        // update rollout revision
+	f.expectUpdateRolloutStatusAction(r2)                  // update rollout conditions
+	patchedRolloutIndex := f.expectPatchRolloutAction(r2)
+	f.run(getKey(r2, t))
+
+	createdRS2 := f.getCreatedReplicaSet(createdRS2Index)
+	assert.Equal(t, int32(10), *createdRS2.Spec.Replicas) // verify we ignored steps
+
+	patchedRollout := f.getPatchedRolloutAsObject(patchedRolloutIndex)
+	assert.Equal(t, int32(2), *patchedRollout.Status.CurrentStepIndex) // verify we updated to last step
+	assert.False(t, patchedRollout.Status.PromoteFull)
+}
+
+// TesBlueGreenPromoteFull verifies skip pause, analysis when promote full is set for a blue-green rollout
+func TestBlueGreenPromoteFull(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	at := analysisTemplate("bar")
+	r1 := newBlueGreenRollout("foo", 10, nil, "active", "preview")
+	r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
+	r1.Spec.Strategy.BlueGreen.PrePromotionAnalysis = &v1alpha1.RolloutAnalysis{
+		Templates: []v1alpha1.RolloutAnalysisTemplate{
+			{
+				TemplateName: at.Name,
+			},
+		},
+	}
+	r1.Spec.Strategy.BlueGreen.PostPromotionAnalysis = &v1alpha1.RolloutAnalysis{
+		Templates: []v1alpha1.RolloutAnalysisTemplate{
+			{
+				TemplateName: at.Name,
+			},
+		},
+	}
+	rs1 := newReplicaSetWithStatus(r1, 10, 10)
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	r1.Status.StableRS = rs1PodHash
+	r1.Status.BlueGreen.ActiveSelector = rs1PodHash
+	r1.Status.BlueGreen.PreviewSelector = rs1PodHash
+	activeSvc := newService("active", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}, r1)
+
+	// create a replicaset on the verge of promotion
+	r2 := bumpVersion(r1)
+	r2.Status.PromoteFull = true
+	rs2 := newReplicaSetWithStatus(r2, 10, 10)
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	r2.Status.BlueGreen.PreviewSelector = rs2PodHash
+	previewSvc := newService("preview", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}, r2)
+
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2, at)
+	f.serviceLister = append(f.serviceLister, activeSvc, previewSvc)
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2, previewSvc, activeSvc)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+
+	f.expectPatchServiceAction(activeSvc, rs2PodHash) // update active to rs2
+	f.expectPatchReplicaSetAction(rs1)                // set scaledown delay on rs1
+	patchRolloutIdx := f.expectPatchRolloutAction(r2) // update rollout status
+	f.run(getKey(r2, t))
+
+	patchedRollout := f.getPatchedRolloutAsObject(patchRolloutIdx)
+	assert.Equal(t, rs2PodHash, patchedRollout.Status.StableRS)
+	assert.Equal(t, rs2PodHash, patchedRollout.Status.BlueGreen.ActiveSelector)
+	assert.False(t, patchedRollout.Status.PromoteFull)
 }

--- a/test/e2e/analysis_test.go
+++ b/test/e2e/analysis_test.go
@@ -169,7 +169,6 @@ spec:
 		When().
 		ApplyManifests(original). // perform a rollback and make sure we skip pause/analysis
 		Sleep(2 * time.Second).   // checking too early may not catch the bug where we create analysis unnecessarily
-		//WaitForRolloutStatus("Healthy", 2*time.Second). // rollout is Progressing->Healthy immediately
 		Then().
 		ExpectRolloutStatus("Healthy"). // rollout is healthy immediately
 		ExpectAnalysisRunCount(2).      // no new analysis runs created

--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -292,6 +292,9 @@ func GetCurrentCanaryStep(rollout *v1alpha1.Rollout) (*v1alpha1.CanaryStep, *int
 
 // GetCanaryReplicasOrWeight either returns a static set of replicas or a weight percentage
 func GetCanaryReplicasOrWeight(rollout *v1alpha1.Rollout) (*int32, int32) {
+	if rollout.Status.PromoteFull {
+		return nil, 100
+	}
 	if scs := UseSetCanaryScale(rollout); scs != nil {
 		if scs.Replicas != nil {
 			return scs.Replicas, 0


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/573

Introduces the `--full` flag to the `promote` command, for fully promoting a rollout which is in the middle of update, including blue-green rollouts. Adds controller changes to support it. Fully promoting a rollout will cause the rollout to ignore Abort and Pause conditions, steps, and skip analysis. 

```shell
kubectl argo rollouts promote --full ROLLOUT
```

Implementation details: full promotion is accomplished by introducing:

```yaml
status:
  promoteFull: true
```

which the plugin (and eventually Argo CD) will set to true when full promotion is desired. The controller understands when this flag is set, and skips abort/pause/analysis to get to the new version ASAP. 