### PR TITLE
feat: add healthz probe port and update the install.yaml

### DIFF
--- a/analysis/controller_test.go
+++ b/analysis/controller_test.go
@@ -94,7 +94,7 @@ func (f *fixture) newController(resync resyncFunc) (*Controller, informers.Share
 	metricsServer := metrics.NewMetricsServer(metrics.ServerConfig{
 		Addr:               "localhost:8080",
 		K8SRequestProvider: &metrics.K8sRequestsCountProvider{},
-	})
+	}, true)
 
 	c := NewController(ControllerConfig{
 		KubeClientSet:        f.kubeclient,

--- a/cmd/rollouts-controller/main.go
+++ b/cmd/rollouts-controller/main.go
@@ -45,6 +45,7 @@ func newCommand() *cobra.Command {
 		logLevel             string
 		klogLevel            int
 		metricsPort          int
+		healthzPort          int
 		instanceID           string
 		rolloutThreads       int
 		experimentThreads    int
@@ -169,6 +170,7 @@ func newCommand() *cobra.Command {
 				resyncDuration,
 				instanceID,
 				metricsPort,
+				healthzPort,
 				k8sRequestProvider,
 				nginxIngressClasses,
 				albIngressClasses)
@@ -203,6 +205,7 @@ func newCommand() *cobra.Command {
 	command.Flags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")
 	command.Flags().IntVar(&klogLevel, "kloglevel", 0, "Set the klog logging level")
 	command.Flags().IntVar(&metricsPort, "metricsport", controller.DefaultMetricsPort, "Set the port the metrics endpoint should be exposed over")
+	command.Flags().IntVar(&healthzPort, "healthzPort", controller.DefaultHealthzPort, "Set the port the healthz endpoint should be exposed over")
 	command.Flags().StringVar(&instanceID, "instance-id", "", "Indicates which argo rollout objects the controller should operate on")
 	command.Flags().IntVar(&rolloutThreads, "rollout-threads", controller.DefaultRolloutThreads, "Set the number of worker threads for the Rollout controller")
 	command.Flags().IntVar(&experimentThreads, "experiment-threads", controller.DefaultExperimentThreads, "Set the number of worker threads for the Experiment controller")

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1,0 +1,378 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	notificationapi "github.com/argoproj/notifications-engine/pkg/api"
+	notificationcontroller "github.com/argoproj/notifications-engine/pkg/controller"
+	smifake "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/split/clientset/versioned/fake"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kubeinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/argoproj/argo-rollouts/analysis"
+	"github.com/argoproj/argo-rollouts/controller/metrics"
+	experimentsController "github.com/argoproj/argo-rollouts/experiments"
+	"github.com/argoproj/argo-rollouts/ingress"
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
+	informers "github.com/argoproj/argo-rollouts/pkg/client/informers/externalversions"
+	rolloutController "github.com/argoproj/argo-rollouts/rollout"
+	"github.com/argoproj/argo-rollouts/service"
+	istioutil "github.com/argoproj/argo-rollouts/utils/istio"
+	"github.com/argoproj/argo-rollouts/utils/queue"
+	"github.com/argoproj/argo-rollouts/utils/record"
+)
+
+var (
+	alwaysReady        = func() bool { return true }
+	noResyncPeriodFunc = func() time.Duration { return 0 }
+)
+
+type fixture struct {
+	t *testing.T
+
+	client     *fake.Clientset
+	kubeclient *k8sfake.Clientset
+}
+
+func newFixture(t *testing.T) *fixture {
+	f := &fixture{}
+	f.t = t
+
+	f.client = fake.NewSimpleClientset()
+	f.kubeclient = k8sfake.NewSimpleClientset()
+	return f
+}
+
+func (f *fixture) newManager(t *testing.T) *Manager {
+	rolloutWorkqueue := workqueue.NewNamedRateLimitingQueue(queue.DefaultArgoRolloutsRateLimiter(), "Rollouts")
+	serviceWorkqueue := workqueue.NewNamedRateLimitingQueue(queue.DefaultArgoRolloutsRateLimiter(), "Services")
+	ingressWorkqueue := workqueue.NewNamedRateLimitingQueue(queue.DefaultArgoRolloutsRateLimiter(), "Ingresses")
+	experimentWorkqueue := workqueue.NewNamedRateLimitingQueue(queue.DefaultArgoRolloutsRateLimiter(), "Experiments")
+	analysisRunWorkqueue := workqueue.NewNamedRateLimitingQueue(queue.DefaultArgoRolloutsRateLimiter(), "AnalysisRuns")
+
+	cm := &Manager{
+
+		kubeClientSet: f.kubeclient,
+
+		ingressWorkqueue:     ingressWorkqueue,
+		serviceWorkqueue:     serviceWorkqueue,
+		rolloutWorkqueue:     rolloutWorkqueue,
+		experimentWorkqueue:  experimentWorkqueue,
+		analysisRunWorkqueue: analysisRunWorkqueue,
+
+		rolloutSynced:                 alwaysReady,
+		serviceSynced:                 alwaysReady,
+		ingressSynced:                 alwaysReady,
+		jobSynced:                     alwaysReady,
+		experimentSynced:              alwaysReady,
+		analysisRunSynced:             alwaysReady,
+		analysisTemplateSynced:        alwaysReady,
+		replicasSetSynced:             alwaysReady,
+		configMapSynced:               alwaysReady,
+		secretSynced:                  alwaysReady,
+		clusterAnalysisTemplateSynced: alwaysReady,
+
+		healthzServer: NewHealthzServer(fmt.Sprintf(listenAddr, 8080)),
+	}
+
+	metricsAddr := fmt.Sprintf(listenAddr, 8090)
+	cm.metricsServer = metrics.NewMetricsServer(metrics.ServerConfig{
+		Addr: metricsAddr,
+	}, false)
+
+	i := informers.NewSharedInformerFactory(f.client, noResyncPeriodFunc())
+	k8sI := kubeinformers.NewSharedInformerFactory(f.kubeclient, noResyncPeriodFunc())
+	tgbGVR := schema.GroupVersionResource{
+		Group:    "elbv2.k8s.aws",
+		Version:  "v1beta1",
+		Resource: "targetgroupbindings",
+	}
+	vsvcGVR := istioutil.GetIstioVirtualServiceGVR()
+	scheme := runtime.NewScheme()
+	listMapping := map[schema.GroupVersionResource]string{
+		tgbGVR:  "TargetGroupBindingList",
+		vsvcGVR: vsvcGVR.Resource + "List",
+	}
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listMapping)
+	dynamicInformerFactory := dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0)
+	istioVirtualServiceInformer := dynamicInformerFactory.ForResource(istioutil.GetIstioVirtualServiceGVR()).Informer()
+	istioDestinationRuleInformer := dynamicInformerFactory.ForResource(istioutil.GetIstioDestinationRuleGVR()).Informer()
+
+	cm.rolloutController = rolloutController.NewController(rolloutController.ControllerConfig{
+		Namespace:                       metav1.NamespaceAll,
+		KubeClientSet:                   f.kubeclient,
+		ArgoProjClientset:               f.client,
+		DynamicClientSet:                dynamicClient,
+		ExperimentInformer:              i.Argoproj().V1alpha1().Experiments(),
+		AnalysisRunInformer:             i.Argoproj().V1alpha1().AnalysisRuns(),
+		AnalysisTemplateInformer:        i.Argoproj().V1alpha1().AnalysisTemplates(),
+		ClusterAnalysisTemplateInformer: i.Argoproj().V1alpha1().ClusterAnalysisTemplates(),
+		ReplicaSetInformer:              k8sI.Apps().V1().ReplicaSets(),
+		ServicesInformer:                k8sI.Core().V1().Services(),
+		IngressInformer:                 k8sI.Extensions().V1beta1().Ingresses(),
+		RolloutsInformer:                i.Argoproj().V1alpha1().Rollouts(),
+		IstioPrimaryDynamicClient:       dynamicClient,
+		IstioVirtualServiceInformer:     istioVirtualServiceInformer,
+		IstioDestinationRuleInformer:    istioDestinationRuleInformer,
+		ResyncPeriod:                    noResyncPeriodFunc(),
+		RolloutWorkQueue:                rolloutWorkqueue,
+		ServiceWorkQueue:                serviceWorkqueue,
+		IngressWorkQueue:                ingressWorkqueue,
+		MetricsServer:                   cm.metricsServer,
+		Recorder:                        record.NewFakeEventRecorder(),
+	})
+
+	cm.analysisController = analysis.NewController(analysis.ControllerConfig{
+		KubeClientSet:        f.kubeclient,
+		ArgoProjClientset:    f.client,
+		AnalysisRunInformer:  i.Argoproj().V1alpha1().AnalysisRuns(),
+		JobInformer:          k8sI.Batch().V1().Jobs(),
+		ResyncPeriod:         noResyncPeriodFunc(),
+		AnalysisRunWorkQueue: analysisRunWorkqueue,
+		MetricsServer:        cm.metricsServer,
+		Recorder:             record.NewFakeEventRecorder(),
+	})
+
+	cm.ingressController = ingress.NewController(ingress.ControllerConfig{
+		Client:           f.kubeclient,
+		IngressInformer:  k8sI.Extensions().V1beta1().Ingresses(),
+		IngressWorkQueue: ingressWorkqueue,
+
+		RolloutsInformer: i.Argoproj().V1alpha1().Rollouts(),
+		RolloutWorkQueue: rolloutWorkqueue,
+		ALBClasses:       []string{"alb"},
+		NGINXClasses:     []string{"nginx"},
+		MetricsServer:    cm.metricsServer,
+	})
+
+	cm.serviceController = service.NewController(service.ControllerConfig{
+		Kubeclientset:     f.kubeclient,
+		Argoprojclientset: f.client,
+		RolloutsInformer:  i.Argoproj().V1alpha1().Rollouts(),
+		ServicesInformer:  k8sI.Core().V1().Services(),
+		RolloutWorkqueue:  rolloutWorkqueue,
+		ServiceWorkqueue:  serviceWorkqueue,
+		ResyncPeriod:      0,
+		MetricsServer:     cm.metricsServer,
+	})
+
+	cm.experimentController = experimentsController.NewController(experimentsController.ControllerConfig{
+		KubeClientSet:                   f.kubeclient,
+		ArgoProjClientset:               f.client,
+		ReplicaSetInformer:              k8sI.Apps().V1().ReplicaSets(),
+		ExperimentsInformer:             i.Argoproj().V1alpha1().Experiments(),
+		AnalysisRunInformer:             i.Argoproj().V1alpha1().AnalysisRuns(),
+		AnalysisTemplateInformer:        i.Argoproj().V1alpha1().AnalysisTemplates(),
+		ClusterAnalysisTemplateInformer: i.Argoproj().V1alpha1().ClusterAnalysisTemplates(),
+		ServiceInformer:                 k8sI.Core().V1().Services(),
+		ResyncPeriod:                    noResyncPeriodFunc(),
+		RolloutWorkQueue:                rolloutWorkqueue,
+		ExperimentWorkQueue:             experimentWorkqueue,
+		MetricsServer:                   cm.metricsServer,
+		Recorder:                        record.NewFakeEventRecorder(),
+	})
+
+	apiFactory := notificationapi.NewFactory(record.NewAPIFactorySettings(), "default", k8sI.Core().V1().Secrets().Informer(), k8sI.Core().V1().ConfigMaps().Informer())
+	// rolloutsInformer := rolloutinformers.NewRolloutInformer(f.client, "", time.Minute, cache.Indexers{})
+	cm.notificationsController = notificationcontroller.NewController(dynamicClient.Resource(v1alpha1.RolloutGVR), i.Argoproj().V1alpha1().Rollouts().Informer(), apiFactory,
+		notificationcontroller.WithToUnstructured(func(obj metav1.Object) (*unstructured.Unstructured, error) {
+			return nil, nil
+		}),
+	)
+
+	return cm
+}
+
+func newElectorConfig(kubeclientset kubernetes.Interface, id string, electOpts LeaderElectionOptions) *leaderelection.LeaderElectionConfig {
+	lec := leaderelection.LeaderElectionConfig{
+		Lock: &resourcelock.LeaseLock{
+			LeaseMeta: metav1.ObjectMeta{Name: defaultLeaderElectionLeaseLockName, Namespace: electOpts.LeaderElectionNamespace}, Client: kubeclientset.CoordinationV1(),
+			LockConfig: resourcelock.ResourceLockConfig{Identity: id},
+		},
+		ReleaseOnCancel: true,
+		LeaseDuration:   electOpts.LeaderElectionLeaseDuration,
+		RenewDeadline:   electOpts.LeaderElectionRenewDeadline,
+		RetryPeriod:     electOpts.LeaderElectionRetryPeriod,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(ctx context.Context) {
+				log.Info("Starting leading")
+			},
+			OnStoppedLeading: func() {
+				log.Infof("Stopped leading controller: %s", id)
+				return
+			},
+			OnNewLeader: func(identity string) {
+				if identity == id {
+					return
+				}
+				log.Infof("New leader elected: %s", identity)
+			},
+		},
+	}
+	return &lec
+}
+
+func TestNewManager(t *testing.T) {
+	f := newFixture(t)
+
+	i := informers.NewSharedInformerFactory(f.client, noResyncPeriodFunc())
+	k8sI := kubeinformers.NewSharedInformerFactory(f.kubeclient, noResyncPeriodFunc())
+
+	scheme := runtime.NewScheme()
+	listMapping := map[schema.GroupVersionResource]string{}
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listMapping)
+	dynamicInformerFactory := dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0)
+	istioVirtualServiceInformer := dynamicInformerFactory.ForResource(istioutil.GetIstioVirtualServiceGVR()).Informer()
+	istioDestinationRuleInformer := dynamicInformerFactory.ForResource(istioutil.GetIstioDestinationRuleGVR()).Informer()
+
+	k8sRequestProvider := &metrics.K8sRequestsCountProvider{}
+	cm := NewManager(
+		"default",
+		f.kubeclient,
+		f.client,
+		dynamicClient,
+		smifake.NewSimpleClientset(),
+		&discoveryfake.FakeDiscovery{},
+		k8sI.Apps().V1().ReplicaSets(),
+		k8sI.Core().V1().Services(),
+		k8sI.Extensions().V1beta1().Ingresses(),
+		k8sI.Batch().V1().Jobs(),
+		i.Argoproj().V1alpha1().Rollouts(),
+		i.Argoproj().V1alpha1().Experiments(),
+		i.Argoproj().V1alpha1().AnalysisRuns(),
+		i.Argoproj().V1alpha1().AnalysisTemplates(),
+		i.Argoproj().V1alpha1().ClusterAnalysisTemplates(),
+		dynamicClient,
+		istioVirtualServiceInformer,
+		istioDestinationRuleInformer,
+		k8sI.Core().V1().ConfigMaps(),
+		k8sI.Core().V1().Secrets(),
+		noResyncPeriodFunc(),
+		"test",
+		8090,
+		8080,
+		k8sRequestProvider,
+		nil,
+		nil,
+	)
+
+	assert.NotNil(t, cm)
+}
+
+func TestPrimaryController(t *testing.T) {
+	f := newFixture(t)
+
+	stopCh := make(chan struct{})
+
+	cm := f.newManager(t)
+	electOpts := NewLeaderElectionOptions()
+	go cm.Run(1, 1, 1, 1, 1, electOpts, stopCh)
+	time.Sleep(2 * time.Second)
+	close(stopCh)
+
+	// Test primary controller shutdown secondary metrics server
+	cm.secondaryMetricsServer = metrics.NewMetricsServer(metrics.ServerConfig{}, false)
+	time.Sleep(2 * time.Second)
+	stopCh = make(chan struct{})
+	go cm.Run(1, 1, 1, 1, 1, electOpts, stopCh)
+	time.Sleep(2 * time.Second)
+	close(stopCh)
+}
+
+func TestTwoControllers(t *testing.T) {
+	f := newFixture(t)
+
+	stopCh := make(chan struct{})
+	primary := f.newManager(t)
+	electOpts := NewLeaderElectionOptions()
+	go primary.Run(1, 1, 1, 1, 1, electOpts, stopCh)
+	time.Sleep(1 * time.Second)
+
+	secondary := f.newManager(t)
+	secondary.healthzServer = NewHealthzServer(fmt.Sprintf(listenAddr, 8081))
+	secondary.metricsServer.Addr = (fmt.Sprintf(listenAddr, 8091))
+	go secondary.Run(1, 1, 1, 1, 1, electOpts, stopCh)
+	time.Sleep(1 * time.Second)
+
+	var verifyEndpoints func(url string)
+	verifyEndpoints = func(url string) {
+		_, err := http.Get(url)
+		assert.NoErrorf(t, err, "error connecting to %s", url)
+		rr := httptest.NewRecorder()
+		assert.Equal(t, rr.Code, http.StatusOK)
+	}
+
+	verifyEndpoints("http://localhost:8080/healthz")
+	verifyEndpoints("http://localhost:8090/metrics")
+	verifyEndpoints("http://localhost:8081/healthz")
+	verifyEndpoints("http://localhost:8091/metrics")
+
+	// stop all controllers
+	time.Sleep(1 * time.Second)
+	close(stopCh)
+}
+
+func TestSecondaryController(t *testing.T) {
+	f := newFixture(t)
+
+	stopCh := make(chan struct{})
+
+	cm := f.newManager(t)
+
+	electOpts := NewLeaderElectionOptions()
+	lec := newElectorConfig(f.kubeclient, "holder-123-456", *electOpts)
+	le, err := leaderelection.NewLeaderElector(*lec)
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go le.Run(ctx)
+	time.Sleep(1 * time.Second)
+	assert.True(t, le.IsLeader())
+
+	go cm.Run(1, 1, 1, 1, 1, electOpts, stopCh)
+	time.Sleep(2 * time.Second)
+	assert.True(t, le.IsLeader())
+	close(stopCh)
+	time.Sleep(1 * time.Second)
+
+	// Test secondary metrics server has been started
+	stopCh = make(chan struct{})
+	go cm.Run(1, 1, 1, 1, 1, electOpts, stopCh)
+	time.Sleep(2 * time.Second)
+	assert.True(t, le.IsLeader())
+	close(stopCh)
+	time.Sleep(1 * time.Second)
+
+	// Test secondary metrics server listen port is taken
+	metricsServer := metrics.NewMetricsServer(metrics.ServerConfig{
+		Addr: fmt.Sprintf(listenAddr, DefaultMetricsPort),
+	}, false)
+	go metricsServer.ListenAndServe()
+	time.Sleep(1 * time.Second)
+	cm.secondaryMetricsServer = nil
+	stopCh = make(chan struct{})
+	go cm.Run(1, 1, 1, 1, 1, electOpts, stopCh)
+	time.Sleep(2 * time.Second)
+	close(stopCh)
+}

