### PR TITLE
feat(controller): multiple TrafficRoutingReconciler

### DIFF
--- a/rollout/controller.go
+++ b/rollout/controller.go
@@ -139,9 +139,9 @@ type reconcilerBase struct {
 	podRestarter RolloutPodRestarter
 
 	// used for unit testing
-	enqueueRollout              func(obj interface{})                                                        //nolint:structcheck
-	enqueueRolloutAfter         func(obj interface{}, duration time.Duration)                                //nolint:structcheck
-	newTrafficRoutingReconciler func(roCtx *rolloutContext) (trafficrouting.TrafficRoutingReconciler, error) //nolint:structcheck
+	enqueueRollout              func(obj interface{})                                                          //nolint:structcheck
+	enqueueRolloutAfter         func(obj interface{}, duration time.Duration)                                  //nolint:structcheck
+	newTrafficRoutingReconciler func(roCtx *rolloutContext) ([]trafficrouting.TrafficRoutingReconciler, error) //nolint:structcheck
 
 	// recorder is an event recorder for recording Event resources to the Kubernetes API.
 	recorder     record.EventRecorder
@@ -211,7 +211,6 @@ func NewController(cfg ControllerConfig) *Controller {
 		VirtualServiceInformer:  cfg.IstioVirtualServiceInformer,
 		DestinationRuleInformer: cfg.IstioDestinationRuleInformer,
 	})
-
 	controller.newTrafficRoutingReconciler = controller.NewTrafficRoutingReconciler
 
 	log.Info("Setting up event handlers")

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -44,7 +44,6 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
 	informers "github.com/argoproj/argo-rollouts/pkg/client/informers/externalversions"
 	"github.com/argoproj/argo-rollouts/rollout/mocks"
-	"github.com/argoproj/argo-rollouts/rollout/trafficrouting"
 	"github.com/argoproj/argo-rollouts/utils/annotations"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
