### PR TITLE
feat: lint supporting rollout in multiple doc

### DIFF
--- a/pkg/kubectl-argo-rollouts/cmd/lint/lint.go
+++ b/pkg/kubectl-argo-rollouts/cmd/lint/lint.go
@@ -3,6 +3,7 @@ package lint
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"io/ioutil"
 	"unicode"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options"
 	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
+	goyaml "gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -73,21 +75,12 @@ func unmarshal(fileBytes []byte, obj interface{}) error {
 	return yaml.UnmarshalStrict(fileBytes, &obj, yaml.DisallowUnknownFields)
 }
 
-func (l *LintOptions) lintResource(path string) error {
-	fileBytes, err := ioutil.ReadFile(path)
-	if err != nil {
-		return err
-	}
-	var un unstructured.Unstructured
-	err = unmarshal(fileBytes, &un)
-	if err != nil {
-		return err
-	}
+func validate(fileBytes []byte, un *unstructured.Unstructured) error {
 	gvk := un.GroupVersionKind()
 	switch {
 	case gvk.Group == rollouts.Group && gvk.Kind == rollouts.RolloutKind:
 		var ro v1alpha1.Rollout
-		err = unmarshal(fileBytes, &ro)
+		err := unmarshal(fileBytes, &ro)
 		if err != nil {
 			return err
 		}
@@ -96,5 +89,46 @@ func (l *LintOptions) lintResource(path string) error {
 			return errs[0]
 		}
 	}
+	return nil
+}
+
+func (l *LintOptions) lintResource(path string) error {
+	fileBytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	var un unstructured.Unstructured
+
+	if isJSON(fileBytes) {
+		if err = unmarshal(fileBytes, un); err != nil {
+			return err
+		}
+		return validate(fileBytes, &un)
+	}
+
+	decoder := goyaml.NewDecoder(bytes.NewReader(fileBytes))
+	for {
+		var value interface{}
+		if err := decoder.Decode(&value); err != nil {
+			if err != io.EOF {
+				return err
+			}
+			break
+		}
+		valueBytes, err := goyaml.Marshal(value)
+		if err != nil {
+			return err
+		}
+
+		if err = yaml.UnmarshalStrict(valueBytes, &un, yaml.DisallowUnknownFields); err != nil {
+			return err
+		}
+
+		if err = validate(valueBytes, &un); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/pkg/kubectl-argo-rollouts/cmd/lint/lint_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/lint/lint_test.go
@@ -23,17 +23,45 @@ func TestLintValidRollout(t *testing.T) {
 }
 
 func TestLintInvalidRollout(t *testing.T) {
-	tf, o := options.NewFakeArgoRolloutsOptions()
-	defer tf.Cleanup()
+	var runCmd func(string, string)
 
-	cmd := NewCmdLint(o)
-	cmd.PersistentPreRunE = o.PersistentPreRunE
-	cmd.SetArgs([]string{"-f", "testdata/invalid.yml"})
-	err := cmd.Execute()
-	assert.Error(t, err)
+	tests := []struct {
+		filename string
+		errmsg   string
+	}{
 
-	stdout := o.Out.(*bytes.Buffer).String()
-	stderr := o.ErrOut.(*bytes.Buffer).String()
-	assert.Empty(t, stdout)
-	assert.Equal(t, "Error: spec.strategy.maxSurge: Invalid value: intstr.IntOrString{Type:0, IntVal:0, StrVal:\"\"}: MaxSurge and MaxUnavailable both can not be zero\n", stderr)
+		{
+			"testdata/invalid.yml",
+			"Error: spec.strategy.maxSurge: Invalid value: intstr.IntOrString{Type:0, IntVal:0, StrVal:\"\"}: MaxSurge and MaxUnavailable both can not be zero\n",
+		},
+		{
+			"testdata/invalid-multiple-docs.yml",
+			"Error: spec.strategy.maxSurge: Invalid value: intstr.IntOrString{Type:0, IntVal:0, StrVal:\"\"}: MaxSurge and MaxUnavailable both can not be zero\n",
+		},
+
+		{
+			"testdata/invalid-unknown-field.yml",
+			"Error: error unmarshaling JSON: while decoding JSON: json: unknown field \"unknown-strategy\"\n",
+		},
+	}
+
+	runCmd = func(filename string, errmsg string) {
+		tf, o := options.NewFakeArgoRolloutsOptions()
+		defer tf.Cleanup()
+
+		cmd := NewCmdLint(o)
+		cmd.PersistentPreRunE = o.PersistentPreRunE
+		cmd.SetArgs([]string{"-f", filename})
+		err := cmd.Execute()
+		assert.Error(t, err)
+
+		stdout := o.Out.(*bytes.Buffer).String()
+		stderr := o.ErrOut.(*bytes.Buffer).String()
+		assert.Empty(t, stdout)
+		assert.Equal(t, errmsg, stderr)
+	}
+
+	for _, t := range tests {
+		runCmd(t.filename, t.errmsg)
+	}
 }

--- a/pkg/kubectl-argo-rollouts/cmd/lint/testdata/invalid-multiple-docs.yml
+++ b/pkg/kubectl-argo-rollouts/cmd/lint/testdata/invalid-multiple-docs.yml
@@ -1,0 +1,53 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: argo-rollouts-metrics
+  labels:
+    region: us-west
+spec:
+  ports:
+  - name: metrics
+    protocol: TCP
+    port: 8090
+    targetPort: 8090
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: invalid-rollout
+spec:
+  revisionHistoryLimit: 1
+  replicas: 1
+  strategy:
+    canary:
+      maxUnavailable: 0
+      maxSurge: 0
+      analysis:
+        templates:
+          - templateName: integrationtests
+      steps:
+        - setWeight: 10
+        - setWeight: 20
+        - setWeight: 40
+        - setWeight: 80
+  selector:
+    matchLabels:
+      app: invalid-rollout
+  template:
+    metadata:
+      labels:
+        app: invalid-rollout
+    spec:
+      containers:
+        - name: invalid-rollout
+          image: invalid-rollout:0.0.0
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 8080
+            periodSeconds: 5

--- a/pkg/kubectl-argo-rollouts/cmd/lint/testdata/invalid-unknown-field.yml
+++ b/pkg/kubectl-argo-rollouts/cmd/lint/testdata/invalid-unknown-field.yml
@@ -1,0 +1,34 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: invalid-rollout
+spec:
+  replicas: 10
+  strategy:
+    unknown-strategy:
+      analysis:
+        templates:
+          - templateName: integrationtests
+      steps:
+        - setWeight: 10
+  selector:
+    matchLabels:
+      app: invalid-rollout
+  template:
+    metadata:
+      labels:
+        app: invalid-rollout
+    spec:
+      containers:
+        - name: invalid-rollout
+          image: valid-rollout:0.0.0
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 8080
+            periodSeconds: 5


### PR DESCRIPTION
- to support use cases where the yaml file may contain other objects like
  deploy, service, etc

The current lint implementation does not report error if an invalid rollout yaml contains another valid resource like service - added example in unit test.

Signed-off-by: Hui Kang <hui.kang@salesforce.com>
