### PR TITLE
fix: ephemeral metadata injection was dropping metadata injected by mutating webhooks

### DIFF
--- a/docs/getting-started/setup/index.md
+++ b/docs/getting-started/setup/index.md
@@ -8,7 +8,9 @@ purposes.
 Some dependencies are installable via the Helm stable repository:
 
 ```shell
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add stable https://charts.helm.sh/stable
+helm repo add grafana https://grafana.github.io/helm-charts
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 ```
 
@@ -28,7 +30,7 @@ Optionally, Prometheus and Grafana can be installed to utilize progressive deliv
 ```
 # Install Prometheus
 kubectl create ns monitoring
-helm install prometheus stable/prometheus -n monitoring -f docs/getting-started/setup/values-prometheus.yaml
+helm install prometheus prometheus-community/prometheus -n monitoring -f docs/getting-started/setup/values-prometheus.yaml
 
 # Patch the ingress-nginx-controller pod so that it has the required
 # prometheus annotations. This allows the pod to be scraped by the
@@ -36,7 +38,7 @@ helm install prometheus stable/prometheus -n monitoring -f docs/getting-started/
 kubectl patch deploy ingress-nginx-controller -n kube-system -p "$(cat docs/getting-started/setup/ingress-nginx-controller-metrics-scrape.yaml)"
 
 # Install grafana along with nginx ingress dashboards
-helm install grafana stable/grafana -n monitoring -f docs/getting-started/setup/values-grafana-nginx.yaml
+helm install grafana grafana/grafana -n monitoring -f docs/getting-started/setup/values-grafana-nginx.yaml
 
 # Grafana UI can be accessed by running:
 minikube service grafana -n monitoring
@@ -64,7 +66,7 @@ functionality:
 
 ```
 # Install Grafana and Istio dashboards
-helm install grafana stable/grafana -n istio-system -f docs/getting-started/setup/values-grafana-istio.yaml
+helm install grafana grafana/grafana -n istio-system -f docs/getting-started/setup/values-grafana-istio.yaml
 
 # Grafana UI can be accessed by running
 minikube service grafana -n istio-system
@@ -125,9 +127,9 @@ supplied in the request in order to determine how to route the request to the co
 ### Determining the hostname to IP mapping
 
 For the Host header to be set in the request, the hostname of the service should resolve to the
-public IP address of the ingress or service mesh. Depending on if you are using a ingress controller
-or a service mesh, use one of the following techniques to determine the correct hostname to IP
-mapping:
+public IP address of the ingress or service mesh. Depending on if you are using an ingress
+controller or a service mesh, use one of the following techniques to determine the correct hostname
+to IP mapping:
 
 #### Ingresses
 

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -160,11 +160,11 @@ func (c *rolloutContext) createDesiredReplicaSet() (*appsv1.ReplicaSet, error) {
 		if c.stableRS != nil && c.stableRS != c.newRS {
 			// If this is a canary rollout, with ephemeral *canary* metadata, and there is a stable RS,
 			// then inject the canary metadata so that all the RS's new pods get the canary labels/annotation
-			newRS, _ = replicasetutil.UpdateEphemeralPodMetadata(newRS, c.rollout.Spec.Strategy.Canary.CanaryMetadata)
+			newRS, _ = replicasetutil.SyncReplicaSetEphemeralPodMetadata(newRS, c.rollout.Spec.Strategy.Canary.CanaryMetadata)
 		} else {
 			// Otherwise, if stableRS is nil, we are in a brand-new rollout and then this replicaset
 			// will eventually become the stableRS, so we should inject the stable labels/annotation
-			newRS, _ = replicasetutil.UpdateEphemeralPodMetadata(newRS, c.rollout.Spec.Strategy.Canary.StableMetadata)
+			newRS, _ = replicasetutil.SyncReplicaSetEphemeralPodMetadata(newRS, c.rollout.Spec.Strategy.Canary.StableMetadata)
 		}
 	}
 

--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
@@ -404,77 +405,101 @@ func GetCurrentExperimentStep(r *v1alpha1.Rollout) *v1alpha1.RolloutExperimentSt
 	return nil
 }
 
