### PR TITLE
fix: reset the progress condition when a pod is restarted

### DIFF
--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -229,6 +229,9 @@ func newProgressingCondition(reason string, resourceObj runtime.Object, optional
 		if reason == conditions.NewRSAvailableReason {
 			msg = fmt.Sprintf(conditions.ReplicaSetCompletedMessage, resource.Name)
 		}
+		if reason == conditions.ReplicaSetNotAvailableReason {
+			msg = conditions.NotAvailableMessage
+		}
 	case *v1alpha1.Rollout:
 		if reason == conditions.ReplicaSetUpdatedReason {
 			msg = fmt.Sprintf(conditions.RolloutProgressingMessage, resource.Name)

--- a/rollout/restart.go
+++ b/rollout/restart.go
@@ -2,11 +2,11 @@ package rollout
 
 import (
 	"context"
-	"fmt"
+	// "fmt"
 	"sort"
 	"time"
 
-	"github.com/argoproj/argo-rollouts/utils/conditions"
+	// "github.com/argoproj/argo-rollouts/utils/conditions"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1beta1"
@@ -125,14 +125,17 @@ func (p *RolloutPodRestarter) Reconcile(roCtx *rolloutContext) error {
 		canRestart -= 1
 		restarted += 1
 
-		// Everytime a pod is restarted, updating the rollout's progressingCondition
-		existProgressingCondition := conditions.GetRolloutCondition(roCtx.rollout.Status, v1alpha1.RolloutProgressing)
-		if existProgressingCondition != nil {
-			conditions.RemoveRolloutCondition(&roCtx.rollout.Status, v1alpha1.RolloutProgressing)
-		}
-		msg := fmt.Sprintf("pod %s restarted", pod.Name)
-		newProgressingCondition := conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionTrue, conditions.NewRSAvailableReason, msg)
-		conditions.SetRolloutCondition(&roCtx.rollout.Status, *newProgressingCondition)
+		// TODO: remove
+		/*
+			// Everytime a pod is restarted, updating the rollout's progressingCondition
+			existProgressingCondition := conditions.GetRolloutCondition(roCtx.rollout.Status, v1alpha1.RolloutProgressing)
+			if existProgressingCondition != nil {
+				conditions.RemoveRolloutCondition(&roCtx.rollout.Status, v1alpha1.RolloutProgressing)
+			}
+			msg := fmt.Sprintf("pod %s restarted", pod.Name)
+			newProgressingCondition := conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionTrue, conditions.NewRSAvailableReason, msg)
+			conditions.SetRolloutCondition(&roCtx.rollout.Status, *newProgressingCondition)
+		*/
 	}
 	remaining := needsRestart - restarted
 

--- a/rollout/restart.go
+++ b/rollout/restart.go
@@ -2,9 +2,11 @@ package rollout
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"time"
 
+	"github.com/argoproj/argo-rollouts/utils/conditions"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1beta1"
@@ -122,6 +124,15 @@ func (p *RolloutPodRestarter) Reconcile(roCtx *rolloutContext) error {
 		}
 		canRestart -= 1
 		restarted += 1
+
+		// Everytime a pod is restarted, updating the rollout's progressingCondition
+		existProgressingCondition := conditions.GetRolloutCondition(roCtx.rollout.Status, v1alpha1.RolloutProgressing)
+		if existProgressingCondition != nil {
+			conditions.RemoveRolloutCondition(&roCtx.rollout.Status, v1alpha1.RolloutProgressing)
+		}
+		msg := fmt.Sprintf("pod %s restarted", pod.Name)
+		newProgressingCondition := conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionTrue, conditions.NewRSAvailableReason, msg)
+		conditions.SetRolloutCondition(&roCtx.rollout.Status, *newProgressingCondition)
 	}
 	remaining := needsRestart - restarted
 

