### PR TITLE
fix(docs): Remove Non-Existent Metrics From Docs

### DIFF
--- a/docs/features/controller-metrics.md
+++ b/docs/features/controller-metrics.md
@@ -45,19 +45,16 @@ The Argo Rollouts controller publishes the following prometheus metrics about Ar
 
 | Name                                | Description |
 | ----------------------------------- | ----------- |
-| `rollout_created_time`              | Creation time in unix timestamp for an rollout. |
 | `rollout_info`                      | Information about rollout. |
 | `rollout_info_replicas_available`   | The number of available replicas per rollout. |
 | `rollout_info_replicas_unavailable` | The number of unavailable replicas per rollout. |
 | `rollout_phase`                     | Information on the state of the rollout. |
 | `rollout_reconcile`                 | Rollout reconciliation performance. |
 | `rollout_reconcile_error`           | Error occurring during the rollout. |
-| `experiment_created_time`           | Creation time in unix timestamp for an experiment. |
 | `experiment_info`                   | Information about Experiment. |
 | `experiment_phase`                  | Information on the state of the experiment. |
 | `experiment_reconcile`              | Experiments reconciliation performance. |
 | `experiment_reconcile_error`        | Error occurring during the experiment. |
-| `analysis_run_created_time`         | Creation time in unix timestamp for an Analysis Run. |
 | `analysis_run_info`                 | Information about analysis run. |
 | `analysis_run_metric_phase`         | Information on the duration of a specific metric in the Analysis Run. |
 | `analysis_run_metric_type`          | Information on the type of a specific metric in the Analysis Runs. |


### PR DESCRIPTION
# Description

This PR removes the non-existent metrics from the documentation.

# Checklist

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

---
**Signed-off-by: Rohit Agrawal <rohit.agrawal@databricks.com>**