### PR TITLE
fix: inconsistent status command output

### DIFF
--- a/pkg/kubectl-argo-rollouts/cmd/status/status_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/status/status_test.go
@@ -66,7 +66,7 @@ func TestStatusBlueGreenRollout(t *testing.T) {
 	assert.NoError(t, err)
 	stdout := o.Out.(*bytes.Buffer).String()
 	stderr := o.ErrOut.(*bytes.Buffer).String()
-	assert.Equal(t, "Paused\n", stdout)
+	assert.Equal(t, "Paused - BlueGreenPause\n", stdout)
 	assert.Empty(t, stderr)
 }
 
@@ -81,11 +81,11 @@ func TestStatusInvalidRollout(t *testing.T) {
 	cmd.SetArgs([]string{rolloutObjs.Rollouts[0].Name, noWatch})
 	err := cmd.Execute()
 
-	assert.NoError(t, err)
+	assert.Error(t, err)
 	stdout := o.Out.(*bytes.Buffer).String()
 	stderr := o.ErrOut.(*bytes.Buffer).String()
 	assert.Equal(t, "Degraded\n", stdout)
-	assert.Empty(t, stderr)
+	assert.Equal(t, "Error: The rollout is in a degraded state with message: InvalidSpec: The Rollout \"rollout-invalid\" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{\"app\":\"doesnt-match\"}: `selector` does not match template `labels`\n", stderr)
 }
 
 func TestStatusAbortedRollout(t *testing.T) {
@@ -99,11 +99,11 @@ func TestStatusAbortedRollout(t *testing.T) {
 	cmd.SetArgs([]string{rolloutObjs.Rollouts[0].Name, noWatch})
 	err := cmd.Execute()
 
-	assert.NoError(t, err)
+	assert.Error(t, err)
 	stdout := o.Out.(*bytes.Buffer).String()
 	stderr := o.ErrOut.(*bytes.Buffer).String()
 	assert.Equal(t, "Degraded\n", stdout)
-	assert.Empty(t, stderr)
+	assert.Equal(t, "Error: The rollout is in a degraded state with message: RolloutAborted: metric \"web\" assessed Failed due to failed (1) > failureLimit (0)\n", stderr)
 }
 
 func TestWatchAbortedRollout(t *testing.T) {
@@ -139,5 +139,5 @@ func TestWatchTimeoutRollout(t *testing.T) {
 	stdout := o.Out.(*bytes.Buffer).String()
 	stderr := o.ErrOut.(*bytes.Buffer).String()
 	assert.Equal(t, "Paused - BlueGreenPause\n", stdout)
-	assert.Equal(t, "Error: Rollout progress exceeded timeout\n", stderr)
+	assert.Equal(t, "Error: Rollout status watch exceeded timeout\n", stderr)
 }


### PR DESCRIPTION
Signed-off-by: Hui Kang <hui.kang@salesforce.com>

close #1391 

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).