### PR TITLE
fix: wavefront queries would return no datapoints. surface evaluate errors. retry errors faster

### DIFF
--- a/metricproviders/datadog/datadog.go
+++ b/metricproviders/datadog/datadog.go
@@ -144,8 +144,8 @@ func (p *Provider) parseResponse(metric v1alpha1.Metric, response *http.Response
 		return "", v1alpha1.AnalysisPhaseError, fmt.Errorf("Datadog returned no value: %s", string(bodyBytes))
 	}
 
-	status := evaluate.EvaluateResult(datapoint[1], metric, p.logCtx)
-	return strconv.FormatFloat(datapoint[1], 'f', -1, 64), status, nil
+	status, err := evaluate.EvaluateResult(datapoint[1], metric, p.logCtx)
+	return strconv.FormatFloat(datapoint[1], 'f', -1, 64), status, err
 }
 
 // Resume should not be used the Datadog provider since all the work should occur in the Run method

--- a/metricproviders/newrelic/newrelic.go
+++ b/metricproviders/newrelic/newrelic.go
@@ -95,15 +95,15 @@ func (p *Provider) processResponse(metric v1alpha1.Metric, results []nrdb.NrdbRe
 		if err != nil {
 			return "", v1alpha1.AnalysisPhaseError, fmt.Errorf("could not marshal results: %w", err)
 		}
-		newStatus := evaluate.EvaluateResult(result, metric, p.logCtx)
-		return valueStr, newStatus, nil
+		newStatus, err := evaluate.EvaluateResult(result, metric, p.logCtx)
+		return valueStr, newStatus, err
 	} else if len(results) > 1 {
 		valueStr, err := toJSONString(results)
 		if err != nil {
 			return "", v1alpha1.AnalysisPhaseError, fmt.Errorf("could not marshal results: %w", err)
 		}
-		newStatus := evaluate.EvaluateResult(results, metric, p.logCtx)
-		return valueStr, newStatus, nil
+		newStatus, err := evaluate.EvaluateResult(results, metric, p.logCtx)
+		return valueStr, newStatus, err
 	} else {
 		return "", v1alpha1.AnalysisPhaseFailed, fmt.Errorf("no results returned from NRQL query")
 	}

--- a/metricproviders/prometheus/prometheus.go
+++ b/metricproviders/prometheus/prometheus.go
@@ -94,8 +94,8 @@ func (p *Provider) processResponse(metric v1alpha1.Metric, response model.Value)
 	case *model.Scalar:
 		valueStr := value.Value.String()
 		result := float64(value.Value)
-		newStatus := evaluate.EvaluateResult(result, metric, p.logCtx)
-		return valueStr, newStatus, nil
+		newStatus, err := evaluate.EvaluateResult(result, metric, p.logCtx)
+		return valueStr, newStatus, err
 	case model.Vector:
 		results := make([]float64, 0, len(value))
 		valueStr := "["
@@ -110,8 +110,8 @@ func (p *Provider) processResponse(metric v1alpha1.Metric, response model.Value)
 			valueStr = valueStr[:len(valueStr)-1]
 		}
 		valueStr = valueStr + "]"
-		newStatus := evaluate.EvaluateResult(results, metric, p.logCtx)
-		return valueStr, newStatus, nil
+		newStatus, err := evaluate.EvaluateResult(results, metric, p.logCtx)
+		return valueStr, newStatus, err
 	//TODO(dthomson) add other response types
 	default:
 		return "", v1alpha1.AnalysisPhaseError, fmt.Errorf("Prometheus metric type not supported")

--- a/metricproviders/wavefront/wavefront.go
+++ b/metricproviders/wavefront/wavefront.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	wavefrontapi "github.com/spaceapegames/go-wavefront"
@@ -62,6 +63,7 @@ type wavefrontResponse struct {
 	newValue   string
 	newStatus  v1alpha1.AnalysisPhase
 	epochsUsed string
+	drift      string
 }
 
 // Run queries with wavefront provider for the metric
@@ -72,15 +74,20 @@ func (p *Provider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1alph
 		Metadata:  map[string]string{},
 	}
 
