### PR TITLE
fix: missing rollout informer writeback

### DIFF
--- a/rollout/controller.go
+++ b/rollout/controller.go
@@ -389,7 +389,10 @@ func (c *Controller) syncHandler(key string) error {
 	if rollout.Spec.Replicas == nil {
 		logCtx.Info("Defaulting .spec.replica to 1")
 		r.Spec.Replicas = pointer.Int32Ptr(defaults.DefaultReplicas)
-		_, err := c.argoprojclientset.ArgoprojV1alpha1().Rollouts(r.Namespace).Update(ctx, r, metav1.UpdateOptions{})
+		newRollout, err := c.argoprojclientset.ArgoprojV1alpha1().Rollouts(r.Namespace).Update(ctx, r, metav1.UpdateOptions{})
+		if err == nil {
+			c.writeBackToInformer(newRollout)
+		}
 		return err
 	}
 


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/913

I finally encountered the e2e flakiness https://github.com/argoproj/argo-rollouts/issues/913 in local development and spent some time studying the sequence of events and logs. I believe the root cause to be a bug in the controller with the informer cache becoming stale, because we don't write back the rollout in the event where `spec.replicas` is defaulted. 

Update: this will only fix one source of e2e flakiness, but there is much more to be done

Signed-off-by: Jesse Suen <jesse@akuity.io>
