### PR TITLE
fix: lint subcommand for workload ref rollout

### DIFF
--- a/pkg/apis/rollouts/validation/validation_test.go
+++ b/pkg/apis/rollouts/validation/validation_test.go
@@ -47,6 +47,13 @@ func TestValidateRollout(t *testing.T) {
 		assert.Equal(t, message, allErrs[0].Detail)
 	})
 
+	t.Run("empty selector", func(t *testing.T) {
+		invalidRo := ro.DeepCopy()
+		invalidRo.Spec.Selector = &metav1.LabelSelector{}
+		allErrs := ValidateRollout(invalidRo)
+		assert.Equal(t, "empty selector is invalid for deployment", allErrs[0].Detail)
+	})
+
 	t.Run("invalid progressDeadlineSeconds", func(t *testing.T) {
 		invalidRo := ro.DeepCopy()
 		invalidRo.Spec.MinReadySeconds = defaults.GetProgressDeadlineSecondsOrDefault(invalidRo) + 1

--- a/pkg/apis/rollouts/validation/validation_test.go
+++ b/pkg/apis/rollouts/validation/validation_test.go
@@ -341,8 +341,20 @@ func TestWorkloadRefWithTemplate(t *testing.T) {
 	t.Run("workload reference with template", func(t *testing.T) {
 		ro := ro.DeepCopy()
 		allErrs := ValidateRollout(ro)
-		assert.Equal(t, 2, len(allErrs))
+		assert.Equal(t, 1, len(allErrs))
 		assert.EqualError(t, allErrs[0], "spec.template: Internal error: template must be empty for workload reference rollout")
-		assert.EqualError(t, allErrs[1], "spec.template.spec.containers: Required value")
+	})
+	t.Run("valid workload reference with selector", func(t *testing.T) {
+		ro := ro.DeepCopy()
+		ro.Spec.Template = corev1.PodTemplateSpec{}
+		allErrs := ValidateRollout(ro)
+		assert.Equal(t, 0, len(allErrs))
+	})
+	t.Run("valid workload reference without selector", func(t *testing.T) {
+		ro := ro.DeepCopy()
+		ro.Spec.Selector = nil
+		ro.Spec.Template = corev1.PodTemplateSpec{}
+		allErrs := ValidateRollout(ro)
+		assert.Equal(t, 0, len(allErrs))
 	})
 }

--- a/pkg/kubectl-argo-rollouts/cmd/lint/lint_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/lint/lint_test.go
@@ -15,7 +15,7 @@ func TestLintValidRollout(t *testing.T) {
 	cmd := NewCmdLint(o)
 	cmd.PersistentPreRunE = o.PersistentPreRunE
 
-	for _, filename := range []string{"testdata/valid.yml", "testdata/valid-with-another-empty-object.yml"} {
+	for _, filename := range []string{"testdata/valid.yml", "testdata/valid-workload-ref.yaml", "testdata/valid-with-another-empty-object.yml"} {
 		cmd.SetArgs([]string{"-f", filename})
 		err := cmd.Execute()
 		assert.NoError(t, err)

--- a/pkg/kubectl-argo-rollouts/cmd/lint/testdata/valid-workload-ref.yaml
+++ b/pkg/kubectl-argo-rollouts/cmd/lint/testdata/valid-workload-ref.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1               # Create a rollout resource
+kind: Rollout
+metadata:
+  name: rollout-ref-deployment
+spec:
+  replicas: 5
+  workloadRef:                                 # Reference an existing Deployment using workloadRef field
+    apiVersion: apps/v1
+    kind: Deployment
+    name: rollout-ref-deployment
+  strategy:
+    canary:
+      steps:
+        - setWeight: 20
+        - pause: {duration: 10s}


### PR DESCRIPTION
Signed-off-by: Hui Kang <hui.kang@salesforce.com>

close #1327 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).