### PR TITLE
refactor: controller could panic in scaling events with analysis

### DIFF
--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -394,6 +394,10 @@ func (c *rolloutContext) syncRolloutStatusCanary() error {
 }
 
 func (c *rolloutContext) reconcileCanaryReplicaSets() (bool, error) {
+	if haltReason := c.haltProgress(); haltReason != "" {
+		c.log.Infof("Skipping canary/stable ReplicaSet reconciliation: %s", haltReason)
+		return false, nil
+	}
 	err := c.removeScaleDownDeadlines()
 	if err != nil {
 		return false, err

--- a/rollout/service.go
+++ b/rollout/service.go
@@ -76,6 +76,10 @@ func (c *rolloutContext) reconcilePreviewService(previewSvc *corev1.Service) err
 	if previewSvc == nil {
 		return nil
 	}
+	if haltReason := c.haltProgress(); haltReason != "" {
+		c.log.Infof("Skipping preview service reconciliation: %s", haltReason)
+		return nil
+	}
 	newPodHash := c.newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 	err := c.switchServiceSelector(previewSvc, newPodHash, c.rollout)
 	if err != nil {
@@ -86,6 +90,10 @@ func (c *rolloutContext) reconcilePreviewService(previewSvc *corev1.Service) err
 }
 
 func (c *rolloutContext) reconcileActiveService(activeSvc *corev1.Service) error {
+	if haltReason := c.haltProgress(); haltReason != "" {
+		c.log.Infof("Skipping active service reconciliation: %s", haltReason)
+		return nil
+	}
 	if !replicasetutil.ReadyForPause(c.rollout, c.newRS, c.allRSs) || !annotations.IsSaturated(c.rollout, c.newRS) {
 		c.log.Infof("skipping active service switch: New RS '%s' is not fully saturated", c.newRS.Name)
 		return nil


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/1696

The panic in https://github.com/argoproj/argo-rollouts/issues/1696 is caused by an unfrequented executed code path that happens during scaling events. The original code of syncReplicasOnly written 3 years ago was only supposed to adjust replica counts and nothing else. But it somehow evolved to do redundant work.

This change is a refactoring that eliminates the redundant work done in syncReplicasOnly such that it goes back to the original behavior of scaling the ReplicaSets and nothing else, which simplifies our logic.