### PR TITLE
fix: Abort rollout removes all canary pods for setCanaryScale. Fixes #1337

### DIFF
--- a/test/e2e/istio/istio-rollout-abort-delete-all-canary-pods.yaml
+++ b/test/e2e/istio/istio-rollout-abort-delete-all-canary-pods.yaml
@@ -1,0 +1,90 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-host-split-canary
+spec:
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: istio-host-split
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-host-split-stable
+spec:
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: istio-host-split
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: istio-host-split-vsvc
+spec:
+  hosts:
+    - istio-host-split
+  http:
+    - name: primary
+      route:
+        - destination:
+            host: istio-host-split-stable
+          weight: 100
+        - destination:
+            host: istio-host-split-canary
+          weight: 0
+
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: istio-host-split
+spec:
+  replicas: 5
+  strategy:
+    canary:
+      canaryService: istio-host-split-canary
+      stableService: istio-host-split-stable
+      trafficRouting:
+        istio:
+          virtualService:
+            name: istio-host-split-vsvc
+            routes:
+              - primary
+      steps:
+        - setCanaryScale:
+            replicas: 2
+        - setWeight: 20
+        - pause: {}
+        - setCanaryScale:
+            replicas: 4
+        - setWeight: 40
+        - pause: {}
+  selector:
+    matchLabels:
+      app: istio-host-split
+  template:
+    metadata:
+      labels:
+        app: istio-host-split
+    spec:
+      containers:
+        - name: istio-host-split
+          image: nginx:1.19-alpine
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          resources:
+            requests:
+              memory: 16Mi
+              cpu: 5m

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -224,3 +224,32 @@ func (s *IstioSuite) TestIstioAbortUpdate() {
 		Then().
 		ExpectRevisionPodCount("2", 1)
 }
+
+func (s *IstioSuite) TestIstioAbortUpdateDeleteAllCanaryPods() {
+	s.Given().
+		RolloutObjects("@istio/istio-rollout-abort-delete-all-canary-pods.yaml").
+		When().
+		ApplyManifests().
+		WaitForRolloutStatus("Healthy").
+		Then().
+		When().
+		UpdateSpec().
+		WaitForRolloutStatus("Paused").
+		Then().
+		ExpectRevisionPodCount("2", 2).
+		When().
+		PromoteRollout().
+		WaitForRolloutStatus("Paused").
+		Then().
+		When().
+		PromoteRollout().
+		WaitForRolloutStatus("Paused").
+		Then().
+		ExpectRevisionPodCount("2", 4).
+		When().
+		AbortRollout().
+		WaitForRolloutStatus("Degraded").
+		Then().
+		ExpectRevisionPodCount("2", 0).
+		ExpectRevisionPodCount("1", 5)
+}

--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -331,6 +331,10 @@ func GetCurrentSetWeight(rollout *v1alpha1.Rollout) int32 {
 // TrafficRouting is required to be set for SetCanaryScale to be applicable.
 // If MatchTrafficWeight is set after a previous SetCanaryScale step, it will likewise be ignored.
 func UseSetCanaryScale(rollout *v1alpha1.Rollout) *v1alpha1.SetCanaryScale {
+	// Return nil when rollout is aborted
+	if rollout.Status.Abort {
+		return nil
+	}
 	currentStep, currentStepIndex := GetCurrentCanaryStep(rollout)
 	if currentStep == nil {
 		return nil


### PR DESCRIPTION
Signed-off-by: Chinmoy Samant chinmoy.samant@salesforce.com

fixes #1337 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).