### PR TITLE
fix: remove unused field in Manager struct

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -94,8 +94,6 @@ type Manager struct {
 
 	refResolver rollout.TemplateRefResolver
 
-	dynamicClientSet dynamic.Interface
-
 	namespace string
 }
 
@@ -266,7 +264,6 @@ func NewManager(
 		experimentController:          experimentController,
 		analysisController:            analysisController,
 		notificationsController:       notificationsController,
-		dynamicClientSet:              dynamicclientset,
 		refResolver:                   refResolver,
 		namespace:                     namespace,
 	}


### PR DESCRIPTION
- dynamicClientSet is redundant

Signed-off-by: Hui Kang <hui.kang@salesforce.com>

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).