### PR TITLE
docs: example data is used in both examples

### DIFF
--- a/docs/analysis/web.md
+++ b/docs/analysis/web.md
@@ -9,7 +9,7 @@ of the as the result variable.
 ```yaml
   metrics:
   - name: webmetric
-    successCondition: result == 'true'
+    successCondition: result == true
     provider:
       web:
         url: "http://my-server.com/api/v1/measurement?service={{ args.service-name }}"
@@ -17,7 +17,7 @@ of the as the result variable.
         headers:
           - key: Authorization
             value: "Bearer {{ args.api-token }}"
-        jsonPath: "{$.results.ok}" 
+        jsonPath: "{$.data.ok}" 
 ```
 
 In the following example, given the payload, the measurement will be Successful if the `data.ok` field was `true`, and the `data.successPercent`


### PR DESCRIPTION
### Discussion

The Analyst/Web Doc should be adjusted so that people don't get confused where the "$.results" come from in the current documentation. I've also updated the docs so that the types match (boolean vs string). Many people have read this and probably thought that the AnalystRun will automatically return everything from the response body to `.results`. This PR will adjust the docs so that the same `json` example regarding `data` is used both in the previous example and the following example:

Current confusing example:
![image](https://user-images.githubusercontent.com/20627284/136517849-3db79ed5-ad2a-4c65-9d7d-b1e9446e841f.png)


Proposed example:
![image](https://user-images.githubusercontent.com/20627284/136517765-5b4c9bc5-b0ef-4897-b48c-6d2bbb839af7.png)


Checklist:

* [c] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [yes ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ yes] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ n/a] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [n/a ] My builds are green. Try syncing with master if they are not. 
* [ n/a] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).