### PR TITLE
feat: record events for RolloutPaused and RolloutResumed

### DIFF
--- a/controller/metrics/rollouts.go
+++ b/controller/metrics/rollouts.go
@@ -68,7 +68,7 @@ func calculatePhase(rollout *v1alpha1.Rollout) RolloutPhase {
 		if progressing.Reason == conditions.NewRSAvailableReason {
 			phase = RolloutCompleted
 		}
-		if progressing.Reason == conditions.PausedRolloutReason {
+		if progressing.Reason == conditions.RolloutPausedReason {
 			phase = RolloutPaused
 		}
 		if progressing.Reason == conditions.ServiceNotFoundReason || progressing.Reason == conditions.FailedRSCreateReason {

--- a/rollout/analysis_test.go
+++ b/rollout/analysis_test.go
@@ -1443,7 +1443,7 @@ func TestDoNotCreateBackgroundAnalysisRunAfterInconclusiveRun(t *testing.T) {
 		StartTime: metav1.Now(),
 	}}
 
-	progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2, "")
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, r2, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 	pausedCondition, _ := newPausedCondition(true)
@@ -1553,7 +1553,7 @@ func TestCreatePrePromotionAnalysisRun(t *testing.T) {
 	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
 	r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
-	progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2, "")
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, r2, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 	pausedCondition, _ := newPausedCondition(true)
@@ -1736,7 +1736,7 @@ func TestRolloutPrePromotionAnalysisBecomesInconclusive(t *testing.T) {
 		Name:   ar.Name,
 		Status: v1alpha1.AnalysisPhaseRunning,
 	}
-	progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2, "")
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, r2, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 	pausedCondition, _ := newPausedCondition(true)
@@ -1804,7 +1804,7 @@ func TestRolloutPrePromotionAnalysisSwitchServiceAfterSuccess(t *testing.T) {
 		Name:   ar.Name,
 		Status: v1alpha1.AnalysisPhaseRunning,
 	}
-	progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2, "")
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, r2, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 	pausedCondition, _ := newPausedCondition(true)
@@ -1870,7 +1870,7 @@ func TestRolloutPrePromotionAnalysisHonorAutoPromotionSeconds(t *testing.T) {
 	r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
 	now := metav1.NewTime(metav1.Now().Add(-10 * time.Second))
 	r2.Status.PauseConditions[0].StartTime = now
-	progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2, "")
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, r2, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 	pausedCondition, _ := newPausedCondition(true)
@@ -1936,7 +1936,7 @@ func TestRolloutPrePromotionAnalysisDoNothingOnInconclusiveAnalysis(t *testing.T
 	}
 	r2.Status.PauseConditions = append(r2.Status.PauseConditions, inconclusivePauseCondition)
 	r2.Status.ObservedGeneration = strconv.Itoa(int(r2.Generation))
-	progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2, "")
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, r2, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 	pausedCondition, _ := newPausedCondition(true)
@@ -1982,7 +1982,7 @@ func TestAbortRolloutOnErrorPrePromotionAnalysis(t *testing.T) {
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
 	r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
-	progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2, "")
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, r2, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 	pausedCondition, _ := newPausedCondition(true)
@@ -2148,7 +2148,7 @@ func TestPostPromotionAnalysisRunHandleInconclusive(t *testing.T) {
 		Reason:    v1alpha1.PauseReasonInconclusiveAnalysis,
 		StartTime: metav1.Now(),
 	}}
