### PR TITLE
fix(build): remove extra set of parens in echo command

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -87,7 +87,7 @@ jobs:
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
 
-          echo '::set-output name=tag::$(echo $IMAGE_ID:$VERSION)'
+          echo ::set-output name=tag::$(echo $IMAGE_ID:$VERSION)
       - name: Build and push image
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
Fix broken image push due to extra parens in echo command. 

Signed-off-by: Jonah Back <jonah@jonahback.com>

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [X] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [X] I've signed the CLA.
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).