### PR TITLE
fix: blue-green rollouts could pause prematurely during prePromotionAnalysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ test-kustomize:
 
 .PHONY: start-e2e
 start-e2e:
-	go run ./cmd/rollouts-controller/main.go --instance-id ${E2E_INSTANCE_ID}
+	go run ./cmd/rollouts-controller/main.go --instance-id ${E2E_INSTANCE_ID} --loglevel debug
 
 .PHONY: test-e2e
 test-e2e:

--- a/pkg/apis/rollouts/v1alpha1/openapi_generated.go
+++ b/pkg/apis/rollouts/v1alpha1/openapi_generated.go
@@ -704,7 +704,7 @@ func schema_pkg_apis_rollouts_v1alpha1_BlueGreenStrategy(ref common.ReferenceCal
 					},
 					"previewReplicaCount": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PreviewReplica the number of replicas to run under the preview service before the switchover. Once the rollout is resumed the new replicaset will be full scaled up before the switch occurs",
+							Description: "PreviewReplicaCount is the number of replicas to run for the preview stack before the switchover. Once the rollout is resumed the desired replicaset will be full scaled up before the switch occurs",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -718,14 +718,14 @@ func schema_pkg_apis_rollouts_v1alpha1_BlueGreenStrategy(ref common.ReferenceCal
 					},
 					"autoPromotionSeconds": {
 						SchemaProps: spec.SchemaProps{
-							Description: "AutoPromotionSeconds automatically promotes the current ReplicaSet to active after the specified pause delay in seconds after the ReplicaSet becomes ready. If omitted, the Rollout enters and remains in a paused state until manually resumed by removing the pause condition.",
+							Description: "AutoPromotionSeconds is a duration in seconds in which to delay auto-promotion (default: 0). The countdown begins after the preview ReplicaSet have reached full availability. This option is ignored if autoPromotionEnabled is set to false.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
 					},
 					"maxUnavailable": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MaxUnavailable The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total pods at the start of update (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. By default, a fixed value of 1 is used. Example: when this is set to 30%, the old RC can be scaled down by 30% immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that at least 70% of original number of pods are available at all times during the update.",
+							Description: "MaxUnavailable The maximum number of pods that can be unavailable during a restart operation. Defaults to 25% of total replicas.",
 							Ref:         ref("k8s.io/apimachinery/pkg/util/intstr.IntOrString"),
 						},
 					},
@@ -2922,7 +2922,7 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutStatus(ref common.ReferenceCallbac
 					},
 					"controllerPause": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ControllerPause indicates the controller has paused the rollout",
+							Description: "ControllerPause indicates the controller has paused the rollout. It is set to true when the controller adds a pause condition. This field helps to discern the scenario where a rollout was resumed after being paused by the controller (e.g. via the plugin). In that situation, the pauseConditions would have been cleared , but controllerPause would still be set to true.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/pkg/apis/rollouts/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/rollouts/v1alpha1/zz_generated.deepcopy.go
@@ -388,11 +388,6 @@ func (in *BlueGreenStrategy) DeepCopyInto(out *BlueGreenStrategy) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.AutoPromotionSeconds != nil {
-		in, out := &in.AutoPromotionSeconds, &out.AutoPromotionSeconds
-		*out = new(int32)
-		**out = **in
-	}
 	if in.MaxUnavailable != nil {
 		in, out := &in.MaxUnavailable, &out.MaxUnavailable
 		*out = new(intstr.IntOrString)

--- a/pkg/apis/rollouts/validation/validation_test.go
+++ b/pkg/apis/rollouts/validation/validation_test.go
@@ -105,7 +105,7 @@ func TestValidateRolloutStrategyBlueGreen(t *testing.T) {
 					PreviewService:              "service-name",
 					ActiveService:               "service-name",
 					ScaleDownDelayRevisionLimit: &scaleDownDelayRevisionLimit,
-					AutoPromotionSeconds:        &autoPromotionSeconds,
+					AutoPromotionSeconds:        autoPromotionSeconds,
 				},
 			},
 		},

