### PR TITLE
fix: lint valid file with another empty object

### DIFF
--- a/pkg/kubectl-argo-rollouts/cmd/lint/lint.go
+++ b/pkg/kubectl-argo-rollouts/cmd/lint/lint.go
@@ -116,6 +116,9 @@ func (l *LintOptions) lintResource(path string) error {
 			}
 			break
 		}
+		if value == nil {
+			continue
+		}
 		valueBytes, err := goyaml.Marshal(value)
 		if err != nil {
 			return err

--- a/pkg/kubectl-argo-rollouts/cmd/lint/lint_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/lint/lint_test.go
@@ -14,12 +14,15 @@ func TestLintValidRollout(t *testing.T) {
 
 	cmd := NewCmdLint(o)
 	cmd.PersistentPreRunE = o.PersistentPreRunE
-	cmd.SetArgs([]string{"-f", "testdata/valid.yml"})
-	err := cmd.Execute()
-	assert.NoError(t, err)
 
-	stdout := o.Out.(*bytes.Buffer).String()
-	assert.Empty(t, stdout)
+	for _, filename := range []string{"testdata/valid.yml", "testdata/valid-with-another-empty-object.yml"} {
+		cmd.SetArgs([]string{"-f", filename})
+		err := cmd.Execute()
+		assert.NoError(t, err)
+
+		stdout := o.Out.(*bytes.Buffer).String()
+		assert.Empty(t, stdout)
+	}
 }
 
 func TestLintInvalidRollout(t *testing.T) {

--- a/pkg/kubectl-argo-rollouts/cmd/lint/testdata/valid-with-another-empty-object.yml
+++ b/pkg/kubectl-argo-rollouts/cmd/lint/testdata/valid-with-another-empty-object.yml
@@ -1,0 +1,25 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: valid-rollout
+spec:
+  revisionHistoryLimit: 1
+  replicas: 10
+  strategy:
+    canary:
+      steps:
+        - setWeight: 10
+        - setWeight: 20
+  selector:
+    matchLabels:
+      app: valid-rollout
+  template:
+    metadata:
+      labels:
+        app: valid-rollout
+    spec:
+      containers:
+        - name: valid-rollout
+          image: valid-rollout:0.0.0
+---


### PR DESCRIPTION
- empty object may appear in the yaml file (e.g., helm2)
  In this case, go-yaml will decode to null, which will
  be interrepted as "null" in json. In this case,
  yaml.UnmarshalStrict will fail.

Signed-off-by: Hui Kang <hui.kang@salesforce.com>

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).