--- a/controller/healthz.go
+++ b/controller/healthz.go
@@ -1,0 +1,31 @@
+package controller
+
+import (
+	"fmt"
+	"net/http"
+)
+
+const (
+	// HealthzPath is the endpoint to probe if controller is running
+	HealthzPath = "/healthz"
+)
+
+type healthzHandler struct{}
+
+func (h *healthzHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(http.StatusOK)
+
+	fmt.Fprintf(w, "ok")
+}
+
+func NewHealthzServer(addr string) *http.Server {
+	mux := http.NewServeMux()
+	mux.Handle(HealthzPath, &healthzHandler{})
+
+	return &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+}

--- a/controller/healthz_test.go
+++ b/controller/healthz_test.go
@@ -1,0 +1,37 @@
+package controller
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHealthzServer(t *testing.T) {
+	expectedResponse := `ok`
+
+	addr := fmt.Sprintf("0.0.0.0:%d", DefaultHealthzPort)
+	healthzServ := NewHealthzServer(addr)
+
+	t.Helper()
+	req, err := http.NewRequest("GET", "/healthz", nil)
+	assert.NoError(t, err)
+	rr := httptest.NewRecorder()
+	healthzServ.Handler.ServeHTTP(rr, req)
+	assert.Equal(t, rr.Code, http.StatusOK)
+	body := rr.Body.String()
+	log.Println(body)
+	for _, line := range strings.Split(expectedResponse, "\n") {
+		assert.Contains(t, body, line)
+	}
+
+	req, err = http.NewRequest("GET", "/extraneousPath", nil)
+	assert.NoError(t, err)
+	rr = httptest.NewRecorder()
+	healthzServ.Handler.ServeHTTP(rr, req)
+	assert.Equal(t, rr.Code, http.StatusNotFound)
+}

