### PR TITLE
fix: spec.preserveUnknownFields must be explicitly false to allow upgrades from apiextensions.k8s.io/v1beta1

### DIFF
--- a/manifests/crds/analysis-run-crd.yaml
+++ b/manifests/crds/analysis-run-crd.yaml
@@ -13,6 +13,7 @@ spec:
     shortNames:
     - ar
     singular: analysisrun
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/manifests/crds/analysis-template-crd.yaml
+++ b/manifests/crds/analysis-template-crd.yaml
@@ -13,6 +13,7 @@ spec:
     shortNames:
     - at
     singular: analysistemplate
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1alpha1

--- a/manifests/crds/cluster-analysis-template-crd.yaml
+++ b/manifests/crds/cluster-analysis-template-crd.yaml
@@ -13,6 +13,7 @@ spec:
     shortNames:
     - cat
     singular: clusteranalysistemplate
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1

--- a/manifests/crds/experiment-crd.yaml
+++ b/manifests/crds/experiment-crd.yaml
@@ -13,6 +13,7 @@ spec:
     shortNames:
     - exp
     singular: experiment
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/manifests/crds/rollout-crd.yaml
+++ b/manifests/crds/rollout-crd.yaml
@@ -13,6 +13,7 @@ spec:
     shortNames:
     - ro
     singular: rollout
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -14,6 +14,7 @@ spec:
     shortNames:
     - ar
     singular: analysisrun
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -2516,6 +2517,7 @@ spec:
     shortNames:
     - at
     singular: analysistemplate
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1alpha1
@@ -4940,6 +4942,7 @@ spec:
     shortNames:
     - cat
     singular: clusteranalysistemplate
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1
@@ -7364,6 +7367,7 @@ spec:
     shortNames:
     - exp
     singular: experiment
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -9698,6 +9702,7 @@ spec:
     shortNames:
     - ro
     singular: rollout
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -14,6 +14,7 @@ spec:
     shortNames:
     - ar
     singular: analysisrun
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -2516,6 +2517,7 @@ spec:
     shortNames:
     - at
     singular: analysistemplate
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1alpha1
@@ -4940,6 +4942,7 @@ spec:
     shortNames:
     - cat
     singular: clusteranalysistemplate
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1
@@ -7364,6 +7367,7 @@ spec:
     shortNames:
     - exp
     singular: experiment
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -9698,6 +9702,7 @@ spec:
     shortNames:
     - ro
     singular: rollout
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/1067

After switching from v1beta1 to v1 CRD, the default value of `spec.preserveUnknownFields` in Kubernetes went from true to false. Because this field is unmanaged in our previous and current set of manifests, when upgrading from the v1beta1 CRD version to v1, it would encounter the following error:

> spec.preserveUnknownFields: Invalid value: true: must be false in order to use defaults in the schema

This is because when the v1 CRD was attempted to be applied (over the existing v1beta1 version), K8s rejected the update stating the value must be false (since a v1 manifest was being applied). This change explicitly sets it to false so that upgrades can happen from v0.10 to v1.0

Also removes our removeDescriptions workaround now that `controller-gen` has the ability to remove descriptions.

Signed-off-by: Jesse Suen <jesse_suen@intuit.com>
