### PR TITLE
fix: verify analysis arguments name with those in the rollout

### DIFF
--- a/pkg/apis/rollouts/validation/validation_references.go
+++ b/pkg/apis/rollouts/validation/validation_references.go
@@ -65,7 +65,7 @@ func ValidateRolloutReferencedResources(rollout *v1alpha1.Rollout, referencedRes
 		allErrs = append(allErrs, ValidateService(service, rollout)...)
 	}
 	for _, template := range referencedResources.AnalysisTemplateWithType {
-		allErrs = append(allErrs, ValidateAnalysisTemplateWithType(template)...)
+		allErrs = append(allErrs, ValidateAnalysisTemplateWithType(rollout, template)...)
 	}
 	for _, ingress := range referencedResources.Ingresses {
 		allErrs = append(allErrs, ValidateIngress(rollout, ingress)...)
@@ -92,7 +92,7 @@ func ValidateService(svc ServiceWithType, rollout *v1alpha1.Rollout) field.Error
 	return allErrs
 }
 
-func ValidateAnalysisTemplateWithType(template AnalysisTemplateWithType) field.ErrorList {
+func ValidateAnalysisTemplateWithType(rollout *v1alpha1.Rollout, template AnalysisTemplateWithType) field.ErrorList {
 	allErrs := field.ErrorList{}
 	fldPath := GetAnalysisTemplateWithTypeFieldPath(template.TemplateType, template.AnalysisIndex, template.CanaryStepIndex)
 	if fldPath == nil {
@@ -119,6 +119,29 @@ func ValidateAnalysisTemplateWithType(template AnalysisTemplateWithType) field.E
 					msg := fmt.Sprintf("AnalysisTemplate %s has metric %s which runs indefinitely. Invalid value for count: %s", templateName, metric.Name, metric.Count)
 					allErrs = append(allErrs, field.Invalid(fldPath, templateName, msg))
 				}
+			}
+		}
+	} else if template.TemplateType == BackgroundAnalysis && len(templateSpec.Args) > 0 {
+		if rollout.Spec.Strategy.Canary == nil || rollout.Spec.Strategy.Canary.Analysis == nil || rollout.Spec.Strategy.Canary.Analysis.Args == nil {
+			allErrs = append(allErrs, field.Invalid(fldPath, templateName, "missing analysis arguments in rollout spec"))
+			return allErrs
+		}
+
+		if len(rollout.Spec.Strategy.Canary.Analysis.Args) < len(templateSpec.Args) {
+			allErrs = append(allErrs, field.Invalid(fldPath, templateName, "not enough analysis arguments in rollout spec"))
+			return allErrs
+		}
+
+		for _, arg := range templateSpec.Args {
+			foundArg := false
+			for _, rolloutarg := range rollout.Spec.Strategy.Canary.Analysis.Args {
+				if arg.Name == rolloutarg.Name {
+					foundArg = true
+					break
+				}
+			}
+			if !foundArg {
+				allErrs = append(allErrs, field.Invalid(fldPath, templateName, arg.Name))
 			}
 		}
 	}

--- a/pkg/apis/rollouts/validation/validation_references.go
+++ b/pkg/apis/rollouts/validation/validation_references.go
@@ -122,20 +122,18 @@ func ValidateAnalysisTemplateWithType(rollout *v1alpha1.Rollout, template Analys
 			}
 		}
 	} else if template.TemplateType == BackgroundAnalysis && len(templateSpec.Args) > 0 {
-		if rollout.Spec.Strategy.Canary == nil || rollout.Spec.Strategy.Canary.Analysis == nil || rollout.Spec.Strategy.Canary.Analysis.Args == nil {
-			allErrs = append(allErrs, field.Invalid(fldPath, templateName, "missing analysis arguments in rollout spec"))
-			return allErrs
-		}
-
-		if len(rollout.Spec.Strategy.Canary.Analysis.Args) < len(templateSpec.Args) {
-			allErrs = append(allErrs, field.Invalid(fldPath, templateName, "not enough analysis arguments in rollout spec"))
-			return allErrs
-		}
-
 		for _, arg := range templateSpec.Args {
+			if arg.Value != nil || arg.ValueFrom != nil {
+				continue
+			}
+			if rollout.Spec.Strategy.Canary == nil || rollout.Spec.Strategy.Canary.Analysis == nil || rollout.Spec.Strategy.Canary.Analysis.Args == nil {
+				allErrs = append(allErrs, field.Invalid(fldPath, templateName, "missing analysis arguments in rollout spec"))
+				continue
+			}
+
 			foundArg := false
-			for _, rolloutarg := range rollout.Spec.Strategy.Canary.Analysis.Args {
-				if arg.Name == rolloutarg.Name {
+			for _, rolloutArg := range rollout.Spec.Strategy.Canary.Analysis.Args {
+				if arg.Name == rolloutArg.Name {
 					foundArg = true
 					break
 				}

--- a/pkg/apis/rollouts/validation/validation_references_test.go
+++ b/pkg/apis/rollouts/validation/validation_references_test.go
@@ -225,6 +225,17 @@ func TestValidateAnalysisTemplateWithType(t *testing.T) {
 		allErrs := ValidateAnalysisTemplateWithType(rollout, template)
 		assert.Empty(t, allErrs)
 
+		// default value should be fine
+		defaultValue := "value-name"
+		template.AnalysisTemplate.Spec.Args = []v1alpha1.Argument{
+			{
+				Name:  "service-name",
+				Value: &defaultValue,
+			},
+		}
+		allErrs = ValidateAnalysisTemplateWithType(rollout, template)
+		assert.Empty(t, allErrs)
+
 		template.AnalysisTemplate.Spec.Args = []v1alpha1.Argument{
 			{
 				Name: "service-name",


### PR DESCRIPTION
- return error if arguments do not match between rollout spec and analysis template

close #1052 