-	progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2, "")
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, r2, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 	pausedCondition, _ := newPausedCondition(true)
@@ -2203,7 +2203,7 @@ func TestAbortRolloutOnErrorPostPromotionAnalysis(t *testing.T) {
 	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
 	r2 = updateBlueGreenRolloutStatus(r2, "", rs2PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
-	progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2, "")
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, r2, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 	pausedCondition, _ := newPausedCondition(true)

--- a/rollout/bluegreen_test.go
+++ b/rollout/bluegreen_test.go
@@ -249,7 +249,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 				"conditions": %s
 			}
 		}`
-		addedConditions := generateConditionsPatchWithPause(true, conditions.PausedRolloutReason, rs2, true, "", true)
+		addedConditions := generateConditionsPatchWithPause(true, conditions.RolloutPausedReason, rs2, true, "", true)
 		assert.Equal(t, calculatePatch(r2, fmt.Sprintf(expectedPatch, addedConditions)), patch)
 	})
 
@@ -267,7 +267,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
 		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
-		progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2, "")
+		progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, r2, "")
 		conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 		pausedCondition, _ := newPausedCondition(true)
@@ -314,7 +314,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 			Reason:    v1alpha1.PauseReasonInconclusiveAnalysis,
 			StartTime: now,
 		})
-		progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2, "")
+		progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, r2, "")
 		conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 		pausedCondition, _ := newPausedCondition(true)
@@ -354,7 +354,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
 		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
-		progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2, "")
+		progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, r2, "")
 		conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 		pausedCondition, _ := newPausedCondition(true)
@@ -395,7 +395,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		before := metav1.NewTime(now.Add(-1 * time.Minute))
 		r2.Status.PauseConditions[0].StartTime = before
 		r2.Status.ControllerPause = true
-		progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, rs2, "")
+		progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, rs2, "")
 		conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 		pausedCondition, _ := newPausedCondition(true)
@@ -452,7 +452,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		r2.Status.PauseConditions[0].StartTime = before
 		r2.Status.ControllerPause = true
 		r2.Spec.Paused = true
-		progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, rs2, "")
+		progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, rs2, "")
 		conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 		pausedCondition, _ := newPausedCondition(true)
@@ -633,7 +633,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		r2.Spec.Strategy.BlueGreen.ScaleDownDelaySeconds = pointer.Int32Ptr(10)
 		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 1, 2, 1, false, true)
 		r2.Status.ControllerPause = true
-		pausedCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, rs2, "")
+		pausedCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, rs2, "")
 		conditions.SetRolloutCondition(&r2.Status, pausedCondition)
 
 		activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}
@@ -656,7 +656,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		f.verifyPatchedService(servicePatchIndex, rs2PodHash, "")
 		f.verifyPatchedReplicaSet(patchedRSIndex, 10)
 		unpausePatch := f.getPatchedRollout(unpausePatchIndex)
-		unpauseConditions := generateConditionsPatch(true, conditions.ResumedRolloutReason, rs2, true, "")
+		unpauseConditions := generateConditionsPatch(true, conditions.RolloutResumedReason, rs2, true, "")
 		expectedUnpausePatch := `{
 			"status": {
 				"conditions": %s
@@ -747,7 +747,7 @@ func TestBlueGreenRolloutStatusHPAStatusFieldsActiveSelectorSet(t *testing.T) {
 
 	r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 0, 0, 0, 0, true, false)
 	r2.Status.Selector = ""
-	progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, rs2, "")
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, rs2, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 	pausedCondition, _ := newPausedCondition(true)
@@ -1033,7 +1033,7 @@ func TestBlueGreenRolloutCompletedFalse(t *testing.T) {
 
 	r2 := bumpVersion(r1)
 	rs2 := newReplicaSetWithStatus(r2, 1, 1)
-	progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, rs2, "")
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, rs2, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 	pausedCondition, _ := newPausedCondition(true)
 	conditions.SetRolloutCondition(&r2.Status, pausedCondition)

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -186,7 +186,7 @@ func TestCanaryRolloutNoProgressWhilePaused(t *testing.T) {
 	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(1), intstr.FromInt(0))
 	r2 := bumpVersion(r1)
 
-	progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2, "")
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, r2, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 	pausedCondition, _ := newPausedCondition(true)
@@ -219,7 +219,7 @@ func TestCanaryRolloutUpdatePauseConditionWhilePaused(t *testing.T) {
 	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(1), intstr.FromInt(0))
 	r2 := bumpVersion(r1)
 
-	progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2, "")
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, r2, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 	pausedCondition, _ := newPausedCondition(true)
@@ -881,7 +881,7 @@ func TestSyncRolloutWaitAddToQueue(t *testing.T) {
 	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
 
 	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 10, 1, 10, true)
-	progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, rs2, "")
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, rs2, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 	pausedCondition, _ := newPausedCondition(true)
@@ -926,7 +926,7 @@ func TestSyncRolloutIgnoreWaitOutsideOfReconciliationPeriod(t *testing.T) {
 
 	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 10, 1, 10, true)
 	r2.Status.ObservedGeneration = strconv.Itoa(int(r2.Generation))
