### PR TITLE
fix: Promote-full with TrafficRouting will dynamically increase weight according to available canary pods. Fixes: #1681

### DIFF
--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -129,7 +129,12 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 		} else if c.rollout.Status.PromoteFull {
 			// on a promote full, desired stable weight should be 0 (100% to canary),
 			// But we can only increase canary weight according to available replica counts of the canary.
-			desiredWeight = (100 * c.newRS.Status.AvailableReplicas) / *c.rollout.Spec.Replicas
+			// we will need to set the desiredWeight to 0 when the newRS is not available.
+			newRSAvailableReplicas := int32(0)
+			if c.newRS != nil {
+				newRSAvailableReplicas = c.newRS.Status.AvailableReplicas
+			}
+			desiredWeight = (100 * newRSAvailableReplicas) / *c.rollout.Spec.Replicas
 		} else if c.newRS == nil || c.newRS.Status.AvailableReplicas == 0 {
 			// when newRS is not available or replicas num is 0. never weight to canary
 			weightDestinations = append(weightDestinations, c.calculateWeightDestinationsFromExperiment()...)

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -130,11 +130,11 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			// on a promote full, desired stable weight should be 0 (100% to canary),
 			// But we can only increase canary weight according to available replica counts of the canary.
 			// we will need to set the desiredWeight to 0 when the newRS is not available.
-			newRSAvailableReplicas := int32(0)
-			if c.newRS != nil {
-				newRSAvailableReplicas = c.newRS.Status.AvailableReplicas
+			if c.rollout.Spec.Strategy.Canary.DynamicStableScale {
+				desiredWeight = (100 * c.newRS.Status.AvailableReplicas) / *c.rollout.Spec.Replicas
+			} else if c.rollout.Status.Canary.Weights != nil {
+				desiredWeight = c.rollout.Status.Canary.Weights.Canary.Weight
 			}
-			desiredWeight = (100 * newRSAvailableReplicas) / *c.rollout.Spec.Replicas
 		} else if c.newRS == nil || c.newRS.Status.AvailableReplicas == 0 {
 			// when newRS is not available or replicas num is 0. never weight to canary
 			weightDestinations = append(weightDestinations, c.calculateWeightDestinationsFromExperiment()...)

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -126,6 +126,10 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			if c.rollout.Spec.Strategy.Canary.DynamicStableScale {
 				desiredWeight = 100 - ((100 * c.stableRS.Status.AvailableReplicas) / *c.rollout.Spec.Replicas)
 			}
+		} else if c.rollout.Status.PromoteFull {
+			// on a promote full, desired stable weight should be 0 (100% to canary),
+			// But we can only increase canary weight according to available replica counts of the canary.
+			desiredWeight = (100 * c.newRS.Status.AvailableReplicas) / *c.rollout.Spec.Replicas
 		} else if c.newRS == nil || c.newRS.Status.AvailableReplicas == 0 {
 			// when newRS is not available or replicas num is 0. never weight to canary
 			weightDestinations = append(weightDestinations, c.calculateWeightDestinationsFromExperiment()...)

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -187,13 +187,16 @@ func TestRolloutUseDesiredWeight(t *testing.T) {
 
 	f.expectPatchRolloutAction(r2)
 
-	f.fakeSingleTrafficRouting = newUnmockedSingalFakeTrafficRoutingReconciler()
-	f.fakeSingleTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	f.fakeSingleTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, additionalDestinations ...v1alpha1.WeightDestination) error {
-		assert.Equal(t, int32(10), desiredWeight)
-		return nil
-	})
-	f.fakeSingleTrafficRouting.On("VerifyWeight", mock.Anything).Return(true, nil)
+	f.fakeTrafficRouting = *newUnmockedFakeTrafficRoutingReconciler()
+	for _, fakeTrafficRouting := range f.fakeTrafficRouting {
+		fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, additionalDestinations ...v1alpha1.WeightDestination) error {
+			// make sure SetWeight was called with correct value
+			assert.Equal(t, int32(10), desiredWeight)
+			return nil
+		})
+		fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(true, nil)
+	}
 
 	f.run(getKey(r2, t))
 }


### PR DESCRIPTION
On promote-full calculate the weight by (100 * canaryAvailablereplicas) / Replica.
This will make sure we will not have an outage when we do promote full.

fixes: https://github.com/argoproj/argo-rollouts/issues/1681

Signed-off-by: Nissan Hefetz <nissy34@gmail.com>