### PR TITLE
chore: rename variable to clarify the logic

### DIFF
--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -66,17 +66,19 @@ func (c *rolloutContext) rolloutCanary() error {
 		return err
 	}
 
-	noScalingOccurred, err := c.reconcileCanaryReplicaSets()
+	// isReconciling if changes are made to canary or stable RS
+	isReconciling, err := c.reconcileCanaryReplicaSets()
 	if err != nil {
 		return err
 	}
-	if noScalingOccurred {
+	if isReconciling {
 		c.log.Info("Not finished reconciling ReplicaSets")
 		return c.syncRolloutStatusCanary()
 	}
 
-	stillReconciling := c.reconcileCanaryPause()
-	if stillReconciling {
+	// isReconciling if a new paused condition is added
+	isReconciling = c.reconcileCanaryPause()
+	if isReconciling {
 		c.log.Infof("Not finished reconciling Canary Pause")
 		return c.syncRolloutStatusCanary()
 	}
@@ -361,7 +363,7 @@ func (c *rolloutContext) reconcileCanaryReplicaSets() (bool, error) {
 		return false, err
 	}
 	if scaledStableRS {
-		c.log.Infof("Not finished reconciling stableRS")
+		c.log.Infof("Not finished reconciling stable ReplicaSet")
 		return true, nil
 	}
 


### PR DESCRIPTION
- noScalingOccurred sounds confusing, so rename to stillReconciling
- update a log message to make it consistent with others in the
  same function.

Signed-off-by: Hui Kang <hui.kang@salesforce.com>

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).