### PR TITLE
chore: use a base image that has a shell for the kubectl plugin image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN make ${MAKE_TARGET}
 ####################################################################################################
 # Kubectl plugin image
 ####################################################################################################
-FROM ubuntu:20.10 as kubectl-argo-rollouts
+FROM docker.io/library/ubuntu:20.10 as kubectl-argo-rollouts
 
 COPY --from=argo-rollouts-build /go/src/github.com/argoproj/argo-rollouts/dist/kubectl-argo-rollouts-linux-amd64 /bin/kubectl-argo-rollouts
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN make ${MAKE_TARGET}
 ####################################################################################################
 # Kubectl plugin image
 ####################################################################################################
-FROM scratch as kubectl-argo-rollouts
+FROM ubuntu:20.10 as kubectl-argo-rollouts
 
 COPY --from=argo-rollouts-build /go/src/github.com/argoproj/argo-rollouts/dist/kubectl-argo-rollouts-linux-amd64 /bin/kubectl-argo-rollouts
 

--- a/USERS.md
+++ b/USERS.md
@@ -16,3 +16,4 @@ Organizations below are **officially** using Argo Rollouts. Please send a PR wit
 1. [Quizlet](https://quizlet.com)
 1. [Skillz](https://www.skillz.com)
 1. [PayPal](https://www.paypal.com/)
+1. [Shipt](https://www.shipt.com/)


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x ] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).