### PR TITLE
refactor: stop using mpatch

### DIFF
--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -8,13 +8,12 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"

--- a/analysis/controller.go
+++ b/analysis/controller.go
@@ -22,6 +22,7 @@ import (
 	controllerutil "github.com/argoproj/argo-rollouts/utils/controller"
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
 	"github.com/argoproj/argo-rollouts/utils/record"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 // Controller is the controller implementation for Analysis resources
@@ -136,7 +137,7 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) error {
 }
 
 func (c *Controller) syncHandler(key string) error {
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err

--- a/analysis/controller_test.go
+++ b/analysis/controller_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 	"time"
 
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
+
 	"github.com/argoproj/argo-rollouts/utils/queue"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"github.com/undefinedlabs/go-mpatch"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -59,11 +60,13 @@ func newFixture(t *testing.T) *fixture {
 	f.objects = []runtime.Object{}
 	f.enqueuedObjects = make(map[string]int)
 	now := time.Now()
-	patch, err := mpatch.PatchMethod(time.Now, func() time.Time {
+	timeutil.Now = func() time.Time {
 		return now
-	})
-	assert.NoError(t, err)
-	f.unfreezeTime = patch.Unpatch
+	}
+	f.unfreezeTime = func() error {
+		timeutil.Now = time.Now
+		return nil
+	}
 	return f
 }
 

--- a/experiments/conditions_test.go
+++ b/experiments/conditions_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 func TestUpdateProgressingLastUpdateTime(t *testing.T) {
@@ -20,7 +21,7 @@ func TestUpdateProgressingLastUpdateTime(t *testing.T) {
 		Name: "bar",
 	}}
 	prevCond := newCondition(conditions.ReplicaSetUpdatedReason, e)
-	prevTime := metav1.NewTime(metav1.Now().Add(-10 * time.Second))
+	prevTime := metav1.NewTime(timeutil.Now().Add(-10 * time.Second))
 	prevCond.LastUpdateTime = prevTime
 	prevCond.LastTransitionTime = prevTime
 	e.Status.Conditions = []v1alpha1.ExperimentCondition{
@@ -53,7 +54,7 @@ func TestEnterTimeoutDegradedState(t *testing.T) {
 		Status: v1alpha1.TemplateStatusProgressing,
 	}}
 	e.Spec.ProgressDeadlineSeconds = pointer.Int32Ptr(30)
-	prevTime := metav1.NewTime(metav1.Now().Add(-1 * time.Minute).Truncate(time.Second))
+	prevTime := metav1.NewTime(timeutil.Now().Add(-1 * time.Minute).Truncate(time.Second))
 	e.Status.TemplateStatuses[0].LastTransitionTime = &prevTime
 
 	rs := templateToRS(e, templates[0], 0)

--- a/experiments/controller.go
+++ b/experiments/controller.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"time"
 
-	informersv1 "k8s.io/client-go/informers/core/v1"
-	listersv1 "k8s.io/client-go/listers/core/v1"
-
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -15,8 +12,10 @@ import (
 	patchtypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	appsinformers "k8s.io/client-go/informers/apps/v1"
+	informersv1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	appslisters "k8s.io/client-go/listers/apps/v1"
+	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/kubernetes/pkg/controller"
@@ -33,6 +32,7 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/diff"
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
 	"github.com/argoproj/argo-rollouts/utils/record"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 	unstructuredutil "github.com/argoproj/argo-rollouts/utils/unstructured"
 )
 
@@ -233,7 +233,7 @@ func (ec *Controller) Run(threadiness int, stopCh <-chan struct{}) error {
 }
 
 func (ec *Controller) syncHandler(key string) error {
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err

--- a/experiments/controller_test.go
+++ b/experiments/controller_test.go
@@ -8,10 +8,11 @@ import (
 	"testing"
 	"time"
 
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
+
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/undefinedlabs/go-mpatch"
 
 	"github.com/argoproj/argo-rollouts/utils/queue"
 
@@ -52,12 +53,12 @@ const (
 )
 
 func now() *metav1.Time {
-	now := metav1.Time{Time: time.Now().Truncate(time.Second)}
+	now := metav1.Time{Time: timeutil.Now().Truncate(time.Second)}
 	return &now
 }
 
 func secondsAgo(seconds int) *metav1.Time {
-	ago := metav1.Time{Time: time.Now().Add(-1 * time.Second * time.Duration(seconds)).Truncate(time.Second)}
+	ago := metav1.Time{Time: timeutil.Now().Add(-1 * time.Second * time.Duration(seconds)).Truncate(time.Second)}
 	return &ago
 }
 
@@ -114,11 +115,13 @@ func newFixture(t *testing.T, objects ...runtime.Object) *fixture {
 	f.kubeclient = k8sfake.NewSimpleClientset(f.kubeobjects...)
 	f.enqueuedObjects = make(map[string]int)
 	now := time.Now()
-	patch, err := mpatch.PatchMethod(time.Now, func() time.Time {
+	timeutil.Now = func() time.Time {
 		return now
-	})
-	assert.NoError(t, err)
-	f.unfreezeTime = patch.Unpatch
+	}
+	f.unfreezeTime = func() error {
+		timeutil.Now = time.Now
+		return nil
+	}
 	return f
 }
 
@@ -200,8 +203,8 @@ func newCondition(reason string, experiment *v1alpha1.Experiment) *v1alpha1.Expe
 		return &v1alpha1.ExperimentCondition{
 			Type:               v1alpha1.ExperimentProgressing,
 			Status:             corev1.ConditionTrue,
-			LastUpdateTime:     metav1.Now().Rfc3339Copy(),
-			LastTransitionTime: metav1.Now().Rfc3339Copy(),
+			LastUpdateTime:     timeutil.MetaNow().Rfc3339Copy(),
+			LastTransitionTime: timeutil.MetaNow().Rfc3339Copy(),
 			Reason:             reason,
 			Message:            fmt.Sprintf(conditions.ExperimentProgressingMessage, experiment.Name),
 		}
@@ -210,8 +213,8 @@ func newCondition(reason string, experiment *v1alpha1.Experiment) *v1alpha1.Expe
 		return &v1alpha1.ExperimentCondition{
 			Type:               v1alpha1.ExperimentProgressing,
 			Status:             corev1.ConditionFalse,
-			LastUpdateTime:     metav1.Now().Rfc3339Copy(),
-			LastTransitionTime: metav1.Now().Rfc3339Copy(),
+			LastUpdateTime:     timeutil.MetaNow().Rfc3339Copy(),
+			LastTransitionTime: timeutil.MetaNow().Rfc3339Copy(),
 			Reason:             reason,
 			Message:            fmt.Sprintf(conditions.ExperimentCompletedMessage, experiment.Name),
 		}
@@ -220,8 +223,8 @@ func newCondition(reason string, experiment *v1alpha1.Experiment) *v1alpha1.Expe
 		return &v1alpha1.ExperimentCondition{
 			Type:               v1alpha1.ExperimentProgressing,
 			Status:             corev1.ConditionFalse,
-			LastUpdateTime:     metav1.Now().Rfc3339Copy(),
-			LastTransitionTime: metav1.Now().Rfc3339Copy(),
+			LastUpdateTime:     timeutil.MetaNow().Rfc3339Copy(),
+			LastTransitionTime: timeutil.MetaNow().Rfc3339Copy(),
 			Reason:             reason,
 			Message:            fmt.Sprintf(conditions.ExperimentRunningMessage, experiment.Name),
 		}
@@ -230,8 +233,8 @@ func newCondition(reason string, experiment *v1alpha1.Experiment) *v1alpha1.Expe
 		return &v1alpha1.ExperimentCondition{
 			Type:               v1alpha1.InvalidExperimentSpec,
 			Status:             corev1.ConditionTrue,
-			LastUpdateTime:     metav1.Now().Rfc3339Copy(),
-			LastTransitionTime: metav1.Now().Rfc3339Copy(),
+			LastUpdateTime:     timeutil.MetaNow().Rfc3339Copy(),
+			LastTransitionTime: timeutil.MetaNow().Rfc3339Copy(),
 			Reason:             reason,
 			Message:            fmt.Sprintf(conditions.ExperimentTemplateNameEmpty, experiment.Name, 0),
 		}
@@ -643,7 +646,7 @@ func (f *fixture) verifyPatchedReplicaSetAddScaleDownDelay(index int, scaleDownD
 	if !ok {
 		assert.Fail(f.t, "Expected Patch action, not %s", action.GetVerb())
 	}
-	now := metav1.Now().Add(time.Duration(scaleDownDelaySeconds) * time.Second).UTC().Format(time.RFC3339)
+	now := timeutil.Now().Add(time.Duration(scaleDownDelaySeconds) * time.Second).UTC().Format(time.RFC3339)
 	patch := fmt.Sprintf(addScaleDownAtAnnotationsPatch, v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey, now)
 	assert.Equal(f.t, string(patchAction.GetPatch()), patch)
 }
@@ -728,7 +731,7 @@ func TestNoReconcileForDeletedExperiment(t *testing.T) {
 	defer f.Close()
 
 	e := newExperiment("foo", nil, "10s")
-	now := metav1.Now()
+	now := timeutil.MetaNow()
 	e.DeletionTimestamp = &now
 
 	f.experimentLister = append(f.experimentLister, e)

--- a/experiments/replicaset.go
+++ b/experiments/replicaset.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	"github.com/argoproj/argo-rollouts/utils/defaults"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 
+	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,7 +24,6 @@ import (
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
 	"github.com/argoproj/argo-rollouts/utils/record"
 	replicasetutil "github.com/argoproj/argo-rollouts/utils/replicaset"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -227,7 +228,7 @@ func (ec *experimentContext) addScaleDownDelay(rs *appsv1.ReplicaSet) (bool, err
 		}
 	}
 
-	deadline := metav1.Now().Add(scaleDownDelaySeconds * time.Second).UTC().Format(time.RFC3339)
+	deadline := timeutil.MetaNow().Add(scaleDownDelaySeconds * time.Second).UTC().Format(time.RFC3339)
 	patch := fmt.Sprintf(addScaleDownAtAnnotationsPatch, v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey, deadline)
 	_, err := ec.kubeclientset.AppsV1().ReplicaSets(rs.Namespace).Patch(ctx, rs.Name, patchtypes.JSONPatchType, []byte(patch), metav1.PatchOptions{})
 	if err == nil {

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0
 	github.com/tj/assert v0.0.3
-	github.com/undefinedlabs/go-mpatch v1.0.6
 	github.com/valyala/fasttemplate v1.2.1
 	google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a
 	google.golang.org/grpc v1.33.1

--- a/go.sum
+++ b/go.sum
@@ -1134,8 +1134,6 @@ github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oW
 github.com/ultraware/funlen v0.0.2/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=
 github.com/ultraware/funlen v0.0.3/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=
 github.com/ultraware/whitespace v0.0.4/go.mod h1:aVMh/gQve5Maj9hQ/hg+F75lr/X5A89uZnzAmWSineA=
-github.com/undefinedlabs/go-mpatch v1.0.6 h1:h8q5ORH/GaOE1Se1DMhrOyljXZEhRcROO7agMqWXCOY=
-github.com/undefinedlabs/go-mpatch v1.0.6/go.mod h1:TyJZDQ/5AgyN7FSLiBJ8RO9u2c6wbtRvK827b6AVqY4=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=

--- a/metricproviders/cloudwatch/cloudwatch.go
+++ b/metricproviders/cloudwatch/cloudwatch.go
@@ -9,11 +9,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	log "github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/evaluate"
 	metricutil "github.com/argoproj/argo-rollouts/utils/metric"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 const (
@@ -30,7 +30,7 @@ type CloudWatchClient struct {
 }
 
 func (c *CloudWatchClient) Query(interval time.Duration, query []types.MetricDataQuery) (*cloudwatch.GetMetricDataOutput, error) {
-	endTime := time.Now()
+	endTime := timeutil.Now()
 	startTime := endTime.Add(-interval)
 	return c.client.GetMetricData(context.TODO(), &cloudwatch.GetMetricDataInput{
 		StartTime:         &startTime,
@@ -52,7 +52,7 @@ func (p *Provider) Type() string {
 
 // Run queries with CloudWatch provider for the metric
 func (p *Provider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1alpha1.Measurement {
-	startTime := metav1.Now()
+	startTime := timeutil.MetaNow()
 	measurement := v1alpha1.Measurement{
 		StartedAt: &startTime,
 		Metadata:  map[string]string{},
@@ -92,7 +92,7 @@ func (p *Provider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1alph
 	}
 
 	measurement.Phase = status
-	finishedTime := metav1.Now()
+	finishedTime := timeutil.MetaNow()
 	measurement.FinishedAt = &finishedTime
 
 	return measurement

--- a/metricproviders/datadog/datadog.go
+++ b/metricproviders/datadog/datadog.go
@@ -17,12 +17,14 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/defaults"
 	"github.com/argoproj/argo-rollouts/utils/evaluate"
 	metricutil "github.com/argoproj/argo-rollouts/utils/metric"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
+
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
-var unixNow = func() int64 { return time.Now().Unix() }
+var unixNow = func() int64 { return timeutil.Now().Unix() }
 
 const (
 	//ProviderType indicates the provider is datadog
@@ -58,7 +60,7 @@ func (p *Provider) Type() string {
 }
 
 func (p *Provider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1alpha1.Measurement {
-	startTime := metav1.Now()
+	startTime := timeutil.MetaNow()
 
 	// Measurement to pass back
 	measurement := v1alpha1.Measurement{
@@ -116,7 +118,7 @@ func (p *Provider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1alph
 
 	measurement.Value = value
 	measurement.Phase = status
-	finishedTime := metav1.Now()
+	finishedTime := timeutil.MetaNow()
 	measurement.FinishedAt = &finishedTime
 
 	return measurement

--- a/metricproviders/graphite/graphite.go
+++ b/metricproviders/graphite/graphite.go
@@ -8,11 +8,11 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/evaluate"
 	metricutil "github.com/argoproj/argo-rollouts/utils/metric"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 const (
@@ -51,7 +51,7 @@ func (p *Provider) Type() string {
 
 // Run queries Graphite for the metric.
 func (p *Provider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1alpha1.Measurement {
-	startTime := metav1.Now()
+	startTime := timeutil.MetaNow()
 	newMeasurement := v1alpha1.Measurement{
 		StartedAt: &startTime,
 	}
@@ -72,7 +72,7 @@ func (p *Provider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1alph
 	}
 
 	newMeasurement.Phase = newStatus
-	finishedTime := metav1.Now()
+	finishedTime := timeutil.MetaNow()
 	newMeasurement.FinishedAt = &finishedTime
 
 	return newMeasurement

--- a/metricproviders/job/job.go
+++ b/metricproviders/job/job.go
@@ -17,6 +17,7 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	analysisutil "github.com/argoproj/argo-rollouts/utils/analysis"
 	metricutil "github.com/argoproj/argo-rollouts/utils/metric"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 const (
@@ -93,7 +94,7 @@ func newMetricJob(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) (*batchv1.J
 
 func (p *JobProvider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1alpha1.Measurement {
 	ctx := context.TODO()
-	now := metav1.Now()
+	now := timeutil.MetaNow()
 	measurement := v1alpha1.Measurement{
 		StartedAt: &now,
 		Phase:     v1alpha1.AnalysisPhaseRunning,
@@ -133,7 +134,7 @@ func (p *JobProvider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1a
 
 func (p *JobProvider) Resume(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric, measurement v1alpha1.Measurement) v1alpha1.Measurement {
 	jobName, err := getJobName(measurement)
-	now := metav1.Now()
+	now := timeutil.MetaNow()
 	if err != nil {
 		return metricutil.MarkMeasurementError(measurement, err)
 	}
@@ -166,7 +167,7 @@ func (p *JobProvider) Terminate(run *v1alpha1.AnalysisRun, metric v1alpha1.Metri
 	if err != nil {
 		return metricutil.MarkMeasurementError(measurement, err)
 	}
-	now := metav1.Now()
+	now := timeutil.MetaNow()
 	measurement.FinishedAt = &now
 	measurement.Phase = v1alpha1.AnalysisPhaseSuccessful
 	p.logCtx.Infof("job %s/%s terminated", run.Namespace, jobName)

--- a/metricproviders/kayenta/kayenta.go
+++ b/metricproviders/kayenta/kayenta.go
@@ -9,14 +9,13 @@ import (
 	"net/http"
 	"time"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
-
 	metricutil "github.com/argoproj/argo-rollouts/utils/metric"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 const (
@@ -97,7 +96,7 @@ func getCanaryConfigId(metric v1alpha1.Metric, p *Provider) (string, error) {
 
 // Run queries kayentd for the metric
 func (p *Provider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1alpha1.Measurement {
-	startTime := metav1.Now()
+	startTime := timeutil.MetaNow()
 	newMeasurement := v1alpha1.Measurement{
 		StartedAt: &startTime,
 	}
@@ -157,7 +156,7 @@ func (p *Provider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1alph
 
 	newMeasurement.Phase = v1alpha1.AnalysisPhaseRunning
 
-	resumeTime := metav1.NewTime(time.Now().Add(resumeDelay))
+	resumeTime := metav1.NewTime(timeutil.Now().Add(resumeDelay))
 	newMeasurement.ResumeAt = &resumeTime
 
 	return newMeasurement
@@ -191,7 +190,7 @@ func (p *Provider) Resume(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric, mea
 	status, ok, err := unstructured.NestedBool(patch, "complete")
 	if ok {
 		if !status { //resume later since it is incomplete
-			resumeTime := metav1.NewTime(time.Now().Add(resumeDelay))
+			resumeTime := metav1.NewTime(timeutil.Now().Add(resumeDelay))
 			measurement.ResumeAt = &resumeTime
 			measurement.Phase = v1alpha1.AnalysisPhaseRunning
 
@@ -217,7 +216,7 @@ func (p *Provider) Resume(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric, mea
 		return metricutil.MarkMeasurementError(measurement, err)
 	}
 
-	finishTime := metav1.Now()
+	finishTime := timeutil.MetaNow()
 	measurement.FinishedAt = &finishTime
 
 	return measurement

--- a/metricproviders/newrelic/newrelic.go
+++ b/metricproviders/newrelic/newrelic.go
@@ -17,6 +17,7 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/defaults"
 	"github.com/argoproj/argo-rollouts/utils/evaluate"
 	metricutil "github.com/argoproj/argo-rollouts/utils/metric"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 	"github.com/argoproj/argo-rollouts/utils/version"
 )
 
@@ -55,7 +56,7 @@ type Provider struct {
 
 // Run queries NewRelic for the metric
 func (p *Provider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1alpha1.Measurement {
-	startTime := metav1.Now()
+	startTime := timeutil.MetaNow()
 	newMeasurement := v1alpha1.Measurement{
 		StartedAt: &startTime,
 	}
@@ -72,7 +73,7 @@ func (p *Provider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1alph
 	newMeasurement.Value = valueStr
 	newMeasurement.Phase = newStatus
 
-	finishedTime := metav1.Now()
+	finishedTime := timeutil.MetaNow()
 	newMeasurement.FinishedAt = &finishedTime
 	return newMeasurement
 }

--- a/metricproviders/prometheus/prometheus.go
+++ b/metricproviders/prometheus/prometheus.go
@@ -9,11 +9,11 @@ import (
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	log "github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/evaluate"
 	metricutil "github.com/argoproj/argo-rollouts/utils/metric"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 const (
@@ -34,7 +34,7 @@ func (p *Provider) Type() string {
 
 // Run queries prometheus for the metric
 func (p *Provider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1alpha1.Measurement {
-	startTime := metav1.Now()
+	startTime := timeutil.MetaNow()
 	newMeasurement := v1alpha1.Measurement{
 		StartedAt: &startTime,
 	}
@@ -67,7 +67,7 @@ func (p *Provider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1alph
 	}
 
 	newMeasurement.Phase = newStatus
-	finishedTime := metav1.Now()
+	finishedTime := timeutil.MetaNow()
 	newMeasurement.FinishedAt = &finishedTime
 	return newMeasurement
 }

--- a/metricproviders/wavefront/wavefront.go
+++ b/metricproviders/wavefront/wavefront.go
@@ -17,6 +17,7 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/defaults"
 	"github.com/argoproj/argo-rollouts/utils/evaluate"
 	metricutil "github.com/argoproj/argo-rollouts/utils/metric"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 const (
@@ -68,7 +69,7 @@ type wavefrontResponse struct {
 
 // Run queries with wavefront provider for the metric
 func (p *Provider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1alpha1.Measurement {
-	startTime := metav1.Now()
+	startTime := timeutil.MetaNow()
 	newMeasurement := v1alpha1.Measurement{
 		StartedAt: &startTime,
 		Metadata:  map[string]string{},
@@ -103,7 +104,7 @@ func (p *Provider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1alph
 	newMeasurement.Phase = result.newStatus
 	newMeasurement.Metadata["timestamps"] = result.epochsUsed
 	newMeasurement.Metadata["drift"] = result.drift
-	finishedTime := metav1.Now()
+	finishedTime := timeutil.MetaNow()
 	newMeasurement.FinishedAt = &finishedTime
 	return newMeasurement
 }

--- a/metricproviders/webmetric/webmetric.go
+++ b/metricproviders/webmetric/webmetric.go
@@ -12,13 +12,13 @@ import (
 	"strings"
 	"time"
 
-	metricutil "github.com/argoproj/argo-rollouts/utils/metric"
 	log "github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/jsonpath"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/evaluate"
+	metricutil "github.com/argoproj/argo-rollouts/utils/metric"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 const (
@@ -40,7 +40,7 @@ func (p *Provider) Type() string {
 }
 
 func (p *Provider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1alpha1.Measurement {
-	startTime := metav1.Now()
+	startTime := timeutil.MetaNow()
 
 	// Measurement to pass back
 	measurement := v1alpha1.Measurement{
@@ -91,7 +91,7 @@ func (p *Provider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1alph
 
 	measurement.Value = value
 	measurement.Phase = status
-	finishedTime := metav1.Now()
+	finishedTime := timeutil.MetaNow()
 	measurement.FinishedAt = &finishedTime
 
 	return measurement

--- a/pkg/kubectl-argo-rollouts/cmd/get/get_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/get/get_test.go
@@ -7,14 +7,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/stretchr/testify/assert"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/info/testdata"
 	options "github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options/fake"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 func assertStdout(t *testing.T, expectedOut string, o genericclioptions.IOStreams) {
@@ -163,7 +162,7 @@ NAME                                        KIND        STATUS        AGE  INFO
 
 func TestGetBlueGreenRolloutScaleDownDelay(t *testing.T) {
 	rolloutObjs := testdata.NewBlueGreenRollout()
-	inFourHours := metav1.Now().Add(4 * time.Hour).Truncate(time.Second).UTC().Format(time.RFC3339)
+	inFourHours := timeutil.Now().Add(4 * time.Hour).Truncate(time.Second).UTC().Format(time.RFC3339)
 	rolloutObjs.ReplicaSets[2].Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey] = inFourHours
 	delete(rolloutObjs.ReplicaSets[2].Labels, v1alpha1.DefaultRolloutUniqueLabelKey)
 
@@ -211,7 +210,7 @@ NAME                                        KIND        STATUS        AGE  INFO
 
 func TestGetBlueGreenRolloutScaleDownDelayPassed(t *testing.T) {
 	rolloutObjs := testdata.NewBlueGreenRollout()
-	anHourAgo := metav1.Now().Add(-1 * time.Hour).Truncate(time.Second).UTC().Format(time.RFC3339)
+	anHourAgo := timeutil.Now().Add(-1 * time.Hour).Truncate(time.Second).UTC().Format(time.RFC3339)
 	rolloutObjs.ReplicaSets[2].Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey] = anHourAgo
 	delete(rolloutObjs.ReplicaSets[2].Labels, v1alpha1.DefaultRolloutUniqueLabelKey)
 

--- a/pkg/kubectl-argo-rollouts/cmd/list/list_experiments.go
+++ b/pkg/kubectl-argo-rollouts/cmd/list/list_experiments.go
@@ -11,6 +11,7 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options"
 	experimentutil "github.com/argoproj/argo-rollouts/utils/experiment"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 const (
@@ -85,7 +86,7 @@ func (o *ListOptions) PrintExperimentTable(expList *v1alpha1.ExperimentList) err
 	}
 	fmt.Fprintf(w, headerStr)
 	for _, exp := range expList.Items {
-		age := duration.HumanDuration(metav1.Now().Sub(exp.CreationTimestamp.Time))
+		age := duration.HumanDuration(timeutil.MetaNow().Sub(exp.CreationTimestamp.Time))
 		dur := "-"
 		remaining := "-"
 		if exp.Spec.Duration != "" {

--- a/pkg/kubectl-argo-rollouts/cmd/list/list_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/list/list_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/undefinedlabs/go-mpatch"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	kubetesting "k8s.io/client-go/testing"
@@ -176,22 +175,14 @@ func TestListNamespaceAndTimestamp(t *testing.T) {
 	cmd.PersistentPreRunE = o.PersistentPreRunE
 	cmd.SetArgs([]string{"--all-namespaces", "--timestamps"})
 
-	patch, err := mpatch.PatchMethod(time.Now, func() time.Time {
-		return time.Time{}
-	})
-	assert.NoError(t, err)
-	err = cmd.Execute()
-	patch.Unpatch()
+	err := cmd.Execute()
 
 	assert.NoError(t, err)
 	stdout := o.Out.(*bytes.Buffer).String()
 	stderr := o.ErrOut.(*bytes.Buffer).String()
 	assert.Empty(t, stderr)
-	expectedOut := strings.TrimPrefix(`
-TIMESTAMP             NAMESPACE  NAME           STRATEGY   STATUS        STEP  SET-WEIGHT  READY  DESIRED  UP-TO-DATE  AVAILABLE
-0001-01-01T00:00:00Z  test       can-guestbook  Canary     Progressing   1/3   10          1/4    5        3           2        
-`, "\n")
-	assert.Equal(t, expectedOut, stdout)
+	assert.Contains(t, stdout, "TIMESTAMP             NAMESPACE  NAME           STRATEGY   STATUS        STEP  SET-WEIGHT  READY  DESIRED  UP-TO-DATE  AVAILABLE")
+	assert.Contains(t, stdout, "test       can-guestbook  Canary     Progressing   1/3   10          1/4    5        3           2")
 }
 
 func TestListWithWatch(t *testing.T) {

--- a/pkg/kubectl-argo-rollouts/cmd/list/rollloutinfo.go
+++ b/pkg/kubectl-argo-rollouts/cmd/list/rollloutinfo.go
@@ -8,6 +8,7 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	replicasetutil "github.com/argoproj/argo-rollouts/utils/replicaset"
 	rolloututil "github.com/argoproj/argo-rollouts/utils/rollout"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 const (
@@ -92,7 +93,7 @@ func (ri *rolloutInfo) String(timestamp, namespace bool) string {
 	}
 	if timestamp {
 		fmtString = "%-20s\t" + fmtString
-		timestampStr := time.Now().UTC().Truncate(time.Second).Format("2006-01-02T15:04:05Z")
+		timestampStr := timeutil.Now().UTC().Truncate(time.Second).Format("2006-01-02T15:04:05Z")
 		args = append([]interface{}{timestampStr}, args...)
 	}
 	return fmt.Sprintf(fmtString, args...)

--- a/pkg/kubectl-argo-rollouts/cmd/restart/restart.go
+++ b/pkg/kubectl-argo-rollouts/cmd/restart/restart.go
@@ -12,6 +12,7 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	clientset "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/typed/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 const (
@@ -70,7 +71,7 @@ func NewCmdRestart(o *options.ArgoRolloutsOptions) *cobra.Command {
 func RestartRollout(rolloutIf clientset.RolloutInterface, name string, restartAt *time.Time) (*v1alpha1.Rollout, error) {
 	ctx := context.TODO()
 	if restartAt == nil {
-		t := time.Now().UTC()
+		t := timeutil.Now().UTC()
 		restartAt = &t
 	}
 	patch := fmt.Sprintf(restartPatch, restartAt.Format(time.RFC3339))

--- a/pkg/kubectl-argo-rollouts/info/info.go
+++ b/pkg/kubectl-argo-rollouts/info/info.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/annotations"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 const (
@@ -38,7 +39,7 @@ type ImageInfo struct {
 }
 
 func Age(m v1.ObjectMeta) string {
-	return duration.HumanDuration(metav1.Now().Sub(m.CreationTimestamp.Time))
+	return duration.HumanDuration(timeutil.MetaNow().Sub(m.CreationTimestamp.Time))
 }
 
 func ownerRef(ownerRefs []metav1.OwnerReference, uids []types.UID) *metav1.OwnerReference {

--- a/pkg/kubectl-argo-rollouts/info/info_test.go
+++ b/pkg/kubectl-argo-rollouts/info/info_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/info/testdata"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 func TestAge(t *testing.T) {
@@ -63,7 +64,7 @@ func TestBlueGreenRolloutInfo(t *testing.T) {
 	}
 	{
 		rolloutObjs := testdata.NewBlueGreenRollout()
-		inFourHours := metav1.Now().Add(4 * time.Hour).Truncate(time.Second).UTC().Format(time.RFC3339)
+		inFourHours := timeutil.Now().Add(4 * time.Hour).Truncate(time.Second).UTC().Format(time.RFC3339)
 		rolloutObjs.ReplicaSets[0].Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey] = inFourHours
 		delayedRs := rolloutObjs.ReplicaSets[0].ObjectMeta.UID
 		roInfo := NewRolloutInfo(rolloutObjs.Rollouts[0], rolloutObjs.ReplicaSets, rolloutObjs.Pods, rolloutObjs.Experiments, rolloutObjs.AnalysisRuns)

--- a/pkg/kubectl-argo-rollouts/info/replicaset_info.go
+++ b/pkg/kubectl-argo-rollouts/info/replicaset_info.go
@@ -4,17 +4,16 @@ import (
 	"sort"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/duration"
 
 	"github.com/argoproj/argo-rollouts/pkg/apiclient/rollout"
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	replicasetutil "github.com/argoproj/argo-rollouts/utils/replicaset"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 func GetReplicaSetInfo(ownerUID types.UID, ro *v1alpha1.Rollout, allReplicaSets []*appsv1.ReplicaSet, allPods []*corev1.Pod) []*rollout.ReplicaSetInfo {
@@ -121,7 +120,7 @@ func getReplicaSetCondition(status appsv1.ReplicaSetStatus, condType appsv1.Repl
 
 func ScaleDownDelay(rs rollout.ReplicaSetInfo) string {
 	if deadline, err := time.Parse(time.RFC3339, rs.ScaleDownDeadline); err == nil {
-		now := metav1.Now().Time
+		now := timeutil.MetaNow().Time
 		if deadline.Before(now) {
 			return "passed"
 		}

--- a/rollout/analysis_test.go
+++ b/rollout/analysis_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
+
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -977,7 +979,7 @@ func TestDeleteAnalysisRunsAfterRSDelete(t *testing.T) {
 	arToDelete.Spec.Terminate = true
 	arAlreadyDeleted := arToDelete.DeepCopy()
 	arAlreadyDeleted.Name = "already-deleted-analysis-run"
-	now := metav1.Now()
+	now := timeutil.MetaNow()
 	arAlreadyDeleted.DeletionTimestamp = &now
 
 	r3 = updateCanaryRolloutStatus(r3, rs2PodHash, 1, 0, 1, false)
@@ -1100,7 +1102,7 @@ func TestPausedOnInconclusiveBackgroundAnalysisRun(t *testing.T) {
 	patchIndex := f.expectPatchRolloutAction(r2)
 	f.run(getKey(r2, t))
 	patch := f.getPatchedRollout(patchIndex)
-	now := metav1.Now().UTC().Format(time.RFC3339)
+	now := timeutil.MetaNow().UTC().Format(time.RFC3339)
 	expectedPatch := `{
 		"status": {
 			"conditions": %s,
@@ -1164,7 +1166,7 @@ func TestPausedStepAfterInconclusiveAnalysisRun(t *testing.T) {
 	patchIndex := f.expectPatchRolloutAction(r2)
 	f.run(getKey(r2, t))
 	patch := f.getPatchedRollout(patchIndex)
-	now := metav1.Now().UTC().Format(time.RFC3339)
+	now := timeutil.MetaNow().UTC().Format(time.RFC3339)
 	expectedPatch := `{
 		"status": {
 			"conditions": %s,
@@ -1246,7 +1248,7 @@ func TestErrorConditionAfterErrorAnalysisRunStep(t *testing.T) {
 			"message": "RolloutAborted: %s"
 		}
 	}`
-	now := metav1.Now().UTC().Format(time.RFC3339)
+	now := timeutil.MetaNow().UTC().Format(time.RFC3339)
 	errmsg := fmt.Sprintf(conditions.RolloutAbortedMessage, 2) + ": " + ar.Status.Message
 	condition := generateConditionsPatch(true, conditions.RolloutAbortedReason, r2, false, errmsg)
 	expectedPatch = fmt.Sprintf(expectedPatch, condition, now, errmsg)
@@ -1325,7 +1327,7 @@ func TestErrorConditionAfterErrorAnalysisRunBackground(t *testing.T) {
 	errmsg := fmt.Sprintf(conditions.RolloutAbortedMessage, 2)
 	condition := generateConditionsPatch(true, conditions.RolloutAbortedReason, r2, false, "")
 
-	now := metav1.Now().UTC().Format(time.RFC3339)
+	now := timeutil.Now().UTC().Format(time.RFC3339)
 	assert.Equal(t, calculatePatch(r2, fmt.Sprintf(expectedPatch, condition, now, errmsg)), patch)
 }
 
@@ -1386,7 +1388,7 @@ func TestCancelAnalysisRunsWhenAborted(t *testing.T) {
 		}
 	}`
 	errmsg := fmt.Sprintf(conditions.RolloutAbortedMessage, 2)
-	now := metav1.Now().UTC().Format(time.RFC3339)
+	now := timeutil.Now().UTC().Format(time.RFC3339)
 	assert.Equal(t, calculatePatch(r2, fmt.Sprintf(expectedPatch, newConditions, now, errmsg)), patch)
 }
 
@@ -1465,7 +1467,7 @@ func TestDoNotCreateBackgroundAnalysisRunAfterInconclusiveRun(t *testing.T) {
 
 	r2.Status.PauseConditions = []v1alpha1.PauseCondition{{
 		Reason:    v1alpha1.PauseReasonInconclusiveAnalysis,
-		StartTime: metav1.Now(),
+		StartTime: timeutil.MetaNow(),
 	}}
 	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 1, 0, 1, false)
 
@@ -1781,7 +1783,7 @@ func TestRolloutPrePromotionAnalysisBecomesInconclusive(t *testing.T) {
 	patchIndex := f.expectPatchRolloutActionWithPatch(r2, OnlyObservedGenerationPatch)
 	f.run(getKey(r2, t))
 	patch := f.getPatchedRollout(patchIndex)
-	now := metav1.Now().UTC().Format(time.RFC3339)
+	now := timeutil.MetaNow().UTC().Format(time.RFC3339)
 	expectedPatch := fmt.Sprintf(`{
 		"status": {
 			"pauseConditions":[
@@ -1894,7 +1896,7 @@ func TestRolloutPrePromotionAnalysisHonorAutoPromotionSeconds(t *testing.T) {
 	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
 	r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
-	now := metav1.NewTime(metav1.Now().Add(-10 * time.Second))
+	now := metav1.NewTime(timeutil.MetaNow().Add(-10 * time.Second))
 	r2.Status.PauseConditions[0].StartTime = now
 	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, r2, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
@@ -1959,7 +1961,7 @@ func TestRolloutPrePromotionAnalysisDoNothingOnInconclusiveAnalysis(t *testing.T
 	r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
 	inconclusivePauseCondition := v1alpha1.PauseCondition{
 		Reason:    v1alpha1.PauseReasonInconclusiveAnalysis,
-		StartTime: metav1.Now(),
+		StartTime: timeutil.MetaNow(),
 	}
 	r2.Status.PauseConditions = append(r2.Status.PauseConditions, inconclusivePauseCondition)
 	r2.Status.ObservedGeneration = strconv.Itoa(int(r2.Generation))
@@ -2049,7 +2051,7 @@ func TestAbortRolloutOnErrorPrePromotionAnalysis(t *testing.T) {
 			"message": "%s: %s"
 		}
 	}`
-	now := metav1.Now().UTC().Format(time.RFC3339)
+	now := timeutil.MetaNow().UTC().Format(time.RFC3339)
 	progressingFalseAborted, _ := newProgressingCondition(conditions.RolloutAbortedReason, r2, "")
 	newConditions := updateConditionsPatch(*r2, progressingFalseAborted)
 	assert.Equal(t, calculatePatch(r2, fmt.Sprintf(expectedPatch, now, newConditions, conditions.RolloutAbortedReason, progressingFalseAborted.Message)), patch)
@@ -2183,7 +2185,7 @@ func TestPostPromotionAnalysisRunHandleInconclusive(t *testing.T) {
 	r2 = updateBlueGreenRolloutStatus(r2, "", rs2PodHash, rs1PodHash, 1, 1, 2, 1, false, true)
 	r2.Status.PauseConditions = []v1alpha1.PauseCondition{{
 		Reason:    v1alpha1.PauseReasonInconclusiveAnalysis,
-		StartTime: metav1.Now(),
+		StartTime: timeutil.MetaNow(),
 	}}
 	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, r2, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
@@ -2278,7 +2280,7 @@ func TestAbortRolloutOnErrorPostPromotionAnalysis(t *testing.T) {
 			"message": "%s: %s"
 		}
 	}`
-	now := metav1.Now().UTC().Format(time.RFC3339)
+	now := timeutil.MetaNow().UTC().Format(time.RFC3339)
 	progressingFalseAborted, _ := newProgressingCondition(conditions.RolloutAbortedReason, r2, "")
 	newConditions := updateConditionsPatch(*r2, progressingFalseAborted)
 	assert.Equal(t, calculatePatch(r2, fmt.Sprintf(expectedPatch, now, newConditions, conditions.RolloutAbortedReason, progressingFalseAborted.Message)), patch)

--- a/rollout/bluegreen_test.go
+++ b/rollout/bluegreen_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/annotations"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
 	rolloututil "github.com/argoproj/argo-rollouts/utils/rollout"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 var (
@@ -330,7 +331,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 				"message": "BlueGreenPause"
 			}
 		}`
-		now := metav1.Now().UTC().Format(time.RFC3339)
+		now := timeutil.Now().UTC().Format(time.RFC3339)
 		assert.Equal(t, calculatePatch(r2, fmt.Sprintf(expectedPatch, v1alpha1.PauseReasonBlueGreenPause, now)), patch)
 
 	})
@@ -433,7 +434,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
 		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 1, 2, 1, false, true)
-		now := metav1.Now()
+		now := timeutil.MetaNow()
 		r2.Status.PauseConditions = append(r2.Status.PauseConditions, v1alpha1.PauseCondition{
 			Reason:    v1alpha1.PauseReasonInconclusiveAnalysis,
 			StartTime: now,
@@ -517,7 +518,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
 		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
-		now := metav1.Now()
+		now := timeutil.MetaNow()
 		before := metav1.NewTime(now.Add(-1 * time.Minute))
 		r2.Status.PauseConditions[0].StartTime = before
 		r2.Status.ControllerPause = true
@@ -575,7 +576,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
 		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
-		now := metav1.Now()
+		now := timeutil.MetaNow()
 		before := metav1.NewTime(now.Add(-1 * time.Minute))
 		r2.Status.PauseConditions[0].StartTime = before
 		r2.Status.ControllerPause = true
@@ -682,7 +683,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
 		f.serviceLister = append(f.serviceLister, activeSvc)
 
-		now := metav1.Now().UTC().Format(time.RFC3339)
+		now := timeutil.MetaNow().UTC().Format(time.RFC3339)
 		expectedPatchWithoutSubs := `{
 			"status": {
 				"pauseConditions": [{
@@ -1247,7 +1248,7 @@ func TestBlueGreenNotReadyToScaleDownOldReplica(t *testing.T) {
 	rs2 := newReplicaSetWithStatus(r2, 1, 1)
 	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-	inTheFuture := metav1.Now().Add(10 * time.Second).UTC().Format(time.RFC3339)
+	inTheFuture := timeutil.Now().Add(10 * time.Second).UTC().Format(time.RFC3339)
 
 	rs1.Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey] = inTheFuture
 
@@ -1280,7 +1281,7 @@ func TestBlueGreenReadyToScaleDownOldReplica(t *testing.T) {
 	rs2 := newReplicaSetWithStatus(r2, 1, 1)
 	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-	inThePast := metav1.Now().Add(-10 * time.Second).UTC().Format(time.RFC3339)
+	inThePast := timeutil.Now().Add(-10 * time.Second).UTC().Format(time.RFC3339)
 
 	rs1.Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey] = inThePast
 
@@ -1319,7 +1320,7 @@ func TestFastRollback(t *testing.T) {
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
 	//Setting the scaleDownAt time
-	inTheFuture := metav1.Now().Add(10 * time.Second).UTC().Format(time.RFC3339)
+	inTheFuture := timeutil.Now().Add(10 * time.Second).UTC().Format(time.RFC3339)
 	rs1.Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey] = inTheFuture
 	rs2.Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey] = inTheFuture
 
@@ -1363,7 +1364,7 @@ func TestBlueGreenScaleDownLimit(t *testing.T) {
 	rs3PodHash := rs3.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
 	//Setting the scaleDownAt time
-	inTheFuture := metav1.Now().Add(10 * time.Second).UTC().Format(time.RFC3339)
+	inTheFuture := timeutil.MetaNow().Add(10 * time.Second).UTC().Format(time.RFC3339)
 	rs1.Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey] = inTheFuture
 	rs2.Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey] = inTheFuture
 
@@ -1398,7 +1399,7 @@ func TestBlueGreenAbort(t *testing.T) {
 	r1 := newBlueGreenRollout("foo", 1, nil, "bar", "")
 	r2 := bumpVersion(r1)
 	r2.Status.Abort = true
-	now := metav1.Now()
+	now := timeutil.MetaNow()
 	r2.Status.AbortedAt = &now
 
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
@@ -1449,7 +1450,7 @@ func TestBlueGreenHandlePauseAutoPromoteWithConditions(t *testing.T) {
 	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
 	r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 1, 2, 1, true, true)
-	now := metav1.Now()
+	now := timeutil.MetaNow()
 	before := metav1.NewTime(now.Add(-1 * time.Minute))
 	r2.Status.PauseConditions[0].StartTime = before
 	r2.Status.ControllerPause = true

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -25,6 +25,7 @@ import (
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
 	"github.com/argoproj/argo-rollouts/utils/record"
 	rolloututil "github.com/argoproj/argo-rollouts/utils/rollout"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 func newCanaryRollout(name string, replicas int, revisionHistoryLimit *int32, steps []v1alpha1.CanaryStep, stepIndex *int32, maxSurge, maxUnavailable intstr.IntOrString) *v1alpha1.Rollout {
@@ -177,7 +178,7 @@ func TestCanaryRolloutEnterPauseState(t *testing.T) {
 	}`
 
 	conditions := generateConditionsPatch(true, conditions.ReplicaSetUpdatedReason, r2, false, "")
-	now := metav1.Now().UTC().Format(time.RFC3339)
+	now := timeutil.MetaNow().UTC().Format(time.RFC3339)
 	expectedPatchWithoutObservedGen := fmt.Sprintf(expectedPatchTemplate, v1alpha1.PauseReasonCanaryPauseStep, now, conditions, v1alpha1.PauseReasonCanaryPauseStep)
 	expectedPatch := calculatePatch(r2, expectedPatchWithoutObservedGen)
 	assert.Equal(t, expectedPatch, patch)
@@ -1089,7 +1090,7 @@ func TestSyncRolloutWaitIncrementStepIndex(t *testing.T) {
 	pausedCondition, _ := newPausedCondition(true)
 	conditions.SetRolloutCondition(&r2.Status, pausedCondition)
 
-	earlier := metav1.Now()
+	earlier := timeutil.MetaNow()
 	earlier.Time = earlier.Add(-10 * time.Second)
 	r2.Status.ControllerPause = true
 	r2.Status.PauseConditions = []v1alpha1.PauseCondition{{
@@ -1560,7 +1561,7 @@ func TestHandleCanaryAbort(t *testing.T) {
 
 		r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 10, 1, 10, false)
 		r2.Status.Abort = true
-		now := metav1.Now()
+		now := timeutil.MetaNow()
 		r2.Status.AbortedAt = &now
 		f.rolloutLister = append(f.rolloutLister, r2)
 		f.objects = append(f.objects, r2)
@@ -1597,7 +1598,7 @@ func TestHandleCanaryAbort(t *testing.T) {
 		}
 		r1 := newCanaryRollout("foo", 2, nil, steps, int32Ptr(3), intstr.FromInt(1), intstr.FromInt(0))
 		r1.Status.Abort = true
-		now := metav1.Now()
+		now := timeutil.MetaNow()
 		r1.Status.AbortedAt = &now
 		rs1 := newReplicaSetWithStatus(r1, 2, 2)
 		rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]

--- a/rollout/controller.go
+++ b/rollout/controller.go
@@ -52,6 +52,7 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/record"
 	replicasetutil "github.com/argoproj/argo-rollouts/utils/replicaset"
 	serviceutil "github.com/argoproj/argo-rollouts/utils/service"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 	unstructuredutil "github.com/argoproj/argo-rollouts/utils/unstructured"
 )
 
@@ -341,7 +342,7 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) error {
 // with the current status of the resource.
 func (c *Controller) syncHandler(key string) error {
 	ctx := context.TODO()
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err

--- a/rollout/replicaset.go
+++ b/rollout/replicaset.go
@@ -15,6 +15,7 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
 	replicasetutil "github.com/argoproj/argo-rollouts/utils/replicaset"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 var controllerKind = v1alpha1.SchemeGroupVersion.WithKind("Rollout")
@@ -53,7 +54,7 @@ func (c *rolloutContext) addScaleDownDelay(rs *appsv1.ReplicaSet, scaleDownDelay
 		}
 		return nil
 	}
-	deadline := metav1.Now().Add(scaleDownDelaySeconds).UTC().Format(time.RFC3339)
+	deadline := timeutil.MetaNow().Add(scaleDownDelaySeconds).UTC().Format(time.RFC3339)
 	patch := fmt.Sprintf(addScaleDownAtAnnotationsPatch, v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey, deadline)
 	_, err := c.kubeclientset.AppsV1().ReplicaSets(rs.Namespace).Patch(ctx, rs.Name, patchtypes.JSONPatchType, []byte(patch), metav1.PatchOptions{})
 	if err == nil {
@@ -131,7 +132,7 @@ func (c *rolloutContext) reconcileNewReplicaSet() (bool, error) {
 			if err != nil {
 				c.log.Warnf("Unable to read scaleDownAt label on rs '%s'", c.newRS.Name)
 			} else {
-				now := metav1.Now()
+				now := timeutil.MetaNow()
 				scaleDownAt := metav1.NewTime(scaleDownAtTime)
 				if scaleDownAt.After(now.Time) {
 					c.log.Infof("RS '%s' has not reached the scaleDownTime", c.newRS.Name)

--- a/rollout/replicaset_test.go
+++ b/rollout/replicaset_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/annotations"
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
 	"github.com/argoproj/argo-rollouts/utils/record"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 func newRolloutControllerRef(r *v1alpha1.Rollout) *metav1.OwnerReference {
@@ -221,9 +222,9 @@ func TestReconcileNewReplicaSet(t *testing.T) {
 				if test.abortScaleDownAnnotated {
 					var deadline string
 					if test.abortScaleDownDelayPassed {
-						deadline = metav1.Now().Add(-time.Duration(test.abortScaleDownDelaySeconds) * time.Second).UTC().Format(time.RFC3339)
+						deadline = timeutil.Now().Add(-time.Duration(test.abortScaleDownDelaySeconds) * time.Second).UTC().Format(time.RFC3339)
 					} else {
-						deadline = metav1.Now().Add(time.Duration(test.abortScaleDownDelaySeconds) * time.Second).UTC().Format(time.RFC3339)
+						deadline = timeutil.Now().Add(time.Duration(test.abortScaleDownDelaySeconds) * time.Second).UTC().Format(time.RFC3339)
 					}
 					roCtx.newRS.Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey] = deadline
 				}

--- a/rollout/restart.go
+++ b/rollout/restart.go
@@ -18,6 +18,7 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/defaults"
 	"github.com/argoproj/argo-rollouts/utils/replicaset"
 	replicasetutil "github.com/argoproj/argo-rollouts/utils/replicaset"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 const (
@@ -167,7 +168,7 @@ func (p *RolloutPodRestarter) getRolloutPods(ctx context.Context, ro *v1alpha1.R
 
 func getAvailablePodCount(pods []*corev1.Pod, minReadySeconds int32) int32 {
 	var available int32
-	now := metav1.Now()
+	now := timeutil.MetaNow()
 	for _, pod := range pods {
 		if podutil.IsPodAvailable(pod, minReadySeconds, now) && pod.DeletionTimestamp == nil {
 			available += 1

--- a/rollout/service_test.go
+++ b/rollout/service_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/conditions"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
 	ingressutil "github.com/argoproj/argo-rollouts/utils/ingress"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 	unstructuredutil "github.com/argoproj/argo-rollouts/utils/unstructured"
 )
 
@@ -622,7 +623,7 @@ func TestCanaryAWSVerifyTargetGroupsSkip(t *testing.T) {
 
 	rs1 := newReplicaSetWithStatus(r1, 3, 3)
 	// set an annotation on old RS to cause verification to be skipped
-	rs1.Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey] = metav1.Now().Add(600 * time.Second).UTC().Format(time.RFC3339)
+	rs1.Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey] = timeutil.Now().Add(600 * time.Second).UTC().Format(time.RFC3339)
 	rs2 := newReplicaSetWithStatus(r2, 3, 3)
 
 	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]

--- a/rollout/sync_test.go
+++ b/rollout/sync_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,7 +20,7 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/conditions"
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
 	"github.com/argoproj/argo-rollouts/utils/record"
-	"github.com/stretchr/testify/assert"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 func rs(name string, replicas int, selector map[string]string, timestamp metav1.Time, ownerRef *metav1.OwnerReference) *appsv1.ReplicaSet {
@@ -46,7 +47,7 @@ func rs(name string, replicas int, selector map[string]string, timestamp metav1.
 }
 
 func TestReconcileRevisionHistoryLimit(t *testing.T) {
-	now := metav1.Now()
+	now := timeutil.MetaNow()
 	before := metav1.Time{Time: now.Add(-time.Minute)}
 
 	newRS := func(name string) *appsv1.ReplicaSet {
@@ -376,7 +377,7 @@ func TestBlueGreenPromoteFull(t *testing.T) {
 
 // TestSendStateChangeEvents verifies we emit appropriate events on rollout state changes
 func TestSendStateChangeEvents(t *testing.T) {
-	now := metav1.Now()
+	now := timeutil.MetaNow()
 	tests := []struct {
 		prevStatus           v1alpha1.RolloutStatus
 		newStatus            v1alpha1.RolloutStatus

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/dynamic/dynamiclister"
@@ -24,6 +23,7 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/conditions"
 	istioutil "github.com/argoproj/argo-rollouts/utils/istio"
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 // newFakeTrafficRoutingReconciler returns a fake TrafficRoutingReconciler with mocked success return values
@@ -605,7 +605,7 @@ func TestCanaryWithTrafficRoutingScaleDownLimit(t *testing.T) {
 	f := newFixture(t)
 	defer f.Close()
 
-	inTheFuture := metav1.Now().Add(10 * time.Second).UTC().Format(time.RFC3339)
+	inTheFuture := timeutil.MetaNow().Add(10 * time.Second).UTC().Format(time.RFC3339)
 
 	r1 := newCanaryRollout("foo", 1, nil, nil, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(1))
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)

--- a/utils/conditions/conditions.go
+++ b/utils/conditions/conditions.go
@@ -9,12 +9,12 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 const (
@@ -163,8 +163,8 @@ func NewRolloutCondition(condType v1alpha1.RolloutConditionType, status corev1.C
 	return &v1alpha1.RolloutCondition{
 		Type:               condType,
 		Status:             status,
-		LastUpdateTime:     metav1.Now(),
-		LastTransitionTime: metav1.Now(),
+		LastUpdateTime:     timeutil.MetaNow(),
+		LastTransitionTime: timeutil.MetaNow(),
 		Reason:             reason,
 		Message:            message,
 	}
@@ -322,7 +322,7 @@ func RolloutTimedOut(rollout *v1alpha1.Rollout, newStatus *v1alpha1.RolloutStatu
 	// progress or tried to create a replica set, or resumed a paused rollout and
 	// compare against progressDeadlineSeconds.
 	from := condition.LastUpdateTime
-	now := time.Now()
+	now := timeutil.Now()
 
 	progressDeadlineSeconds := defaults.GetProgressDeadlineSecondsOrDefault(rollout)
 	delta := time.Duration(progressDeadlineSeconds) * time.Second

--- a/utils/conditions/experiments.go
+++ b/utils/conditions/experiments.go
@@ -10,6 +10,7 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
 	experimentutil "github.com/argoproj/argo-rollouts/utils/experiment"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 const (
@@ -39,8 +40,8 @@ func NewExperimentConditions(condType v1alpha1.ExperimentConditionType, status c
 	return &v1alpha1.ExperimentCondition{
 		Type:               condType,
 		Status:             status,
-		LastUpdateTime:     metav1.Now(),
-		LastTransitionTime: metav1.Now(),
+		LastUpdateTime:     timeutil.MetaNow(),
+		LastTransitionTime: timeutil.MetaNow(),
 		Reason:             reason,
 		Message:            message,
 	}
@@ -127,7 +128,7 @@ func ExperimentRunning(experiment *v1alpha1.Experiment) bool {
 
 func newInvalidSpecExperimentCondition(prevCond *v1alpha1.ExperimentCondition, reason string, message string) *v1alpha1.ExperimentCondition {
 	if prevCond != nil && prevCond.Message == message {
-		prevCond.LastUpdateTime = metav1.Now()
+		prevCond.LastUpdateTime = timeutil.MetaNow()
 		return prevCond
 	}
 	return NewExperimentConditions(v1alpha1.InvalidExperimentSpec, corev1.ConditionTrue, reason, message)

--- a/utils/experiment/experiment.go
+++ b/utils/experiment/experiment.go
@@ -13,6 +13,7 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	rolloutsclient "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/typed/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 var terminateExperimentPatch = []byte(`{"spec":{"terminate":true}}`)
@@ -88,7 +89,7 @@ func PassedDurations(experiment *v1alpha1.Experiment) (bool, time.Duration) {
 	if experiment.Status.AvailableAt == nil {
 		return false, 0
 	}
-	now := metav1.Now()
+	now := timeutil.MetaNow()
 	dur, err := experiment.Spec.Duration.Duration()
 	if err != nil {
 		return false, 0

--- a/utils/metric/metric.go
+++ b/utils/metric/metric.go
@@ -1,9 +1,8 @@
 package metric
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 // MarkMeasurementError sets an error message on a measurement along with finish time
@@ -11,7 +10,7 @@ func MarkMeasurementError(m v1alpha1.Measurement, err error) v1alpha1.Measuremen
 	m.Phase = v1alpha1.AnalysisPhaseError
 	m.Message = err.Error()
 	if m.FinishedAt == nil {
-		finishedTime := metav1.Now()
+		finishedTime := timeutil.MetaNow()
 		m.FinishedAt = &finishedTime
 	}
 	return m

--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -25,6 +25,7 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/conditions"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 // FindNewReplicaSet returns the new RS this given rollout targets from the given list.
@@ -204,7 +205,7 @@ func IfInjectedAntiAffinityRuleNeedsUpdate(affinity *corev1.Affinity, rollout v1
 }
 
 func NeedsRestart(rollout *v1alpha1.Rollout) bool {
-	now := metav1.Now().UTC()
+	now := timeutil.MetaNow().UTC()
 	if rollout.Spec.RestartAt == nil {
 		return false
 	}
@@ -594,7 +595,7 @@ func GetTimeRemainingBeforeScaleDownDeadline(rs *appsv1.ReplicaSet) (*time.Durat
 		if err != nil {
 			return nil, fmt.Errorf("unable to read scaleDownAt label on rs '%s'", rs.Name)
 		}
-		now := metav1.Now()
+		now := timeutil.MetaNow()
 		scaleDownAt := metav1.NewTime(scaleDownAtTime)
 		if scaleDownAt.After(now.Time) {
 			remainingTime := scaleDownAt.Sub(now.Time)

--- a/utils/replicaset/replicaset_test.go
+++ b/utils/replicaset/replicaset_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/annotations"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 // generateRollout creates a rollout, with the input image as its template
@@ -1184,13 +1185,13 @@ func TestGetTimeRemainingBeforeScaleDownDeadline(t *testing.T) {
 		assert.Nil(t, remainingTime)
 	}
 	{
-		rs.ObjectMeta.Annotations = map[string]string{v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey: metav1.Now().Add(-600 * time.Second).UTC().Format(time.RFC3339)}
+		rs.ObjectMeta.Annotations = map[string]string{v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey: timeutil.Now().Add(-600 * time.Second).UTC().Format(time.RFC3339)}
 		remainingTime, err := GetTimeRemainingBeforeScaleDownDeadline(&rs)
 		assert.Nil(t, err)
 		assert.Nil(t, remainingTime)
 	}
 	{
-		rs.ObjectMeta.Annotations = map[string]string{v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey: metav1.Now().Add(600 * time.Second).UTC().Format(time.RFC3339)}
+		rs.ObjectMeta.Annotations = map[string]string{v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey: timeutil.Now().Add(600 * time.Second).UTC().Format(time.RFC3339)}
 		remainingTime, err := GetTimeRemainingBeforeScaleDownDeadline(&rs)
 		assert.Nil(t, err)
 		assert.NotNil(t, remainingTime)

--- a/utils/time/now.go
+++ b/utils/time/now.go
@@ -1,0 +1,15 @@
+package time
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Now is a wrapper around time.Now() and used to override behavior in tests.
+var Now = time.Now
+
+// MetaNow is a wrapper around metav1.Now() and used to override behavior in tests.
+var MetaNow = func() metav1.Time {
+	return metav1.Time{Time: Now()}
+}


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Unit tests are failing on mac :( Looks like https://github.com/undefinedlabs/go-mpatch does not work well on the latest mac os versions. There is no ARM support as well: https://github.com/undefinedlabs/go-mpatch/issues/2 . The ARM support was requested in 2020, so unlikely it will be supported. 

I suggest to stop using https://github.com/undefinedlabs/go-mpatch. PR removes the usage in one place. We still use the library in `controller_test.go#newFixture`