### PR TITLE
feat: support a custom base URL for the new relic provider

### DIFF
--- a/docs/analysis/newrelic.md
+++ b/docs/analysis/newrelic.md
@@ -38,3 +38,19 @@ data:
   account-id: <newrelic-account-id>
   region: "us" # optional, defaults to "us" if not set. Only set to "eu" if you use EU New Relic
 ```
+
+To use the New Relic metric provider from behind a proxy, provide a `base-url-rest` key pointing to the base URL of the New Relic REST API for your proxy, and a `base-url-nerdgraph` key pointing to the base URL for NerdGraph for your proxy:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: newrelic
+type: Opaque
+data:
+  personal-api-key: <newrelic-personal-api-key>
+  account-id: <newrelic-account-id>
+  region: "us" # optional, defaults to "us" if not set. Only set to "eu" if you use EU New Relic
+  base-url-rest: <your-base-url>
+  base-url-nerdgraph: <your-base-url>
+```

--- a/metricproviders/newrelic/newrelic.go
+++ b/metricproviders/newrelic/newrelic.go
@@ -155,15 +155,20 @@ func NewNewRelicAPIClient(metric v1alpha1.Metric, kubeclientset kubernetes.Inter
 
 	newrelicOptions := []newrelic.ConfigOption{newrelic.ConfigPersonalAPIKey(apiKey), newrelic.ConfigUserAgent(userAgent)}
 
-	// support either base-url or region; default to us region if neither is used
-	if _, ok := secret.Data["base-url"]; ok {
-		newrelicOptions = append(newrelicOptions, newrelic.ConfigBaseURL(string(secret.Data["base-url"])))
-	} else {
-		region := "us"
-		if _, ok := secret.Data["region"]; ok {
-			region = string(secret.Data["region"])
-		}
-		newrelicOptions = append(newrelicOptions, newrelic.ConfigRegion(region))
+	region := "us"
+	if _, ok := secret.Data["region"]; ok {
+		region = string(secret.Data["region"])
+	}
+	newrelicOptions = append(newrelicOptions, newrelic.ConfigRegion(region))
+
+	// base URL for the new relic REST API
+	if _, ok := secret.Data["base-url-rest"]; ok {
+		newrelicOptions = append(newrelicOptions, newrelic.ConfigBaseURL(string(secret.Data["base-url-rest"])))
+	}
+
+	// base URL for the nerdgraph (graphQL) API
+	if _, ok := secret.Data["base-url-nerdgraph"]; ok {
+		newrelicOptions = append(newrelicOptions, newrelic.ConfigNerdGraphBaseURL(string(secret.Data["base-url-nerdgraph"])))
 	}
 
 	if apiKey != "" && accountID != "" {

--- a/metricproviders/newrelic/newrelic_test.go
+++ b/metricproviders/newrelic/newrelic_test.go
@@ -348,9 +348,10 @@ func TestNewNewRelicAPIClient(t *testing.T) {
 
 	t.Run("when a base-url is set", func(t *testing.T) {
 		tokenSecret.Data = map[string][]byte{
-			"personal-api-key": []byte("ABCDEFG01234"),
-			"account-id":       []byte("12345"),
-			"base-url":         []byte("example.com"),
+			"personal-api-key":   []byte("ABCDEFG01234"),
+			"account-id":         []byte("12345"),
+			"base-url-rest":      []byte("example.com/api/v2"),
+			"base-url-nerdgraph": []byte("example.com/query"),
 		}
 		_, err := NewNewRelicAPIClient(metric, fakeClient)
 

--- a/metricproviders/newrelic/newrelic_test.go
+++ b/metricproviders/newrelic/newrelic_test.go
@@ -345,6 +345,17 @@ func TestNewNewRelicAPIClient(t *testing.T) {
 		// client defaults to US when not set or set to something incorrect, does not error
 		assert.Nil(t, err)
 	})
+
+	t.Run("when a base-url is set", func(t *testing.T) {
+		tokenSecret.Data = map[string][]byte{
+			"personal-api-key": []byte("ABCDEFG01234"),
+			"account-id":       []byte("12345"),
+			"base-url":         []byte("example.com"),
+		}
+		_, err := NewNewRelicAPIClient(metric, fakeClient)
+
+		assert.Nil(t, err)
+	})
 	t.Run("with api token or account id missing missing", func(t *testing.T) {
 		tokenSecret.Data = map[string][]byte{
 			"personal-api-key": []byte("ABCDEFG01234"),


### PR DESCRIPTION
Enables use of the provider by people accessing new relic via a proxy. Users should set either a `region` key or a `base-url` key in their new relic secret, and if neither is provided the provider will continue to default to the US region.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).