### PR TITLE
feat: Implement rollout status command. Fixes #596

### DIFF
--- a/pkg/kubectl-argo-rollouts/cmd/cmd.go
+++ b/pkg/kubectl-argo-rollouts/cmd/cmd.go
@@ -13,6 +13,7 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/restart"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/retry"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/set"
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/status"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/terminate"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/undo"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/version"
@@ -64,5 +65,6 @@ func NewCmdArgoRollouts(o *options.ArgoRolloutsOptions) *cobra.Command {
 	cmd.AddCommand(terminate.NewCmdTerminate(o))
 	cmd.AddCommand(set.NewCmdSet(o))
 	cmd.AddCommand(undo.NewCmdUndo(o))
+	cmd.AddCommand(status.NewCmdStatus(o))
 	return cmd
 }

--- a/pkg/kubectl-argo-rollouts/cmd/status/status.go
+++ b/pkg/kubectl-argo-rollouts/cmd/status/status.go
@@ -12,9 +12,8 @@ import (
 )
 
 const (
-	statusLong = `Watch the progress of a rollout until it is done. The return will be success if
-the Rollout ends as Healthy and error if the Rollout ends degraded or if the
-timeout is hit before the progress finishes.`
+	statusLong = `Watch rollout until it finishes or the specified timeout is exceeded. Returns
+success if the rollout is healthy upon completion and an error otherwise.`
 	statusExample = `
 	# Watch the rollout until it succeeds
 	%[1]s status gestbook

--- a/pkg/kubectl-argo-rollouts/cmd/status/status.go
+++ b/pkg/kubectl-argo-rollouts/cmd/status/status.go
@@ -3,6 +3,7 @@ package status
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/info"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options"
@@ -40,7 +41,8 @@ func NewCmdStatus(o *options.ArgoRolloutsOptions) *cobra.Command {
 			}
 			name := args[0]
 			controller := viewcontroller.NewRolloutViewController(o.Namespace(), name, statusOptions.KubeClientset(), statusOptions.RolloutsClientset())
-			ctx := context.Background()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			controller.Start(ctx)
 
 			ri, err := controller.GetRolloutInfo()
@@ -48,7 +50,17 @@ func NewCmdStatus(o *options.ArgoRolloutsOptions) *cobra.Command {
 				return err
 			}
 
-			statusOptions.PrintStatus(ri)
+			if !statusOptions.Watch {
+				fmt.Println(ri.Status)
+			} else {
+				rolloutUpdates := make(chan *info.RolloutInfo)
+				defer close(rolloutUpdates)
+				controller.RegisterCallback(func(roInfo *info.RolloutInfo) {
+					rolloutUpdates <- roInfo
+				})
+				go statusOptions.WatchStatus(ctx.Done(), cancel, rolloutUpdates)
+				controller.Run(ctx)
+			}
 
 			return nil
 		},
@@ -57,6 +69,27 @@ func NewCmdStatus(o *options.ArgoRolloutsOptions) *cobra.Command {
 	return cmd
 }
 
-func (o *StatusOptions) PrintStatus(roInfo *info.RolloutInfo) {
-	fmt.Println(roInfo.Status)
+func (o *StatusOptions) WatchStatus(stopCh <-chan struct{}, cancelFunc context.CancelFunc, rolloutUpdates chan *info.RolloutInfo) {
+	ticker := time.NewTicker(time.Second)
+	var roInfo *info.RolloutInfo
+	var preventFlicker time.Time
+
+	for {
+		select {
+		case roInfo = <-rolloutUpdates:
+		case <-ticker.C:
+		case <-stopCh:
+			return
+		}
+		if roInfo != nil && time.Now().After(preventFlicker.Add(200*time.Millisecond)) {
+			fmt.Printf("%s - %s\n", roInfo.Status, roInfo.Message)
+
+			if roInfo.Status == "Healthy" || roInfo.Status == "Degraded" {
+				cancelFunc()
+				return
+			}
+
+			preventFlicker = time.Now()
+		}
+	}
 }

--- a/pkg/kubectl-argo-rollouts/cmd/status/status.go
+++ b/pkg/kubectl-argo-rollouts/cmd/status/status.go
@@ -16,7 +16,7 @@ const (
 the rollout is healthy upon completion and an error otherwise.`
 	statusExample = `
 	# Watch the rollout until it succeeds
-	%[1]s status gestbook
+	%[1]s status guestbook
 
 	# Watch the rollout until it succeeds, fail if it takes more than 60 seconds
 	%[1]s status --timeout 60 guestbook
@@ -38,7 +38,7 @@ func NewCmdStatus(o *options.ArgoRolloutsOptions) *cobra.Command {
 
 	var cmd = &cobra.Command{
 		Use:          "status ROLLOUT_NAME",
-		Short:        "Show the status of a rollout.",
+		Short:        "Show the status of a rollout",
 		Long:         statusLong,
 		Example:      o.Example(statusExample),
 		SilenceUsage: true,

--- a/pkg/kubectl-argo-rollouts/cmd/status/status.go
+++ b/pkg/kubectl-argo-rollouts/cmd/status/status.go
@@ -76,7 +76,7 @@ func NewCmdStatus(o *options.ArgoRolloutsOptions) *cobra.Command {
 				if finalRi.Status == "Degraded" {
 					return fmt.Errorf("The rollout is in a degraded state with message: %s", finalRi.Message)
 				} else if finalRi.Status != "Healthy" {
-					return fmt.Errorf("Timeout reached before rollout completed")
+					return fmt.Errorf("Rollout progress exceeded timeout")
 				}
 			}
 

--- a/pkg/kubectl-argo-rollouts/cmd/status/status.go
+++ b/pkg/kubectl-argo-rollouts/cmd/status/status.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	statusLong = `Watch rollout until it finishes or the specified timeout is exceeded. Returns
-success if the rollout is healthy upon completion and an error otherwise.`
+	statusLong = `Watch rollout until it finishes or the timeout is exceeded. Returns success if
+the rollout is healthy upon completion and an error otherwise.`
 	statusExample = `
 	# Watch the rollout until it succeeds
 	%[1]s status gestbook

--- a/pkg/kubectl-argo-rollouts/cmd/status/status.go
+++ b/pkg/kubectl-argo-rollouts/cmd/status/status.go
@@ -31,7 +31,7 @@ type StatusOptions struct {
 	options.ArgoRolloutsOptions
 }
 
-// NewCmdStatus returns a new instance of an `rollouts status` command
+// NewCmdStatus returns a new instance of a `rollouts status` command
 func NewCmdStatus(o *options.ArgoRolloutsOptions) *cobra.Command {
 	statusOptions := StatusOptions{
 		ArgoRolloutsOptions: *o,
@@ -75,9 +75,9 @@ func NewCmdStatus(o *options.ArgoRolloutsOptions) *cobra.Command {
 				}
 
 				if finalRi.Status == "Degraded" {
-					return fmt.Errorf("The rollout is in degraded state with message: %s", finalRi.Message)
+					return fmt.Errorf("The rollout is in a degraded state with message: %s", finalRi.Message)
 				} else if finalRi.Status != "Healthy" {
-					return fmt.Errorf("The rollout progress did not finish within the specified timeout")
+					return fmt.Errorf("Timeout reached before rollout completed")
 				}
 			}
 
@@ -85,7 +85,7 @@ func NewCmdStatus(o *options.ArgoRolloutsOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVarP(&statusOptions.Watch, "watch", "w", true, "Watch the status of the rollout until it's done")
-	cmd.Flags().Int64VarP(&statusOptions.Timeout, "timeout", "t", 300, "The length of time in seconds to wait before ending watch, zero means never.")
+	cmd.Flags().Int64VarP(&statusOptions.Timeout, "timeout", "t", 300, "The length of time in seconds to watch before giving up, zero means wait forever")
 	return cmd
 }
 

--- a/pkg/kubectl-argo-rollouts/cmd/status/status.go
+++ b/pkg/kubectl-argo-rollouts/cmd/status/status.go
@@ -84,7 +84,7 @@ func NewCmdStatus(o *options.ArgoRolloutsOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVarP(&statusOptions.Watch, "watch", "w", true, "Watch the status of the rollout until it's done")
-	cmd.Flags().Int64VarP(&statusOptions.Timeout, "timeout", "t", 300, "The length of time in seconds to watch before giving up, zero means wait forever")
+	cmd.Flags().Int64VarP(&statusOptions.Timeout, "timeout", "t", 0, "The length of time in seconds to watch before giving up, zero means wait forever")
 	return cmd
 }
 

--- a/pkg/kubectl-argo-rollouts/cmd/status/status.go
+++ b/pkg/kubectl-argo-rollouts/cmd/status/status.go
@@ -1,0 +1,62 @@
+package status
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/info"
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options"
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/viewcontroller"
+	"github.com/spf13/cobra"
+)
+
+const (
+	statusExample     = ``
+	statusUsage       = ``
+	statusUsageCommon = ``
+)
+
+type StatusOptions struct {
+	Watch bool
+
+	options.ArgoRolloutsOptions
+}
+
+// NewCmdStatus returns a new instance of an `rollouts status` command
+func NewCmdStatus(o *options.ArgoRolloutsOptions) *cobra.Command {
+	statusOptions := StatusOptions{
+		ArgoRolloutsOptions: *o,
+	}
+
+	var cmd = &cobra.Command{
+		Use:          "status ROLLOUT_NAME",
+		Short:        "",
+		Long:         "",
+		Example:      "",
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return o.UsageErr(c)
+			}
+			name := args[0]
+			controller := viewcontroller.NewRolloutViewController(o.Namespace(), name, statusOptions.KubeClientset(), statusOptions.RolloutsClientset())
+			ctx := context.Background()
+			controller.Start(ctx)
+
+			ri, err := controller.GetRolloutInfo()
+			if err != nil {
+				return err
+			}
+
+			statusOptions.PrintStatus(ri)
+
+			return nil
+		},
+	}
+	cmd.Flags().BoolVarP(&statusOptions.Watch, "watch", "w", false, "Watch the status of the rollout until it's done")
+	return cmd
+}
+
+func (o *StatusOptions) PrintStatus(roInfo *info.RolloutInfo) {
+	fmt.Println(roInfo.Status)
+}

