### PR TITLE
fix: build 'latest' tag from master. prefix 'v' in release builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,6 +31,30 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
+      - name: Docker meta (controller)
+        id: controller-meta
+        uses: crazy-max/ghaction-docker-meta@v2
+        with:
+          images: |
+            quay.io/argoproj/argo-rollouts
+            ghcr.io/argoproj/argo-rollouts
+          tags: |
+            type=ref,event=branch
+          flavor: |
+            latest=${{ github.ref == 'refs/heads/master' }}
+
+      - name: Docker meta (plugin)
+        id: plugin-meta
+        uses: crazy-max/ghaction-docker-meta@v2
+        with:
+          images: |
+            quay.io/argoproj/kubectl-argo-rollouts
+            ghcr.io/argoproj/kubectl-argo-rollouts
+          tags: |
+            type=ref,event=branch
+          flavor: |
+            latest=${{ github.ref == 'refs/heads/master' }}
+
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v1 
@@ -46,26 +70,6 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
-
-      - name: Docker meta (controller)
-        id: controller-meta
-        uses: crazy-max/ghaction-docker-meta@v2
-        with:
-          images: |
-            quay.io/argoproj/argo-rollouts
-            ghcr.io/argoproj/argo-rollouts
-          tags: |
-            type=ref,event=branch
-
-      - name: Docker meta (plugin)
-        id: plugin-meta
-        uses: crazy-max/ghaction-docker-meta@v2
-        with:
-          images: |
-            quay.io/argoproj/kubectl-argo-rollouts
-            ghcr.io/argoproj/kubectl-argo-rollouts
-          tags: |
-            type=ref,event=branch
 
       # avoid building linux/arm64 for PRs since it takes so long
       - name: Set Platform Matrix

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,26 @@ jobs:
           df -ah
           docker buildx du
 
+      - name: Docker meta (controller)
+        id: controller-meta
+        uses: crazy-max/ghaction-docker-meta@v2
+        with:
+          images: |
+            quay.io/argoproj/argo-rollouts
+            ghcr.io/argoproj/argo-rollouts
+          tags: |
+            type=semver,pattern={{version}},prefix=v,value=${{ github.event.inputs.tag }}
+
+      - name: Docker meta (plugin)
+        id: plugin-meta
+        uses: crazy-max/ghaction-docker-meta@v2
+        with:
+          images: |
+            quay.io/argoproj/kubectl-argo-rollouts
+            ghcr.io/argoproj/kubectl-argo-rollouts
+          tags: |
+            type=semver,pattern={{version}},prefix=v,value=${{ github.event.inputs.tag }}
+
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v1 
@@ -51,26 +71,6 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
-
-      - name: Docker meta (controller)
-        id: controller-meta
-        uses: crazy-max/ghaction-docker-meta@v2
-        with:
-          images: |
-            quay.io/argoproj/argo-rollouts
-            ghcr.io/argoproj/argo-rollouts
-          tags: |
-            type=semver,pattern=v{{version}},value=${{ github.event.inputs.tag }}
-
-      - name: Docker meta (plugin)
-        id: plugin-meta
-        uses: crazy-max/ghaction-docker-meta@v2
-        with:
-          images: |
-            quay.io/argoproj/kubectl-argo-rollouts
-            ghcr.io/argoproj/kubectl-argo-rollouts
-          tags: |
-            type=semver,pattern=v{{version}},value=${{ github.event.inputs.tag }}
 
       - name: Build and push (controller-image)
         uses: docker/build-push-action@v2


### PR DESCRIPTION
* fix: `latest` docker tag will now be built from `master` branch. 
* fix: the release build still did not prefix `v` in the image tag

Signed-off-by: Jesse Suen <jesse_suen@intuit.com>