### PR TITLE
fix: replicaset count would flap when interrupting update with new pod spec

### DIFF
--- a/rollout/service.go
+++ b/rollout/service.go
@@ -242,7 +242,7 @@ func (c *rolloutContext) reconcileStableAndCanaryService() error {
 		return err
 	}
 
-	if c.newRSReady() {
+	if replicasetutil.IsReplicaSetReady(c.newRS) {
 		err = c.ensureSVCTargets(c.rollout.Spec.Strategy.Canary.CanaryService, c.newRS)
 		if err != nil {
 			return err
@@ -266,13 +266,4 @@ func (c *rolloutContext) ensureSVCTargets(svcName string, rs *appsv1.ReplicaSet)
 		}
 	}
 	return nil
-}
-
-func (c *rolloutContext) newRSReady() bool {
-	if c.newRS == nil {
-		return false
-	}
-	replicas := c.newRS.Spec.Replicas
-	readyReplicas := c.newRS.Status.ReadyReplicas
-	return replicas != nil && *replicas != 0 && readyReplicas != 0 && *replicas <= readyReplicas
 }

--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -616,3 +616,13 @@ func GetPodsOwnedByReplicaSet(ctx context.Context, client kubernetes.Interface, 
 	}
 	return podOwnedByRS, nil
 }
+
+// IsReplicaSetReady returns if a ReplicaSet is scaled up and its ready count is >= desired count
+func IsReplicaSetReady(rs *appsv1.ReplicaSet) bool {
+	if rs == nil {
+		return false
+	}
+	replicas := rs.Spec.Replicas
+	readyReplicas := rs.Status.ReadyReplicas
+	return replicas != nil && *replicas != 0 && readyReplicas != 0 && *replicas <= readyReplicas
+}

--- a/utils/replicaset/replicaset_test.go
+++ b/utils/replicaset/replicaset_test.go
@@ -1247,3 +1247,54 @@ spec:
 
 	assert.True(t, PodTemplateEqualIgnoreHash(&live, &desired))
 }
+
+func TestIsReplicaSetReady(t *testing.T) {
+	{
+		assert.False(t, IsReplicaSetReady(nil))
+	}
+	{
+		rs := appsv1.ReplicaSet{
+			Spec: appsv1.ReplicaSetSpec{
+				Replicas: pointer.Int32Ptr(1),
+			},
+			Status: appsv1.ReplicaSetStatus{
+				ReadyReplicas: 0,
+			},
+		}
+		assert.False(t, IsReplicaSetReady(&rs))
+	}
+	{
+		rs := appsv1.ReplicaSet{
+			Spec: appsv1.ReplicaSetSpec{
+				Replicas: pointer.Int32Ptr(1),
+			},
+			Status: appsv1.ReplicaSetStatus{
+				ReadyReplicas: 1,
+			},
+		}
+		assert.True(t, IsReplicaSetReady(&rs))
+	}
+	{
+		rs := appsv1.ReplicaSet{
+			Spec: appsv1.ReplicaSetSpec{
+				Replicas: pointer.Int32Ptr(1),
+			},
+			Status: appsv1.ReplicaSetStatus{
+				ReadyReplicas: 2,
+			},
+		}
+		assert.True(t, IsReplicaSetReady(&rs))
+	}
+	{
+		rs := appsv1.ReplicaSet{
+			Spec: appsv1.ReplicaSetSpec{
+				Replicas: pointer.Int32Ptr(0),
+			},
+			Status: appsv1.ReplicaSetStatus{
+				ReadyReplicas: 0,
+			},
+		}
+		// NOTE: currently consider scaled down replicas as not ready
+		assert.False(t, IsReplicaSetReady(&rs))
+	}
+}


### PR DESCRIPTION
This fixes an issue (that exists only in master) where a ReplicaSet count would flap from 0 to N when an update was interrupted by an apply of a third pod spec. The scenario is:

1. Traffic routed canary Rollout is in middle of updating from V1 -> V2
2. V3 version of Rollout was applied
3. The ReplicaSet for V2 would flap from 0 to N on different reconciliations

The fix is that we should choose to leave V2 up and running until we believe it is safe to scale it down (because V1 and V3 have reached full readiness).

Signed-off-by: Jesse Suen <jessesuen@gmail.com>
