### PR TITLE
Updates (istio.md): changes the comment in DR 

### DIFF
--- a/docs/features/traffic-management/istio.md
+++ b/docs/features/traffic-management/istio.md
@@ -235,7 +235,7 @@ spec:
     labels:        # labels will be injected with canary rollouts-pod-template-hash value
       app: rollout-example
   - name: stable   # referenced in canary.trafficRouting.istio.destinationRule.stableSubsetName
-    labels:        # labels will be injected with canary rollouts-pod-template-hash value
+    labels:        # labels will be injected with stable rollouts-pod-template-hash value
       app: rollout-example
 ```
 


### PR DESCRIPTION
Based on my understanding, I think this the destination rule comment should contains `stable` instead of `canary`. 
I will close the PR if the existing comment is correct, or change it to make more clear like `during rollout it will be replaced as stable pod hash, once rollout is completed then it will be replaced by canary pod hash (which is now the new stable)`.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).