### PR TITLE
docs: add @huikang as a reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,3 +9,4 @@ approvers:
 
 reviewers:
 - dthomson25
+- huikang


### PR DESCRIPTION
@huikang has been nominated (sponsors: @jessesuen, @alexmt) and has been approved as a reviewer for his contributions to argo-rollouts. Welcome @huikang!

Signed-off-by: Jesse Suen <jessesuen@gmail.com>
