### PR TITLE
fix: parse string to fixed-size int32

### DIFF
--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -543,7 +543,7 @@ type RolloutPause struct {
 func (p RolloutPause) DurationSeconds() int32 {
 	if p.Duration != nil {
 		if p.Duration.Type == intstr.String {
-			s, err := strconv.Atoi(p.Duration.StrVal)
+			s, err := strconv.ParseInt(p.Duration.StrVal, 10, 32)
 			if err != nil {
 				d, err := time.ParseDuration(p.Duration.StrVal)
 				if err != nil {

--- a/pkg/apis/rollouts/v1alpha1/types_test.go
+++ b/pkg/apis/rollouts/v1alpha1/types_test.go
@@ -21,4 +21,6 @@ func TestRolloutPauseDuration(t *testing.T) {
 	assert.Equal(t, int32(0), rp.DurationSeconds())
 	rp.Duration = DurationFromString("1z")
 	assert.Equal(t, int32(-1), rp.DurationSeconds())
+	rp.Duration = DurationFromString("20000000000") // out of int32
+	assert.Equal(t, int32(-1), rp.DurationSeconds())
 }

--- a/utils/annotations/annotations.go
+++ b/utils/annotations/annotations.go
@@ -40,7 +40,7 @@ func getIntFromAnnotation(rs *appsv1.ReplicaSet, annotationKey string) (int32, b
 	if !ok {
 		return int32(0), false
 	}
-	intValue, err := strconv.Atoi(annotationValue)
+	intValue, err := strconv.ParseInt(annotationValue, 10, 32)
 	if err != nil {
 		log.Warnf("Cannot convert the value %q with annotation key %q for the replica set %q", annotationValue, annotationKey, rs.Name)
 		return int32(0), false
@@ -186,7 +186,7 @@ func IsSaturated(rollout *v1alpha1.Rollout, rs *appsv1.ReplicaSet) bool {
 		return false
 	}
 	desiredString := rs.Annotations[DesiredReplicasAnnotation]
-	desired, err := strconv.Atoi(desiredString)
+	desired, err := strconv.ParseInt(desiredString, 10, 32)
 	if err != nil {
 		return false
 	}

--- a/utils/annotations/annotations_test.go
+++ b/utils/annotations/annotations_test.go
@@ -246,6 +246,13 @@ func TestAnnotationUtils(t *testing.T) {
 		}
 	})
 
+	t.Run("GetDesiredReplicasAnnotationOutOfInt32Value", func(t *testing.T) {
+		cRS := tRS.DeepCopy()
+		cRS.Annotations[DesiredReplicasAnnotation] = "20000000000"
+		_, ok := GetDesiredReplicasAnnotation(cRS)
+		assert.Equal(t, false, ok, "Should be an error as 20M value does not fit into int32")
+	})
+
 	//Check if annotations reflect rollouts state
 	tRS.Annotations[DesiredReplicasAnnotation] = "1"
 	tRS.Status.AvailableReplicas = 1


### PR DESCRIPTION
Use trconv.ParseInt method with fixed-size 32 bit int instead of Atoi to avoid undesirable program behavior

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).