+	// NOTE: Currently our queries to wavefront set StartTime and EndTime to be the same value.
+	// By doing so,  we should also set SeriesOutsideTimeWindow to true, otherwise there is a high
+	// likelihood of returning no datapoints from wavefront.
+	// If in the future, we adjust StartTime such that there is a larger query window, we
+	// will also need to remove MaxPoints, since Wavefront will pick data points closer to StartTime
+	// which will result in a larger drift.
 	queryParams := &wavefrontapi.QueryParams{
 		QueryString:             metric.Provider.Wavefront.Query,
 		StartTime:               strconv.FormatInt(startTime.Unix()*1000, 10),
 		EndTime:                 strconv.FormatInt(startTime.Unix()*1000, 10),
 		MaxPoints:               "1",
 		Granularity:             "s",
-		SeriesOutsideTimeWindow: false,
+		SeriesOutsideTimeWindow: true,
 	}
-
 	response, err := p.api.NewQuery(queryParams).Execute()
 	if response != nil && response.Warnings != "" {
 		newMeasurement.Metadata["warnings"] = response.Warnings
@@ -91,11 +98,11 @@ func (p *Provider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1alph
 	result, err := p.processResponse(metric, response, startTime)
 	if err != nil {
 		return metricutil.MarkMeasurementError(newMeasurement, err)
-
 	}
 	newMeasurement.Value = result.newValue
 	newMeasurement.Phase = result.newStatus
 	newMeasurement.Metadata["timestamps"] = result.epochsUsed
+	newMeasurement.Metadata["drift"] = result.drift
 	finishedTime := metav1.Now()
 	newMeasurement.FinishedAt = &finishedTime
 	return newMeasurement
@@ -118,55 +125,54 @@ func (p *Provider) GarbageCollect(run *v1alpha1.AnalysisRun, metric v1alpha1.Met
 	return nil
 }
 
-func (p *Provider) findDataPointValue(datapoints []wavefrontapi.DataPoint, startTime metav1.Time) (float64, string) {
+// findDataPointValue returns the value of the closest data point to the measurement time.
+// Returns the value, timestamp in epoch seconds, and drift in seconds of the chosen datapoint
+// Wavefront DataPoint struct is of type []float{<timestamp>, <value>}
+func (p *Provider) findDataPointValue(datapoints []wavefrontapi.DataPoint, mTime metav1.Time) (float64, int64, int64) {
 	currentValue := float64(0)
 	currentTime := float64(0)
 	delta := math.Inf(1)
-	startTimeEpoch := float64(startTime.Unix())
+	startTimeEpoch := float64(mTime.Unix())
 	for _, dp := range datapoints {
-		newDelta := math.Abs(startTimeEpoch - dp[0])
-		if newDelta < delta {
+		newDelta := dp[0] - startTimeEpoch
+		if math.Abs(newDelta) < math.Abs(delta) {
 			currentValue = dp[1]
 			currentTime = dp[0]
 			delta = newDelta
 		}
 	}
-	p.logCtx.Infof("Selected Timestamp has drift of %.0f seconds", delta)
-	return currentValue, fmt.Sprintf("%.0f", currentTime)
+	return currentValue, int64(currentTime), int64(delta)
 }
 
 func (p *Provider) processResponse(metric v1alpha1.Metric, response *wavefrontapi.QueryResponse, startTime metav1.Time) (wavefrontResponse, error) {
 	wavefrontResponse := wavefrontResponse{}
+	var err error
 	if len(response.TimeSeries) == 1 {
 		series := response.TimeSeries[0]
-		value, time := p.findDataPointValue(series.DataPoints, startTime) // Wavefront DataPoint struct is of type []float{<timestamp>, <value>}
+		value, epoch, drift := p.findDataPointValue(series.DataPoints, startTime)
 		wavefrontResponse.newValue = fmt.Sprintf("%.2f", value)
-		wavefrontResponse.epochsUsed = time
-		wavefrontResponse.newStatus = evaluate.EvaluateResult(value, metric, p.logCtx)
-		return wavefrontResponse, nil
+		wavefrontResponse.epochsUsed = strconv.Itoa(int(epoch))
+		wavefrontResponse.newStatus, err = evaluate.EvaluateResult(value, metric, p.logCtx)
+		wavefrontResponse.drift = strconv.Itoa(int(drift))
+		return wavefrontResponse, err
 
 	} else if len(response.TimeSeries) > 1 {
 		results := make([]float64, 0, len(response.TimeSeries))
-		valueStr := "["
-		epochsStr := "["
+		resultStrs := []string{}
+		epochStrs := []string{}
+		driftStrs := []string{}
 		for _, series := range response.TimeSeries {
-			value, epoch := p.findDataPointValue(series.DataPoints, startTime) // Wavefront DataPoint struct is of type []float{<timestamp>, <value>}
-			valueStr = valueStr + fmt.Sprintf("%.2f", value) + ","
-			epochsStr = epochsStr + epoch + ","
+			value, epoch, drift := p.findDataPointValue(series.DataPoints, startTime)
 			results = append(results, value)
+			resultStrs = append(resultStrs, fmt.Sprintf("%.2f", value))
+			epochStrs = append(epochStrs, strconv.Itoa(int(epoch)))
+			driftStrs = append(driftStrs, strconv.Itoa(int(drift)))
 		}
-		if len(valueStr) > 1 {
-			valueStr = valueStr[:len(valueStr)-1]
-		}
-		valueStr = valueStr + "]"
-		if len(epochsStr) > 1 {
-			epochsStr = epochsStr[:len(epochsStr)-1]
-		}
-		epochsStr = epochsStr + "]"
-		wavefrontResponse.newValue = valueStr
-		wavefrontResponse.epochsUsed = epochsStr
-		wavefrontResponse.newStatus = evaluate.EvaluateResult(results, metric, p.logCtx)
-		return wavefrontResponse, nil
+		wavefrontResponse.newValue = fmt.Sprintf("[%s]", strings.Join(resultStrs, ","))
+		wavefrontResponse.epochsUsed = fmt.Sprintf("[%s]", strings.Join(epochStrs, ","))
+		wavefrontResponse.drift = fmt.Sprintf("[%s]", strings.Join(driftStrs, ","))
+		wavefrontResponse.newStatus, err = evaluate.EvaluateResult(results, metric, p.logCtx)
+		return wavefrontResponse, err
 
 	} else {
 		wavefrontResponse.newStatus = v1alpha1.AnalysisPhaseFailed

--- a/metricproviders/wavefront/wavefront_test.go
+++ b/metricproviders/wavefront/wavefront_test.go
@@ -233,9 +233,10 @@ func TestFindDataPointValue(t *testing.T) {
 			dp(0, 1),
 			dp(5, 2),
 		}
-		value, epoch := p.findDataPointValue(dataPoints, metav1.Unix(1, 0))
+		value, epoch, drift := p.findDataPointValue(dataPoints, metav1.Unix(1, 0))
 		assert.Equal(t, float64(1), value)
-		assert.Equal(t, "0", epoch)
+		assert.Equal(t, int64(0), epoch)
+		assert.Equal(t, int64(-1), drift)
 	})
 
 	t.Run("Choose later but closer point", func(t *testing.T) {
@@ -243,9 +244,10 @@ func TestFindDataPointValue(t *testing.T) {
 			dp(0, 1),
 			dp(5, 2),
 		}
-		value, epoch := p.findDataPointValue(dataPoints, metav1.Unix(4, 0))
+		value, epoch, drift := p.findDataPointValue(dataPoints, metav1.Unix(4, 0))
 		assert.Equal(t, float64(2), value)
-		assert.Equal(t, "5", epoch)
+		assert.Equal(t, int64(5), epoch)
+		assert.Equal(t, int64(1), drift)
 	})
 
 	t.Run("Choose exact point", func(t *testing.T) {
@@ -253,8 +255,9 @@ func TestFindDataPointValue(t *testing.T) {
 			dp(0, 1),
 			dp(5, 2),
 		}
-		value, epoch := p.findDataPointValue(dataPoints, metav1.Unix(0, 0))
+		value, epoch, drift := p.findDataPointValue(dataPoints, metav1.Unix(0, 0))
 		assert.Equal(t, float64(1), value)
-		assert.Equal(t, "0", epoch)
+		assert.Equal(t, int64(0), epoch)
+		assert.Equal(t, int64(0), drift)
 	})
 }

--- a/metricproviders/webmetric/webmetric.go
+++ b/metricproviders/webmetric/webmetric.go
@@ -107,8 +107,8 @@ func (p *Provider) parseResponse(metric v1alpha1.Metric, response *http.Response
 		return "", v1alpha1.AnalysisPhaseError, err
 	}
 
-	status := evaluate.EvaluateResult(val, metric, p.logCtx)
-	return valString, status, nil
+	status, err := evaluate.EvaluateResult(val, metric, p.logCtx)
+	return valString, status, err
 }
 
 func getValue(fullResults [][]reflect.Value) (interface{}, string, error) {

--- a/utils/evaluate/evaluate_test.go
+++ b/utils/evaluate/evaluate_test.go
@@ -17,8 +17,9 @@ func TestEvaluateResultWithSuccess(t *testing.T) {
 		FailureCondition: "false",
 	}
 	logCtx := logrus.WithField("test", "test")
-	status := EvaluateResult(true, metric, *logCtx)
+	status, err := EvaluateResult(true, metric, *logCtx)
 	assert.Equal(t, v1alpha1.AnalysisPhaseSuccessful, status)
+	assert.NoError(t, err)
 }
 
 func TestEvaluateResultWithFailure(t *testing.T) {
@@ -27,8 +28,9 @@ func TestEvaluateResultWithFailure(t *testing.T) {
 		FailureCondition: "true",
 	}
 	logCtx := logrus.WithField("test", "test")
-	status := EvaluateResult(true, metric, *logCtx)
+	status, err := EvaluateResult(true, metric, *logCtx)
 	assert.Equal(t, v1alpha1.AnalysisPhaseFailed, status)
+	assert.NoError(t, err)
 
 }
 
@@ -38,8 +40,9 @@ func TestEvaluateResultInconclusive(t *testing.T) {
 		FailureCondition: "false",
 	}
 	logCtx := logrus.WithField("test", "test")
-	status := EvaluateResult(true, metric, *logCtx)
+	status, err := EvaluateResult(true, metric, *logCtx)
 	assert.Equal(t, v1alpha1.AnalysisPhaseInconclusive, status)
+	assert.NoError(t, err)
 }
 
 func TestEvaluateResultNoSuccessConditionAndNotFailing(t *testing.T) {
@@ -48,8 +51,9 @@ func TestEvaluateResultNoSuccessConditionAndNotFailing(t *testing.T) {
 		FailureCondition: "false",
 	}
 	logCtx := logrus.WithField("test", "test")
-	status := EvaluateResult(true, metric, *logCtx)
+	status, err := EvaluateResult(true, metric, *logCtx)
 	assert.Equal(t, v1alpha1.AnalysisPhaseSuccessful, status)
+	assert.NoError(t, err)
 }
 
 func TestEvaluateResultNoFailureConditionAndNotSuccessful(t *testing.T) {
@@ -58,8 +62,9 @@ func TestEvaluateResultNoFailureConditionAndNotSuccessful(t *testing.T) {
 		FailureCondition: "",
 	}
 	logCtx := logrus.WithField("test", "test")
-	status := EvaluateResult(true, metric, *logCtx)
+	status, err := EvaluateResult(true, metric, *logCtx)
 	assert.Equal(t, v1alpha1.AnalysisPhaseFailed, status)
+	assert.NoError(t, err)
 }
 
 func TestEvaluateResultNoFailureConditionAndNoSuccessCondition(t *testing.T) {
@@ -68,8 +73,9 @@ func TestEvaluateResultNoFailureConditionAndNoSuccessCondition(t *testing.T) {
 		FailureCondition: "",
 	}
 	logCtx := logrus.WithField("test", "test")
-	status := EvaluateResult(true, metric, *logCtx)
+	status, err := EvaluateResult(true, metric, *logCtx)
 	assert.Equal(t, v1alpha1.AnalysisPhaseSuccessful, status)
+	assert.NoError(t, err)
 }
 
 func TestEvaluateResultWithErrorOnSuccessCondition(t *testing.T) {
@@ -78,8 +84,9 @@ func TestEvaluateResultWithErrorOnSuccessCondition(t *testing.T) {
 		FailureCondition: "true",
 	}
 	logCtx := logrus.WithField("test", "test")
-	status := EvaluateResult(true, metric, *logCtx)
+	status, err := EvaluateResult(true, metric, *logCtx)
 	assert.Equal(t, v1alpha1.AnalysisPhaseError, status)
+	assert.Error(t, err)
 }
 
 func TestEvaluateResultWithErrorOnFailureCondition(t *testing.T) {
@@ -88,8 +95,9 @@ func TestEvaluateResultWithErrorOnFailureCondition(t *testing.T) {
 		FailureCondition: "a == true",
 	}
 	logCtx := logrus.WithField("test", "test")
-	status := EvaluateResult(true, metric, *logCtx)
+	status, err := EvaluateResult(true, metric, *logCtx)
 	assert.Equal(t, v1alpha1.AnalysisPhaseError, status)
+	assert.Error(t, err)
 }
 
 func TestEvaluateConditionWithSuccess(t *testing.T) {


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/1012
Resolves https://github.com/argoproj/argo-rollouts/issues/1006
Resolves https://github.com/argoproj/argo-rollouts/issues/1008

fix: Wavefront query will now allow data points to return outside the time window
fix: expr evaluation errors were not surfaced in the message
fix: metrics which errored, were not retried at 10s error interval

Also, datapoint drift is calculated as a convenience for debugging.

Signed-off-by: Jesse Suen <jesse_suen@intuit.com>
