### PR TITLE
docs: Fix links on architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,16 +12,16 @@ will read all the details of the rollout and bring the cluster to the same state
 Note that Argo Rollouts will not tamper with or respond to any changes that happen on normal [Deployment Resources](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/). This means
 that you can install Argo Rollouts in a cluster that is also deploying applications with alternative methods.
 
-To install the controller in your cluster and get started with Progressive Delivery, see the [Installation page](../installation/).
+To install the controller in your cluster and get started with Progressive Delivery, see the [Installation page](installation/).
 
 ## Rollout resource
 
 The Rollout resource is a custom Kubernetes resource introduced and managed by Argo Rollouts. It is mostly compatible with the native Kubernetes Deployment resource but with extra
 fields that control the stages, thresholds and methods of advanced deployment methods such as canaries and blue/green deployments.
 
-Note that the Argo Rollouts controller will only responds to changes that happen in Rollout sources. It will do nothing for normal deployment resources. This means that you need to [migrate your Deployments to Rollouts](../migrating/) if you want to manage them with Argo Rollouts.
+Note that the Argo Rollouts controller will only responds to changes that happen in Rollout sources. It will do nothing for normal deployment resources. This means that you need to [migrate your Deployments to Rollouts](migrating/) if you want to manage them with Argo Rollouts.
 
-You can see all possible options of a Rollout in the [full specification page](../features/specification/).
+You can see all possible options of a Rollout in the [full specification page](features/specification/).
 
 ## Replica sets for old and new version
 
@@ -34,7 +34,7 @@ Note also that the replica sets that take part in a Rollout are fully managed by
 This is the mechanism that traffic from live users enters your cluster and is redirected to the appropriate version. Argo Rollouts use the [standard Kubernetes service resource](https://kubernetes.io/docs/concepts/services-networking/service/), but with some extra metadata needed for management.
 
 Argo Rollouts is very flexible on networking options. First of all you can have different services during a Rollout, that go only to the new version, only to the old version or both.
-Specifically for Canary deployments, Argo Rollouts supports several [service mesh and ingress solutions](../features/traffic-management/) for splitting traffic with specific percentages instead of simple balancing based on pod counts.
+Specifically for Canary deployments, Argo Rollouts supports several [service mesh and ingress solutions](features/traffic-management/) for splitting traffic with specific percentages instead of simple balancing based on pod counts.
 
 ## Analysis and AnalysisRun
 
@@ -44,14 +44,14 @@ Analysis is just a template on what metrics to query. The actual result that is 
 
 Note that using Analysis and metrics in a Rollout is completely optional. You can manually pause and promote a rollout or use other external methods (e.g. smoke tests) via the API or the CLI. You don't need a metric solution just to use Argo Rollouts. You can also mix both automated (i.e. analysis based) and manual steps in a Rollout.
 
-Apart from metrics, you can also decide the success of a rollout by running a [Kubernetes job](../analysis/job/) or running [a webhook](../analysis/web/).
+Apart from metrics, you can also decide the success of a rollout by running a [Kubernetes job](analysis/job/) or running [a webhook](analysis/web/).
 
 
 ## Metric providers
 
-Argo Rollouts includes [native integration for several popular metrics providers](../features/analysis/) that you can use in the Analysis resources to automatically promote or rollback  a rollout. See the documentation of each provider for specific setup options.
+Argo Rollouts includes [native integration for several popular metrics providers](features/analysis/) that you can use in the Analysis resources to automatically promote or rollback  a rollout. See the documentation of each provider for specific setup options.
 
 ## CLI and UI (Not shown in the diagram)
 
-You can view and manage Rollouts with the [Argo Rollouts CLI](../features/kubectl-plugin/) or the [integrated UI](../dashboard/). Both are optional.
+You can view and manage Rollouts with the [Argo Rollouts CLI](features/kubectl-plugin/) or the [integrated UI](dashboard/). Both are optional.
 


### PR DESCRIPTION
It seems the links on the architecture page are broken and point to the wrong places so I fixed it. 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).