### PR TITLE
bugfix: get rollout always return not found except default namespace

### DIFF
--- a/pkg/kubectl-argo-rollouts/cmd/create/create.go
+++ b/pkg/kubectl-argo-rollouts/cmd/create/create.go
@@ -67,7 +67,6 @@ const (
 
 // NewCmdCreate returns a new instance of an `rollouts create` command
 func NewCmdCreate(o *options.ArgoRolloutsOptions) *cobra.Command {
-	o.DynamicClientset()
 	createOptions := CreateOptions{
 		ArgoRolloutsOptions: *o,
 	}
@@ -78,6 +77,7 @@ func NewCmdCreate(o *options.ArgoRolloutsOptions) *cobra.Command {
 		Example:      o.Example(createExample),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
+			createOptions.DynamicClientset()
 			if len(createOptions.Files) == 0 {
 				return o.UsageErr(c)
 			}


### PR DESCRIPTION
Signed-off-by: zhouchencheng <zhouchencheng@bilibili.com>

affected by #932, rollout cli can not get rollout in other namespaces except default.    


Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).