### PR TITLE
fix: undo referenced object for workloadRef rollout

### DIFF
--- a/pkg/kubectl-argo-rollouts/info/testdata/canary/canary-ref-deploy.yaml
+++ b/pkg/kubectl-argo-rollouts/info/testdata/canary/canary-ref-deploy.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: canary-demo-deploy
+  namespace: jesse-test
+spec:
+  selector:
+    matchLabels:
+      app: canary-demo-deploy
+  replicas: 0
+  template:
+    metadata:
+      labels:
+        app: canary-demo-deploy
+    spec:
+      containers:
+        - name: canary-demo-deploy
+          image: argoproj/rollouts-demo:red
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            requests:
+              memory: 32Mi
+              cpu: 5m

--- a/pkg/kubectl-argo-rollouts/info/testdata/canary/canary-rollout2.yaml
+++ b/pkg/kubectl-argo-rollouts/info/testdata/canary/canary-rollout2.yaml
@@ -1,0 +1,68 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  annotations:
+    rollout.argoproj.io/revision: "31"
+  creationTimestamp: "2019-10-25T06:07:18Z"
+  generation: 429
+  labels:
+    app: canary-demo
+    app.kubernetes.io/instance: jesse-test
+  name: canary-demo-workloadRef
+  namespace: jesse-test
+  resourceVersion: "28253567"
+  selfLink: /apis/argoproj.io/v1alpha1/namespaces/jesse-test/rollouts/canary-demo
+  uid: b350ba76-f6ed-11e9-a15b-42010aa80033
+spec:
+  progressDeadlineSeconds: 30
+  replicas: 5
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: canary-demo
+  strategy:
+    canary:
+      canaryService: canary-demo-preview
+      steps:
+      - setWeight: 20
+      - pause: {}
+      - setWeight: 40
+      - pause:
+          duration: 10s
+      - setWeight: 60
+      - pause:
+          duration: 10s
+      - setWeight: 80
+      - pause:
+          duration: 10s
+  workloadRef:
+    apiVersion: apps/v1
+    kind: ReplicaSet
+    name: canary-demo-65fb5ffc84
+status:
+  HPAReplicas: 6
+  availableReplicas: 5
+  blueGreen: {}
+  canary: {}
+  stableRS: 877894d5b
+  conditions:
+  - lastTransitionTime: "2019-10-25T06:07:29Z"
+    lastUpdateTime: "2019-10-25T06:07:29Z"
+    message: Rollout has minimum availability
+    reason: AvailableReason
+    status: "True"
+    type: Available
+  - lastTransitionTime: "2019-10-28T04:52:55Z"
+    lastUpdateTime: "2019-10-28T04:52:55Z"
+    message: ReplicaSet "canary-demo-65fb5ffc84" has timed out progressing.
+    reason: ProgressDeadlineExceeded
+    status: "False"
+    type: Progressing
+  currentPodHash: 65fb5ffc84
+  currentStepHash: f64cdc9d
+  currentStepIndex: 0
+  observedGeneration: "429"
+  readyReplicas: 5
+  replicas: 6
+  selector: app=canary-demo
+  updatedReplicas: 1