--- a/pkg/kubectl-argo-rollouts/cmd/status/status_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/status/status_test.go
@@ -121,7 +121,7 @@ func TestWatchAbortedRollout(t *testing.T) {
 	stdout := o.Out.(*bytes.Buffer).String()
 	stderr := o.ErrOut.(*bytes.Buffer).String()
 	assert.Equal(t, "Degraded\n", stdout)
-	assert.Equal(t, "Error: The rollout is in degraded state with message: RolloutAborted: metric \"web\" assessed Failed due to failed (1) > failureLimit (0)\n", stderr)
+	assert.Equal(t, "Error: The rollout is in a degraded state with message: RolloutAborted: metric \"web\" assessed Failed due to failed (1) > failureLimit (0)\n", stderr)
 }
 
 func TestWatchTimeoutRollout(t *testing.T) {
@@ -139,5 +139,5 @@ func TestWatchTimeoutRollout(t *testing.T) {
 	stdout := o.Out.(*bytes.Buffer).String()
 	stderr := o.ErrOut.(*bytes.Buffer).String()
 	assert.Equal(t, "Paused - BlueGreenPause\n", stdout)
-	assert.Equal(t, "Error: The rollout progress did not finish within the specified timeout\n", stderr)
+	assert.Equal(t, "Error: Timeout reached before rollout completed\n", stderr)
 }

--- a/pkg/kubectl-argo-rollouts/cmd/status/status_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/status/status_test.go
@@ -139,5 +139,5 @@ func TestWatchTimeoutRollout(t *testing.T) {
 	stdout := o.Out.(*bytes.Buffer).String()
 	stderr := o.ErrOut.(*bytes.Buffer).String()
 	assert.Equal(t, "Paused - BlueGreenPause\n", stdout)
-	assert.Equal(t, "Error: Timeout reached before rollout completed\n", stderr)
+	assert.Equal(t, "Error: Rollout progress exceeded timeout\n", stderr)
 }

--- a/pkg/kubectl-argo-rollouts/cmd/status/status_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/status/status_test.go
@@ -1,0 +1,143 @@
+package status
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/info/testdata"
+	options "github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options/fake"
+	"github.com/stretchr/testify/assert"
+)
+
+const noWatch = "--watch=false"
+
+func TestStatusUsage(t *testing.T) {
+	tf, o := options.NewFakeArgoRolloutsOptions()
+	defer tf.Cleanup()
+	cmd := NewCmdStatus(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+
+	assert.Error(t, err)
+}
+
+func TestStatusRolloutNotFound(t *testing.T) {
+	tf, o := options.NewFakeArgoRolloutsOptions()
+	defer tf.Cleanup()
+	cmd := NewCmdStatus(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{"does-not-exist", noWatch})
+	err := cmd.Execute()
+
+	assert.Error(t, err)
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Empty(t, stdout)
+	assert.Equal(t, "Error: rollout.argoproj.io \"does-not-exist\" not found\n", stderr)
+}
+
+func TestWatchStatusRolloutNotFound(t *testing.T) {
+	tf, o := options.NewFakeArgoRolloutsOptions()
+	defer tf.Cleanup()
+	cmd := NewCmdStatus(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{"does-not-exist"})
+	err := cmd.Execute()
+
+	assert.Error(t, err)
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Empty(t, stdout)
+	assert.Equal(t, "Error: rollout.argoproj.io \"does-not-exist\" not found\n", stderr)
+}
+
+func TestStatusBlueGreenRollout(t *testing.T) {
+	rolloutObjs := testdata.NewBlueGreenRollout()
+
+	tf, o := options.NewFakeArgoRolloutsOptions(rolloutObjs.AllObjects()...)
+	o.RESTClientGetter = tf.WithNamespace(rolloutObjs.Rollouts[0].Namespace)
+	defer tf.Cleanup()
+	cmd := NewCmdStatus(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{rolloutObjs.Rollouts[0].Name, noWatch})
+	err := cmd.Execute()
+
+	assert.NoError(t, err)
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Equal(t, "Paused\n", stdout)
+	assert.Empty(t, stderr)
+}
+
+func TestStatusInvalidRollout(t *testing.T) {
+	rolloutObjs := testdata.NewInvalidRollout()
+
+	tf, o := options.NewFakeArgoRolloutsOptions(rolloutObjs.AllObjects()...)
+	o.RESTClientGetter = tf.WithNamespace(rolloutObjs.Rollouts[0].Namespace)
+	defer tf.Cleanup()
+	cmd := NewCmdStatus(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{rolloutObjs.Rollouts[0].Name, noWatch})
+	err := cmd.Execute()
+
+	assert.NoError(t, err)
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Equal(t, "Degraded\n", stdout)
+	assert.Empty(t, stderr)
+}
+
+func TestStatusAbortedRollout(t *testing.T) {
+	rolloutObjs := testdata.NewAbortedRollout()
+
+	tf, o := options.NewFakeArgoRolloutsOptions(rolloutObjs.AllObjects()...)
+	o.RESTClientGetter = tf.WithNamespace(rolloutObjs.Rollouts[0].Namespace)
+	defer tf.Cleanup()
+	cmd := NewCmdStatus(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{rolloutObjs.Rollouts[0].Name, noWatch})
+	err := cmd.Execute()
+
+	assert.NoError(t, err)
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Equal(t, "Degraded\n", stdout)
+	assert.Empty(t, stderr)
+}
+
+func TestWatchAbortedRollout(t *testing.T) {
+	rolloutObjs := testdata.NewAbortedRollout()
+
+	tf, o := options.NewFakeArgoRolloutsOptions(rolloutObjs.AllObjects()...)
+	o.RESTClientGetter = tf.WithNamespace(rolloutObjs.Rollouts[0].Namespace)
+	defer tf.Cleanup()
+	cmd := NewCmdStatus(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{rolloutObjs.Rollouts[0].Name})
+	err := cmd.Execute()
+
+	assert.Error(t, err)
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Equal(t, "Degraded\n", stdout)
+	assert.Equal(t, "Error: The rollout is in degraded state with message: RolloutAborted: metric \"web\" assessed Failed due to failed (1) > failureLimit (0)\n", stderr)
+}
+
+func TestWatchTimeoutRollout(t *testing.T) {
+	rolloutObjs := testdata.NewBlueGreenRollout()
+
+	tf, o := options.NewFakeArgoRolloutsOptions(rolloutObjs.AllObjects()...)
+	o.RESTClientGetter = tf.WithNamespace(rolloutObjs.Rollouts[0].Namespace)
+	defer tf.Cleanup()
+	cmd := NewCmdStatus(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{rolloutObjs.Rollouts[0].Name, "--timeout=1"})
+	err := cmd.Execute()
+
+	assert.Error(t, err)
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Equal(t, "Paused - BlueGreenPause\n", stdout)
+	assert.Equal(t, "Error: The rollout progress did not finish within the specified timeout\n", stderr)
+}


### PR DESCRIPTION
Closes #596

This replicates the `kubectl rollout status deployment [--watch] <name>` command, but for Rollouts.

This is implemented as:

```
# Returns Rollout status: Healthy, Progressing, Degraded, etc
kubectl argo rollouts status --watch=false <name>

# Waits until status is Healthy or Degraded (default behaviour without flags)
kubectl argo rollouts status --watch <name>
```

The flags and defaults for them replicate the `kubectl rollout status deployment <name>` command. As in it, `--watch` is default and the default timeout is 5 minutes.

---

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, ~(b) this is a bug fix, or (c) this is a chore~.
  * (a) See #596
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).