--- a/controller/metrics/analysis_test.go
+++ b/controller/metrics/analysis_test.go
@@ -162,7 +162,7 @@ analysis_run_reconcile_bucket{name="ar-test",namespace="ar-namespace",le="1"} 1
 analysis_run_reconcile_bucket{name="ar-test",namespace="ar-namespace",le="+Inf"} 1
 analysis_run_reconcile_sum{name="ar-test",namespace="ar-namespace"} 0.001
 analysis_run_reconcile_count{name="ar-test",namespace="ar-namespace"} 1`
-	metricsServ := NewMetricsServer(newFakeServerConfig())
+	metricsServ := NewMetricsServer(newFakeServerConfig(), true)
 	ar := &v1alpha1.AnalysisRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ar-test",

--- a/controller/metrics/client_test.go
+++ b/controller/metrics/client_test.go
@@ -12,7 +12,7 @@ controller_clientset_k8s_request_total{kind="replicasets",name="N/A",namespace="
 
 func TestIncKubernetesRequest(t *testing.T) {
 	config := newFakeServerConfig()
-	metricsServ := NewMetricsServer(config)
+	metricsServ := NewMetricsServer(config, true)
 	config.K8SRequestProvider.IncKubernetesRequest(kubeclientmetrics.ResourceInfo{
 		Kind:       "replicasets",
 		Namespace:  "default",

--- a/controller/metrics/experiment_test.go
+++ b/controller/metrics/experiment_test.go
@@ -148,7 +148,7 @@ experiment_reconcile_bucket{name="ex-test",namespace="ex-namespace",le="+Inf"} 1
 experiment_reconcile_sum{name="ex-test",namespace="ex-namespace"} 0.001
 experiment_reconcile_count{name="ex-test",namespace="ex-namespace"} 1`
 