--- a/pkg/kubectl-argo-rollouts/info/testdata/canary/canary-rollout3.yaml
+++ b/pkg/kubectl-argo-rollouts/info/testdata/canary/canary-rollout3.yaml
@@ -1,0 +1,68 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  annotations:
+    rollout.argoproj.io/revision: "31"
+  creationTimestamp: "2019-10-25T06:07:18Z"
+  generation: 429
+  labels:
+    app: canary-demo
+    app.kubernetes.io/instance: jesse-test
+  name: canary-demo-workloadRef-deploy
+  namespace: jesse-test
+  resourceVersion: "28253567"
+  selfLink: /apis/argoproj.io/v1alpha1/namespaces/jesse-test/rollouts/canary-demo
+  uid: b350ba76-f6ed-11e9-a15b-42010aa80033
+spec:
+  progressDeadlineSeconds: 30
+  replicas: 5
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: canary-demo
+  strategy:
+    canary:
+      canaryService: canary-demo-preview
+      steps:
+      - setWeight: 20
+      - pause: {}
+      - setWeight: 40
+      - pause:
+          duration: 10s
+      - setWeight: 60
+      - pause:
+          duration: 10s
+      - setWeight: 80
+      - pause:
+          duration: 10s
+  workloadRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: canary-demo-deploy
+status:
+  HPAReplicas: 6
+  availableReplicas: 5
+  blueGreen: {}
+  canary: {}
+  stableRS: 877894d5b
+  conditions:
+  - lastTransitionTime: "2019-10-25T06:07:29Z"
+    lastUpdateTime: "2019-10-25T06:07:29Z"
+    message: Rollout has minimum availability
+    reason: AvailableReason
+    status: "True"
+    type: Available
+  - lastTransitionTime: "2019-10-28T04:52:55Z"
+    lastUpdateTime: "2019-10-28T04:52:55Z"
+    message: ReplicaSet "canary-demo-65fb5ffc84" has timed out progressing.
+    reason: ProgressDeadlineExceeded
+    status: "False"
+    type: Progressing
+  currentPodHash: 65fb5ffc84
+  currentStepHash: f64cdc9d
+  currentStepIndex: 0
+  observedGeneration: "429"
+  readyReplicas: 5
+  replicas: 6
+  selector: app=canary-demo
+  updatedReplicas: 1

--- a/pkg/kubectl-argo-rollouts/info/testdata/canary/canary-rs.yaml
+++ b/pkg/kubectl-argo-rollouts/info/testdata/canary/canary-rs.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   annotations:

--- a/pkg/kubectl-argo-rollouts/info/testdata/canary/old-rs.yaml
+++ b/pkg/kubectl-argo-rollouts/info/testdata/canary/old-rs.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   annotations:

--- a/pkg/kubectl-argo-rollouts/info/testdata/canary/stable-rs.yaml
+++ b/pkg/kubectl-argo-rollouts/info/testdata/canary/stable-rs.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   annotations:

--- a/pkg/kubectl-argo-rollouts/info/testdata/testdata.go
+++ b/pkg/kubectl-argo-rollouts/info/testdata/testdata.go
@@ -29,6 +29,7 @@ type RolloutObjects struct {
 	Pods         []*corev1.Pod
 	Experiments  []*v1alpha1.Experiment
 	AnalysisRuns []*v1alpha1.AnalysisRun
+	Deployments  []*appsv1.Deployment
 }
 
 func (r *RolloutObjects) AllObjects() []k8sruntime.Object {
@@ -37,6 +38,9 @@ func (r *RolloutObjects) AllObjects() []k8sruntime.Object {
 		objs = append(objs, o)
 	}
 	for _, o := range r.ReplicaSets {
+		objs = append(objs, o)
+	}
+	for _, o := range r.Deployments {
 		objs = append(objs, o)
 	}
 	for _, o := range r.Pods {
@@ -107,6 +111,14 @@ func discoverObjects(path string) *RolloutObjects {
 			}
 			rs.CreationTimestamp = aWeekAgo
 			objs.ReplicaSets = append(objs.ReplicaSets, &rs)
+		case "Deployment":
+			var de appsv1.Deployment
+			err = yaml.UnmarshalStrict(yamlBytes, &de, yaml.DisallowUnknownFields)
+			if err != nil {
+				panic(err)
+			}
+			de.CreationTimestamp = aWeekAgo
+			objs.Deployments = append(objs.Deployments, &de)
 		case "Pod":
 			var pod corev1.Pod
 			err = yaml.UnmarshalStrict(yamlBytes, &pod, yaml.DisallowUnknownFields)


### PR DESCRIPTION
- rollback by patching the referenceed object, e.g., deployment, replicaset
- unit test is added

close #1254 

Signed-off-by: Hui Kang <hui.kang@salesforce.com>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).