### PR TITLE
fix: timeout should take a string

### DIFF
--- a/pkg/kubectl-argo-rollouts/cmd/status/status.go
+++ b/pkg/kubectl-argo-rollouts/cmd/status/status.go
@@ -19,13 +19,13 @@ the rollout is healthy upon completion and an error otherwise.`
 	%[1]s status guestbook
 
 	# Watch the rollout until it succeeds, fail if it takes more than 60 seconds
-	%[1]s status --timeout 60 guestbook
+	%[1]s status --timeout 60s guestbook
 	`
 )
 
 type StatusOptions struct {
 	Watch   bool
-	Timeout int64
+	Timeout time.Duration
 
 	options.ArgoRolloutsOptions
 }
@@ -84,18 +84,18 @@ func NewCmdStatus(o *options.ArgoRolloutsOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVarP(&statusOptions.Watch, "watch", "w", true, "Watch the status of the rollout until it's done")
-	cmd.Flags().Int64VarP(&statusOptions.Timeout, "timeout", "t", 0, "The length of time in seconds to watch before giving up, zero means wait forever")
+	cmd.Flags().DurationVarP(&statusOptions.Timeout, "timeout", "t", time.Duration(0), "The length of time to watch before giving up. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). Zero means wait forever")
 	return cmd
 }
 
-func (o *StatusOptions) WatchStatus(stopCh <-chan struct{}, cancelFunc context.CancelFunc, timeoutSeconds int64, rolloutUpdates chan *rollout.RolloutInfo) {
+func (o *StatusOptions) WatchStatus(stopCh <-chan struct{}, cancelFunc context.CancelFunc, timeoutDuration time.Duration, rolloutUpdates chan *rollout.RolloutInfo) {
 	timeout := make(chan bool)
 	var roInfo *rollout.RolloutInfo
 	var preventFlicker time.Time
 
-	if timeoutSeconds != 0 {
+	if timeoutDuration != 0 {
 		go func() {
-			time.Sleep(time.Duration(timeoutSeconds) * time.Second)
+			time.Sleep(timeoutDuration)
 			timeout <- true
 		}()
 	}

--- a/pkg/kubectl-argo-rollouts/cmd/status/status_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/status/status_test.go
@@ -132,7 +132,7 @@ func TestWatchTimeoutRollout(t *testing.T) {
 	defer tf.Cleanup()
 	cmd := NewCmdStatus(o)
 	cmd.PersistentPreRunE = o.PersistentPreRunE
-	cmd.SetArgs([]string{rolloutObjs.Rollouts[0].Name, "--timeout=1"})
+	cmd.SetArgs([]string{rolloutObjs.Rollouts[0].Name, "--timeout=1s"})
 	err := cmd.Execute()
 
 	assert.Error(t, err)


### PR DESCRIPTION
Signed-off-by: Andrii Perenesenko <andrii.perenesenko@gmail.com>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).