### PR TITLE
chore: Change PR template to reflect CLA->DCO

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@ Checklist:
 
 * [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
 * [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
-* [ ] I've signed the CLA.
+* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
 * [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
 * [ ] My builds are green. Try syncing with master if they are not. 
 * [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).


### PR DESCRIPTION
Signed-off-by: Laurent Benchimol <laurent_benchimol@intuit.com>

Checklist:

* [x ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x ] I've signed the CLA.
* [ x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x ] My builds are green. Try syncing with master if they are not. 
* [ x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).