### PR TITLE
chore: Fix istio vs reconcile errors

### DIFF
--- a/rollout/trafficrouting/istio/istio.go
+++ b/rollout/trafficrouting/istio/istio.go
@@ -242,16 +242,22 @@ func (r *Reconciler) reconcileVirtualService(obj *unstructured.Unstructured, vsv
 		}
 	}
 
+	// Generate Patches
 	patches := r.generateVirtualServicePatches(vsvcRouteNames, httpRoutes, vsvcTLSRoutes, tlsRoutes, int64(desiredWeight), additionalDestinations...)
 	err = patches.patchVirtualService(httpRoutesI, tlsRoutesI)
 	if err != nil {
 		return nil, false, err
 	}
 
-	err = unstructured.SetNestedSlice(newObj.Object, httpRoutesI, "spec", Http)
-	if err != nil {
-		return newObj, len(patches) > 0, err
+	// Set HTTP Route Slice
+	if len(httpRoutes) > 0 {
+		err = unstructured.SetNestedSlice(newObj.Object, httpRoutesI, "spec", Http)
+		if err != nil {
+			return newObj, len(patches) > 0, err
+		}
 	}
+
+	// Set TLS Route Slice
 	if tlsRoutesI != nil {
 		err = unstructured.SetNestedSlice(newObj.Object, tlsRoutesI, "spec", Tls)
 	}


### PR DESCRIPTION
**Signed-off-by:** Rohit Agrawal <rohit.agrawal@databricks.com>

This PR fixes a small error in `reconcileVirtualService(...)` where we try to set the HTTP routes back to the modified VirtualService even if it doesn't exist.

**Checklist:**

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [X] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [X] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My builds are green. Try syncing with master if they are not. 
* [X] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).