@@ -103,7 +102,7 @@ type fixture struct {
 
 	// events holds all the K8s Event Reasons emitted during the run
 	events             []string
-	fakeTrafficRouting *mocks.TrafficRoutingReconciler
+	fakeTrafficRouting *[]mocks.TrafficRoutingReconciler
 }
 
 func newFixture(t *testing.T) *fixture {
@@ -549,10 +548,6 @@ func (f *fixture) newController(resync resyncFunc) (*Controller, informers.Share
 	}
 	c.enqueueRolloutAfter = func(obj interface{}, duration time.Duration) {
 		c.enqueueRollout(obj)
-	}
-
-	c.newTrafficRoutingReconciler = func(roCtx *rolloutContext) (trafficrouting.TrafficRoutingReconciler, error) {
-		return f.fakeTrafficRouting, nil
 	}
 
 	for _, r := range f.rolloutLister {

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -17,152 +17,197 @@ import (
 )
 
 // NewTrafficRoutingReconciler identifies return the TrafficRouting Plugin that the rollout wants to modify
-func (c *Controller) NewTrafficRoutingReconciler(roCtx *rolloutContext) (trafficrouting.TrafficRoutingReconciler, error) {
+func (c *Controller) NewTrafficRoutingReconciler(roCtx *rolloutContext) ([]trafficrouting.TrafficRoutingReconciler, error) {
 	rollout := roCtx.rollout
+	traffic_reconciliers := []trafficrouting.TrafficRoutingReconciler{}
 	if rollout.Spec.Strategy.Canary.TrafficRouting == nil {
 		return nil, nil
 	}
 	if rollout.Spec.Strategy.Canary.TrafficRouting.Istio != nil {
 		if c.IstioController.VirtualServiceInformer.HasSynced() {
-			return istio.NewReconciler(rollout, c.IstioController.DynamicClientSet, c.recorder, c.IstioController.VirtualServiceLister, c.IstioController.DestinationRuleLister), nil
+			// return istio.NewReconciler(rollout, c.IstioController.DynamicClientSet, c.recorder, c.IstioController.VirtualServiceLister, c.IstioController.DestinationRuleLister), nil
+			traffic_reconciliers = append(traffic_reconciliers, istio.NewReconciler(rollout, c.IstioController.DynamicClientSet, c.recorder, c.IstioController.VirtualServiceLister, c.IstioController.DestinationRuleLister))
 		} else {
-			return istio.NewReconciler(rollout, c.IstioController.DynamicClientSet, c.recorder, nil, nil), nil
+			traffic_reconciliers = append(traffic_reconciliers, istio.NewReconciler(rollout, c.IstioController.DynamicClientSet, c.recorder, nil, nil))
+			// return istio.NewReconciler(rollout, c.IstioController.DynamicClientSet, c.recorder, nil, nil), nil
 		}
 	}
 	if rollout.Spec.Strategy.Canary.TrafficRouting.Nginx != nil {
-		return nginx.NewReconciler(nginx.ReconcilerConfig{
+		/*
+			return nginx.NewReconciler(nginx.ReconcilerConfig{
+				Rollout:        rollout,
+				Client:         c.kubeclientset,
+				Recorder:       c.recorder,
+				ControllerKind: controllerKind,
+				IngressLister:  c.ingressesLister,
+			}), nil
+		*/
+		traffic_reconciliers = append(traffic_reconciliers, nginx.NewReconciler(nginx.ReconcilerConfig{
 			Rollout:        rollout,
 			Client:         c.kubeclientset,
 			Recorder:       c.recorder,
 			ControllerKind: controllerKind,
 			IngressLister:  c.ingressesLister,
-		}), nil
+		}))
 	}
 	if rollout.Spec.Strategy.Canary.TrafficRouting.ALB != nil {
-		return alb.NewReconciler(alb.ReconcilerConfig{
+		/*
+			return alb.NewReconciler(alb.ReconcilerConfig{
+				Rollout:        rollout,
+				Client:         c.kubeclientset,
+				Recorder:       c.recorder,
+				ControllerKind: controllerKind,
+				IngressLister:  c.ingressesLister,
+			})
+		*/
+		alb_reconcilier, err := alb.NewReconciler(alb.ReconcilerConfig{
 			Rollout:        rollout,
 			Client:         c.kubeclientset,
 			Recorder:       c.recorder,
 			ControllerKind: controllerKind,
 			IngressLister:  c.ingressesLister,
 		})
+		if err != nil {
+			traffic_reconciliers = append(traffic_reconciliers, alb_reconcilier)
+		}
 	}
 	if rollout.Spec.Strategy.Canary.TrafficRouting.SMI != nil {
-		return smi.NewReconciler(smi.ReconcilerConfig{
+		/*
+			return smi.NewReconciler(smi.ReconcilerConfig{
+				Rollout:        rollout,
+				Client:         c.smiclientset,
+				Recorder:       c.recorder,
+				ControllerKind: controllerKind,
+			})
+		*/
+		smi_reconcilier, err := smi.NewReconciler(smi.ReconcilerConfig{
 			Rollout:        rollout,
 			Client:         c.smiclientset,
 			Recorder:       c.recorder,
 			ControllerKind: controllerKind,
 		})
+		if err != nil {
+			traffic_reconciliers = append(traffic_reconciliers, smi_reconcilier)
+		}
 	}
 	if rollout.Spec.Strategy.Canary.TrafficRouting.Ambassador != nil {
 		ac := ambassador.NewDynamicClient(c.dynamicclientset, rollout.GetNamespace())
-		return ambassador.NewReconciler(rollout, ac, c.recorder), nil
+		/*
+			return ambassador.NewReconciler(rollout, ac, c.recorder), nil
+		*/
+		traffic_reconciliers = append(traffic_reconciliers, ambassador.NewReconciler(rollout, ac, c.recorder))
 	}
+
+	if len(traffic_reconciliers) > 0 {
+		return traffic_reconciliers, nil
+	}
+
 	return nil, nil
 }
 
 func (c *rolloutContext) reconcileTrafficRouting() error {
-	reconciler, err := c.newTrafficRoutingReconciler(c)
+	reconcilers, err := c.newTrafficRoutingReconciler(c)
 	if err != nil {
 		return err
 	}
-	if reconciler == nil {
+	if len(reconcilers) < 1 {
 		return nil
 	}
-	c.log.Infof("Reconciling TrafficRouting with type '%s'", reconciler.Type())
 
-	var canaryHash, stableHash string
-	if c.stableRS != nil {
-		stableHash = c.stableRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
-	}
-	if c.newRS != nil {
-		canaryHash = c.newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
-	}
-	err = reconciler.UpdateHash(canaryHash, stableHash)
-	if err != nil {
-		return err
-	}
+	for _, reconciler := range reconcilers {
+		c.log.Infof("Reconciling TrafficRouting with type '%s'", reconciler.Type())
 
-	currentStep, index := replicasetutil.GetCurrentCanaryStep(c.rollout)
-	desiredWeight := int32(0)
-	weightDestinations := make([]trafficrouting.WeightDestination, 0)
-	if rolloututil.IsFullyPromoted(c.rollout) {
-		// when we are fully promoted. desired canary weight should be 0
-	} else if c.pauseContext.IsAborted() {
-		// when promote aborted. desired canary weight should be 0
-	} else if c.newRS == nil || c.newRS.Status.AvailableReplicas == 0 {
-		// when newRS is not available or replicas num is 0. never weight to canary
-	} else if index != nil {
-		atDesiredReplicaCount := replicasetutil.AtDesiredReplicaCountsForCanary(c.rollout, c.newRS, c.stableRS, c.otherRSs)
-		if !atDesiredReplicaCount {
-			// Use the previous weight since the new RS is not ready for a new weight
-			for i := *index - 1; i >= 0; i-- {
-				step := c.rollout.Spec.Strategy.Canary.Steps[i]
-				if step.SetWeight != nil {
-					desiredWeight = *step.SetWeight
-					break
-				}
-			}
-		} else if *index != int32(len(c.rollout.Spec.Strategy.Canary.Steps)) {
-			// This if statement prevents the desiredWeight from being set to 100
-			// when the rollout has progressed through all the steps. The rollout
-			// should send all traffic to the stable service by using a weight of
-			// 0. If the rollout is progressing through the steps, the desired
-			// weight of the traffic routing service should be at the value of the
-			// last setWeight step, which is set by GetCurrentSetWeight.
-			desiredWeight = replicasetutil.GetCurrentSetWeight(c.rollout)
+		var canaryHash, stableHash string
+		if c.stableRS != nil {
+			stableHash = c.stableRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 		}
-
-		// Checks for experiment step
-		// If current experiment exists, then create WeightDestinations for each experiment template
-		exStep := replicasetutil.GetCurrentExperimentStep(c.rollout)
-		if exStep != nil && c.currentEx != nil && c.currentEx.Status.Phase == v1alpha1.AnalysisPhaseRunning {
-			getTemplateWeight := func(name string) *int32 {
-				for _, tmpl := range exStep.Templates {
-					if tmpl.Name == name {
-						return tmpl.Weight
-					}
-				}
-				return nil
-			}
-			for _, templateStatus := range c.currentEx.Status.TemplateStatuses {
-				templateWeight := getTemplateWeight(templateStatus.Name)
-				weightDestinations = append(weightDestinations, trafficrouting.WeightDestination{
-					ServiceName:     templateStatus.ServiceName,
-					PodTemplateHash: templateStatus.PodTemplateHash,
-					Weight:          *templateWeight,
-				})
-			}
+		if c.newRS != nil {
+			canaryHash = c.newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 		}
-	}
-
-	err = reconciler.SetWeight(desiredWeight, weightDestinations...)
-	if err != nil {
-		c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: "TrafficRoutingError"}, err.Error())
-		return err
-	}
-
-	// If we are in the middle of an update at a setWeight step, also perform weight verification.
-	// Note that we don't do this every reconciliation because weight verification typically involves
-	// API calls to the cloud provider which could incur rate limiting
-	shouldVerifyWeight := c.rollout.Status.StableRS != "" &&
-		c.rollout.Status.CurrentPodHash != c.rollout.Status.StableRS &&
-		currentStep != nil && currentStep.SetWeight != nil
-
-	if shouldVerifyWeight {
-		weightVerified, err := reconciler.VerifyWeight(desiredWeight, weightDestinations...)
+		err = reconciler.UpdateHash(canaryHash, stableHash)
 		if err != nil {
 			return err
 		}
-		if !weightVerified {
-			c.log.Infof("Desired weight (stepIdx: %d) %d not yet verified", *index, desiredWeight)
-			c.enqueueRolloutAfter(c.rollout, 10*time.Second)
-		} else {
-			c.log.Infof("Desired weight (stepIdx: %d) %d verified", *index, desiredWeight)
-		}
-		c.targetsVerified = &weightVerified
-	}
 
+		currentStep, index := replicasetutil.GetCurrentCanaryStep(c.rollout)
+		desiredWeight := int32(0)
+		weightDestinations := make([]trafficrouting.WeightDestination, 0)
+		if rolloututil.IsFullyPromoted(c.rollout) {
+			// when we are fully promoted. desired canary weight should be 0
+		} else if c.pauseContext.IsAborted() {
+			// when promote aborted. desired canary weight should be 0
+		} else if c.newRS == nil || c.newRS.Status.AvailableReplicas == 0 {
+			// when newRS is not available or replicas num is 0. never weight to canary
+		} else if index != nil {
+			atDesiredReplicaCount := replicasetutil.AtDesiredReplicaCountsForCanary(c.rollout, c.newRS, c.stableRS, c.otherRSs)
+			if !atDesiredReplicaCount {
+				// Use the previous weight since the new RS is not ready for a new weight
+				for i := *index - 1; i >= 0; i-- {
+					step := c.rollout.Spec.Strategy.Canary.Steps[i]
+					if step.SetWeight != nil {
+						desiredWeight = *step.SetWeight
+						break
+					}
+				}
+			} else if *index != int32(len(c.rollout.Spec.Strategy.Canary.Steps)) {
+				// This if statement prevents the desiredWeight from being set to 100
+				// when the rollout has progressed through all the steps. The rollout
+				// should send all traffic to the stable service by using a weight of
+				// 0. If the rollout is progressing through the steps, the desired
+				// weight of the traffic routing service should be at the value of the
+				// last setWeight step, which is set by GetCurrentSetWeight.
+				desiredWeight = replicasetutil.GetCurrentSetWeight(c.rollout)
+			}
+
+			// Checks for experiment step
+			// If current experiment exists, then create WeightDestinations for each experiment template
+			exStep := replicasetutil.GetCurrentExperimentStep(c.rollout)
+			if exStep != nil && c.currentEx != nil && c.currentEx.Status.Phase == v1alpha1.AnalysisPhaseRunning {
+				getTemplateWeight := func(name string) *int32 {
+					for _, tmpl := range exStep.Templates {
+						if tmpl.Name == name {
+							return tmpl.Weight
+						}
+					}
+					return nil
+				}
+				for _, templateStatus := range c.currentEx.Status.TemplateStatuses {
+					templateWeight := getTemplateWeight(templateStatus.Name)
+					weightDestinations = append(weightDestinations, trafficrouting.WeightDestination{
+						ServiceName:     templateStatus.ServiceName,
+						PodTemplateHash: templateStatus.PodTemplateHash,
+						Weight:          *templateWeight,
+					})
+				}
+			}
+		}
+
+		err = reconciler.SetWeight(desiredWeight, weightDestinations...)
+		if err != nil {
+			c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: "TrafficRoutingError"}, err.Error())
+			return err
+		}
+
+		// If we are in the middle of an update at a setWeight step, also perform weight verification.
+		// Note that we don't do this every reconciliation because weight verification typically involves
+		// API calls to the cloud provider which could incur rate limiting
+		shouldVerifyWeight := c.rollout.Status.StableRS != "" &&
+			c.rollout.Status.CurrentPodHash != c.rollout.Status.StableRS &&
+			currentStep != nil && currentStep.SetWeight != nil
+
+		if shouldVerifyWeight {
+			weightVerified, err := reconciler.VerifyWeight(desiredWeight, weightDestinations...)
+			if err != nil {
+				return err
+			}
+			if !weightVerified {
+				c.log.Infof("Desired weight (stepIdx: %d) %d not yet verified", *index, desiredWeight)
+				c.enqueueRolloutAfter(c.rollout, 10*time.Second)
+			} else {
+				c.log.Infof("Desired weight (stepIdx: %d) %d verified", *index, desiredWeight)
+			}
+			c.targetsVerified = &weightVerified
+		}
+	}
 	return nil
 }

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -28,21 +28,25 @@ import (
 )
 
 // newFakeTrafficRoutingReconciler returns a fake TrafficRoutingReconciler with mocked success return values
-func newFakeTrafficRoutingReconciler() *mocks.TrafficRoutingReconciler {
-	r := mocks.TrafficRoutingReconciler{}
-	r.On("Type").Return("fake")
-	r.On("SetWeight", mock.Anything).Return(nil)
-	r.On("VerifyWeight", mock.Anything).Return(true, nil)
-	r.On("UpdateHash", mock.Anything, mock.Anything).Return(nil)
-	return &r
+func newFakeTrafficRoutingReconciler() *[]mocks.TrafficRoutingReconciler {
+	r_list := []mocks.TrafficRoutingReconciler{}
+	for _, r := range r_list {
+		r.On("Type").Return("fake")
+		r.On("SetWeight", mock.Anything).Return(nil)
+		r.On("VerifyWeight", mock.Anything).Return(true, nil)
+		r.On("UpdateHash", mock.Anything, mock.Anything).Return(nil)
+	}
+	return &r_list
 }
 
 // newUnmockedFakeTrafficRoutingReconciler returns a fake TrafficRoutingReconciler with unmocked
 // methods (except Type() mocked)
-func newUnmockedFakeTrafficRoutingReconciler() *mocks.TrafficRoutingReconciler {
-	r := mocks.TrafficRoutingReconciler{}
-	r.On("Type").Return("fake")
-	return &r
+func newUnmockedFakeTrafficRoutingReconciler() *[]mocks.TrafficRoutingReconciler {
+	r_list := []mocks.TrafficRoutingReconciler{}
+	for _, r := range r_list {
+		r.On("Type").Return("fake")
+	}
+	return &r_list
 }
 
 func newTrafficWeightFixture(t *testing.T) (*fixture, *v1alpha1.Rollout) {
@@ -83,9 +87,11 @@ func TestReconcileTrafficRoutingSetWeightErr(t *testing.T) {
 	f, ro := newTrafficWeightFixture(t)
 	defer f.Close()
 	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
-	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything).Return(nil)
-	f.fakeTrafficRouting.On("SetWeight", mock.Anything).Return(errors.New("Error message"))
-	f.runExpectError(getKey(ro, t), true)
+	for _, fakeTrafficRouting := range *f.fakeTrafficRouting {
+		fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything).Return(nil)
+		fakeTrafficRouting.On("SetWeight", mock.Anything).Return(errors.New("Error message"))
+		f.runExpectError(getKey(ro, t), true)
+	}
 }
 
 // verify error is returned when VerifyWeight returns error
@@ -93,10 +99,12 @@ func TestReconcileTrafficRoutingVerifyWeightErr(t *testing.T) {
 	f, ro := newTrafficWeightFixture(t)
 	defer f.Close()
 	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
-	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything).Return(nil)
-	f.fakeTrafficRouting.On("SetWeight", mock.Anything).Return(nil)
-	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(false, errors.New("Error message"))
-	f.runExpectError(getKey(ro, t), true)
+	for _, fakeTrafficRouting := range *f.fakeTrafficRouting {
+		fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything).Return(nil)
+		fakeTrafficRouting.On("SetWeight", mock.Anything).Return(nil)
+		fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(false, errors.New("Error message"))
+		f.runExpectError(getKey(ro, t), true)
+	}
 }
 
 // verify we requeue when VerifyWeight returns false
@@ -104,17 +112,19 @@ func TestReconcileTrafficRoutingVerifyWeightFalse(t *testing.T) {
 	f, ro := newTrafficWeightFixture(t)
 	defer f.Close()
 	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
-	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything).Return(nil)
-	f.fakeTrafficRouting.On("SetWeight", mock.Anything).Return(nil)
-	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(false, nil)
-	c, i, k8sI := f.newController(noResyncPeriodFunc)
-	enqueued := false
-	c.enqueueRolloutAfter = func(obj interface{}, duration time.Duration) {
-		enqueued = true
+	for _, fakeTrafficRouting := range *f.fakeTrafficRouting {
+		fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything).Return(nil)
+		fakeTrafficRouting.On("SetWeight", mock.Anything).Return(nil)
+		fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(false, nil)
+		c, i, k8sI := f.newController(noResyncPeriodFunc)
+		enqueued := false
+		c.enqueueRolloutAfter = func(obj interface{}, duration time.Duration) {
+			enqueued = true
+		}
+		f.expectPatchRolloutAction(ro)
+		f.runController(getKey(ro, t), true, false, c, i, k8sI)
+		assert.True(t, enqueued)
 	}
-	f.expectPatchRolloutAction(ro)
-	f.runController(getKey(ro, t), true, false, c, i, k8sI)
-	assert.True(t, enqueued)
 }
 
 func TestRolloutUseDesiredWeight(t *testing.T) {
@@ -161,13 +171,15 @@ func TestRolloutUseDesiredWeight(t *testing.T) {
 	f.expectPatchRolloutAction(r2)
 
 	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
-	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything).Return(nil)
-	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, additionalDestinations ...trafficrouting.WeightDestination) error {
-		// make sure SetWeight was called with correct value
-		assert.Equal(t, int32(10), desiredWeight)
-		return nil
-	})
-	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(true, nil)
+	for _, fakeTrafficRouting := range *f.fakeTrafficRouting {
+		fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything).Return(nil)
+		fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, additionalDestinations ...trafficrouting.WeightDestination) error {
+			// make sure SetWeight was called with correct value
+			assert.Equal(t, int32(10), desiredWeight)
+			return nil
+		})
+		fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(true, nil)
+	}
 	f.run(getKey(r2, t))
 }
 
