### PR TITLE
fix: plugin incorrectly treated v0.9 rollout as v0.10 when it had numeric observedGeneration

### DIFF
--- a/pkg/kubectl-argo-rollouts/info/info_test.go
+++ b/pkg/kubectl-argo-rollouts/info/info_test.go
@@ -309,6 +309,20 @@ func TestRolloutStatusProgressing(t *testing.T) {
 		assert.Equal(t, "Progressing", status)
 		assert.Equal(t, "more replicas need to be updated", message)
 	}
+	{
+		// Verify isGenerationObserved detects a v0.9 legacy rollout which has an all numeric hash
+		ro := newCanaryRollout()
+		ro.Generation = 2
+		ro.Spec.Replicas = nil
+		ro.Status = v1alpha1.RolloutStatus{
+			StableRS:           "abc1234",
+			CurrentPodHash:     "abc1234",
+			ObservedGeneration: "1366344857",
+		}
+		status, message := RolloutStatusString(ro)
+		assert.Equal(t, "Progressing", status)
+		assert.Equal(t, "more replicas need to be updated", message)
+	}
 }
 
 func TestRolloutStatusHealthy(t *testing.T) {

--- a/pkg/kubectl-argo-rollouts/info/rollout_info.go
+++ b/pkg/kubectl-argo-rollouts/info/rollout_info.go
@@ -130,6 +130,10 @@ func isGenerationObserved(ro *v1alpha1.Rollout) bool {
 	if err != nil {
 		return true
 	}
+	// It's still possible for a v0.9 rollout to have an all numeric hash, this covers that corner case
+	if int64(observedGen) > ro.Generation {
+		return true
+	}
 	return int64(observedGen) == ro.Generation
 }
 


### PR DESCRIPTION
Checking for numeric observedGeneration is not a reliable indicator of a v0.9 rollout. We also have to check if that observedGeneration is > metadata.generation, since that would indicate that `metadata.generation` isn't being used as observedGeneration.

Signed-off-by: Jesse Suen <jesse_suen@intuit.com>