-	metricsServ := NewMetricsServer(newFakeServerConfig())
+	metricsServ := NewMetricsServer(newFakeServerConfig(), true)
 	ex := &v1alpha1.Experiment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ex-test",

--- a/controller/metrics/metrics.go
+++ b/controller/metrics/metrics.go
@@ -46,10 +46,24 @@ type ServerConfig struct {
 }
 
 // NewMetricsServer returns a new prometheus server which collects rollout metrics
-func NewMetricsServer(cfg ServerConfig) *MetricsServer {
+func NewMetricsServer(cfg ServerConfig, isPrimary bool) *MetricsServer {
 	mux := http.NewServeMux()
 
 	reg := prometheus.NewRegistry()
+
+	// secondary controller doesn't expose any metrics
+	if !isPrimary {
+		mux.Handle(MetricsPath, promhttp.HandlerFor(prometheus.Gatherers{
+			reg,
+		}, promhttp.HandlerOpts{}))
+		return &MetricsServer{
+			Server: &http.Server{
+				Addr:    cfg.Addr,
+				Handler: mux,
+			},
+		}
+	}
+
 	reg.MustRegister(NewRolloutCollector(cfg.RolloutLister))
 	reg.MustRegister(NewAnalysisRunCollector(cfg.AnalysisRunLister, cfg.AnalysisTemplateLister, cfg.ClusterAnalysisTemplateLister))
 	reg.MustRegister(NewExperimentCollector(cfg.ExperimentLister))

--- a/controller/metrics/metrics_test.go
+++ b/controller/metrics/metrics_test.go
@@ -81,10 +81,17 @@ analysis_run_reconcile_error{name="name",namespace="ns"} 1
 # TYPE rollout_reconcile_error counter
 rollout_reconcile_error{name="name",namespace="ns"} 1`
 
-	metricsServ := NewMetricsServer(newFakeServerConfig())
+	metricsServ := NewMetricsServer(newFakeServerConfig(), true)
 
 	metricsServ.IncError("ns", "name", logutil.AnalysisRunKey)
 	metricsServ.IncError("ns", "name", logutil.ExperimentKey)
 	metricsServ.IncError("ns", "name", logutil.RolloutKey)
+	testHttpResponse(t, metricsServ.Handler, expectedResponse)
+}
+
+func TestSecondaryMetricsServer(t *testing.T) {
+	expectedResponse := ``
+
+	metricsServ := NewMetricsServer(newFakeServerConfig(), false)
 	testHttpResponse(t, metricsServ.Handler, expectedResponse)
 }

--- a/controller/metrics/rollout_test.go
+++ b/controller/metrics/rollout_test.go
@@ -180,7 +180,7 @@ rollout_reconcile_sum{name="ro-test",namespace="ro-namespace"} 0.001
 rollout_reconcile_count{name="ro-test",namespace="ro-namespace"} 1
 `
 
-	metricsServ := NewMetricsServer(newFakeServerConfig())
+	metricsServ := NewMetricsServer(newFakeServerConfig(), true)
 	ro := &v1alpha1.Rollout{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ro-test",
@@ -294,7 +294,7 @@ rollout_events_total{name="ro-test-1",namespace="ro-namespace",reason="FooEvent"
 rollout_events_total{name="ro-test-2",namespace="ro-namespace",reason="BazEvent",type="Warning"} 2
 `
 
-	metricsServ := NewMetricsServer(newFakeServerConfig())
+	metricsServ := NewMetricsServer(newFakeServerConfig(), true)
 	MetricRolloutEventsTotal.WithLabelValues("ro-namespace", "ro-test-1", corev1.EventTypeNormal, "FooEvent").Inc()
 	MetricRolloutEventsTotal.WithLabelValues("ro-namespace", "ro-test-1", corev1.EventTypeNormal, "BarEvent").Inc()
 	MetricRolloutEventsTotal.WithLabelValues("ro-namespace", "ro-test-2", corev1.EventTypeWarning, "BazEvent").Inc()

--- a/experiments/controller_test.go
+++ b/experiments/controller_test.go
@@ -357,7 +357,7 @@ func (f *fixture) newController(resync resyncFunc) (*Controller, informers.Share
 	metricsServer := metrics.NewMetricsServer(metrics.ServerConfig{
 		Addr:               "localhost:8080",
 		K8SRequestProvider: &metrics.K8sRequestsCountProvider{},
-	})
+	}, true)
 
 	c := NewController(ControllerConfig{
 		KubeClientSet:                   f.kubeclient,

--- a/ingress/ingress_test.go
+++ b/ingress/ingress_test.go
@@ -80,7 +80,7 @@ func newFakeIngressController(ing *extensionsv1beta1.Ingress, rollout *v1alpha1.
 		MetricsServer: metrics.NewMetricsServer(metrics.ServerConfig{
 			Addr:               "localhost:8080",
 			K8SRequestProvider: &metrics.K8sRequestsCountProvider{},
-		}),
+		}, true),
 	})
 	enqueuedObjects := map[string]int{}
 	var enqueuedObjectsLock sync.Mutex

--- a/manifests/base/argo-rollouts-deployment.yaml
+++ b/manifests/base/argo-rollouts-deployment.yaml
@@ -24,10 +24,12 @@ spec:
         ports:
           - containerPort: 8090
             name: metrics
+          - containerPort: 8080
+            name: healthz
         livenessProbe:
           httpGet:
-            path: /metrics
-            port: 8090
+            path: /healthz
+            port: healthz
           initialDelaySeconds: 30
           periodSeconds: 20
           failureThreshold: 3
@@ -36,7 +38,8 @@ spec:
         readinessProbe:
           httpGet:
             path: /metrics
-            port: 8090
+            port: metrics
+          initialDelaySeconds: 10
           periodSeconds: 5
           failureThreshold: 3
           successThreshold: 1

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -13160,8 +13160,8 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /metrics
-            port: 8090
+            path: /healthz
+            port: healthz
           initialDelaySeconds: 30
           periodSeconds: 20
           successThreshold: 1
@@ -13170,11 +13170,14 @@ spec:
         ports:
         - containerPort: 8090
           name: metrics
+        - containerPort: 8080
+          name: healthz
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /metrics
-            port: 8090
+            port: metrics
+          initialDelaySeconds: 10
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 4

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -13161,8 +13161,8 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /metrics
-            port: 8090
+            path: /healthz
+            port: healthz
           initialDelaySeconds: 30
           periodSeconds: 20
           successThreshold: 1
@@ -13171,11 +13171,14 @@ spec:
         ports:
         - containerPort: 8090
           name: metrics
+        - containerPort: 8080
+          name: healthz
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /metrics
-            port: 8090
+            port: metrics
+          initialDelaySeconds: 10
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 4

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -503,7 +503,7 @@ func (f *fixture) newController(resync resyncFunc) (*Controller, informers.Share
 	metricsServer := metrics.NewMetricsServer(metrics.ServerConfig{
 		Addr:               "localhost:8080",
 		K8SRequestProvider: &metrics.K8sRequestsCountProvider{},
-	})
+	}, true)
 
 	c := NewController(ControllerConfig{
 		Namespace:                       metav1.NamespaceAll,

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -72,7 +72,7 @@ func newFakeServiceController(svc *corev1.Service, rollout *v1alpha1.Rollout) (*
 	metricsServer := metrics.NewMetricsServer(metrics.ServerConfig{
 		Addr:               "localhost:8080",
 		K8SRequestProvider: &metrics.K8sRequestsCountProvider{},
-	})
+	}, true)
 	c := NewController(ControllerConfig{
 		Kubeclientset:     kubeclient,
 		Argoprojclientset: client,

--- a/utils/controller/controller_test.go
+++ b/utils/controller/controller_test.go
@@ -38,7 +38,7 @@ func TestProcessNextWorkItemHandlePanic(t *testing.T) {
 	metricServer := metrics.NewMetricsServer(metrics.ServerConfig{
 		Addr:               "localhost:8080",
 		K8SRequestProvider: &metrics.K8sRequestsCountProvider{},
-	})
+	}, true)
 	syncHandler := func(key string) error {
 		panic("Bad big panic :(")
 	}
@@ -87,7 +87,7 @@ func TestProcessNextWorkItemSyncHandlerReturnError(t *testing.T) {
 	metricServer := metrics.NewMetricsServer(metrics.ServerConfig{
 		Addr:               "localhost:8080",
 		K8SRequestProvider: &metrics.K8sRequestsCountProvider{},
-	})
+	}, true)
 	syncHandler := func(key string) error {
 		return fmt.Errorf("error message")
 	}


### PR DESCRIPTION
   - distinguish between exposed healthz port and metrics port
   - liveness probe uses healthz port
      readiness probe uses metrics port
      In HA mode, only the primary instance is ready to accept request
      and the metrics queries
    
    Signed-off-by: Hui Kang <hui.kang@salesforce.com>


close #1522 

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).