@@ -225,40 +237,44 @@ func TestRolloutWithExperimentStep(t *testing.T) {
 	t.Run("Experiment Running - WeightDestination created", func(t *testing.T) {
 		ex.Status.Phase = v1alpha1.AnalysisPhaseRunning
 		f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
-		f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything).Return(nil)
-		f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, weightDestinations ...trafficrouting.WeightDestination) error {
-			// make sure SetWeight was called with correct value
-			assert.Equal(t, int32(10), desiredWeight)
-			assert.Equal(t, int32(5), weightDestinations[0].Weight)
-			assert.Equal(t, ex.Status.TemplateStatuses[0].ServiceName, weightDestinations[0].ServiceName)
-			assert.Equal(t, ex.Status.TemplateStatuses[0].PodTemplateHash, weightDestinations[0].PodTemplateHash)
-			return nil
-		})
-		f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(func(desiredWeight int32, weightDestinations ...trafficrouting.WeightDestination) error {
-			assert.Equal(t, int32(10), desiredWeight)
-			assert.Equal(t, int32(5), weightDestinations[0].Weight)
-			assert.Equal(t, ex.Status.TemplateStatuses[0].ServiceName, weightDestinations[0].ServiceName)
-			assert.Equal(t, ex.Status.TemplateStatuses[0].PodTemplateHash, weightDestinations[0].PodTemplateHash)
-			return nil
-		})
+		for _, fakeTrafficRouting := range *f.fakeTrafficRouting {
+			fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything).Return(nil)
+			fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, weightDestinations ...trafficrouting.WeightDestination) error {
+				// make sure SetWeight was called with correct value
+				assert.Equal(t, int32(10), desiredWeight)
+				assert.Equal(t, int32(5), weightDestinations[0].Weight)
+				assert.Equal(t, ex.Status.TemplateStatuses[0].ServiceName, weightDestinations[0].ServiceName)
+				assert.Equal(t, ex.Status.TemplateStatuses[0].PodTemplateHash, weightDestinations[0].PodTemplateHash)
+				return nil
+			})
+			fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(func(desiredWeight int32, weightDestinations ...trafficrouting.WeightDestination) error {
+				assert.Equal(t, int32(10), desiredWeight)
+				assert.Equal(t, int32(5), weightDestinations[0].Weight)
+				assert.Equal(t, ex.Status.TemplateStatuses[0].ServiceName, weightDestinations[0].ServiceName)
+				assert.Equal(t, ex.Status.TemplateStatuses[0].PodTemplateHash, weightDestinations[0].PodTemplateHash)
+				return nil
+			})
+		}
 		f.run(getKey(r2, t))
 	})
 
 	t.Run("Experiment Pending - no WeightDestination created", func(t *testing.T) {
 		ex.Status.Phase = v1alpha1.AnalysisPhasePending
 		f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
-		f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything).Return(nil)
-		f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, weightDestinations ...trafficrouting.WeightDestination) error {
-			// make sure SetWeight was called with correct value
-			assert.Equal(t, int32(10), desiredWeight)
-			assert.Len(t, weightDestinations, 0)
-			return nil
-		})
-		f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(func(desiredWeight int32, weightDestinations ...trafficrouting.WeightDestination) error {
-			assert.Equal(t, int32(10), desiredWeight)
-			assert.Len(t, weightDestinations, 0)
-			return nil
-		})
+		for _, fakeTrafficRouting := range *f.fakeTrafficRouting {
+			fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything).Return(nil)
+			fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, weightDestinations ...trafficrouting.WeightDestination) error {
+				// make sure SetWeight was called with correct value
+				assert.Equal(t, int32(10), desiredWeight)
+				assert.Len(t, weightDestinations, 0)
+				return nil
+			})
+			fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(func(desiredWeight int32, weightDestinations ...trafficrouting.WeightDestination) error {
+				assert.Equal(t, int32(10), desiredWeight)
+				assert.Len(t, weightDestinations, 0)
+				return nil
+			})
+		}
 		f.run(getKey(r2, t))
 	})
 }
