### PR TITLE
fix(manifests): Add missing RoleBinding file

### DIFF
--- a/hack/update-manifests.sh
+++ b/hack/update-manifests.sh
@@ -21,5 +21,5 @@ kubectl kustomize "${SRCROOT}/manifests/cluster-install" >> "${SRCROOT}/manifest
 update_image "${SRCROOT}/manifests/install.yaml"
 
 echo "${AUTOGENMSG}" > "${SRCROOT}/manifests/namespace-install.yaml"
-kubectl kustomize "${SRCROOT}/manifests/namespace-install" >> "${SRCROOT}/manifests/namespace-install.yaml"
+kustomize build --load_restrictor none "${SRCROOT}/manifests/namespace-install" >> "${SRCROOT}/manifests/namespace-install.yaml"
 update_image "${SRCROOT}/manifests/namespace-install.yaml"

--- a/hack/update-manifests.sh
+++ b/hack/update-manifests.sh
@@ -21,5 +21,5 @@ kubectl kustomize "${SRCROOT}/manifests/cluster-install" >> "${SRCROOT}/manifest
 update_image "${SRCROOT}/manifests/install.yaml"
 
 echo "${AUTOGENMSG}" > "${SRCROOT}/manifests/namespace-install.yaml"
-kustomize build --load_restrictor none "${SRCROOT}/manifests/namespace-install" >> "${SRCROOT}/manifests/namespace-install.yaml"
+kubectl kustomize "${SRCROOT}/manifests/namespace-install" >> "${SRCROOT}/manifests/namespace-install.yaml"
 update_image "${SRCROOT}/manifests/namespace-install.yaml"

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -11525,11 +11525,13 @@ spec:
     name: Current
     type: integer
   - JSONPath: .status.updatedReplicas
-    description: Total number of non-terminated pods targeted by this rollout that have the desired template spec
+    description: Total number of non-terminated pods targeted by this rollout that
+      have the desired template spec
     name: Up-to-date
     type: integer
   - JSONPath: .status.availableReplicas
-    description: Total number of available pods (ready for at least minReadySeconds) targeted by this rollout
+    description: Total number of available pods (ready for at least minReadySeconds)
+      targeted by this rollout
     name: Available
     type: integer
   group: argoproj.io
@@ -14779,6 +14781,90 @@ metadata:
   name: argo-rollouts
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: aggregate-cluster-role
+    app.kubernetes.io/name: argo-rollouts-aggregate-to-admin
+    app.kubernetes.io/part-of: argo-rollouts
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: argo-rollouts-aggregate-to-admin
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  - rollouts/scale
+  - rollouts/status
+  - experiments
+  - analysistemplates
+  - clusteranalysistemplates
+  - analysisruns
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: aggregate-cluster-role
+    app.kubernetes.io/name: argo-rollouts-aggregate-to-edit
+    app.kubernetes.io/part-of: argo-rollouts
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: argo-rollouts-aggregate-to-edit
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  - rollouts/scale
+  - rollouts/status
+  - experiments
+  - analysistemplates
+  - clusteranalysistemplates
+  - analysisruns
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: aggregate-cluster-role
+    app.kubernetes.io/name: argo-rollouts-aggregate-to-view
+    app.kubernetes.io/part-of: argo-rollouts
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: argo-rollouts-aggregate-to-view
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  - rollouts/scale
+  - experiments
+  - analysistemplates
+  - clusteranalysistemplates
+  - analysisruns
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
@@ -14909,90 +14995,6 @@ rules:
   - get
   - update
   - patch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app.kubernetes.io/component: aggregate-cluster-role
-    app.kubernetes.io/name: argo-rollouts-aggregate-to-admin
-    app.kubernetes.io/part-of: argo-rollouts
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
-  name: argo-rollouts-aggregate-to-admin
-rules:
-- apiGroups:
-  - argoproj.io
-  resources:
-  - rollouts
-  - rollouts/scale
-  - rollouts/status
-  - experiments
-  - analysistemplates
-  - clusteranalysistemplates
-  - analysisruns
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app.kubernetes.io/component: aggregate-cluster-role
-    app.kubernetes.io/name: argo-rollouts-aggregate-to-edit
-    app.kubernetes.io/part-of: argo-rollouts
-    rbac.authorization.k8s.io/aggregate-to-edit: "true"
-  name: argo-rollouts-aggregate-to-edit
-rules:
-- apiGroups:
-  - argoproj.io
-  resources:
-  - rollouts
-  - rollouts/scale
-  - rollouts/status
-  - experiments
-  - analysistemplates
-  - clusteranalysistemplates
-  - analysisruns
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app.kubernetes.io/component: aggregate-cluster-role
-    app.kubernetes.io/name: argo-rollouts-aggregate-to-view
-    app.kubernetes.io/part-of: argo-rollouts
-    rbac.authorization.k8s.io/aggregate-to-view: "true"
-  name: argo-rollouts-aggregate-to-view
-rules:
-- apiGroups:
-  - argoproj.io
-  resources:
-  - rollouts
-  - rollouts/scale
-  - experiments
-  - analysistemplates
-  - clusteranalysistemplates
-  - analysisruns
-  verbs:
-  - get
-  - list
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -11525,13 +11525,11 @@ spec:
     name: Current
     type: integer
   - JSONPath: .status.updatedReplicas
