### PR TITLE
fix: avoid invalid replica in workloadRef

### DIFF
--- a/rollout/controller.go
+++ b/rollout/controller.go
@@ -360,14 +360,6 @@ func (c *Controller) syncHandler(key string) error {
 		return nil
 	}
 
-	// In order to work with HPA, the rollout.Spec.Replica field cannot be nil. As a result, the controller will update
-	// the rollout to have the replicas field set to the default value. see https://github.com/argoproj/argo-rollouts/issues/119
-	if rollout.Spec.Replicas == nil {
-		logCtx.Info("Defaulting .spec.replica to 1")
-		r.Spec.Replicas = pointer.Int32Ptr(defaults.DefaultReplicas)
-		_, err := c.argoprojclientset.ArgoprojV1alpha1().Rollouts(r.Namespace).Update(ctx, r, metav1.UpdateOptions{})
-		return err
-	}
 	defer func() {
 		duration := time.Since(startTime)
 		c.metricsServer.IncRolloutReconcile(r, duration)
@@ -383,6 +375,15 @@ func (c *Controller) syncHandler(key string) error {
 	if resolveErr != nil {
 		roCtx.createInvalidRolloutCondition(resolveErr, r)
 		return resolveErr
+	}
+
+	// In order to work with HPA, the rollout.Spec.Replica field cannot be nil. As a result, the controller will update
+	// the rollout to have the replicas field set to the default value. see https://github.com/argoproj/argo-rollouts/issues/119
+	if rollout.Spec.Replicas == nil {
+		logCtx.Info("Defaulting .spec.replica to 1")
+		r.Spec.Replicas = pointer.Int32Ptr(defaults.DefaultReplicas)
+		_, err := c.argoprojclientset.ArgoprojV1alpha1().Rollouts(r.Namespace).Update(ctx, r, metav1.UpdateOptions{})
+		return err
 	}
 
 	err = roCtx.reconcile()


### PR DESCRIPTION
- defaulting replica after workload ref is resolved

Signed-off-by: Hui Kang <hui.kang@salesforce.com>

close #1302 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).