@@ -302,14 +318,16 @@ func TestRolloutUsePreviousSetWeight(t *testing.T) {
 	f.expectPatchRolloutAction(r2)
 
 	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
-	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything).Return(nil)
-	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, additionalDestinations ...trafficrouting.WeightDestination) error {
-		// make sure SetWeight was called with correct value
-		assert.Equal(t, int32(10), desiredWeight)
-		return nil
-	})
-	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything, mock.Anything).Return(true, nil)
-	f.fakeTrafficRouting.On("error patching alb ingress", mock.Anything, mock.Anything).Return(true, nil)
+	for _, fakeTrafficRouting := range *f.fakeTrafficRouting {
+		fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything).Return(nil)
+		fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, additionalDestinations ...trafficrouting.WeightDestination) error {
+			// make sure SetWeight was called with correct value
+			assert.Equal(t, int32(10), desiredWeight)
+			return nil
+		})
+		fakeTrafficRouting.On("VerifyWeight", mock.Anything, mock.Anything).Return(true, nil)
+		fakeTrafficRouting.On("error patching alb ingress", mock.Anything, mock.Anything).Return(true, nil)
+	}
 	f.run(getKey(r2, t))
 }
 
@@ -344,13 +362,15 @@ func TestRolloutSetWeightToZeroWhenFullyRolledOut(t *testing.T) {
 
 	f.expectPatchRolloutAction(r1)
 	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
-	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything).Return(nil)
-	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, additionalDestinations ...trafficrouting.WeightDestination) error {
-		// make sure SetWeight was called with correct value
-		assert.Equal(t, int32(0), desiredWeight)
-		return nil
-	})
-	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(true, nil)
+	for _, fakeTrafficRouting := range *f.fakeTrafficRouting {
+		fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything).Return(nil)
+		fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, additionalDestinations ...trafficrouting.WeightDestination) error {
+			// make sure SetWeight was called with correct value
+			assert.Equal(t, int32(0), desiredWeight)
+			return nil
+		})
+		fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(true, nil)
+	}
 	f.run(getKey(r1, t))
 }
 
