### PR TITLE
fix: validate service selctor labels matching rollout template labels

### DIFF
--- a/pkg/apis/rollouts/validation/validation_references.go
+++ b/pkg/apis/rollouts/validation/validation_references.go
@@ -91,7 +91,12 @@ func ValidateService(svc ServiceWithType, rollout *v1alpha1.Rollout) field.Error
 	}
 
 	service := svc.Service
+
+	// Verify the service selector labels matches rollout's, except for DefaultRolloutUniqueLabelKey
 	for svcLabelKey, svcLabelValue := range service.Spec.Selector {
+		if svcLabelKey == v1alpha1.DefaultRolloutUniqueLabelKey {
+			continue
+		}
 		if v, ok := rollout.Spec.Template.Labels[svcLabelKey]; !ok || v != svcLabelValue {
 			msg := fmt.Sprintf("Service %q has unmatch lable %q in rollout", service.Name, svcLabelKey)
 			fmt.Println(msg)

--- a/pkg/apis/rollouts/validation/validation_references.go
+++ b/pkg/apis/rollouts/validation/validation_references.go
@@ -91,6 +91,14 @@ func ValidateService(svc ServiceWithType, rollout *v1alpha1.Rollout) field.Error
 	}
 
 	service := svc.Service
+	for svcLabelKey, svcLabelValue := range service.Spec.Selector {
+		if v, ok := rollout.Spec.Template.Labels[svcLabelKey]; !ok || v != svcLabelValue {
+			msg := fmt.Sprintf("Service %q has unmatch lable %q in rollout", service.Name, svcLabelKey)
+			fmt.Println(msg)
+			allErrs = append(allErrs, field.Invalid(fldPath, service.Name, msg))
+		}
+	}
+
 	rolloutManagingService, exists := serviceutil.HasManagedByAnnotation(service)
 	if exists && rolloutManagingService != rollout.Name {
 		msg := fmt.Sprintf(conditions.ServiceReferencingManagedService, service.Name)

--- a/pkg/apis/rollouts/validation/validation_references_test.go
+++ b/pkg/apis/rollouts/validation/validation_references_test.go
@@ -412,6 +412,13 @@ func TestValidateService(t *testing.T) {
 		expectedErr := field.Invalid(GetServiceWithTypeFieldPath(svc.Type), svc.Service.Name, "Service \"stable-service-name\" has unmatch lable \"app\" in rollout")
 		assert.Equal(t, expectedErr.Error(), allErrs[0].Error())
 	})
+
+	t.Run("validate service with Rollout label - success", func(t *testing.T) {
+		svc := getServiceWithType()
+		svc.Service.Spec.Selector = map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: "123-456"}
+		allErrs := ValidateService(svc, getRollout())
+		assert.Empty(t, allErrs)
+	})
 }
 
 func TestValidateVirtualService(t *testing.T) {

--- a/pkg/apis/rollouts/validation/validation_references_test.go
+++ b/pkg/apis/rollouts/validation/validation_references_test.go
@@ -403,6 +403,15 @@ func TestValidateService(t *testing.T) {
 		expectedErr := field.Invalid(GetServiceWithTypeFieldPath(svc.Type), svc.Service.Name, "Service \"stable-service-name\" is managed by another Rollout")
 		assert.Equal(t, expectedErr.Error(), allErrs[0].Error())
 	})
