### PR TITLE
fix(e2e): DeFlake E2E Tests #1647

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ DEV_IMAGE=false
 # E2E variables
 E2E_INSTANCE_ID ?= argo-rollouts-e2e
 E2E_TEST_OPTIONS ?= 
-E2E_PARALLEL ?= 1
+E2E_PARALLEL ?= 4
 
 override LDFLAGS += \
   -X ${PACKAGE}/utils/version.version=${VERSION} \
@@ -244,7 +244,7 @@ start-e2e:
 
 .PHONY: test-e2e
 test-e2e:
-	go test -timeout 20m -v -count 1 --tags e2e -p ${E2E_PARALLEL} --short ./test/e2e ${E2E_TEST_OPTIONS}
+	go test -timeout 30m -v -count 1 --tags e2e -p ${E2E_PARALLEL} --short ./test/e2e ${E2E_TEST_OPTIONS}
 
 .PHONY: coverage
 coverage: test

--- a/test/e2e/analysis_test.go
+++ b/test/e2e/analysis_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 package e2e
@@ -450,6 +451,7 @@ spec:
         args: null
 `).
 		WaitForRolloutStatus("Paused").
+		Sleep(2*time.Second). // Give some time before validating the scaling down event
 		Then().
 		ExpectRevisionPodCount("1", 1).
 		ExpectRevisionScaleDown("2", true).
@@ -459,6 +461,7 @@ spec:
 		When().
 		PromoteRollout().
 		WaitForRolloutStatus("Healthy").
+		Sleep(2*time.Second). // Give some time before validating the scaling down event
 		Then().
 		ExpectRevisionPodCount("1", 1).
 		ExpectRevisionScaleDown("1", true).
@@ -713,6 +716,7 @@ func (s *AnalysisSuite) TestBackgroundAnalysisWithArgs() {
 		When().
 		UpdateSpec().
 		WaitForRolloutStatus("Paused").
+		Sleep(3 * time.Second). // Give some time before validating that AnalysisRun got kicked off
 		Then().
 		ExpectAnalysisRunCount(1).
 		ExpectBackgroundAnalysisRunPhase("Running").


### PR DESCRIPTION
# Description

This is an attempt to fix the E2E failures by increasing the parallelism from **1 -> 4** and increasing the timeout from **20m -> 30m** as we now have a lot of tests.

# Checklist

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

---
**Signed-off-by: Rohit Agrawal <rohit.agrawal@databricks.com>**