### PR TITLE
feat: argo rollout compatibility with emissary and edge stack v2.0

### DIFF
--- a/docs/getting-started/ambassador/index.md
+++ b/docs/getting-started/ambassador/index.md
@@ -7,6 +7,11 @@ This tutorial will walk you through the process of configuring Argo Rollouts to 
 - Kubernetes cluster
 - Argo-Rollouts installed in the cluster
 
+---
+**Note**
+If using Ambassador Edge Stack or Emissary-ingress 2.0+, you will need to install Argo-Rollouts version v1.1+, and you will need to supply `--ambassador-api-version x.getambassador.io/v3alpha1` to your `argo-rollouts` deployment.
+---
+
 ## 1. Install and configure Ambassador Edge Stack
 
 If you don't have Ambassador in your cluster you can install it following the [Edge Stack documentation](https://www.getambassador.io/docs/latest/topics/install/).

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -12778,6 +12778,17 @@ rules:
   - update
   - list
   - delete
+- apiGroups:
+  - x.getambassador.io
+  resources:
+  - ambassadormappings
+  verbs:
+  - create
+  - watch
+  - get
+  - update
+  - list
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -12694,6 +12694,17 @@ rules:
   - update
   - list
   - delete
+- apiGroups:
+  - x.getambassador.io
+  resources:
+  - ambassadormappings
+  verbs:
+  - create
+  - watch
+  - get
+  - update
+  - list
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/manifests/role/argo-rollouts-clusterrole.yaml
+++ b/manifests/role/argo-rollouts-clusterrole.yaml
@@ -170,3 +170,14 @@ rules:
   - update
   - list
   - delete
+- apiGroups:
+  - x.getambassador.io
+  resources:
+  - ambassadormappings
+  verbs:
+  - create
+  - watch
+  - get
+  - update
+  - list
+  - delete

--- a/rollout/trafficrouting/ambassador/ambassador.go
+++ b/rollout/trafficrouting/ambassador/ambassador.go
@@ -36,6 +36,10 @@ const (
 
 var (
 	ambassadorAPIVersion = defaults.DefaultAmbassadorVersion
+	apiGroupToResource   = map[string]string{
+		"getambassador.io":   "mappings",
+		"x.getambassador.io": "ambassadormappings",
+	}
 )
 
 func SetAPIVersion(apiVersion string) {
@@ -300,11 +304,19 @@ func GetMappingGVR() schema.GroupVersionResource {
 
 func toMappingGVR(apiVersion string) schema.GroupVersionResource {
 	parts := strings.Split(apiVersion, "/")
+	group := defaults.DefaultAmbassadorAPIGroup
+	if len(parts) > 1 {
+		group = parts[0]
+	}
+	resourcename, known := apiGroupToResource[group]
+	if !known {
+		resourcename = apiGroupToResource[defaults.DefaultAmbassadorAPIGroup]
+	}
 	version := parts[len(parts)-1]
 	return schema.GroupVersionResource{
-		Group:    "getambassador.io",
+		Group:    group,
 		Version:  version,
-		Resource: "mappings",
+		Resource: resourcename,
 	}
 }
 

--- a/utils/defaults/defaults.go
+++ b/utils/defaults/defaults.go
@@ -31,6 +31,7 @@ const (
 )
 
 const (
+	DefaultAmbassadorAPIGroup     = "getambassador.io"
 	DefaultAmbassadorVersion      = "v2"
 	DefaultIstioVersion           = "v1alpha3"
 	DefaultSMITrafficSplitVersion = "v1alpha1"

--- a/utils/defaults/defaults.go
+++ b/utils/defaults/defaults.go
@@ -32,7 +32,7 @@ const (
 
 const (
 	DefaultAmbassadorAPIGroup     = "getambassador.io"
-	DefaultAmbassadorVersion      = "v2"
+	DefaultAmbassadorVersion      = "getambassador.io/v2"
 	DefaultIstioVersion           = "v1alpha3"
 	DefaultSMITrafficSplitVersion = "v1alpha1"
 )


### PR DESCRIPTION
Signed-off-by: Alix Cook <alixcook@datawire.io>

Allow argo rollouts to work with emissary and edge stack v2, recently announced as developer preview.
See [our release notes](https://www.getambassador.io/docs/edge-stack/2.0/release-notes) for more information.

I'd like to merge this feature, and then update our docs and the argo-docs in a subsequent PR so that I don't have to worry about releasing these things in lockstep.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).