### PR TITLE
fix: false rolloutCondition in metrics and invalidspec

### DIFF
--- a/controller/metrics/rollout_test.go
+++ b/controller/metrics/rollout_test.go
@@ -100,7 +100,7 @@ func TestCollectRollouts(t *testing.T) {
 	}{
 		{
 			fakeRollout,
-			conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionFalse, "Progressing", ""),
+			conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionTrue, "Progressing", ""),
 			`
 # HELP rollout_info Information about rollout.
 # TYPE rollout_info gauge
@@ -115,10 +115,9 @@ rollout_info_replicas_desired{name="guestbook-bluegreen",namespace="default"} 1
 # TYPE rollout_info_replicas_unavailable gauge
 rollout_info_replicas_unavailable{name="guestbook-bluegreen",namespace="default"} 0`,
 		},
-
 		{
 			fakeRollout,
-			conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionFalse, conditions.FailedRSCreateReason, "test"),
+			conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionTrue, conditions.FailedRSCreateReason, "test"),
 			`
 # HELP rollout_info Information about rollout.
 # TYPE rollout_info gauge
@@ -134,8 +133,25 @@ rollout_info_replicas_desired{name="guestbook-bluegreen",namespace="default"} 1
 rollout_info_replicas_unavailable{name="guestbook-bluegreen",namespace="default"} 0`,
 		},
 		{
+			fakeRollout,
+			conditions.NewRolloutCondition(v1alpha1.InvalidSpec, corev1.ConditionTrue, conditions.InvalidSpecReason, "test"),
+			`
+# HELP rollout_info Information about rollout.
+# TYPE rollout_info gauge
+rollout_info{name="guestbook-bluegreen",namespace="default",phase="InvalidSpec",strategy="blueGreen",traffic_router=""} 1
+# HELP rollout_info_replicas_available The number of available replicas per rollout.
+# TYPE rollout_info_replicas_available gauge
+rollout_info_replicas_available{name="guestbook-bluegreen",namespace="default"} 1
+# HELP rollout_info_replicas_desired The number of desired replicas per rollout.
+# TYPE rollout_info_replicas_desired gauge
+rollout_info_replicas_desired{name="guestbook-bluegreen",namespace="default"} 1
+# HELP rollout_info_replicas_unavailable The number of unavailable replicas per rollout.
+# TYPE rollout_info_replicas_unavailable gauge
+rollout_info_replicas_unavailable{name="guestbook-bluegreen",namespace="default"} 0`,
+		},
+		{
 			fakeCanaryRollout,
-			conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionFalse, "Progressing", "test"),
+			conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionTrue, "Progressing", "test"),
 			`
 # HELP rollout_info Information about rollout.
 # TYPE rollout_info gauge

--- a/controller/metrics/rollouts.go
+++ b/controller/metrics/rollouts.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
@@ -64,7 +65,7 @@ func (c *rolloutCollector) Collect(ch chan<- prometheus.Metric) {
 func calculatePhase(rollout *v1alpha1.Rollout) RolloutPhase {
 	phase := RolloutProgressing
 	progressing := conditions.GetRolloutCondition(rollout.Status, v1alpha1.RolloutProgressing)
-	if progressing != nil {
+	if progressing != nil && progressing.Status == corev1.ConditionTrue {
 		if progressing.Reason == conditions.NewRSAvailableReason {
 			phase = RolloutCompleted
 		}
@@ -82,7 +83,7 @@ func calculatePhase(rollout *v1alpha1.Rollout) RolloutPhase {
 		}
 	}
 	invalidSpec := conditions.GetRolloutCondition(rollout.Status, v1alpha1.InvalidSpec)
-	if invalidSpec != nil {
+	if invalidSpec != nil && invalidSpec.Status == corev1.ConditionTrue {
 		phase = RolloutInvalidSpec
 	}
 	return phase

--- a/rollout/controller.go
+++ b/rollout/controller.go
@@ -498,9 +498,18 @@ func (c *rolloutContext) createInvalidRolloutCondition(validationError error, r 
 		if prevCond != nil && prevCond.Message != invalidSpecCond.Message {
 			conditions.RemoveRolloutCondition(newStatus, v1alpha1.InvalidSpec)
 		}
+		progressCondUpdated := conditions.UnprogressRolloutConditions(newStatus)
+
 		err := c.patchCondition(r, newStatus, invalidSpecCond)
 		if err != nil {
 			return err
+		}
+
+		if progressCondUpdated {
+			_, err = c.argoprojclientset.ArgoprojV1alpha1().Rollouts(r.Namespace).UpdateStatus(context.TODO(), c.rollout, metav1.UpdateOptions{})
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
- check condition status when setting metrics
- unprogress conditions when the rollout is not making
  any progress due to invalidSpec. Based on the definition
  of InvalidSpec, the rollout is not making progress.
  RolloutProgressing, RolloutCompleted, RolloutPaused mean
  rollout is progressing.

Signed-off-by: Hui Kang <hui.kang@salesforce.com>

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).