### PR TITLE
feat: [datadog metricprovider] Allow Datadog API and APP keys to be c…

### DIFF
--- a/metricproviders/datadog/datadog.go
+++ b/metricproviders/datadog/datadog.go
@@ -28,6 +28,9 @@ const (
 	//ProviderType indicates the provider is datadog
 	ProviderType            = "Datadog"
 	DatadogTokensSecretName = "datadog"
+	DatadogApiKey           = "api-key"
+	DatadogAppKey           = "app-key"
+	DatadogAddress          = "address"
 )
 
 // Provider contains all the required components to run a Datadog query
@@ -167,36 +170,40 @@ func (p *Provider) GarbageCollect(run *v1alpha1.AnalysisRun, metric v1alpha1.Met
 	return nil
 }
 
-func getSecretValue(key, ns string, kubeclientset kubernetes.Interface, emptyValueOk bool) (string, error) {
-	envKey := strings.ToUpper(strings.ReplaceAll(key, "-", "_"))
-	if value, ok := os.LookupEnv(fmt.Sprintf("DD_%s", envKey)); ok {
-		return value, nil
+func lookupKeysInEnv(keys []string) map[string]string {
+	valuesByKey := make(map[string]string)
+	for i := range keys {
+		key := keys[i]
+		formattedKey := strings.ToUpper(strings.ReplaceAll(key, "-", "_"))
+		if value, ok := os.LookupEnv(fmt.Sprintf("DD_%s", formattedKey)); ok {
+			valuesByKey[key] = value
+		}
 	}
-	secret, err := kubeclientset.CoreV1().Secrets(ns).Get(context.TODO(), DatadogTokensSecretName, metav1.GetOptions{})
-	if err != nil {
-		return "", err
-	}
-	_, valueMaybe := secret.Data[key]
-	if emptyValueOk && !valueMaybe {
-		return "", nil
-	}
-
-	return string(secret.Data[key]), nil
+	return valuesByKey
 }
 
 func NewDatadogProvider(logCtx log.Entry, kubeclientset kubernetes.Interface) (*Provider, error) {
 	ns := defaults.Namespace()
-	apiKey, err := getSecretValue("api-key", ns, kubeclientset, false)
-	if err != nil {
-		return nil, err
-	}
-	appKey, err := getSecretValue("app-key", ns, kubeclientset, false)
-	if err != nil {
-		return nil, err
-	}
-	address, err := getSecretValue("address", ns, kubeclientset, true)
-	if err != nil {
-		return nil, err
+
+	apiKey := ""
+	appKey := ""
+	address := ""
+	secretKeys := []string{DatadogApiKey, DatadogAppKey, DatadogAddress}
+	envValuesByKey := lookupKeysInEnv(secretKeys)
+	if len(envValuesByKey) == len(secretKeys) {
+		apiKey = envValuesByKey[DatadogApiKey]
+		appKey = envValuesByKey[DatadogAppKey]
+		address = envValuesByKey[DatadogAddress]
+	} else {
+		secret, err := kubeclientset.CoreV1().Secrets(ns).Get(context.TODO(), DatadogTokensSecretName, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		apiKey = string(secret.Data[DatadogApiKey])
+		appKey = string(secret.Data[DatadogAppKey])
+		if _, hasAddress := secret.Data[DatadogAddress]; hasAddress {
+			address = string(secret.Data[DatadogAddress])
+		}
 	}
 
 	if apiKey != "" && appKey != "" {


### PR DESCRIPTION
## Why
My organization has a pattern where keys are stored in a secret cloud provider which get auto-synced as generic k8s secrets across regions. Rather than duplicate these keys in their own `datadog` k8s-secret, it would be much more convenient for us to mount the original secret values as environment variables for argo-rollouts. This also eliminates the need for granting the argo-rollouts pod the API permission to access the `datadog` k8s-secret.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).