### PR TITLE
feat: ability to verify AWS TargetGroup after blue-green cutover

### DIFF
--- a/manifests/role/argo-rollouts-clusterrole.yaml
+++ b/manifests/role/argo-rollouts-clusterrole.yaml
@@ -56,17 +56,17 @@ rules:
   - update
   - patch
   - delete
-  # deployments and podtemplates read access needed for workload reference support
+# deployments and podtemplates read access needed for workload reference support
 - apiGroups:
-    - ""
-    - apps
+  - ""
+  - apps
   resources:
-    - deployments
-    - podtemplates
+  - deployments
+  - podtemplates
   verbs:
-    - get
-    - list
-    - watch
+  - get
+  - list
+  - watch
 # services patch needed to update selector of canary/stable/active/preview services
 - apiGroups:
   - ""
@@ -159,20 +159,12 @@ rules:
   - get
   - update
   - patch
+# ambassador access needed for Ambassador provider
 - apiGroups:
   - getambassador.io
-  resources:
-  - mappings
-  verbs:
-  - create
-  - watch
-  - get
-  - update
-  - list
-  - delete
-- apiGroups:
   - x.getambassador.io
   resources:
+  - mappings
   - ambassadormappings
   verbs:
   - create
@@ -181,3 +173,17 @@ rules:
   - update
   - list
   - delete
+# Endpoints and TargetGroupBindings needed for ALB target group verification
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+- apiGroups:
+  - elbv2.k8s.aws
+  resources:
+  - targetgroupbindings
+  verbs:
+  - list
+  - get

--- a/rollout/analysis.go
+++ b/rollout/analysis.go
@@ -284,7 +284,8 @@ func (c *rolloutContext) reconcilePostPromotionAnalysisRun() (*v1alpha1.Analysis
 	}
 
 	c.log.Info("Reconciling Post Promotion Analysis")
