### PR TITLE
fix: dashboard promote buttons disabled during deploy

### DIFF
--- a/ui/src/app/components/rollout-actions/rollout-actions.tsx
+++ b/ui/src/app/components/rollout-actions/rollout-actions.tsx
@@ -18,6 +18,7 @@ export const RolloutActionButton = (props: {action: RolloutAction; rollout: Roll
     const namespaceCtx = React.useContext(NamespaceContext);
 
     const restartedAt = formatTimestamp(props.rollout.restartedAt || '');
+    const isDeploying = props.rollout.status === RolloutStatus.Progressing || props.rollout.status === RolloutStatus.Paused
 
     const actionMap = new Map<RolloutAction, ActionButtonProps & {body?: any}>([
         [
@@ -36,6 +37,7 @@ export const RolloutActionButton = (props: {action: RolloutAction; rollout: Roll
                 label: 'RETRY',
                 icon: 'fa-redo-alt',
                 action: api.rolloutServiceRetryRollout,
+                disabled: props.rollout.status !== RolloutStatus.Degraded,
                 shouldConfirm: true,
             },
         ],
@@ -45,6 +47,7 @@ export const RolloutActionButton = (props: {action: RolloutAction; rollout: Roll
                 label: 'ABORT',
                 icon: 'fa-exclamation-circle',
                 action: api.rolloutServiceAbortRollout,
+                disabled: !isDeploying,
                 shouldConfirm: true,
             },
         ],
@@ -55,7 +58,7 @@ export const RolloutActionButton = (props: {action: RolloutAction; rollout: Roll
                 icon: 'fa-chevron-circle-up',
                 action: api.rolloutServicePromoteRollout,
                 body: {full: false},
-                disabled: props.rollout.status !== RolloutStatus.Paused,
+                disabled: !isDeploying,
                 shouldConfirm: true,
             },
         ],
@@ -64,9 +67,9 @@ export const RolloutActionButton = (props: {action: RolloutAction; rollout: Roll
             {
                 label: 'PROMOTE-FULL',
                 icon: 'fa-arrow-circle-up',
-                body: {full: true},
                 action: api.rolloutServicePromoteRollout,
-                disabled: props.rollout.status !== RolloutStatus.Paused,
+                body: {full: true},
+                disabled: !isDeploying,
                 shouldConfirm: true,
             },
         ],


### PR DESCRIPTION
- keep promote and abort buttons enabled while deploying
- disable them at all other times
- also, only enable retry button when Rollout is degraded

Fixes https://github.com/argoproj/argo-rollouts/issues/1581

Signed-off-by: Ben Poland <ben.poland@faire.com>

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).