### PR TITLE
fix: missing e2e test for istio tls route in rollout

### DIFF
--- a/docs/getting-started/istio/index.md
+++ b/docs/getting-started/istio/index.md
@@ -78,10 +78,9 @@ spec:
       weight: 0
   tls:
   - match:
-    - port: 3000  # Should match the port number of the route defined in spec.strategy.canary.trafficRouting.istio.virtualService.tlsRoutes
+    - port: 443  # Should match the port number of the route defined in spec.strategy.canary.trafficRouting.istio.virtualService.tlsRoutes
       sniHosts: # Should match all the SNI hosts of the route defined in spec.strategy.canary.trafficRouting.istio.virtualService.tlsRoutes
       - reviews.bookinfo.com
-      - localhost
     route:
     - destination:
         host: rollouts-demo-stable  # Should match spec.strategy.canary.stableService
@@ -175,7 +174,6 @@ spec:
     - port: 3000
       sniHosts:
       - reviews.bookinfo.com
-      - localhost
     route:
     - destination:
         host: rollouts-demo-stable

--- a/test/e2e/istio/istio-host-http-tls-split.yaml
+++ b/test/e2e/istio/istio-host-http-tls-split.yaml
@@ -1,0 +1,99 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-host-split-canary
+spec:
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app: istio-host-split
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-host-split-stable
+spec:
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app: istio-host-split
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: istio-host-split-vsvc
+spec:
+  hosts:
+  - istio-host-split
+  http:
+  - name: primary
+    route:
+    - destination:
+        host: istio-host-split-stable
+      weight: 100
+    - destination:
+        host: istio-host-split-canary
+      weight: 0
+  tls:
+  - match:
+    - port: 3000
+      sniHosts:
+      - istio-host-split
+    route:
+    - destination:
+        host: istio-host-split-stable
+      weight: 100
+    - destination:
+        host: istio-host-split-canary
+      weight: 0
+
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: istio-host-split
+spec:
+  strategy:
+    canary:
+      canaryService: istio-host-split-canary
+      stableService: istio-host-split-stable
+      trafficRouting:
+        istio:
+          virtualService: 
+            name: istio-host-split-vsvc
+            routes:
+            - primary
+            tlsRoutes:
+            - port: 3000
+              sniHosts:
+              - istio-host-split
+      steps:
+      - setWeight: 10
+      - pause: {}
+  selector:
+    matchLabels:
+      app: istio-host-split
+  template:
+    metadata:
+      labels:
+        app: istio-host-split
+    spec:
+      containers:
+      - name: istio-host-split
+        image: nginx:1.19-alpine
+        ports:
+        - name: http
+          containerPort: 80
+          protocol: TCP
+        resources:
+          requests:
+            memory: 16Mi
+            cpu: 5m


### PR DESCRIPTION
- remove localhost in example as incompabile with virtual host

Signed-off-by: Hui Kang <hui.kang@salesforce.com>

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).