### PR TITLE
feat: Adding support for defining max destination weights in Istio VS

### DIFF
--- a/docs/getting-started/istio/index.md
+++ b/docs/getting-started/istio/index.md
@@ -33,6 +33,8 @@ spec:
           virtualService:
             # Reference to a VirtualService which the controller updates with canary weights
             name: rollouts-demo-vsvc
+            # Optional if there are only two destinations in your routes or if you want to split 100% traffic between stable and canary services. If specified, this will be used as an upper bound for traffic between canary + stable services.
+            maxWeight: 80
             # Optional if there is a single HTTP route in the VirtualService, otherwise required
             routes:
             - http-primary
@@ -71,11 +73,14 @@ spec:
   - name: http-primary  # Should match spec.strategy.canary.trafficRouting.istio.virtualService.routes
     route:
     - destination:
-        host: rollouts-demo-stable  # Should match spec.strategy.canary.stableService
-      weight: 100
+        host: rollouts-demo-stable  # Should match rollout.spec.strategy.canary.stableService
+      weight: 80
     - destination:
         host: rollouts-demo-canary  # Should match spec.strategy.canary.canaryService
       weight: 0
+    - destination:
+        host: rollouts-demo-legacy
+      weight: 20
   tls:
   - match:
     - port: 3000  # Should match the port number of the route defined in spec.strategy.canary.trafficRouting.istio.virtualService.tlsRoutes
@@ -84,11 +89,14 @@ spec:
       - localhost
     route:
     - destination:
-        host: rollouts-demo-stable  # Should match spec.strategy.canary.stableService
-      weight: 100
+        host: rollouts-demo-stable  # Should match rollout.spec.strategy.canary.stableService
+      weight: 80
     - destination:
         host: rollouts-demo-canary  # Should match spec.strategy.canary.canaryService
       weight: 0
+    - destination:
+        host: rollouts-demo-legacy
+      weight: 20
 ```
 
 Run the following commands to deploy:

--- a/manifests/crds/rollout-crd.yaml
+++ b/manifests/crds/rollout-crd.yaml
@@ -530,6 +530,9 @@ spec:
                                 - name
                                 - stableSubsetName
                                 type: object
+                              maxWeight:
+                                format: int64
+                                type: integer
                               virtualService:
                                 properties:
                                   name:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -10228,6 +10228,9 @@ spec:
                                 - name
                                 - stableSubsetName
                                 type: object
+                              maxWeight:
+                                format: int64
+                                type: integer
                               virtualService:
                                 properties:
                                   name:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -10228,6 +10228,9 @@ spec:
                                 - name
                                 - stableSubsetName
                                 type: object
+                              maxWeight:
+                                format: int64
+                                type: integer
                               virtualService:
                                 properties:
                                   name:

--- a/pkg/apiclient/rollout/rollout.swagger.json
+++ b/pkg/apiclient/rollout/rollout.swagger.json
@@ -833,6 +833,11 @@
         "destinationRule": {
           "$ref": "#/definitions/github.com.argoproj.argo_rollouts.pkg.apis.rollouts.v1alpha1.IstioDestinationRule",
           "title": "DestinationRule references an Istio DestinationRule to modify to shape traffic"
+        },
+        "maxWeight": {
+          "type": "string",
+          "format": "int64",
+          "description": "Max weight that will be split between canary and stable services. If unset, it defaults to 100."
         }
       },
       "title": "IstioTrafficRouting configuration for Istio service mesh to enable fine grain configuration"

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -368,6 +368,8 @@ type IstioTrafficRouting struct {
 	VirtualService IstioVirtualService `json:"virtualService" protobuf:"bytes,1,opt,name=virtualService"`
 	// DestinationRule references an Istio DestinationRule to modify to shape traffic
 	DestinationRule *IstioDestinationRule `json:"destinationRule,omitempty" protobuf:"bytes,2,opt,name=destinationRule"`
+	// Max weight that will be split between canary and stable services. If unset, it defaults to 100.
+	MaxWeight int64 `json:"maxWeight,omitempty" protobuf:"bytes,3,opt,name=maxWeight"`
 }
 
 // IstioVirtualService holds information on the virtual service the rollout needs to modify

--- a/pkg/apis/rollouts/validation/validation_references_test.go
+++ b/pkg/apis/rollouts/validation/validation_references_test.go
@@ -379,7 +379,7 @@ func TestValidateVirtualService(t *testing.T) {
 		vsvc := unstructured.StrToUnstructuredUnsafe(failCaseVsvc)
 		allErrs := ValidateVirtualService(ro, *vsvc)
 		assert.Len(t, allErrs, 1)
-		expectedErr := field.Invalid(field.NewPath("spec", "strategy", "canary", "trafficRouting", "istio", "virtualService", "name"), "istio-vsvc-name", "Istio VirtualService has invalid HTTP routes. Error: Stable Service 'stable' not found in route")
+		expectedErr := field.Invalid(field.NewPath("spec", "strategy", "canary", "trafficRouting", "istio", "virtualService", "name"), "istio-vsvc-name", "Istio VirtualService has invalid HTTP routes. Error: Stable Service 'stable' not found in the route.")
 		assert.Equal(t, expectedErr.Error(), allErrs[0].Error())
 
 	})


### PR DESCRIPTION
### Change Description

This PR adds the support for defining an optional max weight for the destinations in Istio VirtualService. If the `maxWeight` parameter is defined and has a valid value i.e. `0 < maxWeight <= 100` then it'll be used as an upper bound for the traffic sent to stable service + canary service.

The use cases for defining `maxWeight` includes:
- Having another set of fixed destination(s) which the user doesn't want to be affected during the Argo Rollouts (For example, a legacy service).

---

Signed-off-by: Rohit Agrawal <rohit.agrawal@databricks.com>

**Checklist:**

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).