--- a/rollout/analysis_test.go
+++ b/rollout/analysis_test.go
@@ -1830,7 +1830,7 @@ func TestRolloutPrePromotionAnalysisHonorAutoPromotionSeconds(t *testing.T) {
 	r1 := newBlueGreenRollout("foo", 1, nil, "active", "")
 	r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(true)
 	r2 := bumpVersion(r1)
-	r2.Spec.Strategy.BlueGreen.AutoPromotionSeconds = pointer.Int32Ptr(10)
+	r2.Spec.Strategy.BlueGreen.AutoPromotionSeconds = 10
 	r2.Spec.Strategy.BlueGreen.PrePromotionAnalysis = &v1alpha1.RolloutAnalysis{
 		Templates: []v1alpha1.RolloutAnalysisTemplate{{
 			TemplateName: at.Name,

--- a/rollout/bluegreen_test.go
+++ b/rollout/bluegreen_test.go
@@ -338,9 +338,8 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		defer f.Close()
 
 		r1 := newBlueGreenRollout("foo", 1, nil, "active", "preview")
-		r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
 		r2 := bumpVersion(r1)
-		r2.Spec.Strategy.BlueGreen.AutoPromotionSeconds = pointer.Int32Ptr(10)
+		r2.Spec.Strategy.BlueGreen.AutoPromotionSeconds = 10
 
 		rs1 := newReplicaSetWithStatus(r1, 1, 1)
 		rs2 := newReplicaSetWithStatus(r2, 1, 1)
@@ -373,9 +372,8 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		defer f.Close()
 
 		r1 := newBlueGreenRollout("foo", 1, nil, "active", "preview")
-		r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
 		r2 := bumpVersion(r1)
-		r2.Spec.Strategy.BlueGreen.AutoPromotionSeconds = pointer.Int32Ptr(10)
+		r2.Spec.Strategy.BlueGreen.AutoPromotionSeconds = 10
 
 		rs1 := newReplicaSetWithStatus(r1, 1, 1)
 		rs2 := newReplicaSetWithStatus(r2, 1, 1)
@@ -427,9 +425,8 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		defer f.Close()
 
 		r1 := newBlueGreenRollout("foo", 1, nil, "active", "preview")
-		r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
 		r2 := bumpVersion(r1)
-		r2.Spec.Strategy.BlueGreen.AutoPromotionSeconds = pointer.Int32Ptr(10)
+		r2.Spec.Strategy.BlueGreen.AutoPromotionSeconds = 10
 
 		rs1 := newReplicaSetWithStatus(r1, 1, 1)
 		rs2 := newReplicaSetWithStatus(r2, 1, 1)
@@ -843,7 +840,6 @@ func TestPreviewReplicaCountHandleScaleUpPreviewCheckPoint(t *testing.T) {
 
 		r1 := newBlueGreenRollout("foo", 5, nil, "active", "")
 		r1.Spec.Strategy.BlueGreen.PreviewReplicaCount = pointer.Int32Ptr(3)
-		r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
 		rs1 := newReplicaSetWithStatus(r1, 5, 5)
 		r2 := bumpVersion(r1)
 

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -210,7 +210,7 @@ func (c *rolloutContext) completedCurrentCanaryStep() bool {
 	}
 	switch {
 	case currentStep.Pause != nil:
-		return c.pauseContext.CompletedPauseStep(*currentStep.Pause)
+		return c.pauseContext.CompletedCanaryPauseStep(*currentStep.Pause)
 	case currentStep.SetCanaryScale != nil:
 		return replicasetutil.AtDesiredReplicaCountsForCanary(c.rollout, c.newRS, c.stableRS, c.otherRSs)
 	case currentStep.SetWeight != nil:

--- a/test/e2e/analysis_test.go
+++ b/test/e2e/analysis_test.go
@@ -99,6 +99,9 @@ spec:
       prePromotionAnalysis:
         templates:
         - templateName: sleep-job
+        args:
+        - name: duration
+          value: "5"
       postPromotionAnalysis:
         templates:
         - templateName: sleep-job
@@ -149,6 +152,7 @@ spec:
 		WaitForRolloutStatus("Progressing").
 		WaitForRolloutStatus("Paused").
 		Then().
+		ExpectAnalysisRunCount(1).
 		ExpectActiveRevision("1").
 		ExpectPreviewRevision("2").
 		When().
@@ -431,7 +435,7 @@ spec:
       activeService: bluegreen-kitchensink-active
       previewService: bluegreen-kitchensink-preview
       previewReplicaCount: 1
-      autoPromotionSeconds: 5
+      autoPromotionSeconds: 10
       scaleDownDelaySeconds: 5
       prePromotionAnalysis:
         templates:
@@ -476,6 +480,14 @@ spec:
 		ExpectRevisionPodCount("2", 1).
 		ExpectReplicaCounts(2, 3, 1, 2, 2). // desired, current, updated, ready, available
 		ExpectAnalysisRunCount(1).
+		When().
+		Sleep(5*time.Second). // sleep 5 seconds, verify we did not autopromote too early
+		Then().
+		ExpectActiveRevision("1").
+		ExpectStableRevision("1").
+		ExpectRevisionPodCount("1", 2).
+		ExpectRevisionPodCount("2", 1).
+		ExpectReplicaCounts(2, 3, 1, 2, 2). // desired, current, updated, ready, available
 		When().
 		WaitForActiveRevision("2"). // no need to manually promote since autoPromotionSeconds will do it
 		Then().


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/990

Fixes an issue where blue-green would be paused prematurely during prePromotionAnalysis.

Signed-off-by: Jesse Suen <jesse_suen@intuit.com>