### PR TITLE
fix: controller panic with ephemeral containers with bad resource qty

### DIFF
--- a/rollout/controller.go
+++ b/rollout/controller.go
@@ -221,7 +221,7 @@ func NewController(cfg ControllerConfig) *Controller {
 					controller.IstioController.EnqueueDestinationRule(key)
 				}
 			}
-			controller.enqueueRollout(newRollout)
+			controller.enqueueRollout(new)
 		},
 		DeleteFunc: func(obj interface{}) {
 			if ro := unstructuredutil.ObjectToRollout(obj); ro != nil {

--- a/test/e2e/expectedfailures/malformed-rollout-ephemeral.yaml
+++ b/test/e2e/expectedfailures/malformed-rollout-ephemeral.yaml
@@ -1,0 +1,36 @@
+# This example reproduces a cornercase bug where there are multiple errors in the rollout causing a panic:
+# 1. duplicated name in the ephemeralContainer
+# 2. invalid resource request in ephemeral container
+# See: https://github.com/argoproj/argo-rollouts/issues/1045
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+#apiVersion: apps/v1
+#kind: Deployment
+metadata:
+  name: malformed-rollout-ephemeral
+spec:
+  selector:
+    matchLabels:
+      app: malformed-rollout-ephemeral
+  template:
+    metadata:
+      labels:
+        app: malformed-rollout-ephemeral
+    spec:
+      containers:
+      - name: malformed-rollout-ephemeral
+        image: argoproj/rollouts-demo:blue
+        resources:
+          requests:
+            memory: invalid # invalid
+      # NOTE: kubernetes drops the ephemeral containers list completely when one fails to unmarshal
+      # (e.g. when one has an invalid resource quantity). So for better or worse, this rollout will
+      # become healthy.
+      ephemeralContainers: 
+      - name: malformed-rollout-ephemeral   # duplicated name
+        image: argoproj/rollouts-demo:blue
+        resources:
+          requests:
+            memory: invalid # invalid
+  strategy:
+    canary: {}

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -260,6 +260,11 @@ func (s *FunctionalSuite) TestMalformedRollout() {
 		HealthyRollout(`@expectedfailures/malformed-rollout.yaml`)
 }
 
+func (s *FunctionalSuite) TestMalformedRolloutEphemeralCtr() {
+	s.Given().
+		HealthyRollout(`@expectedfailures/malformed-rollout-ephemeral.yaml`)
+}
+
 // TestContainerResourceFormats verifies resource requests are accepted in multiple formats and not
 // rejected by validation
 func (s *FunctionalSuite) TestContainerResourceFormats() {

--- a/utils/unstructured/unstructured.go
+++ b/utils/unstructured/unstructured.go
@@ -3,11 +3,13 @@ package unstructured
 import (
 	"regexp"
 
-	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/ghodss/yaml"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	logutil "github.com/argoproj/argo-rollouts/utils/log"
 )
 
 func StrToUnstructuredUnsafe(jsonStr string) *unstructured.Unstructured {
@@ -34,14 +36,15 @@ func ObjectToRollout(obj interface{}) *v1alpha1.Rollout {
 		var ro v1alpha1.Rollout
 		err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, &ro)
 		if err != nil {
-			log.Warnf("Failed to convert Rollout from Unstructured object: %v", err)
+			logCtx := logutil.WithUnstructured(un)
+			logCtx.Warnf("Failed to convert Rollout from Unstructured object: %v", err)
 			return nil
 		}
 		return &ro
 	}
 	ro, ok := obj.(*v1alpha1.Rollout)
 	if !ok {
-		log.Warn("Object is neither a rollout or unstructured")
+		log.Warnf("Object is neither a rollout or unstructured: %v", obj)
 	}
 	return ro
 }


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/1045

Fixes a controller panic recently introduced in pre-v1.0

Signed-off-by: Jesse Suen <jesse_suen@intuit.com>