@@ -400,10 +420,12 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 			rollout: r,
 			log:     logutil.WithRollout(r),
 		}
-		networkReconciler, err := rc.NewTrafficRoutingReconciler(roCtx)
-		assert.Nil(t, err)
-		assert.NotNil(t, networkReconciler)
-		assert.Equal(t, istio.Type, networkReconciler.Type())
+		networkReconcilerList, err := rc.NewTrafficRoutingReconciler(roCtx)
+		for _, networkReconciler := range networkReconcilerList {
+			assert.Nil(t, err)
+			assert.NotNil(t, networkReconciler)
+			assert.Equal(t, istio.Type, networkReconciler.Type())
+		}
 	}
 	{
 		// With istioVirtualServiceLister
@@ -420,10 +442,12 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 			rollout: r,
 			log:     logutil.WithRollout(r),
 		}
-		networkReconciler, err := rc.NewTrafficRoutingReconciler(roCtx)
-		assert.Nil(t, err)
-		assert.NotNil(t, networkReconciler)
-		assert.Equal(t, istio.Type, networkReconciler.Type())
+		networkReconcilerList, err := rc.NewTrafficRoutingReconciler(roCtx)
+		for _, networkReconciler := range networkReconcilerList {
+			assert.Nil(t, err)
+			assert.NotNil(t, networkReconciler)
+			assert.Equal(t, istio.Type, networkReconciler.Type())
+		}
 	}
 	{
 		r := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
@@ -434,10 +458,12 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 			rollout: r,
 			log:     logutil.WithRollout(r),
 		}
