### PR TITLE
fix: zero-value abortScaleDownDelay was not honored with setCanaryScale

### DIFF
--- a/rollout/replicaset_test.go
+++ b/rollout/replicaset_test.go
@@ -202,12 +202,12 @@ func TestReconcileNewReplicaSet(t *testing.T) {
 					recorder:          record.NewFakeEventRecorder(),
 					resyncPeriod:      30 * time.Second,
 				},
+				pauseContext: &pauseContext{
+					rollout: rollout,
+				},
 			}
 			roCtx.enqueueRolloutAfter = func(obj interface{}, duration time.Duration) {}
 			if test.abortScaleDownDelaySeconds > 0 {
-				roCtx.pauseContext = &pauseContext{
-					rollout: rollout,
-				}
 				rollout.Status.Abort = true
 				// rollout.Spec.ScaleDownOnAbort = true
 				rollout.Spec.Strategy = v1alpha1.RolloutStrategy{

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -390,7 +390,7 @@ func (c *rolloutContext) scaleReplicaSet(rs *appsv1.ReplicaSet, newScale int32, 
 		oldScale := defaults.GetReplicasOrDefault(rs.Spec.Replicas)
 		*(rsCopy.Spec.Replicas) = newScale
 		annotations.SetReplicasAnnotations(rsCopy, rolloutReplicas)
-		if fullScaleDown && !c.isScaleDownOnabort() {
+		if fullScaleDown && !c.shouldDelayScaleDownOnAbort() {
 			delete(rsCopy.Annotations, v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey)
 		}
 		rs, err = c.kubeclientset.AppsV1().ReplicaSets(rsCopy.Namespace).Update(ctx, rsCopy, metav1.UpdateOptions{})
@@ -927,7 +927,7 @@ func (c *rolloutContext) promoteStable(newStatus *v1alpha1.RolloutStatus, reason
 		// Now that we've marked the desired RS as stable, start the scale-down countdown on the previous stable RS
 		previousStableRS, _ := replicasetutil.GetReplicaSetByTemplateHash(c.olderRSs, previousStableHash)
 		if replicasetutil.GetReplicaCountForReplicaSets([]*appsv1.ReplicaSet{previousStableRS}) > 0 {
-			scaleDownDelaySeconds := time.Duration(defaults.GetScaleDownDelaySecondsOrDefault(c.rollout))
+			scaleDownDelaySeconds := defaults.GetScaleDownDelaySecondsOrDefault(c.rollout)
 			err := c.addScaleDownDelay(previousStableRS, scaleDownDelaySeconds)
 			if err != nil {
 				return err

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -250,6 +250,7 @@ func (s *IstioSuite) TestIstioAbortUpdateDeleteAllCanaryPods() {
 		AbortRollout().
 		WaitForRolloutStatus("Degraded").
 		Then().
-		ExpectRevisionPodCount("2", 0).
-		ExpectRevisionPodCount("1", 5)
+		ExpectRevisionPodCount("1", 5).
+		ExpectRevisionPodCount("2", 4).    // canary pods remained scaled
+		ExpectRevisionScaleDown("2", true) // but have a scale down delay
 }

--- a/utils/defaults/defaults.go
+++ b/utils/defaults/defaults.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -102,40 +103,52 @@ func GetExperimentScaleDownDelaySecondsOrDefault(e *v1alpha1.Experiment) int32 {
 	return DefaultScaleDownDelaySeconds
 }
 
-func GetScaleDownDelaySecondsOrDefault(rollout *v1alpha1.Rollout) int32 {
+func GetScaleDownDelaySecondsOrDefault(rollout *v1alpha1.Rollout) time.Duration {
+	var delaySeconds int32
 	if rollout.Spec.Strategy.BlueGreen != nil {
+		delaySeconds = DefaultAbortScaleDownDelaySeconds
 		if rollout.Spec.Strategy.BlueGreen.ScaleDownDelaySeconds != nil {
-			return *rollout.Spec.Strategy.BlueGreen.ScaleDownDelaySeconds
+			delaySeconds = *rollout.Spec.Strategy.BlueGreen.ScaleDownDelaySeconds
 		}
-		return DefaultScaleDownDelaySeconds
 	}
 	if rollout.Spec.Strategy.Canary != nil {
 		if rollout.Spec.Strategy.Canary.TrafficRouting != nil {
+			delaySeconds = DefaultAbortScaleDownDelaySeconds
 			if rollout.Spec.Strategy.Canary.ScaleDownDelaySeconds != nil {
-				return *rollout.Spec.Strategy.Canary.ScaleDownDelaySeconds
+				delaySeconds = *rollout.Spec.Strategy.Canary.ScaleDownDelaySeconds
 			}
-			return DefaultScaleDownDelaySeconds
 		}
 	}
-	return 0
+	return time.Duration(delaySeconds) * time.Second
 }
 
-func GetAbortScaleDownDelaySecondsOrDefault(rollout *v1alpha1.Rollout) int32 {
+// GetAbortScaleDownDelaySecondsOrDefault returns the duration seconds to delay the scale down of
+// the canary/preview ReplicaSet in a abort situation. A nil value indicates it should not
+// scale down at all (abortScaleDownDelaySeconds: 0). A value of 0 indicates it should scale down
+// immediately.
+func GetAbortScaleDownDelaySecondsOrDefault(rollout *v1alpha1.Rollout) *time.Duration {
+	var delaySeconds int32
 	if rollout.Spec.Strategy.BlueGreen != nil {
+		delaySeconds = DefaultAbortScaleDownDelaySeconds
 		if rollout.Spec.Strategy.BlueGreen.AbortScaleDownDelaySeconds != nil {
-			return *rollout.Spec.Strategy.BlueGreen.AbortScaleDownDelaySeconds
-		}
-		return DefaultAbortScaleDownDelaySeconds
-	}
-	if rollout.Spec.Strategy.Canary != nil {
-		if rollout.Spec.Strategy.Canary.TrafficRouting != nil {
-			if rollout.Spec.Strategy.Canary.AbortScaleDownDelaySeconds != nil {
-				return *rollout.Spec.Strategy.Canary.AbortScaleDownDelaySeconds
+			if *rollout.Spec.Strategy.BlueGreen.AbortScaleDownDelaySeconds == 0 {
+				return nil
 			}
-			return DefaultAbortScaleDownDelaySeconds
+			delaySeconds = *rollout.Spec.Strategy.BlueGreen.AbortScaleDownDelaySeconds
+		}
+	} else if rollout.Spec.Strategy.Canary != nil {
+		if rollout.Spec.Strategy.Canary.TrafficRouting != nil {
+			delaySeconds = DefaultAbortScaleDownDelaySeconds
+			if rollout.Spec.Strategy.Canary.AbortScaleDownDelaySeconds != nil {
+				if *rollout.Spec.Strategy.Canary.AbortScaleDownDelaySeconds == 0 {
+					return nil
+				}
+				delaySeconds = *rollout.Spec.Strategy.Canary.AbortScaleDownDelaySeconds
+			}
 		}
 	}
-	return 0
+	dur := time.Duration(delaySeconds) * time.Second
+	return &dur
 }
 
 func GetAutoPromotionEnabledOrDefault(rollout *v1alpha1.Rollout) bool {


### PR DESCRIPTION
Recent PR did not rebase ontop of new scaledowndelay on abort behavior and the two caused a conflict in behavior

Signed-off-by: Jesse Suen <jesse_suen@intuit.com>