### PR TITLE
chore: remove unused code of crd generation

### DIFF
--- a/hack/gen-crd-spec/main.go
+++ b/hack/gen-crd-spec/main.go
@@ -253,10 +253,6 @@ func removeK8S118Fields(un *unstructured.Unstructured) {
 		// Replace this with "spec.template.spec.volumes[].ephemeral.volumeClaimTemplate.spec.resources.{limits/requests}"
 		// when it's ok to only support k8s 1.17+
 		setValidationOverride(un, preserveUnknownFields, "spec.template.spec.volumes")
-		validation, _, _ := unstructured.NestedMap(un.Object, "spec", "validation", "openAPIV3Schema")
-		removeFieldHelper(validation, "x-kubernetes-list-type")
-		removeFieldHelper(validation, "x-kubernetes-list-map-keys")
-		unstructured.SetNestedMap(un.Object, validation, "spec", "validation", "openAPIV3Schema")
 	case "Experiment":
 		setValidationOverride(un, preserveUnknownFields, "spec.templates[].template.spec.containers[].resources.limits")
 		setValidationOverride(un, preserveUnknownFields, "spec.templates[].template.spec.containers[].resources.requests")
@@ -267,10 +263,6 @@ func removeK8S118Fields(un *unstructured.Unstructured) {
 		// Replace this with "spec.templates[].template.spec.volumes[].ephemeral.volumeClaimTemplate.spec.resources.{limits/requests}"
 		// when it's ok to only support k8s 1.17+
 		setValidationOverride(un, preserveUnknownFields, "spec.templates[].template.spec.volumes")
-		validation, _, _ := unstructured.NestedMap(un.Object, "spec", "validation", "openAPIV3Schema")
-		removeFieldHelper(validation, "x-kubernetes-list-type")
-		removeFieldHelper(validation, "x-kubernetes-list-map-keys")
-		unstructured.SetNestedMap(un.Object, validation, "spec", "validation", "openAPIV3Schema")
 	case "ClusterAnalysisTemplate", "AnalysisTemplate", "AnalysisRun":
 		setValidationOverride(un, preserveUnknownFields, "spec.metrics[].provider.job.spec.template.spec.containers[].resources.limits")
 		setValidationOverride(un, preserveUnknownFields, "spec.metrics[].provider.job.spec.template.spec.containers[].resources.requests")
@@ -281,10 +273,6 @@ func removeK8S118Fields(un *unstructured.Unstructured) {
 		// Replace this with "spec.metrics[].provider.job.spec.template.spec.volumes[].ephemeral.volumeClaimTemplate.spec.resources.{limits/requests}"
 		// when it's ok to only support k8s 1.17+
 		setValidationOverride(un, preserveUnknownFields, "spec.metrics[].provider.job.spec.template.spec.volumes")
-		validation, _, _ := unstructured.NestedMap(un.Object, "spec", "validation", "openAPIV3Schema")
-		removeFieldHelper(validation, "x-kubernetes-list-type")
-		removeFieldHelper(validation, "x-kubernetes-list-map-keys")
-		unstructured.SetNestedMap(un.Object, validation, "spec", "validation", "openAPIV3Schema")
 	default:
 		panic(fmt.Sprintf("unknown kind: %s", kind))
 	}


### PR DESCRIPTION
- openAPIV3Schema is the only validation schema

Signed-off-by: Hui Kang <hui.kang@salesforce.com>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).