### PR TITLE
feat: add new v1.0 features to kustomize transformer configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ lint:
 	golangci-lint run --fix
 
 .PHONY: test
-test:
+test: test-kustomize
 	go test -covermode=count -coverprofile=coverage.out ${TEST_TARGET}
 
 .PHONY: test-kustomize

--- a/docs/features/kustomize/rollout-transform.yaml
+++ b/docs/features/kustomize/rollout-transform.yaml
@@ -132,6 +132,11 @@ nameReference:
   fieldSpecs:
   - path: spec/strategy/canary/trafficRouting/istio/virtualService/name
     kind: Rollout
+- kind: DestinationRule
+  group: networking.istio.io
+  fieldSpecs:
+  - path: spec/strategy/canary/trafficRouting/istio/destinationRule/name
+    kind: Rollout
 - kind: Ingress
   group: networking.k8s.io
   fieldSpecs:
@@ -165,6 +170,17 @@ nameReference:
   fieldSpecs:
   - path: spec/scaleTargetRef/name
     kind: HorizontalPodAutoscaler
+- kind: Deployment
+  version: v1
+  group: apps
+  fieldSpecs:
+  - path: spec/workloadRef/name
+    kind: Rollout
+- kind: Mapping
+  group: getambassador.io
+  fieldSpecs:
+  - path: spec/strategy/canary/trafficRouting/ambassador/mappings
+    kind: Rollout
 
 # https://github.com/kubernetes-sigs/kustomize/blob/master/api/konfig/builtinpluginconsts/commonlabels.go
 commonLabels:

--- a/test/kustomize/rollout/expected.yaml
+++ b/test/kustomize/rollout/expected.yaml
@@ -16,7 +16,7 @@ metadata:
     foo: bar
   labels:
     foo: bar
-  name: my-guestbook-cm-bt8kmct6gk
+  name: my-guestbook-cm-m2mg5mb749
 ---
 apiVersion: v1
 data:
@@ -27,7 +27,7 @@ metadata:
     foo: bar
   labels:
     foo: bar
-  name: my-guestbook-secret-t95h96m85d
+  name: my-guestbook-secret-ccbkcc9264
 type: Opaque
 ---
 apiVersion: v1
@@ -64,6 +64,33 @@ spec:
     app: guestbook
     foo: bar
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    foo: bar
+  labels:
+    foo: bar
+  name: my-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+      foo: bar
+  template:
+    metadata:
+      annotations:
+        foo: bar
+      labels:
+        app: nginx
+        foo: bar
+    spec:
+      containers:
+      - image: nginx:1.14.2
+        name: nginx
+        ports:
+        - containerPort: 80
+---
 apiVersion: argoproj.io/v1alpha1
 kind: AnalysisTemplate
 metadata:
@@ -92,11 +119,11 @@ spec:
               serviceAccountName: my-robot
               volumes:
               - configMap:
-                  name: my-guestbook-cm-bt8kmct6gk
+                  name: my-guestbook-cm-m2mg5mb749
                 name: config-volume
               - name: secret-volume
                 secret:
-                  secretName: my-guestbook-secret-t95h96m85d
+                  secretName: my-guestbook-secret-ccbkcc9264
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Experiment
@@ -125,11 +152,11 @@ spec:
         serviceAccountName: my-robot
         volumes:
         - configMap:
-            name: my-guestbook-cm-bt8kmct6gk
+            name: my-guestbook-cm-m2mg5mb749
           name: config-volume
         - name: secret-volume
           secret:
-            secretName: my-guestbook-secret-t95h96m85d
+            secretName: my-guestbook-secret-ccbkcc9264
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
@@ -166,7 +193,12 @@ spec:
       trafficRouting:
         alb:
           ingress: my-networking-ingress
+        ambassador:
+          mappings:
+          - my-mapping
         istio:
+          destinationRule:
+            name: my-guestbook-destrule
           virtualService:
             name: my-guestbook-vsvc
             routes:
@@ -197,12 +229,12 @@ spec:
           valueFrom:
             secretKeyRef:
               key: password
-              name: my-guestbook-secret-t95h96m85d
+              name: my-guestbook-secret-ccbkcc9264
         - name: FOO
           valueFrom:
             configMapKeyRef:
               key: FOO
-              name: my-guestbook-cm-bt8kmct6gk
+              name: my-guestbook-cm-m2mg5mb749
         image: guestbook:v2
         name: guestbook
         ports:
@@ -217,11 +249,15 @@ spec:
       serviceAccountName: my-robot
       volumes:
       - configMap:
-          name: my-guestbook-cm-bt8kmct6gk
+          name: my-guestbook-cm-m2mg5mb749
         name: config-volume
       - name: secret-volume
         secret:
-          secretName: my-guestbook-secret-t95h96m85d
+          secretName: my-guestbook-secret-ccbkcc9264
+  workloadRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: my-deployment
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
@@ -260,6 +296,37 @@ spec:
       - backend:
           serviceName: website
           servicePort: 80
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  annotations:
+    foo: bar
+  labels:
+    foo: bar
+  name: my-mapping
+spec:
+  prefix: /someapp
+  rewrite: /
+  service: someapp-stable:80
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  annotations:
+    foo: bar
+  labels:
+    foo: bar
+  name: my-guestbook-destrule
+spec:
+  host: guestbook
+  subsets:
+  - labels:
+      app: guestbook
+    name: canary
+  - labels:
+      app: guestbook
+    name: stable
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService

--- a/test/kustomize/rollout/rollout.yaml
+++ b/test/kustomize/rollout/rollout.yaml
@@ -1,8 +1,13 @@
+# NOTE: this rollout is invalid and is only used to test kustomize transformers
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
   name: guestbook
 spec:
+  workloadRef:
+    kind: Deployment
+    apiVersion: apps/v1
+    name: deployment
   selector:
     matchLabels:
       app: guestbook
@@ -60,11 +65,16 @@ spec:
           virtualService:
             name: guestbook-vsvc
             routes:
-              - primary
+            - primary
+          destinationRule:
+            name: guestbook-destrule
         nginx:
           stableIngress: extensions-ingress
         alb:
           ingress: networking-ingress
+        ambassador:
+          mappings:
+          - mapping
       analysis:
         templates:
         - templateName: random-fail
@@ -129,6 +139,21 @@ spec:
     - destination:
         host: guestbook-canary-svc
       weight: 0
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: guestbook-destrule
+spec:
+  host: guestbook
+  subsets:
+  - name: canary
+    labels:
+      app: guestbook
+  - name: stable
+    labels:
+      app: guestbook
 
 ---
 apiVersion: v1
@@ -237,4 +262,33 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: robot
-  
+
+---
+apiVersion: getambassador.io/v2
+kind:  Mapping
+metadata:
+  name: mapping
+spec:
+  prefix: /someapp
+  rewrite: /
+  service: someapp-stable:80
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/test/kustomize/test.sh
+++ b/test/kustomize/test.sh
@@ -4,7 +4,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 for i in `ls ${DIR}/*/kustomization.yaml`; do
     dir_name=$(dirname $i)
-    diff_out=$(diff ${dir_name}/expected.yaml <(kustomize build ${dir_name} --load_restrictor none))
+    diff_out=$(diff ${dir_name}/expected.yaml <(kustomize build ${dir_name} --load-restrictor=LoadRestrictionsNone))
     if [[ $? -ne 0 ]]; then
         echo "${i} had unexpected diff:"
         echo "${diff_out}"


### PR DESCRIPTION
Teaches kustomize about:
* istio DestinationRule references
* workload references to Deployments
* ambassador Mapping references

Also updates kustomize test to assume v4.0

Signed-off-by: Jesse Suen <jesse_suen@intuit.com>
