### PR TITLE
chore: release workflow docker build context should use local path and not git context

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,8 @@ jobs:
             ghcr.io/argoproj/argo-rollouts
           tags: |
             type=semver,pattern={{version}},prefix=v,value=${{ github.event.inputs.tag }}
+          flavor: |
+            latest=false
 
       - name: Docker meta (plugin)
         id: plugin-meta
@@ -57,6 +59,8 @@ jobs:
             ghcr.io/argoproj/kubectl-argo-rollouts
           tags: |
             type=semver,pattern={{version}},prefix=v,value=${{ github.event.inputs.tag }}
+          flavor: |
+            latest=false
 
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'
@@ -77,6 +81,7 @@ jobs:
       - name: Build and push (controller-image)
         uses: docker/build-push-action@v2
         with:
+          context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.controller-meta.outputs.tags }}
@@ -86,6 +91,7 @@ jobs:
       - name: Build and push (plugin-image)
         uses: docker/build-push-action@v2
         with:
+          context: .
           target: kubectl-argo-rollouts
           platforms: linux/amd64,linux/arm64
           push: true


### PR DESCRIPTION
Signed-off-by: Jesse Suen <jesse_suen@intuit.com>