+
+	t.Run("validate service with unmatch label - failure", func(t *testing.T) {
+		svc := getServiceWithType()
+		svc.Service.Spec.Selector = map[string]string{"app": "unmatch-rollout-label"}
+		allErrs := ValidateService(svc, getRollout())
+		assert.Len(t, allErrs, 1)
+		expectedErr := field.Invalid(GetServiceWithTypeFieldPath(svc.Type), svc.Service.Name, "Service \"stable-service-name\" has unmatch lable \"app\" in rollout")
+		assert.Equal(t, expectedErr.Error(), allErrs[0].Error())
+	})
 }
 
 func TestValidateVirtualService(t *testing.T) {

--- a/test/e2e/analysis_test.go
+++ b/test/e2e/analysis_test.go
@@ -32,7 +32,7 @@ func (s *AnalysisSuite) SetupSuite() {
 }
 
 // convenience to generate a new service with a given name
-func newService(name string) string {
+func newService(name, label string) string {
 	return fmt.Sprintf(`
 kind: Service
 apiVersion: v1
@@ -44,7 +44,7 @@ spec:
     targetPort: 80
   selector:
     app: %s
-`, name, name)
+`, name, label)
 }
 
 func (s *AnalysisSuite) TestCanaryBackgroundAnalysis() {
@@ -175,8 +175,8 @@ spec:
             cpu: 5m
 `
 	s.Given().
-		RolloutObjects(newService("bluegreen-analysis-active")).
-		RolloutObjects(newService("bluegreen-analysis-preview")).
+		RolloutObjects(newService("bluegreen-analysis-active", "bluegreen-analysis")).
+		RolloutObjects(newService("bluegreen-analysis-preview", "bluegreen-analysis")).
 		RolloutObjects(original).
 		When().
 		ApplyManifests().
@@ -233,8 +233,8 @@ spec:
 // TestBlueGreenPrePromotionFail test rollout behavior when pre promotion analysis fails
 func (s *AnalysisSuite) TestBlueGreenPrePromotionFail() {
 	s.Given().
-		RolloutObjects(newService("pre-promotion-fail-active")).
-		RolloutObjects(newService("pre-promotion-fail-preview")).
+		RolloutObjects(newService("pre-promotion-fail-active", "pre-promotion-fail")).
+		RolloutObjects(newService("pre-promotion-fail-preview", "pre-promotion-fail")).
 		RolloutObjects(`
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
@@ -314,8 +314,8 @@ spec:
 
 func (s *AnalysisSuite) TestBlueGreenPostPromotionFail() {
 	s.Given().
-		RolloutObjects(newService("post-promotion-fail-active")).
-		RolloutObjects(newService("post-promotion-fail-preview")).
+		RolloutObjects(newService("post-promotion-fail-active", "post-promotion-fail")).
+		RolloutObjects(newService("post-promotion-fail-preview", "post-promotion-fail")).
 		RolloutObjects(`
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
@@ -387,8 +387,8 @@ spec:
 // verifies
 func (s *AnalysisSuite) TestBlueGreenAbortAndUpdate() {
 	s.Given().
-		RolloutObjects(newService("bluegreen-abort-and-update-active")).
-		RolloutObjects(newService("bluegreen-abort-and-update-preview")).
+		RolloutObjects(newService("bluegreen-abort-and-update-active", "bluegreen-abort-and-update")).
+		RolloutObjects(newService("bluegreen-abort-and-update-preview", "bluegreen-abort-and-update")).
 		RolloutObjects(`
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
@@ -472,8 +472,8 @@ spec:
 // TestBlueGreenKitchenSink various features of blue-green strategy
 func (s *AnalysisSuite) TestBlueGreenKitchenSink() {
 	s.Given().
-		RolloutObjects(newService("bluegreen-kitchensink-active")).
-		RolloutObjects(newService("bluegreen-kitchensink-preview")).
+		RolloutObjects(newService("bluegreen-kitchensink-active", "bluegreen-kitchensink")).
+		RolloutObjects(newService("bluegreen-kitchensink-preview", "bluegreen-kitchensink")).
 		RolloutObjects(`
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout

--- a/test/e2e/bluegreen_test.go
+++ b/test/e2e/bluegreen_test.go
@@ -78,7 +78,7 @@ spec:
     protocol: TCP
     name: http
   selector:
-    app: ephemeral-metadata
+    app: ephemeral-metadata-bg
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
@@ -282,8 +282,8 @@ spec:
 // TestBlueGreenPreviewReplicaCount verifies the previewReplicaCount feature
 func (s *BlueGreenSuite) TestBlueGreenPreviewReplicaCount() {
 	s.Given().
-		RolloutObjects(newService("bluegreen-preview-replicas-active")).
-		RolloutObjects(newService("bluegreen-preview-replicas-preview")).
+		RolloutObjects(newService("bluegreen-preview-replicas-active", "bluegreen-preview-replicas")).
+		RolloutObjects(newService("bluegreen-preview-replicas-preview", "bluegreen-preview-replicas")).
 		RolloutObjects(`
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
@@ -333,7 +333,7 @@ spec:
 // TestBlueGreenPreviewReplicaCountPromoteFull verifies promote full works with previewReplicaCount
 func (s *FunctionalSuite) TestBlueGreenPreviewReplicaCountPromoteFull() {
 	s.Given().
-		RolloutObjects(newService("bluegreen-preview-replicas-active")).
+		RolloutObjects(newService("bluegreen-preview-replicas-active", "bluegreen-preview-replicas-promote-full")).
 		RolloutObjects(`
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -186,7 +186,7 @@ spec:
 // TestBlueGreenPromoteFull verifies behavior when performing full promotion with a blue-green strategy
 func (s *FunctionalSuite) TestBlueGreenPromoteFull() {
 	s.Given().
-		RolloutObjects(newService("bluegreen-promote-full-active")).
+		RolloutObjects(newService("bluegreen-promote-full-active", "bluegreen-promote-full")).
 		RolloutObjects(`
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
@@ -713,7 +713,7 @@ func (s *FunctionalSuite) TestBlueGreenUpdate() {
 // TestBlueGreenToCanary tests behavior when migrating from bluegreen to canary
 func (s *FunctionalSuite) TestBlueGreenToCanary() {
 	s.Given().
-		RolloutObjects(newService("bluegreen-to-canary")).
+		RolloutObjects(newService("bluegreen-to-canary", "bluegreen-to-canary")).
 		HealthyRollout(`
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
@@ -820,7 +820,7 @@ spec:
 // TestBlueGreenScaleDownDelay verifies the scaleDownDelay feature
 func (s *FunctionalSuite) TestBlueGreenScaleDownDelay() {
 	s.Given().
-		RolloutObjects(newService("bluegreen-scaledowndelay-active")).
+		RolloutObjects(newService("bluegreen-scaledowndelay-active", "bluegreen-scaledowndelay")).
 		RolloutObjects(`
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
@@ -892,7 +892,7 @@ spec:
 // TestBlueGreenAbortExceedProgressDeadline verifies the AbortExceedProgressDeadline feature
 func (s *FunctionalSuite) TestBlueGreenExceedProgressDeadlineAbort() {
 	s.Given().
-		RolloutObjects(newService("bluegreen-scaledowndelay-active")).
+		RolloutObjects(newService("bluegreen-scaledowndelay-active", "bluegreen-scaledowndelay")).
 		RolloutObjects(`
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
@@ -963,8 +963,8 @@ spec:
 // TestBlueGreenScaleDownOnAbort verifies the scaleDownOnAbort feature
 func (s *FunctionalSuite) TestBlueGreenScaleDownOnAbort() {
 	s.Given().
-		RolloutObjects(newService("bluegreen-preview-replicas-active")).
-		RolloutObjects(newService("bluegreen-preview-replicas-preview")).
+		RolloutObjects(newService("bluegreen-preview-replicas-active", "bluegreen-preview-replicas")).
+		RolloutObjects(newService("bluegreen-preview-replicas-preview", "bluegreen-preview-replicas")).
 		RolloutObjects(`
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -1327,7 +1327,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: rollout-bluegreen
+      app: rollout-ref-deployment
   progressDeadlineSeconds: 5
   revisionHistoryLimit: 2
   strategy:
@@ -1336,7 +1336,7 @@ spec:
   template:
     metadata:
       labels:
-        app: rollout-bluegreen
+        app: rollout-ref-deployment
     spec:
       containers:
         - name: rollouts-demo


### PR DESCRIPTION
Signed-off-by: Hui Kang <hui.kang@salesforce.com>

close #1566 

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).