### PR TITLE
fix: abort scaledown stable RS for canary with traffic routing

### DIFF
--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -197,3 +197,30 @@ func (s *IstioSuite) TestIstioSubsetSplitSingleRoute() {
 		}).
 		ExpectRevisionPodCount("1", 1) // don't scale down old replicaset since it will be within scaleDownDelay
 }
+
+func (s *IstioSuite) TestIstioAbortUpdate() {
+	s.Given().
+		RolloutObjects("@istio/istio-host-split.yaml").
+		When().
+		ApplyManifests().
+		WaitForRolloutStatus("Healthy").
+		Then().
+		When().
+		AbortRollout().
+		WaitForRolloutStatus("Degraded").
+		Then().
+		ExpectRevisionPodCount("1", 1).
+		When().
+		UpdateSpec().
+		WaitForRolloutStatus("Paused").
+		Then().
+		When().
+		PromoteRollout().
+		WaitForRolloutStatus("Healthy").
+		Then().
+		When().
+		AbortRollout().
+		WaitForRolloutStatus("Degraded").
+		Then().
+		ExpectRevisionPodCount("2", 1)
+}

--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -107,7 +107,7 @@ func CalculateReplicaCountsForCanary(rollout *v1alpha1.Rollout, newRS *appsv1.Re
 	desiredStableRSReplicaCount := int32(math.Ceil(float64(rolloutSpecReplica) * (1 - (float64(weight) / 100))))
 	desiredNewRSReplicaCount := int32(math.Ceil(float64(rolloutSpecReplica) * (float64(weight) / 100)))
 
-	if rollout.Spec.Strategy.Canary.TrafficRouting != nil {
+	if rollout.Spec.Strategy.Canary.TrafficRouting != nil && !rollout.Status.Abort {
 		return desiredNewRSReplicaCount, rolloutSpecReplica
 	}
 

--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -107,7 +107,7 @@ func CalculateReplicaCountsForCanary(rollout *v1alpha1.Rollout, newRS *appsv1.Re
 	desiredStableRSReplicaCount := int32(math.Ceil(float64(rolloutSpecReplica) * (1 - (float64(weight) / 100))))
 	desiredNewRSReplicaCount := int32(math.Ceil(float64(rolloutSpecReplica) * (float64(weight) / 100)))
 
-	if rollout.Spec.Strategy.Canary.TrafficRouting != nil && !rollout.Status.Abort {
+	if rollout.Spec.Strategy.Canary.TrafficRouting != nil {
 		return desiredNewRSReplicaCount, rolloutSpecReplica
 	}
 
@@ -293,7 +293,7 @@ func GetCurrentCanaryStep(rollout *v1alpha1.Rollout) (*v1alpha1.CanaryStep, *int
 
 // GetCanaryReplicasOrWeight either returns a static set of replicas or a weight percentage
 func GetCanaryReplicasOrWeight(rollout *v1alpha1.Rollout) (*int32, int32) {
-	if rollout.Status.PromoteFull {
+	if rollout.Status.PromoteFull || rollout.Status.CurrentPodHash == rollout.Status.StableRS {
 		return nil, 100
 	}
 	if scs := UseSetCanaryScale(rollout); scs != nil {


### PR DESCRIPTION
Signed-off-by: Hui Kang <hui.kang@salesforce.com>

close #1292 

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).