### PR TITLE
fix: create analysisrun cmd using template generated name

### DIFF
--- a/pkg/kubectl-argo-rollouts/cmd/create/create.go
+++ b/pkg/kubectl-argo-rollouts/cmd/create/create.go
@@ -274,11 +274,11 @@ func NewCmdCreateAnalysisRun(o *options.ArgoRolloutsOptions) *cobra.Command {
 				}
 			}
 
-			objName, notFound, err := unstructured.NestedString(obj.Object, "metadata", "name")
+			objName, found, err := unstructured.NestedString(obj.Object, "metadata", "name")
 			if err != nil {
 				return err
 			}
-			if !notFound {
+			if found {
 				templateName = objName
 			}
 
@@ -291,6 +291,10 @@ func NewCmdCreateAnalysisRun(o *options.ArgoRolloutsOptions) *cobra.Command {
 				generateName = templateName + "-"
 			}
 			ns := o.Namespace()
+
+			if name == "" && generateName == "-" {
+				return fmt.Errorf("name is invalid")
+			}
 
 			obj, err = analysisutil.NewAnalysisRunFromUnstructured(obj, templateArgs, name, generateName, ns)
 			if err != nil {

--- a/pkg/kubectl-argo-rollouts/cmd/create/create_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/create/create_test.go
@@ -155,6 +155,21 @@ func TestCreateAnalysisRunName(t *testing.T) {
 	assert.Empty(t, stderr)
 }
 
+func TestCreateAnalysisRunNameNotSpecified(t *testing.T) {
+	tf, o := options.NewFakeArgoRolloutsOptions()
+	defer tf.Cleanup()
+
+	cmd := NewCmdCreateAnalysisRun(o)
+	cmd.PersistentPreRunE = o.PersistentPreRunE
+	cmd.SetArgs([]string{"--from-file", "testdata/analysis-template-no-name.yaml", "-a", "foo=bar"})
+	err := cmd.Execute()
+	assert.EqualError(t, err, "name is invalid")
+	stdout := o.Out.(*bytes.Buffer).String()
+	stderr := o.ErrOut.(*bytes.Buffer).String()
+	assert.Empty(t, stdout)
+	assert.Equal(t, "Error: name is invalid\n", stderr)
+}
+
 func TestCreateAnalysisRunWithInstanceID(t *testing.T) {
 	tf, o := options.NewFakeArgoRolloutsOptions()
 	defer tf.Cleanup()

--- a/pkg/kubectl-argo-rollouts/cmd/create/testdata/analysis-template-no-name.yaml
+++ b/pkg/kubectl-argo-rollouts/cmd/create/testdata/analysis-template-no-name.yaml
@@ -1,0 +1,22 @@
+kind: AnalysisTemplate
+apiVersion: argoproj.io/v1alpha1
+metadata:
+spec:
+  args:
+  - name: foo
+  metrics:
+  - name: pass
+    interval: 5s
+    failureLimit: 1
+    provider:
+      job:
+        spec:
+          template:
+            spec:
+              containers:
+              - name: sleep
+                image: alpine:3.8
+                command: [sh, -c]
+                args: [exit 0]
+              restartPolicy: Never
+          backoffLimit: 0


### PR DESCRIPTION
- set templateName if analsysit template has name in metadata
- remove resourceVersion and fix spec.args 

Signed-off-by: Hui Kang <hui.kang@salesforce.com>

fix #1473 

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).