-    description: Total number of non-terminated pods targeted by this rollout that
-      have the desired template spec
+    description: Total number of non-terminated pods targeted by this rollout that have the desired template spec
     name: Up-to-date
     type: integer
   - JSONPath: .status.availableReplicas
-    description: Total number of available pods (ready for at least minReadySeconds)
-      targeted by this rollout
+    description: Total number of available pods (ready for at least minReadySeconds) targeted by this rollout
     name: Available
     type: integer
   group: argoproj.io
@@ -14781,90 +14779,6 @@ metadata:
   name: argo-rollouts
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app.kubernetes.io/component: aggregate-cluster-role
-    app.kubernetes.io/name: argo-rollouts-aggregate-to-admin
-    app.kubernetes.io/part-of: argo-rollouts
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
-  name: argo-rollouts-aggregate-to-admin
-rules:
-- apiGroups:
-  - argoproj.io
-  resources:
-  - rollouts
-  - rollouts/scale
-  - rollouts/status
-  - experiments
-  - analysistemplates
-  - clusteranalysistemplates
-  - analysisruns
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app.kubernetes.io/component: aggregate-cluster-role
-    app.kubernetes.io/name: argo-rollouts-aggregate-to-edit
-    app.kubernetes.io/part-of: argo-rollouts
-    rbac.authorization.k8s.io/aggregate-to-edit: "true"
-  name: argo-rollouts-aggregate-to-edit
-rules:
-- apiGroups:
-  - argoproj.io
-  resources:
-  - rollouts
-  - rollouts/scale
-  - rollouts/status
-  - experiments
-  - analysistemplates
-  - clusteranalysistemplates
-  - analysisruns
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app.kubernetes.io/component: aggregate-cluster-role
-    app.kubernetes.io/name: argo-rollouts-aggregate-to-view
-    app.kubernetes.io/part-of: argo-rollouts
-    rbac.authorization.k8s.io/aggregate-to-view: "true"
-  name: argo-rollouts-aggregate-to-view
-rules:
-- apiGroups:
-  - argoproj.io
-  resources:
-  - rollouts
-  - rollouts/scale
-  - experiments
-  - analysistemplates
-  - clusteranalysistemplates
-  - analysisruns
-  verbs:
-  - get
-  - list
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
@@ -14995,6 +14909,106 @@ rules:
   - get
   - update
   - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: aggregate-cluster-role
+    app.kubernetes.io/name: argo-rollouts-aggregate-to-admin
+    app.kubernetes.io/part-of: argo-rollouts
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: argo-rollouts-aggregate-to-admin
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  - rollouts/scale
+  - rollouts/status
+  - experiments
+  - analysistemplates
+  - clusteranalysistemplates
+  - analysisruns
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: aggregate-cluster-role
+    app.kubernetes.io/name: argo-rollouts-aggregate-to-edit
+    app.kubernetes.io/part-of: argo-rollouts
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: argo-rollouts-aggregate-to-edit
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  - rollouts/scale
+  - rollouts/status
+  - experiments
+  - analysistemplates
+  - clusteranalysistemplates
+  - analysisruns
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: aggregate-cluster-role
+    app.kubernetes.io/name: argo-rollouts-aggregate-to-view
+    app.kubernetes.io/part-of: argo-rollouts
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: argo-rollouts-aggregate-to-view
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  - rollouts/scale
+  - experiments
+  - analysistemplates
+  - clusteranalysistemplates
+  - analysisruns
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rollouts-controller
+    app.kubernetes.io/name: argo-rollouts-role-binding
+    app.kubernetes.io/part-of: argo-rollouts
+  name: argo-rollouts-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argo-rollouts-role
+subjects:
+- kind: ServiceAccount
+  name: argo-rollouts
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/namespace-install/kustomization.yaml
+++ b/manifests/namespace-install/kustomization.yaml
@@ -5,6 +5,8 @@ bases:
 - ../crds
 - ../base
 - ../role
+
+resources:
 - argo-rollouts-rolebinding.yaml
 
 patchesStrategicMerge:

--- a/manifests/namespace-install/kustomization.yaml
+++ b/manifests/namespace-install/kustomization.yaml
@@ -5,6 +5,7 @@ bases:
 - ../crds
 - ../base
 - ../role
+- argo-rollouts-rolebinding.yaml
 
 patchesStrategicMerge:
 - add-namespaced-flag.yaml


### PR DESCRIPTION
This supersedes https://github.com/argoproj/argo-rollouts/pull/877 and fixes update-manifests.sh to use `kubectl kustomize` to generate output for consistency.