--- a/rollout/restart.go
+++ b/rollout/restart.go
@@ -2,11 +2,9 @@ package rollout
 
 import (
 	"context"
-	// "fmt"
 	"sort"
 	"time"
 
-	// "github.com/argoproj/argo-rollouts/utils/conditions"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1beta1"
@@ -124,18 +122,6 @@ func (p *RolloutPodRestarter) Reconcile(roCtx *rolloutContext) error {
 		}
 		canRestart -= 1
 		restarted += 1
-
-		// TODO: remove
-		/*
-			// Everytime a pod is restarted, updating the rollout's progressingCondition
-			existProgressingCondition := conditions.GetRolloutCondition(roCtx.rollout.Status, v1alpha1.RolloutProgressing)
-			if existProgressingCondition != nil {
-				conditions.RemoveRolloutCondition(&roCtx.rollout.Status, v1alpha1.RolloutProgressing)
-			}
-			msg := fmt.Sprintf("pod %s restarted", pod.Name)
-			newProgressingCondition := conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionTrue, conditions.NewRSAvailableReason, msg)
-			conditions.SetRolloutCondition(&roCtx.rollout.Status, *newProgressingCondition)
-		*/
 	}
 	remaining := needsRestart - restarted
 

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -577,6 +577,7 @@ func (c *rolloutContext) calculateRolloutConditions(newStatus v1alpha1.RolloutSt
 	isPaused := len(c.rollout.Status.PauseConditions) > 0 || c.rollout.Spec.Paused
 	isAborted := c.pauseContext.IsAborted()
 
+	var becameIncomplete bool // remember if we transitioned from completed
 	completeCond := conditions.GetRolloutCondition(c.rollout.Status, v1alpha1.RolloutCompleted)
 	if !isPaused && conditions.RolloutComplete(c.rollout, &newStatus) {
 		updateCompletedCond := conditions.NewRolloutCondition(v1alpha1.RolloutCompleted, corev1.ConditionTrue, conditions.RolloutCompletedReason, conditions.RolloutCompletedReason)
@@ -584,20 +585,7 @@ func (c *rolloutContext) calculateRolloutConditions(newStatus v1alpha1.RolloutSt
 	} else {
 		if completeCond != nil {
 			updateCompletedCond := conditions.NewRolloutCondition(v1alpha1.RolloutCompleted, corev1.ConditionFalse, conditions.RolloutCompletedReason, conditions.RolloutCompletedReason)
-			changed := conditions.SetRolloutCondition(&newStatus, *updateCompletedCond)
-
-			// When a fully promoted rollout becomes Incomplete, e.g., due to the ReplicaSet status changes like
-			// pod restarts, evicted -> recreated, we'll need to reset the rollout's condition to `PROGRESSING` to
-			// avoid any timeouts.
-			if changed {
-				existProgressingCondition := conditions.GetRolloutCondition(newStatus, v1alpha1.RolloutProgressing)
-				if existProgressingCondition != nil {
-					conditions.RemoveRolloutCondition(&newStatus, v1alpha1.RolloutProgressing)
-				}
-				c.log.Infof(conditions.RolloutBecomesIncompleteMessage)
-				newProgressingCondition := conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionTrue, conditions.RolloutBecomesIncomplete, conditions.RolloutBecomesIncompleteMessage)
-				conditions.SetRolloutCondition(&newStatus, *newProgressingCondition)
-			}
+			becameIncomplete = conditions.SetRolloutCondition(&newStatus, *updateCompletedCond)
 		}
 	}
 
@@ -632,14 +620,24 @@ func (c *rolloutContext) calculateRolloutConditions(newStatus v1alpha1.RolloutSt
 			msg := fmt.Sprintf(conditions.ReplicaSetCompletedMessage, rsName)
 			progressingCondition := conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionTrue, conditions.NewRSAvailableReason, msg)
 			conditions.SetRolloutCondition(&newStatus, *progressingCondition)
-		case conditions.RolloutProgressing(c.rollout, &newStatus):
+		case conditions.RolloutProgressing(c.rollout, &newStatus) || becameIncomplete:
 			// If there is any progress made, continue by not checking if the rollout failed. This
 			// behavior emulates the rolling updater progressDeadline check.
 			msg := fmt.Sprintf(conditions.RolloutProgressingMessage, c.rollout.Name)
 			if c.newRS != nil {
 				msg = fmt.Sprintf(conditions.ReplicaSetProgressingMessage, c.newRS.Name)
 			}
-			condition := conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionTrue, conditions.ReplicaSetUpdatedReason, msg)
+			reason := conditions.ReplicaSetUpdatedReason
+
+			// When a fully promoted rollout becomes Incomplete, e.g., due to the ReplicaSet status changes like
+			// pod restarts, evicted -> recreated, we'll need to reset the rollout's condition to `PROGRESSING` to
+			// avoid any timeouts.
+			if becameIncomplete {
+				reason = conditions.ReplicaSetNotAvailableReason
+				msg = conditions.NotAvailableMessage
+			}
+
+			condition := conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionTrue, reason, msg)
 			// Update the current Progressing condition or add a new one if it doesn't exist.
 			// If a Progressing condition with status=true already exists, we should update
 			// everything but lastTransitionTime. SetRolloutCondition already does that but

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -629,7 +629,7 @@ func (c *rolloutContext) calculateRolloutConditions(newStatus v1alpha1.RolloutSt
 			}
 
 			var reason string
