### PR TITLE
feat: add workload-ref/generation to rollout

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -146,7 +146,7 @@ func NewManager(
 	serviceWorkqueue := workqueue.NewNamedRateLimitingQueue(queue.DefaultArgoRolloutsRateLimiter(), "Services")
 	ingressWorkqueue := workqueue.NewNamedRateLimitingQueue(queue.DefaultArgoRolloutsRateLimiter(), "Ingresses")
 
-	refResolver := rollout.NewInformerBasedWorkloadRefResolver(namespace, dynamicclientset, discoveryClient, argoprojclientset, rolloutWorkqueue, rolloutsInformer.Informer())
+	refResolver := rollout.NewInformerBasedWorkloadRefResolver(namespace, dynamicclientset, discoveryClient, argoprojclientset, rolloutsInformer.Informer())
 	apiFactory := api.NewFactory(record.NewAPIFactorySettings(), defaults.Namespace(), secretInformer.Informer(), configMapInformer.Informer())
 	recorder := record.NewEventRecorder(kubeclientset, metrics.MetricRolloutEventsTotal, apiFactory)
 	notificationsController := controller.NewController(dynamicclientset.Resource(v1alpha1.RolloutGVR), rolloutsInformer.Informer(), apiFactory,

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -146,7 +146,7 @@ func NewManager(
 	serviceWorkqueue := workqueue.NewNamedRateLimitingQueue(queue.DefaultArgoRolloutsRateLimiter(), "Services")
 	ingressWorkqueue := workqueue.NewNamedRateLimitingQueue(queue.DefaultArgoRolloutsRateLimiter(), "Ingresses")
 
-	refResolver := rollout.NewInformerBasedWorkloadRefResolver(namespace, dynamicclientset, discoveryClient, rolloutWorkqueue, rolloutsInformer.Informer())
+	refResolver := rollout.NewInformerBasedWorkloadRefResolver(namespace, dynamicclientset, discoveryClient, argoprojclientset, rolloutWorkqueue, rolloutsInformer.Informer())
 	apiFactory := api.NewFactory(record.NewAPIFactorySettings(), defaults.Namespace(), secretInformer.Informer(), configMapInformer.Informer())
 	recorder := record.NewEventRecorder(kubeclientset, metrics.MetricRolloutEventsTotal, apiFactory)
 	notificationsController := controller.NewController(dynamicclientset.Resource(v1alpha1.RolloutGVR), rolloutsInformer.Informer(), apiFactory,

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -108,6 +108,8 @@ After creation Rollout will spinup required number of Pods side-by-side with the
 Rollout won't try to manage existing Deployment Pods. That means you can safely update add Rollout
 to the production environment without any interruption but you are going to run twice more Pods during migration.
 
+Argo-rollouts controller patches the spec of rollout object with an annotation of `rollout.argoproj.io/workload-generation`, which equals the generation of referenced deployment. Users can detect if the rollout matches desired generation of deployment by checking the `workloadObservedGeneration` in the rollout status.
+
 **Traffic Management During Migration**
 
 The Rollout offers traffic management functionality that manages routing rules and flows the traffic to different

--- a/manifests/crds/rollout-crd.yaml
+++ b/manifests/crds/rollout-crd.yaml
@@ -2820,6 +2820,8 @@ spec:
               updatedReplicas:
                 format: int32
                 type: integer
+              workloadObservedGeneration:
+                type: string
             type: object
         required:
         - spec

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -12509,6 +12509,8 @@ spec:
               updatedReplicas:
                 format: int32
                 type: integer
+              workloadObservedGeneration:
+                type: string
             type: object
         required:
         - spec

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -12509,6 +12509,8 @@ spec:
               updatedReplicas:
                 format: int32
                 type: integer
+              workloadObservedGeneration:
+                type: string
             type: object
         required:
         - spec

--- a/pkg/apiclient/rollout/rollout.swagger.json
+++ b/pkg/apiclient/rollout/rollout.swagger.json
@@ -1223,6 +1223,10 @@
           "type": "string",
           "title": "The generation observed by the rollout controller from metadata.generation\n+optional"
         },
+        "workloadObservedGeneration": {
+          "type": "string",
+          "title": "The generation of referenced workload observed by the rollout controller\n+optional"
+        },
         "conditions": {
           "type": "array",
           "items": {

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -664,6 +664,9 @@ type RolloutStatus struct {
 	// The generation observed by the rollout controller from metadata.generation
 	// +optional
 	ObservedGeneration string `json:"observedGeneration,omitempty" protobuf:"bytes,13,opt,name=observedGeneration"`
+	// The generation of referenced workload observed by the rollout controller
+	// +optional
+	WorkloadObservedGeneration string `json:"workloadObservedGeneration,omitempty" protobuf:"bytes,22,opt,name=workloadObservedGeneration"`
 	// Conditions a list of conditions a rollout can have.
 	// +optional
 	Conditions []RolloutCondition `json:"conditions,omitempty" protobuf:"bytes,14,rep,name=conditions"`

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -666,7 +666,7 @@ type RolloutStatus struct {
 	ObservedGeneration string `json:"observedGeneration,omitempty" protobuf:"bytes,13,opt,name=observedGeneration"`
 	// The generation of referenced workload observed by the rollout controller
 	// +optional
-	WorkloadObservedGeneration string `json:"workloadObservedGeneration,omitempty" protobuf:"bytes,22,opt,name=workloadObservedGeneration"`
+	WorkloadObservedGeneration string `json:"workloadObservedGeneration,omitempty" protobuf:"bytes,24,opt,name=workloadObservedGeneration"`
 	// Conditions a list of conditions a rollout can have.
 	// +optional
 	Conditions []RolloutCondition `json:"conditions,omitempty" protobuf:"bytes,14,rep,name=conditions"`

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -691,6 +691,14 @@ func (c *rolloutContext) persistRolloutStatus(newStatus *v1alpha1.RolloutStatus)
 
 	prevStatus := c.rollout.Status
 	c.pauseContext.CalculatePauseStatus(newStatus)
+	if c.rollout.Spec.TemplateResolvedFromRef {
+		workloadRefObservation, _ := annotations.GetWorkloadGenerationAnnotation(c.rollout)
+		currentWorkloadObservedGeneration, _ := strconv.ParseInt(newStatus.WorkloadObservedGeneration, 10, 32)
+		if workloadRefObservation != int32(currentWorkloadObservedGeneration) {
+			newStatus.WorkloadObservedGeneration = strconv.Itoa(int(workloadRefObservation))
+		}
+	}
+
 	newStatus.ObservedGeneration = strconv.Itoa(int(c.rollout.Generation))
 	newStatus.Phase, newStatus.Message = rolloututil.CalculateRolloutPhase(c.rollout.Spec, *newStatus)
 

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -697,6 +697,8 @@ func (c *rolloutContext) persistRolloutStatus(newStatus *v1alpha1.RolloutStatus)
 		if workloadRefObservation != int32(currentWorkloadObservedGeneration) {
 			newStatus.WorkloadObservedGeneration = strconv.Itoa(int(workloadRefObservation))
 		}
+	} else {
+		newStatus.WorkloadObservedGeneration = ""
 	}
 
 	newStatus.ObservedGeneration = strconv.Itoa(int(c.rollout.Generation))

--- a/rollout/sync_test.go
+++ b/rollout/sync_test.go
@@ -215,6 +215,54 @@ func TestReconcileRevisionHistoryLimit(t *testing.T) {
 	}
 }
 
+func TestPersistWorkloadRefGeneration(t *testing.T) {
+	replica := int32(1)
+	r := &v1alpha1.Rollout{
+		Spec: v1alpha1.RolloutSpec{
+			Replicas: &replica,
+		},
+	}
+	fake := fake.Clientset{}
+	roCtx := &rolloutContext{
+		rollout: r,
+		log:     logutil.WithRollout(r),
+		reconcilerBase: reconcilerBase{
+			argoprojclientset: &fake,
+		},
+		pauseContext: &pauseContext{
+			rollout: r,
+		},
+	}
+
+	tests := []struct {
+		annotatedRefGeneration string
+		currentObserved        string
+	}{
+		{"1", ""},
+		{"2", "1"},
+		{"", "1"},
+	}
+
+	for _, tc := range tests {
+		newStatus := &v1alpha1.RolloutStatus{
+			UpdatedReplicas:   int32(1),
+			AvailableReplicas: int32(1),
+		}
+
+		if tc.annotatedRefGeneration != "" {
+			annotations.SetRolloutWorkloadRefGeneration(r, tc.annotatedRefGeneration)
+			r.Spec.TemplateResolvedFromRef = true
+
+			newStatus.WorkloadObservedGeneration = tc.currentObserved
+		} else {
+			r.Spec.TemplateResolvedFromRef = false
+			annotations.RemoveRolloutWorkloadRefGeneration(r)
+		}
+		roCtx.persistRolloutStatus(newStatus)
+		assert.Equal(t, tc.annotatedRefGeneration, newStatus.WorkloadObservedGeneration)
+	}
+}
+
 // TestCanaryPromoteFull verifies skip pause, analysis, steps when promote full is set for a canary rollout
 func TestCanaryPromoteFull(t *testing.T) {
 	f := newFixture(t)

--- a/rollout/temlateref.go
+++ b/rollout/temlateref.go
@@ -125,6 +125,7 @@ func remarshalMap(objMap map[string]interface{}, res interface{}) error {
 // Resolve verifies if given rollout has template reference and resolves pod template
 func (r *informerBasedTemplateResolver) Resolve(rollout *v1alpha1.Rollout) error {
 	if rollout.Spec.WorkloadRef == nil {
+		annotations.RemoveRolloutWorkloadRefGeneration(rollout)
 		return nil
 	}
 

--- a/rollout/temlateref_test.go
+++ b/rollout/temlateref_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned"
 	"github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
 	rolloutinformers "github.com/argoproj/argo-rollouts/pkg/client/informers/externalversions/rollouts/v1alpha1"
+	"github.com/argoproj/argo-rollouts/utils/annotations"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,7 +29,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 )
 
 func newFakeDiscoClient() *discofake.FakeDiscovery {
@@ -55,8 +55,8 @@ func newFakeDiscoClient() *discofake.FakeDiscovery {
 
 func newResolver(dynamicClient dynamic.Interface, discoveryClient disco.DiscoveryInterface, rolloutClient versioned.Interface) (*informerBasedTemplateResolver, context.CancelFunc) {
 	rolloutsInformer := rolloutinformers.NewRolloutInformer(rolloutClient, "", time.Minute, cache.Indexers{})
-	argoprojectclientset := fake.Clientset{}
-	resolver := NewInformerBasedWorkloadRefResolver("", dynamicClient, discoveryClient, &argoprojectclientset, workqueue.NewDelayingQueue(), rolloutsInformer)
+	// argoprojectclientset := fake.Clientset{}
+	resolver := NewInformerBasedWorkloadRefResolver("", dynamicClient, discoveryClient, rolloutClient, rolloutsInformer)
 	stop := make(chan struct{})
 	go rolloutsInformer.Run(stop)
 	cache.WaitForCacheSync(stop, rolloutsInformer.HasSynced)
@@ -328,20 +328,34 @@ func TestRequeueReferencedRollouts(t *testing.T) {
 			},
 		},
 	}
+	deployment.SetGeneration(int64(1))
 
 	rollout := v1alpha1.Rollout{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+			Kind:       "Rollout",
+		},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "my-rollout",
 			Namespace: "default",
 		},
 		Spec: v1alpha1.RolloutSpec{
+			Strategy: v1alpha1.RolloutStrategy{
+				Canary: &v1alpha1.CanaryStrategy{},
+			},
 			WorkloadRef: &v1alpha1.ObjectRef{
 				Name:       "my-deployment",
 				Kind:       "Deployment",
 				APIVersion: "apps/v1",
 			},
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"test": "app",
+				},
+			},
 		},
 	}
+
 	rolloutsClient := fake.NewSimpleClientset(&rollout)
 
 	discoveryClient := newFakeDiscoClient()
@@ -351,30 +365,25 @@ func TestRequeueReferencedRollouts(t *testing.T) {
 
 	err := resolver.Resolve(&rollout)
 	require.NoError(t, err)
+	assert.True(t, len(rollout.GetAnnotations()) > 0, "Number of annotatioin must be > 0 after resolve")
+	assert.Equal(t, "1", rollout.GetAnnotations()[annotations.WorkloadGenerationAnnotation])
+	// manually apply the update
+	rolloutsClient.ArgoprojV1alpha1().Rollouts("default").Update(context.TODO(), &rollout, v1.UpdateOptions{})
 
+	// Update the deployment
+	deployment.SetGeneration(int64(2))
 	deploymentsClient := dynamicClient.Resource(appsv1.SchemeGroupVersion.WithResource("deployments")).Namespace("default")
-
 	_, err = deploymentsClient.Update(context.TODO(), mustToUnstructured(deployment), v1.UpdateOptions{})
 	require.NoError(t, err)
 
-	go func() {
-		// shutdown queue to make sure test fails if requeue functionality is broken
-		time.Sleep(5 * time.Second)
-		resolver.rolloutWorkQueue.ShutDown()
-	}()
-
-	item, done := resolver.rolloutWorkQueue.Get()
-	require.False(t, done)
-	assert.Equal(t, "default/my-rollout", item)
-	resolver.rolloutWorkQueue.Done(item)
+	// verify rollout's annotation is updated
+	ro, _ := rolloutsClient.ArgoprojV1alpha1().Rollouts("default").Get(context.TODO(), "my-rollout", v1.GetOptions{})
+	assert.NotNil(t, ro)
+	assert.Equal(t, "2", ro.GetAnnotations()[annotations.WorkloadGenerationAnnotation])
 
 	err = deploymentsClient.Delete(context.TODO(), deployment.Name, v1.DeleteOptions{})
 	require.NoError(t, err)
 
-	item, done = resolver.rolloutWorkQueue.Get()
-	require.False(t, done)
-	assert.Equal(t, "default/my-rollout", item)
-	resolver.rolloutWorkQueue.Done(item)
 }
 
 func TestRequeueReferencedRollouts_InvalidMeta(t *testing.T) {
@@ -383,9 +392,7 @@ func TestRequeueReferencedRollouts_InvalidMeta(t *testing.T) {
 	resolver, cancel := newResolver(dynamicClient, discoveryClient, fake.NewSimpleClientset())
 	defer cancel()
 
-	resolver.requeueReferencedRollouts(nil, schema.GroupVersionKind{})
-
-	assert.Equal(t, 0, resolver.rolloutWorkQueue.Len())
+	resolver.updateRolloutsReferenceAnnotation(nil, schema.GroupVersionKind{})
 }
 
 func TestResolveNotRef(t *testing.T) {

--- a/rollout/temlateref_test.go
+++ b/rollout/temlateref_test.go
@@ -55,7 +55,8 @@ func newFakeDiscoClient() *discofake.FakeDiscovery {
 
 func newResolver(dynamicClient dynamic.Interface, discoveryClient disco.DiscoveryInterface, rolloutClient versioned.Interface) (*informerBasedTemplateResolver, context.CancelFunc) {
 	rolloutsInformer := rolloutinformers.NewRolloutInformer(rolloutClient, "", time.Minute, cache.Indexers{})
-	resolver := NewInformerBasedWorkloadRefResolver("", dynamicClient, discoveryClient, workqueue.NewDelayingQueue(), rolloutsInformer)
+	argoprojectclientset := fake.Clientset{}
+	resolver := NewInformerBasedWorkloadRefResolver("", dynamicClient, discoveryClient, &argoprojectclientset, workqueue.NewDelayingQueue(), rolloutsInformer)
 	stop := make(chan struct{})
 	go rolloutsInformer.Run(stop)
 	cache.WaitForCacheSync(stop, rolloutsInformer.HasSynced)

--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -407,7 +407,7 @@ spec:
 		When().
 		PromoteRollout().
 		WaitForRolloutStatus("Degraded").
-		WaitForRolloutStatus("Healthy", time.Second*90)
+		WaitForRolloutStatus("Healthy")
 }
 
 // TestCanaryScaleDownDelay verifies canary uses a scaleDownDelay when traffic routing is used,

--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -407,7 +407,7 @@ spec:
 		When().
 		PromoteRollout().
 		WaitForRolloutStatus("Degraded").
-		WaitForRolloutStatus("Healthy")
+		WaitForRolloutStatus("Healthy", time.Second*90)
 }
 
 // TestCanaryScaleDownDelay verifies canary uses a scaleDownDelay when traffic routing is used,

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -1178,6 +1178,12 @@ spec:
     `).
 		WaitForRolloutStatus("Healthy").
 		Then().
+		ExpectRollout("WorkloadObservedGeneration is 1", func(r *v1alpha1.Rollout) bool {
+			if r.Status.WorkloadObservedGeneration != "1" {
+				return false
+			}
+			return true
+		}).
 		// verify that service is switched after rollout is healthy
 		ExpectServiceSelector("rollout-bluegreen-active", map[string]string{"app": "rollout-ref-deployment"}, true).
 		When().
@@ -1194,6 +1200,12 @@ spec:
 		}).
 		WaitForRolloutStatus("Degraded").
 		Then().
+		ExpectRollout("WorkloadObservedGeneration is 2 after workload ref updated", func(r *v1alpha1.Rollout) bool {
+			if r.Status.WorkloadObservedGeneration != "2" {
+				return false
+			}
+			return true
+		}).
 		When().
 		UpdateResource(appsv1.SchemeGroupVersion.WithResource("deployments"), "rollout-ref-deployment", func(res *unstructured.Unstructured) error {
 			containers, _, err := unstructured.NestedSlice(res.Object, "spec", "template", "spec", "containers")

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -1240,6 +1240,38 @@ spec:
 		ExpectServiceSelector("rollout-bluegreen-active", map[string]string{"app": "rollout-ref-deployment"}, true).
 		ExpectRollout("Resolved template not persisted", func(rollout *v1alpha1.Rollout) bool {
 			return rollout.Spec.Selector == nil && len(rollout.Spec.Template.Spec.Containers) == 0
+		}).
+		When().
+		ApplyManifests(`
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: rollout-ref-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rollout-bluegreen
+  progressDeadlineSeconds: 5
+  revisionHistoryLimit: 2
+  strategy:
+    blueGreen:
+      activeService: rollout-bluegreen-active
+  template:
+    metadata:
+      labels:
+        app: rollout-bluegreen
+    spec:
+      containers:
+        - name: rollouts-demo
+          image: argoproj/rollouts-demo:blue
+`).WaitForRolloutStatus("Healthy").
+		Then().
+		ExpectRollout("WorkloadObservedGeneration must be removed after switch to inline template", func(r *v1alpha1.Rollout) bool {
+			if r.Status.WorkloadObservedGeneration != "" {
+				return false
+			}
+			return true
 		})
 }
 

--- a/utils/annotations/annotations.go
+++ b/utils/annotations/annotations.go
@@ -91,6 +91,14 @@ func SetRolloutWorkloadRefGeneration(rollout *v1alpha1.Rollout, workloadGenerati
 	return false
 }
 
+// RemoveRolloutWorkloadRefGeneration remove the annotation of workload ref generation
+func RemoveRolloutWorkloadRefGeneration(rollout *v1alpha1.Rollout) {
+	if rollout.Annotations == nil {
+		return
+	}
+	delete(rollout.Annotations, WorkloadGenerationAnnotation)
+}
+
 // SetReplicasAnnotations sets the desiredReplicas into the annotations
 func SetReplicasAnnotations(rs *appsv1.ReplicaSet, desiredReplicas int32) bool {
 	if rs.Annotations == nil {

--- a/utils/annotations/annotations_test.go
+++ b/utils/annotations/annotations_test.go
@@ -152,6 +152,11 @@ func TestAnnotationUtils(t *testing.T) {
 	})
 	t.Run("RemoveRolloutWorkloadRefGeneration", func(t *testing.T) {
 		copyRollout := tRollout.DeepCopy()
+
+		copyRollout.Annotations = nil
+		RemoveRolloutWorkloadRefGeneration(copyRollout)
+		assert.Nil(t, copyRollout.Annotations)
+
 		copyRollout.Annotations = map[string]string{WorkloadGenerationAnnotation: "2"}
 		RemoveRolloutWorkloadRefGeneration(copyRollout)
 		_, ok := copyRollout.Annotations[WorkloadGenerationAnnotation]

--- a/utils/annotations/annotations_test.go
+++ b/utils/annotations/annotations_test.go
@@ -150,6 +150,13 @@ func TestAnnotationUtils(t *testing.T) {
 			t.Errorf("WorkloadGeneration Expected=2 Obtained=%s", copyRollout.Annotations[WorkloadGenerationAnnotation])
 		}
 	})
+	t.Run("RemoveRolloutWorkloadRefGeneration", func(t *testing.T) {
+		copyRollout := tRollout.DeepCopy()
+		copyRollout.Annotations = map[string]string{WorkloadGenerationAnnotation: "2"}
+		RemoveRolloutWorkloadRefGeneration(copyRollout)
+		_, ok := copyRollout.Annotations[WorkloadGenerationAnnotation]
+		assert.False(t, ok)
+	})
 
 	t.Run("SetRolloutRevisionAlreadySet", func(t *testing.T) {
 		copyRollout := tRollout.DeepCopy()

--- a/utils/annotations/annotations_test.go
+++ b/utils/annotations/annotations_test.go
@@ -114,6 +114,43 @@ func TestAnnotationUtils(t *testing.T) {
 		}
 	})
 
+	// Check if WorkloadRefGeneration annotations can be set
+	t.Run("SetRolloutWorkloadRefGeneration", func(t *testing.T) {
+		copyRollout := tRollout.DeepCopy()
+		copyRollout.Annotations = nil
+		updated := SetRolloutWorkloadRefGeneration(copyRollout, "1")
+		if !updated {
+			t.Errorf("SetRolloutWorkloadRefGeneration() Expected=True Obtained=False")
+		}
+		if copyRollout.Annotations[WorkloadGenerationAnnotation] != "1" {
+			t.Errorf("Revision Expected=1 Obtained=%s", copyRollout.Annotations[WorkloadGenerationAnnotation])
+		}
+	})
+
+	t.Run("SetRolloutWorkloadRefGenerationAlreadySet", func(t *testing.T) {
+		copyRollout := tRollout.DeepCopy()
+		copyRollout.Annotations = map[string]string{WorkloadGenerationAnnotation: "1"}
+		updated := SetRolloutWorkloadRefGeneration(copyRollout, "2")
+		if !updated {
+			t.Errorf("SetRolloutWorkloadRefGeneration() Expected=True Obtained=False")
+		}
+		if copyRollout.Annotations[WorkloadGenerationAnnotation] != "2" {
+			t.Errorf("WorkloadGeneration Expected=1 Obtained=%s", copyRollout.Annotations[WorkloadGenerationAnnotation])
+		}
+	})
+
+	t.Run("SetRolloutWorkloadRefGenerationUnchanged", func(t *testing.T) {
+		copyRollout := tRollout.DeepCopy()
+		copyRollout.Annotations = map[string]string{WorkloadGenerationAnnotation: "2"}
+		updated := SetRolloutWorkloadRefGeneration(copyRollout, "2")
+		if updated {
+			t.Errorf("SetRolloutWorkloadRefGeneration() Expected=False Obtained=True")
+		}
+		if copyRollout.Annotations[WorkloadGenerationAnnotation] != "2" {
+			t.Errorf("WorkloadGeneration Expected=2 Obtained=%s", copyRollout.Annotations[WorkloadGenerationAnnotation])
+		}
+	})
+
 	t.Run("SetRolloutRevisionAlreadySet", func(t *testing.T) {
 		copyRollout := tRollout.DeepCopy()
 		copyRollout.Labels = map[string]string{RevisionAnnotation: "2"}
@@ -235,6 +272,38 @@ func TestAnnotationUtils(t *testing.T) {
 		if ok {
 			t.Errorf("IsSaturated Expected=false Obtained=true")
 		}
+	})
+
+	// Check if we can grab annotations from rollout
+	t.Run("GetDesiredReplicasAnnotationNotSet", func(t *testing.T) {
+		generation, ok := GetWorkloadGenerationAnnotation(&tRollout)
+		assert.False(t, ok)
+		assert.Equal(t, int32(0), generation)
+	})
+
+	tRollout.Annotations[WorkloadGenerationAnnotation] = "1"
+	t.Run("GetDesiredReplicasAnnotation", func(t *testing.T) {
+		generation, ok := GetWorkloadGenerationAnnotation(&tRollout)
+		assert.True(t, ok)
+		assert.Equal(t, int32(1), generation)
+	})
+
+	tRollout.Annotations[WorkloadGenerationAnnotation] = "20000000000"
+	t.Run("GetDesiredReplicasAnnotationOutOfRange", func(t *testing.T) {
+		_, ok := GetWorkloadGenerationAnnotation(&tRollout)
+		assert.Falsef(t, ok, "Should be an error as 20M value does not fit into int32")
+	})
+
+	t.Run("GetWorkloadGenerationAnnotationNilInput", func(t *testing.T) {
+		generation, ok := GetWorkloadGenerationAnnotation(nil)
+		assert.False(t, ok)
+		assert.Equal(t, int32(0), generation)
+	})
+
+	tRollout.Annotations[WorkloadGenerationAnnotation] = "Not a number"
+	t.Run("GetWorkloadGenerationAnnotationInvalidAnnotations", func(t *testing.T) {
+		_, ok := GetWorkloadGenerationAnnotation(&tRollout)
+		assert.False(t, ok)
 	})
 
 	copyRS := tRS.DeepCopy()

--- a/utils/rollout/rolloututil.go
+++ b/utils/rollout/rolloututil.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/argoproj/argo-rollouts/utils/annotations"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
 )
@@ -16,6 +17,11 @@ func GetRolloutPhase(ro *v1alpha1.Rollout) (v1alpha1.RolloutPhase, string) {
 	if !isGenerationObserved(ro) {
 		return v1alpha1.RolloutPhaseProgressing, "waiting for rollout spec update to be observed"
 	}
+
+	if !isWorkloadGenerationObserved(ro) {
+		return v1alpha1.RolloutPhaseProgressing, "waiting for rollout spec update to be observed for the reference workload"
+	}
+
 	if ro.Status.Phase != "" {
 		// for 1.0+ phase/message is calculated controller side
 		return ro.Status.Phase, ro.Status.Message
@@ -37,6 +43,19 @@ func isGenerationObserved(ro *v1alpha1.Rollout) bool {
 		return true
 	}
 	return int64(observedGen) == ro.Generation
+}
+
+func isWorkloadGenerationObserved(ro *v1alpha1.Rollout) bool {
+	if _, ok := annotations.GetWorkloadGenerationAnnotation(ro); !ok {
+		return true
+	}
+	workloadGeneration, _ := annotations.GetWorkloadGenerationAnnotation(ro)
+	observedWorkloadGen, err := strconv.Atoi(ro.Status.WorkloadObservedGeneration)
+	if err != nil {
+		return true
+	}
+
+	return int32(observedWorkloadGen) == workloadGeneration
 }
 
 // CalculateRolloutPhase calculates a rollout phase and message for the given rollout based on

--- a/utils/rollout/rolloututil.go
+++ b/utils/rollout/rolloututil.go
@@ -18,7 +18,7 @@ func GetRolloutPhase(ro *v1alpha1.Rollout) (v1alpha1.RolloutPhase, string) {
 		return v1alpha1.RolloutPhaseProgressing, "waiting for rollout spec update to be observed"
 	}
 
-	if !isWorkloadGenerationObserved(ro) {
+	if ro.Spec.TemplateResolvedFromRef && !isWorkloadGenerationObserved(ro) {
 		return v1alpha1.RolloutPhaseProgressing, "waiting for rollout spec update to be observed for the reference workload"
 	}
 
@@ -50,7 +50,7 @@ func isWorkloadGenerationObserved(ro *v1alpha1.Rollout) bool {
 		return true
 	}
 	workloadGeneration, _ := annotations.GetWorkloadGenerationAnnotation(ro)
-	observedWorkloadGen, err := strconv.Atoi(ro.Status.WorkloadObservedGeneration)
+	observedWorkloadGen, err := strconv.ParseInt(ro.Status.WorkloadObservedGeneration, 10, 32)
 	if err != nil {
 		return true
 	}

--- a/utils/rollout/rolloututil_test.go
+++ b/utils/rollout/rolloututil_test.go
@@ -223,6 +223,7 @@ func TestRolloutStatusProgressing(t *testing.T) {
 	{
 		//Rollout observed workload generation is not updated
 		ro := newCanaryRollout()
+		ro.Spec.TemplateResolvedFromRef = true
 		annotations.SetRolloutWorkloadRefGeneration(ro, "2")
 		ro.Status = v1alpha1.RolloutStatus{
 			WorkloadObservedGeneration: "1",
@@ -230,6 +231,25 @@ func TestRolloutStatusProgressing(t *testing.T) {
 		status, message := GetRolloutPhase(ro)
 		assert.Equal(t, v1alpha1.RolloutPhaseProgressing, status)
 		assert.Equal(t, "waiting for rollout spec update to be observed for the reference workload", message)
+	}
+	{
+		ro := newCanaryRollout()
+
+		observed := isWorkloadGenerationObserved(ro)
+		assert.True(t, observed)
+
+		annotations.SetRolloutWorkloadRefGeneration(ro, "2")
+		ro.Status.WorkloadObservedGeneration = "222222222222222222"
+		observed = isWorkloadGenerationObserved(ro)
+		assert.True(t, observed)
+
+		ro.Status.WorkloadObservedGeneration = "1"
+		observed = isWorkloadGenerationObserved(ro)
+		assert.False(t, observed)
+
+		ro.Status.WorkloadObservedGeneration = "2"
+		observed = isWorkloadGenerationObserved(ro)
+		assert.True(t, observed)
 	}
 }
 


### PR DESCRIPTION
- Add a "rollout.argoproj.io/workload-generation" annotation to
  the rollout metadata, which equals to the generation of reference
  workload
- workload-generation is updated when the referenced workload is
  updated.
- status.workloadObservedGeneration records the observed generation
  of the rollout
- e2e test is updated

Signed-off-by: Hui Kang <hui.kang@salesforce.com>

close #1189 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).