-		networkReconciler, err := rc.NewTrafficRoutingReconciler(roCtx)
-		assert.Nil(t, err)
-		assert.NotNil(t, networkReconciler)
-		assert.Equal(t, nginx.Type, networkReconciler.Type())
+		networkReconcilerList, err := rc.NewTrafficRoutingReconciler(roCtx)
+		for _, networkReconciler := range networkReconcilerList {
+			assert.Nil(t, err)
+			assert.NotNil(t, networkReconciler)
+			assert.Equal(t, nginx.Type, networkReconciler.Type())
+		}
 	}
 	{
 		r := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
@@ -448,10 +474,12 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 			rollout: r,
 			log:     logutil.WithRollout(r),
 		}
-		networkReconciler, err := rc.NewTrafficRoutingReconciler(roCtx)
-		assert.Nil(t, err)
-		assert.NotNil(t, networkReconciler)
-		assert.Equal(t, alb.Type, networkReconciler.Type())
+		networkReconcilerList, err := rc.NewTrafficRoutingReconciler(roCtx)
+		for _, networkReconciler := range networkReconcilerList {
+			assert.Nil(t, err)
+			assert.NotNil(t, networkReconciler)
+			assert.Equal(t, alb.Type, networkReconciler.Type())
+		}
 	}
 	{
 		tsController := Controller{}
@@ -463,10 +491,12 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 			rollout: r,
 			log:     logutil.WithRollout(r),
 		}