-// removeInjectedPodMetadata removes injected pod metadata from the replicaset
-func removeInjectedPodMetadata(rs *appsv1.ReplicaSet, podMetadata *v1alpha1.PodTemplateMetadata) {
-	if rs.Spec.Template.Annotations != nil {
-		for key := range podMetadata.Annotations {
-			delete(rs.Spec.Template.Annotations, key)
-		}
-	}
-	if rs.Spec.Template.Labels != nil {
-		for key := range podMetadata.Labels {
-			delete(rs.Spec.Template.Labels, key)
-		}
-	}
-	delete(rs.Annotations, EphemeralMetadataAnnotation)
-}
-
-// UpdateEphemeralPodMetadata updates the supplied pod metadata to the replicaset, removing previous
-// existing metadata if it had changed. A podMetadata value of nil indicates canary/stable
-// meta should be removed
-func UpdateEphemeralPodMetadata(rs *appsv1.ReplicaSet, podMetadata *v1alpha1.PodTemplateMetadata) (*appsv1.ReplicaSet, bool) {
-	var metadataStr string
-	if podMetadata != nil {
-		metadataBytes, _ := json.Marshal(podMetadata)
-		metadataStr = string(metadataBytes)
-	}
-
-	var existingPodMetadataStr string
+// ParseExistingPodMetadata returns the existing podMetadata which was injected to the ReplicaSet
+// based on examination of rollout.argoproj.io/ephemeral-metadata annotation on  the ReplicaSet.
+// Returns nil if there was no metadata, or the metadata was not parseable.
+func ParseExistingPodMetadata(rs *appsv1.ReplicaSet) *v1alpha1.PodTemplateMetadata {
 	var existingPodMetadata *v1alpha1.PodTemplateMetadata
 	if rs.Annotations != nil {
-		var ok bool
-		if existingPodMetadataStr, ok = rs.Annotations[EphemeralMetadataAnnotation]; ok {
+		if existingPodMetadataStr, ok := rs.Annotations[EphemeralMetadataAnnotation]; ok {
 			err := json.Unmarshal([]byte(existingPodMetadataStr), &existingPodMetadata)
 			if err != nil {
 				log.Warnf("Failed to determine existing ephemeral metadata from annotation: %s", existingPodMetadataStr)
-				existingPodMetadata = nil
-				existingPodMetadataStr = ""
+				return nil
+			}
+			return existingPodMetadata
+		}
+	}
+	return nil
+}
+
+// SyncEphemeralPodMetadata will inject the desired pod metadata to the ObjectMeta as well as remove
+// previously injected pod metadata which is no longer desired. This function is careful to only
+// modify metadata that we injected previously, and not affect other metadata which might be
+// controlled by other controllers (e.g. istio pod sidecar injector)
+func SyncEphemeralPodMetadata(metadata *metav1.ObjectMeta, existingPodMetadata, desiredPodMetadata *v1alpha1.PodTemplateMetadata) (*metav1.ObjectMeta, bool) {
+	modified := false
+	metadata = metadata.DeepCopy()
+
+	// Inject the desired metadata
+	if desiredPodMetadata != nil {
+		for k, v := range desiredPodMetadata.Annotations {
+			if metadata.Annotations == nil {
+				metadata.Annotations = make(map[string]string)
+			}
+			if prev := metadata.Annotations[k]; prev != v {
+				metadata.Annotations[k] = v
+				modified = true
+			}
+		}
+		for k, v := range desiredPodMetadata.Labels {
+			if metadata.Labels == nil {
+				metadata.Labels = make(map[string]string)
+			}
+			if prev := metadata.Labels[k]; prev != v {
+				metadata.Labels[k] = v
+				modified = true
 			}
 		}
 	}
-	if existingPodMetadataStr == metadataStr {
+
+	isMetadataStillDesired := func(key string, desired map[string]string) bool {
+		_, ok := desired[key]
+		return ok
+	}
+	// Remove existing metadata which is no longer desired
+	if existingPodMetadata != nil {
+		for k := range existingPodMetadata.Annotations {
+			if desiredPodMetadata == nil || !isMetadataStillDesired(k, desiredPodMetadata.Annotations) {
+				if metadata.Annotations != nil {
+					delete(metadata.Annotations, k)
+					modified = true
+				}
+			}
+		}
+		for k := range existingPodMetadata.Labels {
+			if desiredPodMetadata == nil || !isMetadataStillDesired(k, desiredPodMetadata.Labels) {
+				if metadata.Labels != nil {
+					delete(metadata.Labels, k)
+					modified = true
+				}
+			}
+		}
+	}
+	return metadata, modified
+}
+
+// SyncReplicaSetEphemeralPodMetadata injects the desired pod metadata to the ReplicaSet, and
+// removes previously injected metadata (based on the rollout.argoproj.io/ephemeral-metadata
+// annotation) if it is no longer desired. A podMetadata value of nil indicates all ephemeral
+// metadata should be removed completely.
+func SyncReplicaSetEphemeralPodMetadata(rs *appsv1.ReplicaSet, podMetadata *v1alpha1.PodTemplateMetadata) (*appsv1.ReplicaSet, bool) {
+	existingPodMetadata := ParseExistingPodMetadata(rs)
+	newObjectMeta, modified := SyncEphemeralPodMetadata(&rs.Spec.Template.ObjectMeta, existingPodMetadata, podMetadata)
+	if !modified {
 		return rs, false
 	}
-
 	rs = rs.DeepCopy()
-	if existingPodMetadata != nil {
-		// remove existing metadata
-		removeInjectedPodMetadata(rs, existingPodMetadata)
-	}
-
-	// Add new ephemeral metadata to ReplicaSet
+	rs.Spec.Template.ObjectMeta = *newObjectMeta
 	if podMetadata != nil {
-		if len(podMetadata.Annotations) > 0 {
-			if rs.Spec.Template.Annotations == nil {
-				rs.Spec.Template.Annotations = make(map[string]string)
-			}
-			for k, v := range podMetadata.Annotations {
-				rs.Spec.Template.Annotations[k] = v
-			}
-		}
-		if len(podMetadata.Labels) > 0 {
-			if rs.Spec.Template.Labels == nil {
-				rs.Spec.Template.Labels = make(map[string]string)
-			}
-			for k, v := range podMetadata.Labels {
-				rs.Spec.Template.Labels[k] = v
-			}
-		}
 		// remember what we injected by annotating it
+		metadataBytes, _ := json.Marshal(podMetadata)
 		if rs.Annotations == nil {
 			rs.Annotations = make(map[string]string)
 		}
-		rs.Annotations[EphemeralMetadataAnnotation] = metadataStr
+		rs.Annotations[EphemeralMetadataAnnotation] = string(metadataBytes)
+	} else {
+		delete(rs.Annotations, EphemeralMetadataAnnotation)
 	}
 	return rs, true
 }

--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -51,7 +51,7 @@ func FindNewReplicaSet(rollout *v1alpha1.Rollout, rsList []*appsv1.ReplicaSet) *
 	// PodTemplate change, which in turn would triggers an unexpected redeploy of the replicaset.
 	for _, rs := range rsList {
 		// Remove injected canary/stable metadata from spec.template.metadata before comparing
-		rsCopy, _ := UpdateEphemeralPodMetadata(rs, nil)
+		rsCopy, _ := SyncReplicaSetEphemeralPodMetadata(rs, nil)
 		// Remove anti-affinity from template.Spec.Affinity before comparing
 		live := &rsCopy.Spec.Template
 		live.Spec.Affinity = RemoveInjectedAntiAffinityRule(live.Spec.Affinity, *rollout)


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/883

The ephemeral metadata injection feature did not account for mutating webhooks when it modified pods. The incorrect implementation was blindly copying the ReplicaSet's `spec.template.metadata` to the child Pods, not considering that the Pod could have had metadata injected by a mutating webhook (e.g. istio sidecar injector).

This change makes it such that when removing metadata, the rollout controller will only remove metadata that it had previously injected. 

Signed-off-by: Jesse Suen <jesse_suen@intuit.com>