### PR TITLE
fix: workload rollout spec is invalid template is not empty

### DIFF
--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -83,6 +83,16 @@ func (s *RolloutSpec) SetResolvedTemplate(template corev1.PodTemplateSpec) {
 	s.Template = template
 }
 
+func (s *RolloutSpec) EmptyTemplate() bool {
+	if len(s.Template.Labels) > 0 {
+		return false
+	}
+	if len(s.Template.Annotations) > 0 {
+		return false
+	}
+	return true
+}
+
 func (s *RolloutSpec) MarshalJSON() ([]byte, error) {
 	type Alias RolloutSpec
 

--- a/pkg/apis/rollouts/validation/validation.go
+++ b/pkg/apis/rollouts/validation/validation.go
@@ -83,6 +83,12 @@ func ValidateRolloutSpec(rollout *v1alpha1.Rollout, fldPath *field.Path) field.E
 		}
 	}
 
+	// WorkloadRef and template can not be set at the same time
+	if spec.WorkloadRef != nil && !spec.EmptyTemplate() {
+		allErrs = append(allErrs, field.InternalError(fldPath.Child("template"),
+			fmt.Errorf("template must be empty for workload reference rollout")))
+	}
+
 	selector, err := metav1.LabelSelectorAsSelector(spec.Selector)
 	if err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("selector"), spec.Selector, "invalid label selector"))

--- a/pkg/apis/rollouts/validation/validation.go
+++ b/pkg/apis/rollouts/validation/validation.go
@@ -83,8 +83,9 @@ func ValidateRolloutSpec(rollout *v1alpha1.Rollout, fldPath *field.Path) field.E
 		}
 	}
 
-	// WorkloadRef and template can not be set at the same time
-	if spec.WorkloadRef != nil && !spec.EmptyTemplate() {
+	if !rollout.Spec.TemplateResolvedFromRef && (spec.WorkloadRef != nil && !spec.EmptyTemplate()) {
+		// WorkloadRef and template can not be set at the same time for lint plugin
+		// During reconciliation, TemplateResolvedFromRef is true and will not reach here
 		allErrs = append(allErrs, field.InternalError(fldPath.Child("template"),
 			fmt.Errorf("template must be empty for workload reference rollout")))
 	}

--- a/rollout/temlateref.go
+++ b/rollout/temlateref.go
@@ -125,6 +125,12 @@ func (r *informerBasedTemplateResolver) Resolve(rollout *v1alpha1.Rollout) error
 		return nil
 	}
 
+	// When workloadRef is resolved for the first time, TemplateResolvedFromRef = false.
+	// In this case, template must not be set
+	if !rollout.Spec.TemplateResolvedFromRef && !rollout.Spec.EmptyTemplate() {
+		return fmt.Errorf("template must be empty for workload reference rollout")
+	}
+
 	gvk := schema.FromAPIVersionAndKind(rollout.Spec.WorkloadRef.APIVersion, rollout.Spec.WorkloadRef.Kind)
 
 	info, ok := infoByGroupKind[gvk.GroupKind()]


### PR DESCRIPTION
Signed-off-by: Hui Kang <hui.kang@salesforce.com>

close #1222 

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).