### PR TITLE
bugfix:Argo rollout commands not support namespace

### DIFF
--- a/pkg/kubectl-argo-rollouts/options/options.go
+++ b/pkg/kubectl-argo-rollouts/options/options.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -152,9 +153,23 @@ func (o *ArgoRolloutsOptions) DynamicClientset() dynamic.Interface {
 
 // Namespace returns the namespace based on client flags or kube context
 func (o *ArgoRolloutsOptions) Namespace() string {
+	namespace := getNamespace()
+	if namespace != "default" {
+		return namespace
+	}
 	namespace, _, err := o.RESTClientGetter.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		panic(err)
+	}
+	return namespace
+}
+
+func getNamespace() string {
+	namespace := "default"
+	for idx, arg := range os.Args {
+		if (arg == "-n" || arg == "--namespace") && len(os.Args) > idx {
+			namespace = os.Args[idx+1]
+		}
 	}
 	return namespace
 }


### PR DESCRIPTION
Signed-off-by: zhaozhiqiang <zhaozhiqiang@lixiang.com>

Checklist:

argo rollout plugin commands namespace always is default，not support other namespace。
* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).