### PR TITLE
feat: Wait for canary RS to have ready replicas before shifting labels

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -13,3 +13,4 @@ Organizations below are **officially** using Argo Rollouts. Please send a PR wit
 1. [Quipper](https://www.quipper.com/)
 1. [Devtron Labs](https://github.com/devtron-labs/devtron)
 1. [Quizlet](https://quizlet.com)
+1. [Skillz](https://www.skillz.com)

--- a/rollout/service.go
+++ b/rollout/service.go
@@ -126,6 +126,12 @@ func (c *rolloutContext) reconcileStableAndCanaryService() error {
 	if c.rollout.Spec.Strategy.Canary == nil {
 		return nil
 	}
+	if c.newRS == nil || c.newRS.Status.ReadyReplicas == 0 {
+		return nil
+	}
+	if c.newRS.Spec.Replicas == nil || *c.newRS.Spec.Replicas > c.newRS.Status.ReadyReplicas {
+		return nil
+	}
 	if c.rollout.Spec.Strategy.Canary.StableService != "" && c.stableRS != nil {
 		svc, err := c.servicesLister.Services(c.rollout.Namespace).Get(c.rollout.Spec.Strategy.Canary.StableService)
 		if err != nil {


### PR DESCRIPTION
feat: Wait for first batch of new RS pods to be ready before adding canary selector label to an SVC. Fixes #1026
- Last commit does a bit of extra refactoring for the `reconcileStableAndCanaryService` function (can easily be reversed if not desirable).
  - Moves a bit of duplicated logic, previously executed for both canary and stable SVCs and RSs, into it's own function `ensureSVCTargets`.
- Adds a new function `newRSReady` which needs to return `true` before the canary SVC gets the newRS selector label.
  - The newRS needs to exist, not have `ReadyReplicas` < `Replicas` and not have `0` `ReadyReplicas`, thereby ensuring the first batch of Pods are ready before targeting the newRS.
 
(Was also considering perhaps making this label addition an optional `step` so when specified, the user can control precisely when the label swap happens.)

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).