### PR TITLE
fix: Fixed NPE while getting the ReplicaSet labels

### DIFF
--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -523,7 +523,7 @@ func PodTemplateEqualIgnoreHash(live, desired *corev1.PodTemplateSpec) bool {
 
 // GetPodTemplateHash returns the rollouts-pod-template-hash value from a ReplicaSet's labels
 func GetPodTemplateHash(rs *appsv1.ReplicaSet) string {
-	if rs.Labels == nil {
+	if rs == nil || rs.Labels == nil {
 		return ""
 	}
 	return rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]


### PR DESCRIPTION
# Description

This PR fixes a NPE which gets thrown while getting the ReplicaSet labels if the RS itself is `null`. See https://github.com/argoproj/argo-rollouts/issues/1630 for more details.

# Checklist

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

---
Signed-off-by: Rohit Agrawal <rohit.agrawal@databricks.com>