-	progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, rs2, "")
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, rs2, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 	pausedCondition, _ := newPausedCondition(true)
@@ -969,7 +969,7 @@ func TestSyncRolloutWaitIncrementStepIndex(t *testing.T) {
 	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
 
 	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 10, 1, 10, false)
-	progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, rs2, "")
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, rs2, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 	pausedCondition, _ := newPausedCondition(true)
@@ -1013,7 +1013,7 @@ func TestCanaryRolloutStatusHPAStatusFields(t *testing.T) {
 	r1 := newCanaryRollout("foo", 5, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
 	r1.Status.Selector = ""
 	r2 := bumpVersion(r1)
-	progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2, "")
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, r2, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 	pausedCondition, _ := newPausedCondition(true)
@@ -1260,7 +1260,7 @@ func TestCanaryRolloutScaleWhilePaused(t *testing.T) {
 
 	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 5, 0, 5, true)
 	r2.Spec.Replicas = pointer.Int32Ptr(10)
-	progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, rs2, "")
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, rs2, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 	pausedCondition, _ := newPausedCondition(true)
@@ -1359,7 +1359,7 @@ func TestNoResumeAfterPauseDurationIfUserPaused(t *testing.T) {
 		Reason:    v1alpha1.PauseReasonCanaryPauseStep,
 		StartTime: overAMinuteAgo,
 	}}
-	progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, rs1, "")
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, rs1, "")
 	conditions.SetRolloutCondition(&r1.Status, progressingCondition)
 	pausedCondition, _ := newPausedCondition(true)
 	conditions.SetRolloutCondition(&r1.Status, pausedCondition)
@@ -1399,7 +1399,7 @@ func TestHandleNilNewRSOnScaleAndImageChange(t *testing.T) {
 	r2 := bumpVersion(r1)
 	r2.Spec.Replicas = pointer.Int32Ptr(3)
 	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 3, 0, 3, true)
-	progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, rs1, "")
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, rs1, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 	pausedCondition, _ := newPausedCondition(true)

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -187,8 +187,8 @@ func newPausedCondition(isPaused bool) (v1alpha1.RolloutCondition, string) {
 	condition := v1alpha1.RolloutCondition{
 		LastTransitionTime: metav1.Now(),
 		LastUpdateTime:     metav1.Now(),
-		Message:            conditions.PausedRolloutMessage,
-		Reason:             conditions.PausedRolloutReason,
+		Message:            conditions.RolloutPausedMessage,
+		Reason:             conditions.RolloutPausedReason,
 		Status:             status,
 		Type:               v1alpha1.RolloutPaused,
 	}
@@ -274,12 +274,12 @@ func newProgressingCondition(reason string, resourceObj runtime.Object, optional
 		}
 	}
 
