### PR TITLE
fix: requiredForCompletion did not work for an experiment started by a rollout

### DIFF
--- a/manifests/crds/rollout-crd.yaml
+++ b/manifests/crds/rollout-crd.yaml
@@ -371,6 +371,8 @@ spec:
                                       type: boolean
                                     name:
                                       type: string
+                                    requiredForCompletion:
+                                      type: boolean
                                     templateName:
                                       type: string
                                   required:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -11883,6 +11883,8 @@ spec:
                                       type: boolean
                                     name:
                                       type: string
+                                    requiredForCompletion:
+                                      type: boolean
                                     templateName:
                                       type: string
                                   required:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -11883,6 +11883,8 @@ spec:
                                       type: boolean
                                     name:
                                       type: string
+                                    requiredForCompletion:
+                                      type: boolean
                                     templateName:
                                       type: string
                                   required:

--- a/pkg/apis/rollouts/v1alpha1/experiment_types.go
+++ b/pkg/apis/rollouts/v1alpha1/experiment_types.go
@@ -199,7 +199,7 @@ type ExperimentAnalysisTemplateRef struct {
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	Args []Argument `json:"args,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
-	// RequiredForCompletion indicates that experiment should complete after analysis finishes
+	// RequiredForCompletion blocks the Experiment from completing until the analysis has completed
 	RequiredForCompletion bool `json:"requiredForCompletion,omitempty"`
 }
 

--- a/pkg/apis/rollouts/v1alpha1/openapi_generated.go
+++ b/pkg/apis/rollouts/v1alpha1/openapi_generated.go
@@ -1194,7 +1194,7 @@ func schema_pkg_apis_rollouts_v1alpha1_ExperimentAnalysisTemplateRef(ref common.
 					},
 					"requiredForCompletion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "RequiredForCompletion indicates that experiment should complete after analysis finishes",
+							Description: "RequiredForCompletion blocks the Experiment from completing until the analysis has completed",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -2582,6 +2582,13 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutExperimentStepAnalysisTemplateRef(
 									},
 								},
 							},
+						},
+					},
+					"requiredForCompletion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RequiredForCompletion blocks the Experiment from completing until the analysis has completed",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 				},

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -285,6 +285,8 @@ type RolloutExperimentStepAnalysisTemplateRef struct {
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	Args []AnalysisRunArgument `json:"args,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	// RequiredForCompletion blocks the Experiment from completing until the analysis has completed
+	RequiredForCompletion bool `json:"requiredForCompletion,omitempty"`
 }
 
 // RolloutExperimentTemplate defines the template used to create experiments for the Rollout's experiment canary step

--- a/rollout/experiment.go
+++ b/rollout/experiment.go
@@ -103,20 +103,12 @@ func GetExperimentFromTemplate(r *v1alpha1.Rollout, stableRS, newRS *appsv1.Repl
 	for i := range step.Analyses {
 		analysis := step.Analyses[i]
 		args := analysisutil.BuildArgumentsForRolloutAnalysisRun(analysis.Args, stableRS, newRS, r)
-		var analysisTemplate v1alpha1.ExperimentAnalysisTemplateRef
-		if analysis.ClusterScope {
-			analysisTemplate = v1alpha1.ExperimentAnalysisTemplateRef{
-				Name:         analysis.Name,
-				TemplateName: analysis.TemplateName,
-				ClusterScope: true,
-				Args:         args,
-			}
-		} else {
-			analysisTemplate = v1alpha1.ExperimentAnalysisTemplateRef{
-				Name:         analysis.Name,
-				TemplateName: analysis.TemplateName,
-				Args:         args,
-			}
+		analysisTemplate := v1alpha1.ExperimentAnalysisTemplateRef{
+			Name:                  analysis.Name,
+			TemplateName:          analysis.TemplateName,
+			ClusterScope:          analysis.ClusterScope,
+			Args:                  args,
+			RequiredForCompletion: analysis.RequiredForCompletion,
 		}
 		experiment.Spec.Analyses = append(experiment.Spec.Analyses, analysisTemplate)
 	}

--- a/test/e2e/functional/rollout-experiment-analysis.yaml
+++ b/test/e2e/functional/rollout-experiment-analysis.yaml
@@ -48,7 +48,6 @@ spec:
     canary:
       steps:
       - experiment:
-          duration: 10s
           templates:
           - name: baseline
             specRef: stable
@@ -57,6 +56,7 @@ spec:
           analyses:
           - name : echo-pod-hash
             templateName: echo-pod-hash
+            requiredForCompletion: true
             args:
             - name: stable-hash
               valueFrom:


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/878

The type definitions for a canary experiment step was missing the `requiredForCompletion` field, and so it was impossible to use this feature for an Experiment which was launched by a Rollout. The fix is to add the `requiredForCompletion` field to RolloutExperimentStepAnalysisTemplateRef, and carry over the value when creating the Experiment.

E2E test has been updated to exercise this feature. 

Signed-off-by: Jesse Suen <jesse_suen@intuit.com>