### PR TITLE
fix: switch pod restart to use evict API to honor PDBs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+# v0.10.2
+
+## Changes since v0.10.1
+
+### Controller
+* fix: switch pod restart to use evict API to honor PDBs
+* fix: ephemeral metadata injection was dropping metadata injected by mutating webhooks
+* fix: requiredForCompletion did not work for an experiment started by a rollout
+* fix: Add missing RoleBinding file to namespace installation
+
 # v0.10.1
 
 ## Changes since v0.10.0

--- a/docs/features/restart.md
+++ b/docs/features/restart.md
@@ -1,27 +1,47 @@
-# Rollout Pod Restarts
+# Restarting Rollout Pods
 
-For various reasons, applications sometimes need a restart. Since the restart is not changing the 
-version, the application should not have to go through the entire BlueGreen or canary deployment 
-process. The Rollout object supports restarting an application by having the controller do a rolling
-recreate of all the Pods in a Rollout without going through all the regular BlueGreen or Canary 
-deployments. The controller kills up to `maxUnavailable` Pods at a time and relies on the ReplicaSet
-to scale up new Pods until all the Pods are newer than the restarted time.
+For various reasons, applications often need to be restarted, e.g. for hygiene purposes or to force
+startup logic to occur again such as reloading of a modified Secret. In these scenarios, it is
+undesirable to go through an entire blue-green or canary update process. Argo Rollouts supports
+the ability to restart all of its Pods by performing a rolling recreate of all the Pods in a Rollout
+while skipping the regular BlueGreen or Canary update strategy.
 
 ## How it works
 
