### PR TITLE
fix: should use copy rs before modify fields.

### DIFF
--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -486,10 +486,10 @@ func SyncEphemeralPodMetadata(metadata *metav1.ObjectMeta, existingPodMetadata, 
 func SyncReplicaSetEphemeralPodMetadata(rs *appsv1.ReplicaSet, podMetadata *v1alpha1.PodTemplateMetadata) (*appsv1.ReplicaSet, bool) {
 	existingPodMetadata := ParseExistingPodMetadata(rs)
 	newObjectMeta, modified := SyncEphemeralPodMetadata(&rs.Spec.Template.ObjectMeta, existingPodMetadata, podMetadata)
+	rs = rs.DeepCopy()
 	if !modified {
 		return rs, false
 	}
-	rs = rs.DeepCopy()
 	rs.Spec.Template.ObjectMeta = *newObjectMeta
 	if podMetadata != nil {
 		// remember what we injected by annotating it


### PR DESCRIPTION
Signed-off-by: zhouchencheng <zhouchencheng@bilibili.com>

https://github.com/argoproj/argo-rollouts/blob/master/utils/replicaset/replicaset.go#L54

if no modified occur, `SyncReplicaSetEphemeralPodMetadata ` func does not return a copy rs. 
And this rs in memory may be modified in `RemoveInjectedAntiAffinityRule`.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).