-	if skipPostPromotionAnalysisRun(c.rollout, c.newRS) {
+	// don't start post-promotion if we are not ready to, or we are still waiting for target verification
+	if skipPostPromotionAnalysisRun(c.rollout, c.newRS) || !c.areTargetsVerified() {
 		err := c.cancelAnalysisRuns([]*v1alpha1.AnalysisRun{currentAr})
 		return currentAr, err
 	}

--- a/rollout/bluegreen.go
+++ b/rollout/bluegreen.go
@@ -52,6 +52,11 @@ func (c *rolloutContext) rolloutBlueGreen() error {
 		return err
 	}
 
+	err = c.awsVerifyTargetGroups(activeSvc)
+	if err != nil {
+		return err
+	}
+
 	err = c.reconcileAnalysisRuns()
 	if err != nil {
 		return err

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -240,7 +240,7 @@ func (c *rolloutContext) completedCurrentCanaryStep() bool {
 		if !replicasetutil.AtDesiredReplicaCountsForCanary(c.rollout, c.newRS, c.stableRS, c.otherRSs) {
 			return false
 		}
-		if c.weightVerified != nil && !*c.weightVerified {
+		if !c.areTargetsVerified() {
 			return false
 		}
 		return true

--- a/rollout/context.go
+++ b/rollout/context.go
@@ -42,10 +42,13 @@ type rolloutContext struct {
 	newStatus    v1alpha1.RolloutStatus
 	pauseContext *pauseContext
 
-	// weightVerified keeps track of the verified weight. nil indicates the check was not performed.
-	// we only perform weight verification when we are at a setWeight step since we do not want to
-	// continually verify weight in case it could incur rate-limiting or other expenses.
-	weightVerified *bool
+	// targetsVerified indicates if the pods targets have been verified with underlying LoadBalancer.
+	// This is used in pod-aware flat networks where LoadBalancers target Pods and not Nodes.
+	// nil indicates the check was unnecessary or not performed.
+	// NOTE: we only perform target verification when we are at specific points in time
+	// (e.g. a setWeight step, after a blue-green active switch, after stable service switch),
+	// since we do not want to continually verify weight in case it could incur rate-limiting or other expenses.
+	targetsVerified *bool
 }
 
 func (c *rolloutContext) reconcile() error {

--- a/rollout/service.go
+++ b/rollout/service.go
@@ -3,14 +3,18 @@ package rollout
 import (
 	"context"
 	"fmt"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	patchtypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/annotations"
+	"github.com/argoproj/argo-rollouts/utils/aws"
+	"github.com/argoproj/argo-rollouts/utils/defaults"
 	"github.com/argoproj/argo-rollouts/utils/record"
 	replicasetutil "github.com/argoproj/argo-rollouts/utils/replicaset"
 	serviceutil "github.com/argoproj/argo-rollouts/utils/service"
@@ -103,6 +107,91 @@ func (c *rolloutContext) reconcileActiveService(activeSvc *corev1.Service) error
 		return err
 	}
 	return nil
+}
+
+// areTargetsVerified is a convenience to determine if the pod targets have been verified with
+// underlying load balancer. If check was not performed or unnecessary, returns true.
+func (c *rolloutContext) areTargetsVerified() bool {
+	return c.targetsVerified == nil || *c.targetsVerified
+}
+
+// awsVerifyTargetGroups examines a Service and verifies that underlying AWS TargetGroup is properly
+// targetting the Service's Endpoint IPs and port. Only valid for services which are reachable
+// by an ALB Ingress, which can be determined if there exists a TargetGroupBinding object in the
+// namespace that references the given service
+func (c *rolloutContext) awsVerifyTargetGroups(svc *corev1.Service) error {
+	if !c.shouldVerifyTargetGroup(svc) {
+		return nil
+	}
+	ctx := context.TODO()
+	// find all TargetGroupBindings in the namespace which reference the service name + port
+	tgBindings, err := aws.GetTargetGroupBindingsByService(ctx, c.dynamicclientset, *svc)
+	if err != nil {
+		return err
+	}
+	if len(tgBindings) == 0 {
+		// no TargetGroupBinding for the service found (e.g. it is in-cluster blue-green). nothing to verify
+		return nil
+	}
+
+	c.targetsVerified = pointer.BoolPtr(true)
+
+	// get endpoints of service
+	endpoints, err := c.kubeclientset.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	awsClnt, err := aws.NewClient()
+	if err != nil {
+		return err
+	}
+
+	for _, tgb := range tgBindings {
+		verified, err := aws.VerifyTargetGroupBinding(ctx, c.log, awsClnt, tgb, endpoints, svc)
+		if err != nil {
+			return err
+		}
+		if !verified {
+			c.targetsVerified = pointer.BoolPtr(false)
+			c.enqueueRolloutAfter(c.rollout, 10*time.Second)
+			return nil
+		}
+	}
+	return nil
+}
+
+// shouldVerifyTargetGroup returns whether or not we should verify the target group
+func (c *rolloutContext) shouldVerifyTargetGroup(svc *corev1.Service) bool {
+	if !defaults.VerifyTargetGroup() {
+		return false
+	}
+	desiredPodHash := c.newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	if c.rollout.Status.StableRS == desiredPodHash {
+		// we are fully promoted
+		return false
+	}
+	if c.rollout.Spec.Strategy.BlueGreen != nil {
+		svcPodHash := svc.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey]
+		if svcPodHash != desiredPodHash {
+			// we have not yet switched service selector
+			return false
+		}
+		if c.currentArs.BlueGreenPostPromotion != nil {
+			// we already started post-promotion analysis, so verification already occurred
+			return false
+		}
+	} else if c.rollout.Spec.Strategy.Canary != nil {
+		if c.rollout.Spec.Strategy.Canary.TrafficRouting == nil || c.rollout.Spec.Strategy.Canary.TrafficRouting.ALB == nil {
+			return false
+		}
+		// we don't support target group verification on ALB canary yet
+		return false
+	} else {
+		// should not get here
+		return false
+	}
+	return true
 }
 
 func (c *rolloutContext) getPreviewAndActiveServices() (*corev1.Service, *corev1.Service, error) {

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -879,6 +879,10 @@ func (c *rolloutContext) shouldFullPromote(newStatus v1alpha1.RolloutStatus) str
 			// active selector still pointing to previous RS, don't update stable yet
 			return ""
 		}
+		if !c.areTargetsVerified() {
+			// active selector is pointing to desired RS, but we have not verify the target group yet
+			return ""
+		}
 		if c.rollout.Status.PromoteFull {
 			return "Full promotion requested"
 		}

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -144,7 +144,7 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 		} else {
 			c.log.Infof("Desired weight (stepIdx: %d) %d verified", *index, desiredWeight)
 		}
-		c.weightVerified = &weightVerified
+		c.targetsVerified = &weightVerified
 	}
 
 	return nil

--- a/rollout/trafficrouting/alb/alb.go
+++ b/rollout/trafficrouting/alb/alb.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/aws"
+	"github.com/argoproj/argo-rollouts/utils/defaults"
 	"github.com/argoproj/argo-rollouts/utils/diff"
 	ingressutil "github.com/argoproj/argo-rollouts/utils/ingress"
 	jsonutil "github.com/argoproj/argo-rollouts/utils/json"
@@ -43,15 +44,6 @@ type Reconciler struct {
 	cfg ReconcilerConfig
 	log *logrus.Entry
 	aws aws.Client
-}
-
-var (
-	defaultVerifyWeight = false
-)
-
-// SetDefaultVerifyWeight sets the default setWeight verification when instantiating the reconciler
-func SetDefaultVerifyWeight(b bool) {
-	defaultVerifyWeight = b
 }
 
 // NewReconciler returns a reconciler struct that brings the ALB Ingress into the desired state
@@ -119,7 +111,7 @@ func (r *Reconciler) shouldVerifyWeight() bool {
 	if r.cfg.VerifyWeight != nil {
 		return *r.cfg.VerifyWeight
 	}
-	return defaultVerifyWeight
+	return defaults.VerifyTargetGroup()
 }
 
 func (r *Reconciler) VerifyWeight(desiredWeight int32) (bool, error) {
@@ -134,7 +126,7 @@ func (r *Reconciler) VerifyWeight(desiredWeight int32) (bool, error) {
 		return false, err
 	}
 	canaryService := rollout.Spec.Strategy.Canary.CanaryService
-	resourceID := aws.BuildV2TargetGroupID(rollout.Namespace, ingress.Name, canaryService, rollout.Spec.Strategy.Canary.TrafficRouting.ALB.ServicePort)
+	resourceID := aws.BuildTargetGroupResourceID(rollout.Namespace, ingress.Name, canaryService, rollout.Spec.Strategy.Canary.TrafficRouting.ALB.ServicePort)
 	if len(ingress.Status.LoadBalancer.Ingress) == 0 {
 		r.log.Infof("LoadBalancer not yet allocated")
 	}

--- a/rollout/trafficrouting/ambassador/ambassador.go
+++ b/rollout/trafficrouting/ambassador/ambassador.go
@@ -35,20 +35,11 @@ const (
 )
 
 var (
-	ambassadorAPIVersion = defaults.DefaultAmbassadorVersion
-	apiGroupToResource   = map[string]string{
+	apiGroupToResource = map[string]string{
 		"getambassador.io":   "mappings",
 		"x.getambassador.io": "ambassadormappings",
 	}
 )
-
-func SetAPIVersion(apiVersion string) {
-	ambassadorAPIVersion = apiVersion
-}
-
-func GetAPIVersion() string {
-	return ambassadorAPIVersion
-}
 
 // Reconciler implements a TrafficRoutingReconciler for Ambassador.
 type Reconciler struct {
@@ -299,7 +290,7 @@ func buildCanaryMappingName(name string) string {
 // ambassadorAPIVersion variable that is set with a default value. The default value can be
 // changed by invoking the SetAPIVersion function.
 func GetMappingGVR() schema.GroupVersionResource {
-	return toMappingGVR(ambassadorAPIVersion)
+	return toMappingGVR(defaults.GetAmbassadorAPIVersion())
 }
 
 func toMappingGVR(apiVersion string) schema.GroupVersionResource {

--- a/rollout/trafficrouting/smi/smi.go
+++ b/rollout/trafficrouting/smi/smi.go
@@ -51,12 +51,6 @@ type VersionedTrafficSplits struct {
 	ts3 *smiv1alpha3.TrafficSplit
 }
 
-var smiAPIVersion = defaults.DefaultSMITrafficSplitVersion
-
-func SetSMIAPIVersion(apiVersion string) {
-	smiAPIVersion = apiVersion
-}
-
 // NewReconciler returns a reconciler struct that brings the SMI into the desired state
 func NewReconciler(cfg ReconcilerConfig) (*Reconciler, error) {
 	r := &Reconciler{
@@ -64,7 +58,7 @@ func NewReconciler(cfg ReconcilerConfig) (*Reconciler, error) {
 		log: logutil.WithRollout(cfg.Rollout),
 	}
 	ctx := context.TODO()
-	switch smiAPIVersion {
+	switch defaults.GetSMIAPIVersion() {
 	case "v1alpha1":
 		r.getTrafficSplit = func(trafficSplitName string) (VersionedTrafficSplits, error) {
 			ts1, err := r.cfg.Client.SplitV1alpha1().TrafficSplits(r.cfg.Rollout.Namespace).Get(ctx, trafficSplitName, metav1.GetOptions{})
@@ -174,7 +168,7 @@ func NewReconciler(cfg ReconcilerConfig) (*Reconciler, error) {
 			return metav1.IsControlledBy(ts.ts3, r.cfg.Rollout)
 		}
 	default:
-		err := fmt.Errorf("Unsupported TrafficSplit API version `%s`", smiAPIVersion)
+		err := fmt.Errorf("Unsupported TrafficSplit API version `%s`", defaults.GetSMIAPIVersion())
 		return nil, err
 	}
 	return r, nil
@@ -239,7 +233,7 @@ func (r *Reconciler) generateTrafficSplits(trafficSplitName string, desiredWeigh
 
 	objectMeta := objectMeta(trafficSplitName, r.cfg.Rollout, r.cfg.ControllerKind)
 
-	switch smiAPIVersion {
+	switch defaults.GetSMIAPIVersion() {
 	case "v1alpha1":
 		trafficSplits.ts1 = trafficSplitV1Alpha1(r.cfg.Rollout, objectMeta, rootSvc, desiredWeight)
 	case "v1alpha2":

--- a/utils/aws/aws.go
+++ b/utils/aws/aws.go
@@ -2,12 +2,19 @@ package aws
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
+	"github.com/argoproj/argo-rollouts/utils/defaults"
 	"github.com/aws/aws-sdk-go-v2/config"
 	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/dynamic"
 )
 
 // AWSLoadBalancerV2TagKeyResourceID is the tag applied to an AWS resource by the AWS Load Balancer
@@ -15,11 +22,23 @@ import (
 // controller to identify the correct TargetGroups associated with the LoadBalancer. For AWS
 // target group service references, the format is: <namespace>/<ingress-name>-<service-name>:<port>
 // Example: ingress.k8s.aws/resource: default/alb-rollout-ingress-alb-rollout-stable:80
-// See: https://kubernetes-sigs.github.io/aws-load-balancer-controller/guide/ingress/annotations/#resource-tags
-// https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/2e51fbdc5dc978d66e36b376d6dc56b0ae146d8f/internal/alb/generator/tag.go#L125-L128
+// See: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/annotations/#resource-tags
+// https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/da8951f80521651e0a1ffe1361c011d6baad7706/pkg/deploy/tracking/provider.go#L19
 const AWSLoadBalancerV2TagKeyResourceID = "ingress.k8s.aws/resource"
 
+// TargetType is the targetType of your ELBV2 TargetGroup.
+//
+// * with `instance` TargetType, nodes with nodePort for your service will be registered as targets
+// * with `ip` TargetType, Pods with containerPort for your service will be registered as targets
+type TargetType string
+
+const (
+	TargetTypeInstance TargetType = "instance"
+	TargetTypeIP       TargetType = "ip"
+)
+
 type Client interface {
+	GetTargetGroupTargets(ctx context.Context, targetGroupARN string) ([]elbv2types.TargetHealthDescription, error)
 	GetTargetGroupMetadata(ctx context.Context, loadBalancerARN string) ([]TargetGroupMeta, error)
 	FindLoadBalancerByDNSName(ctx context.Context, dnsName string) (*elbv2types.LoadBalancer, error)
 }
@@ -29,6 +48,7 @@ type ELBv2APIClient interface {
 	elbv2.DescribeTargetGroupsAPIClient
 	elbv2.DescribeLoadBalancersAPIClient
 	elbv2.DescribeListenersAPIClient
+	DescribeTargetHealth(ctx context.Context, params *elbv2.DescribeTargetHealthInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeTargetHealthOutput, error)
 	DescribeRules(ctx context.Context, params *elbv2.DescribeRulesInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeRulesOutput, error)
 	DescribeTags(ctx context.Context, params *elbv2.DescribeTagsInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeTagsOutput, error)
 }
@@ -46,6 +66,38 @@ type TargetGroupMeta struct {
 	elbv2types.TargetGroup
 	Tags   map[string]string
 	Weight *int32
+}
+
+// TargetGroupBinding is the Schema for the TargetGroupBinding API
+// This is a subset of actual type definition and should only be used for readonly operations
+// https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/v2.2.1/apis/elbv2/v1beta1/targetgroupbinding_types.go
+type TargetGroupBinding struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec TargetGroupBindingSpec `json:"spec,omitempty"`
+}
+
+// TargetGroupBindingSpec defines the desired state of TargetGroupBinding
+type TargetGroupBindingSpec struct {
+	// targetGroupARN is the Amazon Resource Name (ARN) for the TargetGroup.
+	TargetGroupARN string `json:"targetGroupARN"`
+
+	// targetType is the TargetType of TargetGroup. If unspecified, it will be automatically inferred.
+	// +optional
+	TargetType *TargetType `json:"targetType,omitempty"`
+
+	// serviceRef is a reference to a Kubernetes Service and ServicePort.
+	ServiceRef ServiceReference `json:"serviceRef"`
+}
+
+// ServiceReference defines reference to a Kubernetes Service and its ServicePort.
+type ServiceReference struct {
+	// Name is the name of the Service.
+	Name string `json:"name"`
+
+	// Port is the port of the ServicePort.
+	Port intstr.IntOrString `json:"port"`
 }
 
 func NewClient() (Client, error) {
@@ -154,8 +206,153 @@ func (c *client) GetTargetGroupMetadata(ctx context.Context, loadBalancerARN str
 	return tgMeta, nil
 }
 
-// BuildV2TargetGroupID returns the AWS targetGroup ResourceID that compatible with V2 version.
-// Copied from https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/2e51fbdc5dc978d66e36b376d6dc56b0ae146d8f/internal/alb/generator/tag.go#L125-L128
-func BuildV2TargetGroupID(namespace string, ingressName string, serviceName string, servicePort int32) string {
+func (c *client) GetTargetGroupTargets(ctx context.Context, targetGroupARN string) ([]elbv2types.TargetHealthDescription, error) {
+	// Get target groups associated with LoadBalancer
+	thIn := elbv2.DescribeTargetHealthInput{
+		TargetGroupArn: &targetGroupARN,
+	}
+	thOut, err := c.ELBV2.DescribeTargetHealth(ctx, &thIn)
+	if err != nil {
+		return nil, err
+	}
+	return thOut.TargetHealthDescriptions, nil
+}
+
+// BuildTargetGroupResourceID returns the AWS TargetGroup ResourceID
+// Adapted from https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/57c8ce344fe09089fa2e20b0aa9fc0972696bc05/pkg/ingress/model_build_target_group.go#L398-L400
+func BuildTargetGroupResourceID(namespace string, ingressName string, serviceName string, servicePort int32) string {
 	return fmt.Sprintf("%s/%s-%s:%d", namespace, ingressName, serviceName, servicePort)
+}
+
+func GetTargetGroupBindingsGVR() (schema.GroupVersionResource, error) {
+	gv, err := schema.ParseGroupVersion(defaults.GetTargetGroupBindingAPIVersion())
+	if err != nil {
+		return schema.GroupVersionResource{}, err
+	}
+	return schema.GroupVersionResource{
+		Group:    gv.Group,
+		Version:  gv.Version,
+		Resource: "targetgroupbindings",
+	}, nil
+}
+
+func GetTargetGroupBindingsByService(ctx context.Context, dynamicClient dynamic.Interface, svc corev1.Service) ([]TargetGroupBinding, error) {
+	gvr, err := GetTargetGroupBindingsGVR()
+	if err != nil {
+		return nil, err
+	}
+	tgbList, err := dynamicClient.Resource(gvr).Namespace(svc.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var tgbs []TargetGroupBinding
+	for _, tgbUn := range tgbList.Items {
+		tgb, err := toTargetGroupBinding(tgbUn.Object)
+		if err != nil {
+			return nil, err
+		}
+		if tgb.Spec.ServiceRef.Name != svc.Name {
+			continue
+		}
+		for _, port := range svc.Spec.Ports {
+			if tgb.Spec.ServiceRef.Port.Type == intstr.Int && port.Port == tgb.Spec.ServiceRef.Port.IntVal {
+				tgbs = append(tgbs, *tgb)
+				break
+			} else if tgb.Spec.ServiceRef.Port.StrVal != "" && port.Name == tgb.Spec.ServiceRef.Port.StrVal {
+				tgbs = append(tgbs, *tgb)
+				break
+			}
+		}
+	}
+	return tgbs, nil
+}
+
+func toTargetGroupBinding(obj map[string]interface{}) (*TargetGroupBinding, error) {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+	var tgb TargetGroupBinding
+	err = json.Unmarshal(data, &tgb)
+	if err != nil {
+		return nil, err
+	}
+	return &tgb, nil
+}
+
+// getNumericPort resolves the numeric port which a AWS TargetGroup targets.
+// This is needed in case the TargetGroupBinding's spec.serviceRef.Port is a string and not a number
+// Returns 0 if unable to find matching port in given service.
+func getNumericPort(tgb TargetGroupBinding, svc corev1.Service) int32 {
+	if portInt := tgb.Spec.ServiceRef.Port.IntValue(); portInt > 0 {
+		return int32(portInt)
+	}
+	// port is a string and not a num
+	for _, svcPort := range svc.Spec.Ports {
+		if tgb.Spec.ServiceRef.Port.StrVal == svcPort.Name {
+			return svcPort.Port
+		}
+	}
+	return 0
+}
+
+// VerifyTargetGroupBinding verifies if the underlying AWS TargetGroup:
+// 1. targets all the Pod IPs and port in the given service
+// 2. those targets are in a healthy state
+func VerifyTargetGroupBinding(ctx context.Context, logCtx *log.Entry, awsClnt Client, tgb TargetGroupBinding, endpoints *corev1.Endpoints, svc *corev1.Service) (bool, error) {
+	if tgb.Spec.TargetType == nil || *tgb.Spec.TargetType != TargetTypeIP {
+		// We only need to verify target groups using AWS CNI (spec.targetType: ip)
+		return true, nil
+	}
+	port := getNumericPort(tgb, *svc)
+	if port == 0 {
+		logCtx.Warn("Unable to match TargetGroupBinding spec.serviceRef.port to Service spec.ports")
+		return false, nil
+	}
+	logCtx = logCtx.WithFields(map[string]interface{}{
+		"service":            svc.Name,
+		"targetgroupbinding": tgb.Name,
+		"tg":                 tgb.Spec.TargetGroupARN,
+		"port":               port,
+	})
+	targets, err := awsClnt.GetTargetGroupTargets(ctx, tgb.Spec.TargetGroupARN)
+	if err != nil {
+		return false, err
+	}
+
+	// Remember all of the ip:port of the endpoints list
+	endpointIPs := make(map[string]bool)
+	for _, subset := range endpoints.Subsets {
+		for _, addr := range subset.Addresses {
+			endpointIPs[fmt.Sprintf("%s:%d", addr.IP, port)] = false
+		}
+	}
+
+	logCtx.Infof("verifying %d endpoint addresses (of %d targets)", len(endpointIPs), len(targets))
+
+	// Iterate all targets in AWS TargetGroup. Mark all endpoint IPs which are healthy
+	for _, target := range targets {
+		if target.Target == nil || target.Target.Id == nil || target.Target.Port == nil || target.TargetHealth == nil {
+			logCtx.Warnf("Invalid target in TargetGroup: %v", target)
+			continue
+		}
+		targetStr := fmt.Sprintf("%s:%d", *target.Target.Id, *target.Target.Port)
+		_, isEndpointTarget := endpointIPs[targetStr]
+		if !isEndpointTarget {
+			// this is a target for something not in the endpoint list (e.g. old endpoint entry). Ignore it
+			continue
+		}
+		// Mark the endpoint IP as healthy or not
+		endpointIPs[targetStr] = bool(target.TargetHealth.State == elbv2types.TargetHealthStateEnumHealthy)
+	}
+
+	// Check if any of our desired endpoints are not yet healthy
+	for epIP, healthy := range endpointIPs {
+		if !healthy {
+			logCtx.Infof("Service endpoint IP %s not yet targeted or healthy", epIP)
+			return false, nil
+		}
+	}
+	logCtx.Info("TargetGroupBinding verified")
+	return true, nil
 }

--- a/utils/defaults/defaults.go
+++ b/utils/defaults/defaults.go
@@ -31,10 +31,19 @@ const (
 )
 
 const (
-	DefaultAmbassadorAPIGroup     = "getambassador.io"
-	DefaultAmbassadorVersion      = "getambassador.io/v2"
-	DefaultIstioVersion           = "v1alpha3"
-	DefaultSMITrafficSplitVersion = "v1alpha1"
+	DefaultAmbassadorAPIGroup           = "getambassador.io"
+	DefaultAmbassadorVersion            = "getambassador.io/v2"
+	DefaultIstioVersion                 = "v1alpha3"
+	DefaultSMITrafficSplitVersion       = "v1alpha1"
+	DefaultTargetGroupBindingAPIVersion = "elbv2.k8s.aws/v1beta1"
+)
+
+var (
+	defaultVerifyTargetGroup     = false
+	istioAPIVersion              = DefaultIstioVersion
+	ambassadorAPIVersion         = DefaultAmbassadorVersion
+	smiAPIVersion                = DefaultSMITrafficSplitVersion
+	targetGroupBindingAPIVersion = DefaultTargetGroupBindingAPIVersion
 )
 
 // GetReplicasOrDefault returns the deferenced number of replicas or the default number
@@ -141,4 +150,46 @@ func Namespace() string {
 		}
 	}
 	return "argo-rollouts"
+}
+
+// SetDefaultVerifyTargetGroup sets the default setWeight verification when instantiating the reconciler
+func SetVerifyTargetGroup(b bool) {
+	defaultVerifyTargetGroup = b
+}
+
+// VerifyTargetGroup returns whether or not we should verify target groups
+func VerifyTargetGroup() bool {
+	return defaultVerifyTargetGroup
+}
+
+func SetIstioAPIVersion(apiVersion string) {
+	istioAPIVersion = apiVersion
+}
+
+func GetIstioAPIVersion() string {
+	return istioAPIVersion
+}
+
+func SetAmbassadorAPIVersion(apiVersion string) {
+	ambassadorAPIVersion = apiVersion
+}
+
+func GetAmbassadorAPIVersion() string {
+	return ambassadorAPIVersion
+}
+
+func SetSMIAPIVersion(apiVersion string) {
+	smiAPIVersion = apiVersion
+}
+
+func GetSMIAPIVersion() string {
+	return smiAPIVersion
+}
+
+func SetTargetGroupBindingAPIVersion(apiVersion string) {
+	targetGroupBindingAPIVersion = apiVersion
+}
+
+func GetTargetGroupBindingAPIVersion() string {
+	return targetGroupBindingAPIVersion
 }

--- a/utils/istio/istio.go
+++ b/utils/istio/istio.go
@@ -13,18 +13,6 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/defaults"
 )
 
-var (
-	istioAPIVersion = defaults.DefaultIstioVersion
-)
-
-func SetIstioAPIVersion(apiVersion string) {
-	istioAPIVersion = apiVersion
-}
-
-func GetIstioAPIVersion() string {
-	return istioAPIVersion
-}
-
 func DoesIstioExist(dynamicClient dynamic.Interface, namespace string) bool {
 	_, err := dynamicClient.Resource(GetIstioVirtualServiceGVR()).Namespace(namespace).List(context.TODO(), metav1.ListOptions{Limit: 1})
 	if err != nil {
@@ -36,7 +24,7 @@ func DoesIstioExist(dynamicClient dynamic.Interface, namespace string) bool {
 func GetIstioVirtualServiceGVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
 		Group:    "networking.istio.io",
-		Version:  istioAPIVersion,
+		Version:  defaults.GetIstioAPIVersion(),
 		Resource: "virtualservices",
 	}
 }
@@ -44,7 +32,7 @@ func GetIstioVirtualServiceGVR() schema.GroupVersionResource {
 func GetIstioDestinationRuleGVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
 		Group:    "networking.istio.io",
-		Version:  istioAPIVersion,
+		Version:  defaults.GetIstioAPIVersion(),
 		Resource: "destinationrules",
 	}
 }


### PR DESCRIPTION
Implements approach 1 in https://github.com/argoproj/argo-rollouts/issues/1283.

During a blue-green update, the rollout controller will then verify the AWS target group for the active service, is correctly targeting the correct pod endpoints of the new replicaset. This is executed before postPromotionAnalysis runs.

Signed-off-by: Jesse Suen <jesse_suen@intuit.com>

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).