-The Rollout object has a field called `.spec.restartAt` that takes in a 
-[RFC 3339 formatted](https://tools.ietf.org/html/rfc3339) string (ie. 2020-03-30T21:19:35Z). If the
-current time is past the `restartAt` time, the controller knows it needs to restart all the Pods in
-the Rollout. The controller goes through each ReplicaSet to see if all the Pods have a creation
-timestamp newer than the `restartAt` time. To prevent too many Pods from restarting at once, the
-controller limits itself to deleting up to `maxUnavailable` Pod at a time and checks that no other Pods in that
-ReplicaSet have a deletion timestamp and that ReplicaSet is fully available.  The controller checks
-the ReplicaSets in the following order: 1. stable ReplicaSet, 2. new ReplicaSet, and 3rd. all the
-other ReplicaSets starting with the oldest. Once the controller has confirmed all the Pods are newer
-than the `restartAt` time, the controller sets the `status.restartedAt` field to indicate that the
-Rollout has been successfully restarted. If a change occurs to the `spec.template` during a restart,
-the restart is canceled (by setting the `status.restartedAt` to the `spec.restartAt`) since the
-Rollout has to bring up a new stack.
+A rollout can be restarted via the kubectl plugin, using the
+[restart command](../generated/kubectl-argo-rollouts/kubectl-argo-rollouts_restart.md):
+
+```shell
+kubectl-argo-rollouts restart ROLLOUT
+```
+
+Alternatively, if Rollouts is used with Argo CD, the there is a bundled "restart" action which can
+be performed via the Argo CD UI or CLI:
+
+```shell
+argocd app actions run my-app restart --kind Rollout --resource-name my-rollout
+```
+
+Both of these mechanisms updates the Rollout's `.spec.restartAt` to the current time in the
+form of a [RFC 3339 formatted](https://tools.ietf.org/html/rfc3339) UTC string
+(e.g. 2020-03-30T21:19:35Z), which indicates to the Rollout controller that all of a Rollout's
+Pods should have been created after this timestamp.
+
+During a restart, the controller iterates through each ReplicaSet to see if all the Pods have a 
+creation timestamp which is newer than the `restartAt` time. For every pod older than the
+`restartAt` timestamp, the Pod will be evicted, allowing the ReplicaSet to replace the pod with a
+recreated one.
+
+To prevent too many Pods from restarting at once, the controller limits itself to deleting up to 
+`maxUnavailable` Pods at a time (for the canary strategy). Secondly, since pods are evicted
+and not deleted, the restart process will honor any PodDisruptionBudgets which are in place.
+The controller restarts ReplicaSets in the following order:
+  1. stable ReplicaSet
+  2. current ReplicaSet
+  3. all other ReplicaSets beginning with the oldest
+  
+If a Rollout's pod template spec (`spec.template`) is modified in the middle of a restart, the
+restart is canceled, and the normal blue-green or canary update will occur.
 
 Note: Unlike deployments, where a "restart" is nothing but a normal rolling upgrade that happened to
 be triggered by a timestamp in the pod spec annotation, Argo Rollouts facilitates restarts by
@@ -32,18 +52,12 @@ long-running blue-green/canary update (e.g. a paused canary). However, some cons
 * Restarting a Rollout which has a single replica will cause downtime since Argo Rollouts needs to
   terminate the pod in order to replace it.
 * Restarting a rollout will be slower than a deployment's rolling update, since maxSurge is not
-  considered used to bring up newer pods faster.
+  used to bring up newer pods faster.
 * maxUnavailable will be used to restart multiple pods at a time (starting in v0.10). But if
   maxUnavailable pods is 0, the controller will still restart pods one at a time.
 
+## Scheduled Restarts
 
-## Kubectl command
-
-The Argo Rollouts kubectl plugin has a command for restarting Rollouts. Check it out
-[here](../generated/kubectl-argo-rollouts/kubectl-argo-rollouts_restart.md).
-
-## Rescheduled Restarts
-
-Users can reschedule a restart on their Rollout by setting the `.spec.restartAt` field to a time in
+Users can schedule a restart on their Rollout by setting the `.spec.restartAt` field to a time in
 the future. The controller only starts the restart after the current time is after the restartAt
 time. 

--- a/hack/update-manifests.sh
+++ b/hack/update-manifests.sh
@@ -16,10 +16,12 @@ if [ ! -z "${IMAGE_TAG}" ]; then
   (cd ${SRCROOT}/manifests/base && kustomize edit set image argoproj/argo-rollouts:${IMAGE_TAG})
 fi
 
+kustomize version
+
 echo "${AUTOGENMSG}" > "${SRCROOT}/manifests/install.yaml"
-kubectl kustomize "${SRCROOT}/manifests/cluster-install" >> "${SRCROOT}/manifests/install.yaml"
+kustomize build --load_restrictor none "${SRCROOT}/manifests/cluster-install" >> "${SRCROOT}/manifests/install.yaml"
 update_image "${SRCROOT}/manifests/install.yaml"
 
 echo "${AUTOGENMSG}" > "${SRCROOT}/manifests/namespace-install.yaml"
-kubectl kustomize "${SRCROOT}/manifests/namespace-install" >> "${SRCROOT}/manifests/namespace-install.yaml"
+kustomize build --load_restrictor none "${SRCROOT}/manifests/namespace-install" >> "${SRCROOT}/manifests/namespace-install.yaml"
 update_image "${SRCROOT}/manifests/namespace-install.yaml"

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -14946,8 +14946,13 @@ rules:
   - pods
   verbs:
   - list
-  - delete
   - update
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
 - apiGroups:
   - ""
   resources:
@@ -14957,6 +14962,7 @@ rules:
   - update
   - patch
 - apiGroups:
+  - networking.k8s.io
   - extensions
   resources:
   - ingresses

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -11525,13 +11525,11 @@ spec:
     name: Current
     type: integer
   - JSONPath: .status.updatedReplicas
-    description: Total number of non-terminated pods targeted by this rollout that
-      have the desired template spec
+    description: Total number of non-terminated pods targeted by this rollout that have the desired template spec
     name: Up-to-date
     type: integer
   - JSONPath: .status.availableReplicas
-    description: Total number of available pods (ready for at least minReadySeconds)
-      targeted by this rollout
+    description: Total number of available pods (ready for at least minReadySeconds) targeted by this rollout
     name: Available
     type: integer
   group: argoproj.io

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -14946,8 +14946,13 @@ rules:
   - pods
   verbs:
   - list
-  - delete
   - update
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
 - apiGroups:
   - ""
   resources:
@@ -14957,6 +14962,7 @@ rules:
   - update
   - patch
 - apiGroups:
+  - networking.k8s.io
   - extensions
   resources:
   - ingresses

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -11525,13 +11525,11 @@ spec:
     name: Current
     type: integer
   - JSONPath: .status.updatedReplicas
-    description: Total number of non-terminated pods targeted by this rollout that
-      have the desired template spec
+    description: Total number of non-terminated pods targeted by this rollout that have the desired template spec
     name: Up-to-date
     type: integer
   - JSONPath: .status.availableReplicas
-    description: Total number of available pods (ready for at least minReadySeconds)
-      targeted by this rollout
+    description: Total number of available pods (ready for at least minReadySeconds) targeted by this rollout
     name: Available
     type: integer
   group: argoproj.io
@@ -14783,90 +14781,6 @@ metadata:
   name: argo-rollouts
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app.kubernetes.io/component: aggregate-cluster-role
-    app.kubernetes.io/name: argo-rollouts-aggregate-to-admin
-    app.kubernetes.io/part-of: argo-rollouts
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
-  name: argo-rollouts-aggregate-to-admin
-rules:
-- apiGroups:
-  - argoproj.io
-  resources:
-  - rollouts
-  - rollouts/scale
-  - rollouts/status
-  - experiments
-  - analysistemplates
-  - clusteranalysistemplates
-  - analysisruns
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app.kubernetes.io/component: aggregate-cluster-role
-    app.kubernetes.io/name: argo-rollouts-aggregate-to-edit
-    app.kubernetes.io/part-of: argo-rollouts
-    rbac.authorization.k8s.io/aggregate-to-edit: "true"
-  name: argo-rollouts-aggregate-to-edit
-rules:
-- apiGroups:
-  - argoproj.io
-  resources:
-  - rollouts
-  - rollouts/scale
-  - rollouts/status
-  - experiments
-  - analysistemplates
-  - clusteranalysistemplates
-  - analysisruns
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app.kubernetes.io/component: aggregate-cluster-role
-    app.kubernetes.io/name: argo-rollouts-aggregate-to-view
-    app.kubernetes.io/part-of: argo-rollouts
-    rbac.authorization.k8s.io/aggregate-to-view: "true"
-  name: argo-rollouts-aggregate-to-view
-rules:
-- apiGroups:
-  - argoproj.io
-  resources:
-  - rollouts
-  - rollouts/scale
-  - experiments
-  - analysistemplates
-  - clusteranalysistemplates
-  - analysisruns
-  verbs:
-  - get
-  - list
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
@@ -15003,6 +14917,90 @@ rules:
   - get
   - update
   - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: aggregate-cluster-role
+    app.kubernetes.io/name: argo-rollouts-aggregate-to-admin
+    app.kubernetes.io/part-of: argo-rollouts
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: argo-rollouts-aggregate-to-admin
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  - rollouts/scale
+  - rollouts/status
+  - experiments
+  - analysistemplates
+  - clusteranalysistemplates
+  - analysisruns
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: aggregate-cluster-role
+    app.kubernetes.io/name: argo-rollouts-aggregate-to-edit
+    app.kubernetes.io/part-of: argo-rollouts
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: argo-rollouts-aggregate-to-edit
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  - rollouts/scale
+  - rollouts/status
+  - experiments
+  - analysistemplates
+  - clusteranalysistemplates
+  - analysisruns
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: aggregate-cluster-role
+    app.kubernetes.io/name: argo-rollouts-aggregate-to-view
+    app.kubernetes.io/part-of: argo-rollouts
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: argo-rollouts-aggregate-to-view
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  - rollouts/scale
+  - experiments
+  - analysistemplates
+  - clusteranalysistemplates
+  - analysisruns
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/manifests/role/argo-rollouts-clusterrole.yaml
+++ b/manifests/role/argo-rollouts-clusterrole.yaml
@@ -75,15 +75,21 @@ rules:
   - get
   - list
   - watch
-# pod delete needed for restart. pod update needed for updating ephemeral data
+# pod list/update needed for updating ephemeral data
 - apiGroups:
   - ""
   resources:
   - pods
   verbs:
   - list
-  - delete
   - update
+# pods eviction needed for restart
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
 # event write needed for emitting events
 - apiGroups:
   - ""
@@ -93,8 +99,9 @@ rules:
   - create
   - update
   - patch
-# ingress patch needed for managing ingress annotations
+# ingress patch needed for managing ingress annotations, create needed for nginx canary
 - apiGroups:
+  - networking.k8s.io
   - extensions
   resources:
   - ingresses

--- a/test/fixtures/common.go
+++ b/test/fixtures/common.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -11,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ghodss/yaml"
+	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -74,6 +77,16 @@ func (c *Common) PrintRollout(name string) {
 	ri, err := controller.GetRolloutInfo()
 	c.CheckError(err)
 	getOptions.PrintRollout(ri)
+}
+
+func (c *Common) PrintRolloutYAML(ro *rov1.Rollout) {
+	ro = ro.DeepCopy()
+	// declutter the output
+	delete(ro.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
+	ro.ManagedFields = nil
+	yamlBytes, err := yaml.Marshal(ro)
+	c.CheckError(err)
+	fmt.Fprintf(logrus.StandardLogger().Out, "\n---\n%s\n", string(yamlBytes))
 }
 
 func (c *Common) GetReplicaSetByRevision(revision string) *appsv1.ReplicaSet {

--- a/test/fixtures/common.go
+++ b/test/fixtures/common.go
@@ -386,3 +386,14 @@ func (c *Common) applyObject(obj *unstructured.Unstructured) {
 	}
 	c.log.Info(string(out))
 }
+
+func (c *Common) deleteObject(kind, name string) {
+	cmd := exec.Command("kubectl", "delete", kind, name)
+	cmd.Env = os.Environ()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		c.log.Errorf("kubectl delete of %s/%s failed: %s", kind, name, out)
+		c.t.FailNow()
+	}
+	c.log.Info(string(out))
+}

--- a/test/fixtures/e2e_suite.go
+++ b/test/fixtures/e2e_suite.go
@@ -59,6 +59,11 @@ var (
 		Version:  "v1",
 		Resource: "ingresses",
 	}
+	pdbGVR = schema.GroupVersionResource{
+		Group:    "policy",
+		Version:  "v1beta1",
+		Resource: "poddisruptionbudgets",
+	}
 )
 
 func init() {
@@ -158,6 +163,7 @@ func (s *E2ESuite) deleteResources(req *labels.Requirement, propagationPolicy me
 		rov1.ExperimentGVR,
 		serviceGVR,
 		ingressGVR,
+		pdbGVR,
 		istioutil.GetIstioGVR("v1alpha3"),
 	}
 	deleteOpts := metav1.DeleteOptions{PropagationPolicy: &propagationPolicy}

--- a/test/fixtures/e2e_suite.go
+++ b/test/fixtures/e2e_suite.go
@@ -144,6 +144,7 @@ func (s *E2ESuite) AfterTest(suiteName, testName string) {
 		s.CheckError(err)
 		for _, ro := range roList.Items {
 			s.PrintRollout(ro.Name)
+			s.PrintRolloutYAML(&ro)
 		}
 	}
 	if os.Getenv(EnvVarE2EDebug) == "true" {

--- a/test/fixtures/when.go
+++ b/test/fixtures/when.go
@@ -50,6 +50,11 @@ func (w *When) ApplyManifests(yaml ...string) *When {
 	return w
 }
 
+func (w *When) DeleteObject(kind, name string) *When {
+	w.deleteObject(kind, name)
+	return w
+}
+
 // injectDelays adds postStart/preStop handlers to slow down readiness/termination by adding a
 // preStart and postStart handlers which sleeps for the specified duration.
 func (w *When) injectDelays(un *unstructured.Unstructured) {


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/908

This change switches the controller to use the evict API instead of the delete API for the pod restart feature. By using evict instead of delete, any PodDisruptionBudget targeting rollout pods will be honored.

Signed-off-by: Jesse Suen <jesse_suen@intuit.com>