### PR TITLE
fix: set rollout status to degraded for non-existent deploy 

### DIFF
--- a/rollout/controller.go
+++ b/rollout/controller.go
@@ -353,6 +353,12 @@ func (c *Controller) syncHandler(key string) error {
 	r := remarshalRollout(rollout)
 
 	if err := c.refResolver.Resolve(r); err != nil {
+		invalidSpecCond := conditions.NewRolloutCondition(v1alpha1.InvalidSpec, corev1.ConditionTrue, conditions.InvalidSpecReason, err.Error())
+		cr := r.DeepCopy()
+		cr.Status.Conditions = append(cr.Status.Conditions, *invalidSpecCond)
+		_, err = c.argoprojclientset.ArgoprojV1alpha1().Rollouts(r.Namespace).UpdateStatus(
+			context.TODO(), cr, metav1.UpdateOptions{},
+		)
 		return err
 	}
 

--- a/rollout/controller.go
+++ b/rollout/controller.go
@@ -345,6 +345,7 @@ func (c *Controller) updateInvalidRolloutRefConditions(r *v1alpha1.Rollout, errm
 		invalidSpecCond := conditions.NewRolloutCondition(v1alpha1.InvalidSpec, corev1.ConditionTrue, conditions.InvalidSpecReason, errmsg)
 		cr = r.DeepCopy()
 		cr.Status.Conditions = append(cr.Status.Conditions, *invalidSpecCond)
+		cr.Status.ObservedGeneration = strconv.Itoa(int(cr.Generation))
 	}
 	return cr
 }
@@ -374,7 +375,7 @@ func (c *Controller) syncHandler(key string) error {
 
 	if err := c.refResolver.Resolve(r); err != nil {
 		if cr := c.updateInvalidRolloutRefConditions(r, err.Error()); cr != nil {
-			_, err = c.argoprojclientset.ArgoprojV1alpha1().Rollouts(r.Namespace).UpdateStatus(
+			_, err := c.argoprojclientset.ArgoprojV1alpha1().Rollouts(r.Namespace).UpdateStatus(
 				context.TODO(), cr, metav1.UpdateOptions{},
 			)
 			if err != nil {

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -982,26 +982,6 @@ spec:
     port: 80
     targetPort: 8080
 ---
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app.kubernetes.io/instance: rollout-canary
-  name: rollout-ref-deployment
-spec:
-  replicas: 0
-  selector:
-    matchLabels:
-      app: rollout-ref-deployment
-  template:
-    metadata:
-      labels:
-        app: rollout-ref-deployment
-    spec:
-      containers:
-        - name: rollouts-demo
-          image: argoproj/rollouts-demo:error
----
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
@@ -1025,6 +1005,32 @@ spec:
 		// verify that existing service is not switched to degraded rollout pods
 		ExpectServiceSelector("rollout-bluegreen-active", map[string]string{"app": "rollout-ref-deployment"}, false).
 		When().
+		ApplyManifests(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: rollout-canary
+  name: rollout-ref-deployment
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: rollout-ref-deployment
+  template:
+    metadata:
+      labels:
+        app: rollout-ref-deployment
+    spec:
+      containers:
+        - name: rollouts-demo
+          image: argoproj/rollouts-demo:green
+    `).
+		WaitForRolloutStatus("Healthy").
+		Then().
+		// verify that service is switched after rollout is healthy
+		ExpectServiceSelector("rollout-bluegreen-active", map[string]string{"app": "rollout-ref-deployment"}, true).
+		When().
 		UpdateResource(appsv1.SchemeGroupVersion.WithResource("deployments"), "rollout-ref-deployment", func(res *unstructured.Unstructured) error {
 			containers, _, err := unstructured.NestedSlice(res.Object, "spec", "template", "spec", "containers")
 			if err != nil {
@@ -1032,10 +1038,40 @@ spec:
 			}
 			containers[0] = map[string]interface{}{
 				"name":  "rollouts-demo",
-				"image": "argoproj/rollouts-demo:green",
+				"image": "argoproj/rollouts-demo:error",
 			}
 			return unstructured.SetNestedSlice(res.Object, containers, "spec", "template", "spec", "containers")
 		}).
+		WaitForRolloutStatus("Degraded").
+		Then().
+		When().
+		UpdateResource(appsv1.SchemeGroupVersion.WithResource("deployments"), "rollout-ref-deployment", func(res *unstructured.Unstructured) error {
+			containers, _, err := unstructured.NestedSlice(res.Object, "spec", "template", "spec", "containers")
+			if err != nil {
+				return err
+			}
+			containers[0] = map[string]interface{}{
+				"name":  "rollouts-demo",
+				"image": "argoproj/rollouts-demo:blue",
+			}
+			return unstructured.SetNestedSlice(res.Object, containers, "spec", "template", "spec", "containers")
+		}).
+		WaitForRolloutStatus("Healthy").
+		UpdateSpec(`
+spec:
+  workloadRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: non-existent-deploy
+`).
+		WaitForRolloutStatus("Degraded").
+		UpdateSpec(`
+spec:
+  workloadRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: rollout-ref-deployment
+`).
 		WaitForRolloutStatus("Healthy").
 		Then().
 		// verify that service is switched after rollout is healthy

--- a/test/fixtures/e2e_suite.go
+++ b/test/fixtures/e2e_suite.go
@@ -55,6 +55,12 @@ var (
 	// All e2e tests will be labeled with their test name
 	E2ELabelKeyTestName = "e2e-test-name"
 
+	deploymentGVR = schema.GroupVersionResource{
+		Group:    "apps",
+		Version:  "v1",
+		Resource: "deployments",
+	}
+
 	serviceGVR = schema.GroupVersionResource{
 		Version:  "v1",
 		Resource: "services",
@@ -185,6 +191,7 @@ func (s *E2ESuite) deleteResources(req *labels.Requirement, propagationPolicy me
 		rov1.AnalysisTemplateGVR,
 		rov1.ClusterAnalysisTemplateGVR,
 		rov1.ExperimentGVR,
+		deploymentGVR,
 		serviceGVR,
 		ingressGVR,
 		pdbGVR,


### PR DESCRIPTION
- the rollout status is set to degraded if the referenced
  deployment doesn't exist, while the replicaset of the
  rollout remains

Signed-off-by: Hui Kang <hui.kang@salesforce.com>

Address #1123 