-		networkReconciler, err := tsController.NewTrafficRoutingReconciler(roCtx)
-		assert.Nil(t, err)
-		assert.NotNil(t, networkReconciler)
-		assert.Equal(t, smi.Type, networkReconciler.Type())
+		networkReconcilerList, err := tsController.NewTrafficRoutingReconciler(roCtx)
+		for _, networkReconciler := range networkReconcilerList {
+			assert.Nil(t, err)
+			assert.NotNil(t, networkReconciler)
+			assert.Equal(t, smi.Type, networkReconciler.Type())
+		}
 	}
 }
 


### PR DESCRIPTION
# Current Scenario
You can add multiple `trafficRouting` on rollouts spec. Unfortunately, only the first is used (alphabetically sorted). example:
```
    canary:
      canaryService: rollouts-demo-canary
      stableService: rollouts-demo-stable
      trafficRouting:
        smi: {}
        nginx:
          stableIngress: rollouts-demo-stable
```
In that case, only `nginx` will be used and `smi` will be ignored.

# Feature multiple TrafficRoutingReconciler
With the same spec:
```
    canary:
      canaryService: rollouts-demo-canary
      stableService: rollouts-demo-stable
      trafficRouting:
        smi: {}
        nginx:
          stableIngress: rollouts-demo-stable
```
In this case, both `trafficRouting` definitions are used and they are kept in sync as well. 
```
INFO[2021-09-04T14:01:19Z] Found 2 TrafficRouting Reconciliers           namespace=default rollout=rollouts-demo
INFO[2021-09-04T14:01:19Z] Reconciling TrafficRouting with type 'Nginx'  namespace=default rollout=rollouts-demo
INFO[2021-09-04T14:01:19Z] syncing service                               namespace=default rollout=rollouts-demo service=rollouts-demo-canary
INFO[2021-09-04T14:01:19Z] updating canary Ingress                       desiredWeight=5 ingress=rollouts-demo-rollouts-demo-stable-canary namespace=default rollout=rollouts-demo
INFO[2021-09-04T14:01:19Z] Event(v1.ObjectReference{Kind:"Rollout", Namespace:"default", Name:"rollouts-demo", UID:"02f3c5eb-18c1-41bb-ae05-bc80150c06b3", APIVersion:"argoproj.io/v1alpha1", ResourceVersion:"58651", FieldPath:""}): type: 'Normal' reason: 'PatchingCanaryIngress' Updating Ingress `rollouts-demo-rollouts-demo-stable-canary` to desiredWeight '5'
INFO[2021-09-04T14:01:19Z] Updating Ingress `rollouts-demo-rollouts-demo-stable-canary` to desiredWeight '5'  event_reason=PatchingCanaryIngress namespace=default rollout=rollouts-demo
INFO[2021-09-04T14:01:19Z] Desired weight (stepIdx: 0) 5 verified        namespace=default rollout=rollouts-demo
INFO[2021-09-04T14:01:19Z] Reconciling TrafficRouting with type 'SMI'    namespace=default rollout=rollouts-demo
INFO[2021-09-04T14:01:19Z] TrafficSplit `rollouts-demo` modified         event_reason=TrafficSplitModified namespace=default rollout=rollouts-demo
INFO[2021-09-04T14:01:19Z] Desired weight (stepIdx: 0) 5 verified        namespace=default rollout=rollouts-demo
INFO[2021-09-04T14:01:19Z] Event(v1.ObjectReference{Kind:"Rollout", Namespace:"default", Name:"rollouts-demo", UID:"02f3c5eb-18c1-41bb-ae05-bc80150c06b3", APIVersion:"argoproj.io/v1alpha1", ResourceVersion:"58651", FieldPath:""}): type: 'Normal' reason: 'TrafficSplitModified' TrafficSplit `rollouts-demo` modified
INFO[2021-09-04T14:01:19Z] Rollout step 1/7 completed (setWeight: 5)     event_reason=RolloutStepCompleted namespace=default rollout=rollouts-demo
```
This is performed with the minimum impact by just mutating the structure into a list that is processed one by one sequentially.

# Scenarios
A) existing fleet that can't transition from nginx to VirtualGateways or similars
B) adding sidecars to large throughput nginx controllers is not viable or can have a negative impact
C) adoption of full N-S and W-E canary with zero-downtime on large fleets
D) nginx-service-mesh (nginxinc) ++ ingress-nginx (kubernetes) doesn't work so well together
E) nginx service mesh N/S W/E without using nginxinc ingress.
F) no host header annotations to circumvent routing issues when adding nginx-ingress to a mesh

Despite facing both A+B+C+D+E+F Scenarios, there are a few thoughts behind this:
- Why have to choose between SMI or Nginx?
- Why change 3000 ingresses into VirtualGateways or similar?
- Why adding sidecars to the ingress if the annotations should work fine ?
- Why can accomplish either N/S or W/E traffic shift with minimal cost/impact ?
- Why multiple providers wouldn't be able to work together?

This will be the first to allow the use of multiple traffic-shift mechanisms among the other existing solutions that enables features such as canary around :)

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [X] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [X] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).