### PR TITLE
refactor: Reduce tight-coupling between sync.go <-> canary.go, bluegreen.go

### DIFF
--- a/rollout/replicaset.go
+++ b/rollout/replicaset.go
@@ -13,7 +13,10 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/argoproj/argo-rollouts/utils/annotations"
+	"github.com/argoproj/argo-rollouts/utils/conditions"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
+	"github.com/argoproj/argo-rollouts/utils/record"
 	replicasetutil "github.com/argoproj/argo-rollouts/utils/replicaset"
 )
 
@@ -229,6 +232,48 @@ func (c *rolloutContext) cleanupUnhealthyReplicas(oldRSs []*appsv1.ReplicaSet) (
 		oldRSs[i] = updatedOldRS
 	}
 	return oldRSs, totalScaledDown, nil
+}
+
+func (c *rolloutContext) scaleReplicaSetAndRecordEvent(rs *appsv1.ReplicaSet, newScale int32) (bool, *appsv1.ReplicaSet, error) {
+	// No need to scale
+	if *(rs.Spec.Replicas) == newScale && !annotations.ReplicasAnnotationsNeedUpdate(rs, defaults.GetReplicasOrDefault(c.rollout.Spec.Replicas)) {
+		return false, rs, nil
+	}
+	var scalingOperation string
+	if *(rs.Spec.Replicas) < newScale {
+		scalingOperation = "up"
+	} else {
+		scalingOperation = "down"
+	}
+	scaled, newRS, err := c.scaleReplicaSet(rs, newScale, c.rollout, scalingOperation)
+	return scaled, newRS, err
+}
+
+func (c *rolloutContext) scaleReplicaSet(rs *appsv1.ReplicaSet, newScale int32, rollout *v1alpha1.Rollout, scalingOperation string) (bool, *appsv1.ReplicaSet, error) {
+	ctx := context.TODO()
+	sizeNeedsUpdate := *(rs.Spec.Replicas) != newScale
+	fullScaleDown := newScale == int32(0)
+	rolloutReplicas := defaults.GetReplicasOrDefault(rollout.Spec.Replicas)
+	annotationsNeedUpdate := annotations.ReplicasAnnotationsNeedUpdate(rs, rolloutReplicas)
+
+	scaled := false
+	var err error
+	if sizeNeedsUpdate || annotationsNeedUpdate {
+		rsCopy := rs.DeepCopy()
+		oldScale := defaults.GetReplicasOrDefault(rs.Spec.Replicas)
+		*(rsCopy.Spec.Replicas) = newScale
+		annotations.SetReplicasAnnotations(rsCopy, rolloutReplicas)
+		if fullScaleDown && !c.shouldDelayScaleDownOnAbort() {
+			delete(rsCopy.Annotations, v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey)
+		}
+		rs, err = c.kubeclientset.AppsV1().ReplicaSets(rsCopy.Namespace).Update(ctx, rsCopy, metav1.UpdateOptions{})
+		if err == nil && sizeNeedsUpdate {
+			scaled = true
+			revision, _ := replicasetutil.Revision(rs)
+			c.recorder.Eventf(rollout, record.EventOptions{EventReason: conditions.ScalingReplicaSetReason}, conditions.ScalingReplicaSetMessage, scalingOperation, rs.Name, revision, oldScale, newScale)
+		}
+	}
+	return scaled, rs, err
 }
 
 func (c *rolloutContext) scaleDownDelayHelper(rs *appsv1.ReplicaSet, annotationedRSs int32, rolloutReplicas int32) (int32, int32, error) {

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -353,48 +353,6 @@ func (c *rolloutContext) isScalingEvent() (bool, error) {
 	return false, nil
 }
 
-func (c *rolloutContext) scaleReplicaSetAndRecordEvent(rs *appsv1.ReplicaSet, newScale int32) (bool, *appsv1.ReplicaSet, error) {
-	// No need to scale
-	if *(rs.Spec.Replicas) == newScale && !annotations.ReplicasAnnotationsNeedUpdate(rs, defaults.GetReplicasOrDefault(c.rollout.Spec.Replicas)) {
-		return false, rs, nil
-	}
-	var scalingOperation string
-	if *(rs.Spec.Replicas) < newScale {
-		scalingOperation = "up"
-	} else {
-		scalingOperation = "down"
-	}
-	scaled, newRS, err := c.scaleReplicaSet(rs, newScale, c.rollout, scalingOperation)
-	return scaled, newRS, err
-}
-
-func (c *rolloutContext) scaleReplicaSet(rs *appsv1.ReplicaSet, newScale int32, rollout *v1alpha1.Rollout, scalingOperation string) (bool, *appsv1.ReplicaSet, error) {
-	ctx := context.TODO()
-	sizeNeedsUpdate := *(rs.Spec.Replicas) != newScale
-	fullScaleDown := newScale == int32(0)
-	rolloutReplicas := defaults.GetReplicasOrDefault(rollout.Spec.Replicas)
-	annotationsNeedUpdate := annotations.ReplicasAnnotationsNeedUpdate(rs, rolloutReplicas)
-
-	scaled := false
-	var err error
-	if sizeNeedsUpdate || annotationsNeedUpdate {
-		rsCopy := rs.DeepCopy()
-		oldScale := defaults.GetReplicasOrDefault(rs.Spec.Replicas)
-		*(rsCopy.Spec.Replicas) = newScale
-		annotations.SetReplicasAnnotations(rsCopy, rolloutReplicas)
-		if fullScaleDown && !c.shouldDelayScaleDownOnAbort() {
-			delete(rsCopy.Annotations, v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey)
-		}
-		rs, err = c.kubeclientset.AppsV1().ReplicaSets(rsCopy.Namespace).Update(ctx, rsCopy, metav1.UpdateOptions{})
-		if err == nil && sizeNeedsUpdate {
-			scaled = true
-			revision, _ := replicasetutil.Revision(rs)
-			c.recorder.Eventf(rollout, record.EventOptions{EventReason: conditions.ScalingReplicaSetReason}, conditions.ScalingReplicaSetMessage, scalingOperation, rs.Name, revision, oldScale, newScale)
-		}
-	}
-	return scaled, rs, err
-}
-
 // calculateStatus calculates the common fields for all rollouts by looking into the provided replica sets.
 func (c *rolloutContext) calculateBaseStatus() v1alpha1.RolloutStatus {
 	prevStatus := c.rollout.Status


### PR DESCRIPTION
While I was building a PoC towards #1457, I realized that it was hard to extract the workload interface out of rolloutContext due to tight coupling between sync.go and canary.go + bluegreen.go.

My theory is the dependency graph should ideally be sync.go -> bluegreen.go/canary.go -> replicaset.go. By moving `scaleReplicaSetAndRecordEvent` from sync.go to replicaset.go, I'm removing the unwated reverse dependency.

These source files should eventually be in dedicated go pkgs (if maintainers agree) so that the Go compiler can detect cyclic dependencies. Doing that in a single commit would make reviewing hard, hence I'd like to do it one by one.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
  * I take this as a (c) chore
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
  * I've provided it a `refactor: ` prefix according to the conventional commits standard
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
  * No additional tests as this is purely a refactoring without no logic change
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).