-			if newStatus.StableRS == newStatus.CurrentPodHash {
+			if newStatus.StableRS == newStatus.CurrentPodHash && becameIncomplete {
 				// When a fully promoted rollout becomes Incomplete, e.g., due to the ReplicaSet status changes like
 				// pod restarts, evicted -> recreated, we'll need to reset the rollout's condition to `PROGRESSING` to
 				// avoid any timeouts.

--- a/utils/conditions/conditions.go
+++ b/utils/conditions/conditions.go
@@ -86,14 +86,11 @@ const (
 	// estimated once a rollout is paused.
 	RolloutPausedMessage = "Rollout is paused"
 
-	// RolloutBecomesIncomplete is added when a fully promoted rollout becomes incomplete, e.g.,
+	// ReplicaSetNotAvailableReason is added when the replicaset of an rollout is not available.
+	// This could happen when a fully promoted rollout becomes incomplete, e.g.,
 	// due to  pod restarts, evicted -> recreated. In this case, we'll need to reset the rollout's
 	// condition to `PROGRESSING` to avoid any timeouts.
-	RolloutBecomesIncomplete = "RolloutBecomesIncomplete"
-	// RolloutBecomesIncompleteMessage is added when a fully promoted rollout becomes incomplete, e.g.,
-	// due to  pod restarts, evicted -> recreated. In this case, we'll need to reset the rollout's
-	// condition to `PROGRESSING` to avoid any timeouts.
-	RolloutBecomesIncompleteMessage = "Fully promoted rollout becomes incomplete"
+	ReplicaSetNotAvailableReason = "ReplicaSetNotAvailable"
 
 	// RolloutResumedReason is added in a rollout when it is resumed. Useful for not failing accidentally
 	// rollout that paused amidst a rollout and are bounded by a deadline.

--- a/utils/conditions/conditions.go
+++ b/utils/conditions/conditions.go
@@ -86,6 +86,15 @@ const (
 	// estimated once a rollout is paused.
 	RolloutPausedMessage = "Rollout is paused"
 
+	// RolloutBecomesIncomplete is added when a fully promoted rollout becomes incomplete, e.g.,
+	// due to  pod restarts, evicted -> recreated. In this case, we'll need to reset the rollout's
+	// condition to `PROGRESSING` to avoid any timeouts.
+	RolloutBecomesIncomplete = "RolloutBecomesIncomplete"
+	// RolloutBecomesIncompleteMessage is added when a fully promoted rollout becomes incomplete, e.g.,
+	// due to  pod restarts, evicted -> recreated. In this case, we'll need to reset the rollout's
+	// condition to `PROGRESSING` to avoid any timeouts.
+	RolloutBecomesIncompleteMessage = "Fully promoted rollout becomes incomplete"
+
 	// RolloutResumedReason is added in a rollout when it is resumed. Useful for not failing accidentally
 	// rollout that paused amidst a rollout and are bounded by a deadline.
 	RolloutResumedReason = "RolloutResumed"


### PR DESCRIPTION
- if the progress condition is not reset, the timeout check
  returns true for a healthy rollout

Signed-off-by: Hui Kang <hui.kang@salesforce.com>

fix: #1624 

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).