### PR TITLE
test: update PodDisruptionBudget version to v1

### DIFF
--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -283,7 +283,7 @@ func (s *FunctionalSuite) TestRolloutPDBRestart() {
 	s.Given().
 		HealthyRollout(`
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: rollout-pdb-restart

--- a/test/fixtures/e2e_suite.go
+++ b/test/fixtures/e2e_suite.go
@@ -73,7 +73,7 @@ var (
 	}
 	pdbGVR = schema.GroupVersionResource{
 		Group:    "policy",
-		Version:  "v1beta1",
+		Version:  "v1",
 		Resource: "poddisruptionbudgets",
 	}
 	jobGVR = schema.GroupVersionResource{


### PR DESCRIPTION
When I see [the e2e logs](https://github.com/argoproj/argo-rollouts/pull/1316/checks?check_run_id=2947258104), I noticed many warnings saying `policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget`. To resolve it, I updated pdb version from v1beta1 to v1.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).