-	if reason == conditions.PausedRolloutReason {
-		msg = conditions.PausedRolloutMessage
+	if reason == conditions.RolloutPausedReason {
+		msg = conditions.RolloutPausedMessage
 		status = corev1.ConditionUnknown
 	}
-	if reason == conditions.ResumedRolloutReason {
-		msg = conditions.ResumeRolloutMessage
+	if reason == conditions.RolloutResumedReason {
+		msg = conditions.RolloutResumedMessage
 		status = corev1.ConditionUnknown
 	}
 

--- a/rollout/sync_test.go
+++ b/rollout/sync_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
 	"github.com/argoproj/argo-rollouts/utils/annotations"
+	"github.com/argoproj/argo-rollouts/utils/conditions"
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
 	"github.com/argoproj/argo-rollouts/utils/record"
 	"github.com/stretchr/testify/assert"
@@ -321,4 +322,60 @@ func TestBlueGreenPromoteFull(t *testing.T) {
 	assert.Equal(t, rs2PodHash, patchedRollout.Status.StableRS)
 	assert.Equal(t, rs2PodHash, patchedRollout.Status.BlueGreen.ActiveSelector)
 	assert.False(t, patchedRollout.Status.PromoteFull)
+}
+
+// TestSendStateChangeEvents verifies we emit appropriate events on rollout state changes
+func TestSendStateChangeEvents(t *testing.T) {
+	now := metav1.Now()
+	tests := []struct {
+		prevStatus           v1alpha1.RolloutStatus
+		newStatus            v1alpha1.RolloutStatus
+		expectedEventReasons []string
+	}{
+		{
+			prevStatus: v1alpha1.RolloutStatus{
+				PauseConditions: []v1alpha1.PauseCondition{
+					{Reason: v1alpha1.PauseReasonBlueGreenPause, StartTime: now},
+				},
+			},
+			newStatus: v1alpha1.RolloutStatus{
+				PauseConditions: nil,
+			},
+			expectedEventReasons: []string{conditions.RolloutResumedReason},
+		},
+		{
+			prevStatus: v1alpha1.RolloutStatus{
+				PauseConditions: nil,
+			},
+			newStatus: v1alpha1.RolloutStatus{
+				PauseConditions: []v1alpha1.PauseCondition{
+					{Reason: v1alpha1.PauseReasonBlueGreenPause, StartTime: now},
+				},
+			},
+			expectedEventReasons: []string{conditions.RolloutPausedReason},
+		},
+		{
+			prevStatus: v1alpha1.RolloutStatus{
+				PauseConditions: []v1alpha1.PauseCondition{
+					{Reason: v1alpha1.PauseReasonBlueGreenPause, StartTime: now},
+				},
+			},
+			newStatus: v1alpha1.RolloutStatus{
+				PauseConditions: nil,
+				AbortedAt:       &now,
+			},
+			expectedEventReasons: nil,
+		},
+	}
+	for _, test := range tests {
+		roCtx := &rolloutContext{}
+		roCtx.rollout = &v1alpha1.Rollout{ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		}}
+		recorder := record.NewFakeEventRecorder()
+		roCtx.recorder = recorder
+		roCtx.sendStateChangeEvents(&test.prevStatus, &test.newStatus)
+		assert.Equal(t, test.expectedEventReasons, recorder.Events)
+	}
 }

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -134,7 +134,7 @@ func TestRolloutUseDesiredWeight(t *testing.T) {
 	r2.Spec.Strategy.Canary.CanaryService = "canary"
 	r2.Spec.Strategy.Canary.StableService = "stable"
 
-	progressingCondition, _ := newProgressingCondition(conditions.PausedRolloutReason, r2, "")
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, r2, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
 	pausedCondition, _ := newPausedCondition(true)

--- a/test/fixtures/common.go
+++ b/test/fixtures/common.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"text/tabwriter"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -20,11 +21,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	rov1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	clientset "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/cmd/get"
@@ -469,6 +472,9 @@ func (c *Common) GetDestinationRule() *istio.DestinationRule {
 	return &destRule
 }
 
+// We use a watch to collect events (as opposed to listing them after-the-fact), because:
+// 1. the kubernetes event recorder can dedupe multiple events into one Event object
+// 2. listing events may return events out-of-order from when they were produced
 func (c *Common) StartEventWatch(ctx context.Context) {
 	watchEventsIf, err := c.kubeClient.CoreV1().Events(c.namespace).Watch(ctx, metav1.ListOptions{})
 	c.events = nil
@@ -503,4 +509,25 @@ func (c *Common) GetRolloutEventReasons() []string {
 		}
 	}
 	return reasons
+}
+
+// PrintRolloutEvents prints all Kubernetes events associated with the given rollout.
+// Note that events may be deduplicated, or printed out-of-order from when they were emitted,
+// so this function should only be used to assist with debugging and not correctness.
+func (c *Common) PrintRolloutEvents(ro *v1alpha1.Rollout) {
+	opts := metav1.ListOptions{FieldSelector: fields.ParseSelectorOrDie(fmt.Sprintf("involvedObject.uid=%s", ro.UID)).String()}
+	events, err := c.kubeClient.CoreV1().Events(c.namespace).List(c.Context, opts)
+	c.CheckError(err)
+	buf := bytes.NewBufferString("")
+
+	w := tabwriter.NewWriter(buf, 0, 0, 4, ' ', 0)
+	for _, event := range events.Items {
+		timestamp := event.LastTimestamp.Format(time.RFC3339)
+		if event.Count > 1 {
+			timestamp = fmt.Sprintf("%s (x%d)", timestamp, event.Count)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", timestamp, event.Type, event.Reason, event.Message)
+	}
+	w.Flush()
+	fmt.Fprintln(logrus.StandardLogger().Out, buf.String())
 }

--- a/test/fixtures/e2e_suite.go
+++ b/test/fixtures/e2e_suite.go
@@ -168,6 +168,7 @@ func (s *E2ESuite) AfterTest(suiteName, testName string) {
 		for _, ro := range roList.Items {
 			s.PrintRollout(ro.Name)
 			s.PrintRolloutYAML(&ro)
+			s.PrintRolloutEvents(&ro)
 		}
 	}
 	if os.Getenv(EnvVarE2EDebug) == "true" {

--- a/utils/conditions/conditions.go
+++ b/utils/conditions/conditions.go
@@ -51,6 +51,8 @@ const (
 	NewReplicaSetReason = "NewReplicaSetCreated"
 	//NewReplicaSetMessage is added in a rollout when it creates a new replicas set.
 	NewReplicaSetMessage = "Created new replica set %q"
+	// NewReplicaSetDetailedMessage is a more detailed format message
+	NewReplicaSetDetailedMessage = "Created ReplicaSet %s (revision %d) with size %d"
 
 	// FoundNewRSReason is added in a rollout when it adopts an existing replica set.
 	FoundNewRSReason = "FoundNewReplicaSet"
@@ -77,19 +79,19 @@ const (
 	// RolloutRetryMessage indicates that the rollout is retrying after being aborted
 	RolloutRetryMessage = "Retrying Rollout after abort"
 
-	// PausedRolloutReason is added in a rollout when it is paused. Lack of progress shouldn't be
+	// RolloutPausedReason is added in a rollout when it is paused. Lack of progress shouldn't be
 	// estimated once a rollout is paused.
-	PausedRolloutReason = "RolloutPaused"
-	// PausedRolloutMessage is added in a rollout when it is paused. Lack of progress shouldn't be
+	RolloutPausedReason = "RolloutPaused"
+	// RolloutPausedMessage is added in a rollout when it is paused. Lack of progress shouldn't be
 	// estimated once a rollout is paused.
-	PausedRolloutMessage = "Rollout is paused"
+	RolloutPausedMessage = "Rollout is paused"
 
-	// ResumedRolloutReason is added in a rollout when it is resumed. Useful for not failing accidentally
+	// RolloutResumedReason is added in a rollout when it is resumed. Useful for not failing accidentally
 	// rollout that paused amidst a rollout and are bounded by a deadline.
-	ResumedRolloutReason = "RolloutResumed"
-	// ResumeRolloutMessage is added in a rollout when it is resumed. Useful for not failing accidentally
+	RolloutResumedReason = "RolloutResumed"
+	// RolloutResumedMessage is added in a rollout when it is resumed. Useful for not failing accidentally
 	// rollout that paused amidst a rollout and are bounded by a deadline.
-	ResumeRolloutMessage = "Rollout is resumed"
+	RolloutResumedMessage = "Rollout is resumed"
 
 	// ResumedRolloutReason is added in a rollout when it is resumed. Useful for not failing accidentally
 	// rollout that paused amidst a rollout and are bounded by a deadline.
@@ -121,7 +123,7 @@ const (
 	RolloutTimeOutMessage = "Rollout %q has timed out progressing."
 
 	ScalingReplicaSetReason  = "ScalingReplicaSet"
-	ScalingReplicaSetMessage = "Scaled %s replica set %s (revision %d) from %d to %d"
+	ScalingReplicaSetMessage = "Scaled %s ReplicaSet %s (revision %d) from %d to %d"
 
 	// ReplicaSetTimeOutMessage is added in a rollout when its newest replica set fails to show any progress
 	// within the given deadline (progressDeadlineSeconds).

--- a/utils/record/record_test.go
+++ b/utils/record/record_test.go
@@ -68,9 +68,10 @@ func TestIncCounter(t *testing.T) {
 		rec.Eventf(&r, EventOptions{EventReason: "FooReason"}, "something happened")
 	}
 	ch := make(chan prometheus.Metric, 1)
-	rec.(*EventRecorderAdapter).RolloutEventCounter.Collect(ch)
+	rec.RolloutEventCounter.Collect(ch)
 	m := <-ch
 	buf := dto.Metric{}
 	m.Write(&buf)
 	assert.Equal(t, float64(3), *buf.Counter.Value)
+	assert.Equal(t, []string{"FooReason", "FooReason", "FooReason"}, rec.Events)
 }


### PR DESCRIPTION
This emits kubernetes events for:
* when a rollout becomes paused by the controller (RolloutPaused)
* when a rollout automatically resumes after a pause (RolloutResumed)

Also adds more details about events for NewReplicaSetCreated and ScalingReplicaSet

Signed-off-by: Jesse Suen <jesse_suen@intuit.com>
