### PR TITLE
fix: missing fields in destinationrule

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
 	github.com/lunixbochs/vtclean v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.3.3
 	github.com/newrelic/newrelic-client-go v0.49.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.10.0

--- a/rollout/trafficrouting/istio/istio.go
+++ b/rollout/trafficrouting/istio/istio.go
@@ -243,7 +243,7 @@ func destinationRuleReplaceExtraMarshal(dRule *DestinationRule) []byte {
 		}
 
 		extra := map[string]interface{}{}
-		inputbyte, _ := json.Marshal(dRule.Spec.Subsets[1].Extra)
+		inputbyte, _ := json.Marshal(subset.Extra)
 		json.Unmarshal(inputbyte, &extra)
 
 		subset.Extra = nil
@@ -266,7 +266,7 @@ func updateDestinationRule(ctx context.Context, client dynamic.ResourceInterface
 		return false, err
 	}
 	dRuleNewBytes := destinationRuleReplaceExtraMarshal(dRuleNew)
-	log.Infof("dRuleNewBytes: %s", string(dRuleNewBytes))
+	log.Debugf("dRuleNewBytes: %s", string(dRuleNewBytes))
 
 	patch, err := jsonpatch.CreateMergePatch(dRuleBytes, dRuleNewBytes)
 	if err != nil {

--- a/rollout/trafficrouting/istio/istio.go
+++ b/rollout/trafficrouting/istio/istio.go
@@ -288,7 +288,7 @@ func updateDestinationRule(ctx context.Context, client dynamic.ResourceInterface
 	if err != nil {
 		return false, err
 	}
-	log.Infof("updated destinationrule: %s", string(patch))
+	log.Infof("updating destinationrule: %s", string(patch))
 	return true, nil
 }
 

--- a/rollout/trafficrouting/istio/istio_types.go
+++ b/rollout/trafficrouting/istio/istio_types.go
@@ -47,4 +47,6 @@ type DestinationRuleSpec struct {
 type Subset struct {
 	Name   string            `json:"name,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
+	// TrafficPolicy *json.RawMessage  `json:"trafficPolicy,omitempty"`
+	Extra map[string]interface{} `json:",omitempty"`
 }


### PR DESCRIPTION
- add Extra to DestinationRule to hold any other fields from istio's
  destinationRule
- handle any extra fields that could be introduced to the subsets
  in istio's destinationRule fields
- unit test added

Signed-off-by: Hui Kang <hui.kang@salesforce.com>

close #1238 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).