### PR TITLE
chore: temporarily disable ghcr.io image pushing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
         with:
           images: |
             quay.io/argoproj/argo-rollouts
-            ghcr.io/argoproj/argo-rollouts
+          # ghcr.io/argoproj/argo-rollouts
           tags: |
             type=semver,pattern={{version}},prefix=v,value=${{ github.event.inputs.tag }}
           flavor: |
@@ -56,19 +56,19 @@ jobs:
         with:
           images: |
             quay.io/argoproj/kubectl-argo-rollouts
-            ghcr.io/argoproj/kubectl-argo-rollouts
+          #  ghcr.io/argoproj/kubectl-argo-rollouts
           tags: |
             type=semver,pattern={{version}},prefix=v,value=${{ github.event.inputs.tag }}
           flavor: |
             latest=false
 
-      - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Login to GitHub Container Registry
+      #   if: github.event_name != 'pull_request'
+      #   uses: docker/login-action@v1
+      #   with:
+      #     registry: ghcr.io
+      #     username: ${{ github.repository_owner }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Quay.io
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
Pushing to ghcr.io broke for some reason yet to be determined. I'm disabling this so we can release v1.1 and will investigate why later.

```
#58 [auth] argoproj/argo-rollouts:pull,push token for ghcr.io
#58 DONE 0.0s

#52 exporting to image
#52 pushing layers 0.9s done
#52 ERROR: unexpected status: 403 Forbidden
------
 > exporting to image:
------
error: failed to solve: unexpected status: 403 Forbidden
Error: buildx failed with: error: failed to solve: unexpected status: 403 Forbidden
```

Signed-off-by: Jesse Suen <jessesuen@gmail.com>
