### PR TITLE
fix: target group verification did not work with named ports

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,20 @@
 ####################################################################################################
 # argo-rollouts-dev
 ####################################################################################################
-FROM scratch
+FROM golang:1.16.3 as builder
+
+RUN apt-get update && apt-get install -y \
+    ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+FROM scratch    
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY rollouts-controller-linux-amd64 /bin/rollouts-controller
+
+# Use numeric user, allows kubernetes to identify this user as being
+# non-root when we use a security context with runAsNonRoot: true
+USER 999
+
 ENTRYPOINT [ "/bin/rollouts-controller" ]

--- a/docs/features/traffic-management/alb.md
+++ b/docs/features/traffic-management/alb.md
@@ -172,6 +172,7 @@ the changes made to the Ingress object are reflected in the underlying AWS Targe
     Target Group IP verification available since Argo Rollouts v1.1
 
 The AWS LoadBalancer controller can run in one of two modes:
+
 * [Instance mode](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/how-it-works/#instance-mode)
 * [IP mode](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/how-it-works/#ip-mode)
 
@@ -277,12 +278,26 @@ spec:
 For this feature to work, the argo-rollouts deployment requires the following AWS API permissions
 under the [Elastic Load Balancing API](https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/Welcome.html):
 
-* `DescribeTargetGroups`
-* `DescribeLoadBalancers`
-* `DescribeListeners`
-* `DescribeRules`
-* `DescribeTags`
-* `DescribeTargetHealth`
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:DescribeRules",
+                "elasticloadbalancing:DescribeTags",
+                "elasticloadbalancing:DescribeTargetHealth"
+            ],
+            "Resource": "*",
+            "Effect": "Allow"
+        }
+    ]
+}
+```
 
 There are various ways of granting AWS privileges to the argo-rollouts pods, which is highly
 dependent to your cluster's AWS environment, and out-of-scope of this documentation. Some solutions

--- a/utils/aws/aws_test.go
+++ b/utils/aws/aws_test.go
@@ -291,6 +291,10 @@ func TestVerifyTargetGroupBinding(t *testing.T) {
 		Spec: TargetGroupBindingSpec{
 			TargetType:     (*TargetType)(pointer.StringPtr("ip")),
 			TargetGroupARN: "arn::1234",
+			ServiceRef: ServiceReference{
+				Name: "active",
+				Port: intstr.FromInt(80),
+			},
 		},
 	}
 	ep := corev1.Endpoints{
@@ -311,6 +315,12 @@ func TestVerifyTargetGroupBinding(t *testing.T) {
 						IP: "2.4.6.8", // not registered
 					},
 				},
+				Ports: []corev1.EndpointPort{
+					{
+						Port:     8080,
+						Protocol: "TCP",
+					},
+				},
 			},
 		},
 	}
@@ -324,7 +334,7 @@ func TestVerifyTargetGroupBinding(t *testing.T) {
 			Ports: []corev1.ServicePort{{
 				Protocol:   "TCP",
 				Port:       int32(80),
-				TargetPort: intstr.FromInt(80),
+				TargetPort: intstr.FromInt(8080),
 			}},
 		},
 	}
@@ -334,25 +344,25 @@ func TestVerifyTargetGroupBinding(t *testing.T) {
 			{
 				Target: &elbv2types.TargetDescription{
 					Id:   pointer.StringPtr("1.2.3.4"),
-					Port: pointer.Int32Ptr(80),
+					Port: pointer.Int32Ptr(8080),
 				},
 			},
 			{
 				Target: &elbv2types.TargetDescription{
 					Id:   pointer.StringPtr("5.6.7.8"),
-					Port: pointer.Int32Ptr(80),
+					Port: pointer.Int32Ptr(8080),
 				},
 			},
 			{
 				Target: &elbv2types.TargetDescription{
 					Id:   pointer.StringPtr("2.4.6.8"), // irrelevant
-					Port: pointer.Int32Ptr(81),         // wrong port
+					Port: pointer.Int32Ptr(8081),       // wrong port
 				},
 			},
 			{
 				Target: &elbv2types.TargetDescription{
 					Id:   pointer.StringPtr("9.8.7.6"), // irrelevant ip
-					Port: pointer.Int32Ptr(80),
+					Port: pointer.Int32Ptr(8080),
 				},
 			},
 		},

--- a/utils/aws/aws_test.go
+++ b/utils/aws/aws_test.go
@@ -57,6 +57,43 @@ func TestFindLoadBalancerByDNSName(t *testing.T) {
 	}
 }
 
+func TestGetNumericTargetPort(t *testing.T) {
+	tgb := TargetGroupBinding{
+		Spec: TargetGroupBindingSpec{
+			ServiceRef: ServiceReference{
+				Port: intstr.FromString("web"),
+			},
+		},
+	}
+	svc := corev1.Service{
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "web",
+					TargetPort: intstr.FromString("http"),
+				},
+			},
+		},
+	}
+	eps := corev1.Endpoints{
+		Subsets: []corev1.EndpointSubset{
+			{
+				Ports: []corev1.EndpointPort{
+					{
+						Name: "asdf",
+						Port: 1234,
+					},
+					{
+						Name: "http",
+						Port: 4567,
+					},
+				},
+			},
+		},
+	}
+	assert.Equal(t, int32(4567), getNumericTargetPort(tgb, svc, eps))
+}
+
 func TestGetTargetGroupMetadata(t *testing.T) {
 	fakeELB, c := newFakeClient()
 


### PR DESCRIPTION
The v1.1 AWS target group verification feature was not working when the service was using named instead of numeric ports.

Signed-off-by: Jesse Suen <jessesuen@gmail.com>