### PR TITLE
fix: rollout experiment template changing reference rs template labels. Fixes #1596

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -10,6 +10,7 @@ Organizations below are **officially** using Argo Rollouts. Please send a PR wit
 1. [Codefresh](https://codefresh.io/)
 1. [Databricks](https://github.com/databricks)
 1. [Devtron Labs](https://github.com/devtron-labs/devtron)
+1. [Farfetch](https://www.farfetch.com/)
 1. [Intuit](https://www.intuit.com/)
 1. [New Relic](https://newrelic.com/)
 1. [Nitro](https://www.gonitro.com)

--- a/rollout/experiment.go
+++ b/rollout/experiment.go
@@ -69,9 +69,9 @@ func GetExperimentFromTemplate(r *v1alpha1.Rollout, stableRS, newRS *appsv1.Repl
 		templateRS := &appsv1.ReplicaSet{}
 		switch templateStep.SpecRef {
 		case v1alpha1.CanarySpecRef:
-			templateRS = newRS
+			templateRS = newRS.DeepCopy()
 		case v1alpha1.StableSpecRef:
-			templateRS = stableRS
+			templateRS = stableRS.DeepCopy()
 		default:
 			return nil, fmt.Errorf("Invalid template step SpecRef: must be canary or stable")
 		}


### PR DESCRIPTION
Fixes #1596 

When re-creating an experiment, which has labels defined, from an already on-going canary, the `GetExperimentFromTemplate` is changing the experiment `specRef` replica set `template labels leading to errors:
```yaml
time="2021-10-19T07:49:57Z" level=error msg="roCtx.reconcile err ReplicaSet.apps \"infrastructure-kubernetes-asfvalidator-74f9778454\" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{\"app.kubernetes.io/instance\":\"infrastructure-kubernetes-asfvalidator-zerotraffic\", \"app.kubernetes.io/name\":\"asfvalidator-zerotraffic\", \"rollouts-pod-template-hash\":\"74f9778454\"}: `selector` does not match template `labels`" generation=31 namespace=infrastructure-kubernetes resourceVersion=253727 rollout=infrastructure-kubernetes-asfvalidator

```

Signed-off-by: Flavio Lemos <flavio.lemos@farfetch.com>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).