### PR TITLE
chore: fix flaky TestAbortRolloutAfterFailedExperiment test

### DIFF
--- a/rollout/experiment_test.go
+++ b/rollout/experiment_test.go
@@ -5,14 +5,15 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/uuid"
-
-	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
-	"github.com/argoproj/argo-rollouts/utils/conditions"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/utils/pointer"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/argoproj/argo-rollouts/utils/conditions"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 func TestRolloutCreateExperiment(t *testing.T) {
@@ -308,7 +309,7 @@ func TestAbortRolloutAfterFailedExperiment(t *testing.T) {
 			"message": "%s: %s"
 		}
 	}`
-	now := metav1.Now().UTC().Format(time.RFC3339)
+	now := timeutil.Now().UTC().Format(time.RFC3339)
 	generatedConditions := generateConditionsPatch(true, conditions.RolloutAbortedReason, r2, false, "")
 	assert.Equal(t, calculatePatch(r2, fmt.Sprintf(expectedPatch, now, generatedConditions, conditions.RolloutAbortedReason, fmt.Sprintf(conditions.RolloutAbortedMessage, 2))), patch)
 }


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR fixes flackiness in TestAbortRolloutAfterFailedExperiment introduced by https://github.com/argoproj/argo-rollouts/pull/1654

```
go test -run TestAbortRolloutAfterFailedExperiment github.com/argoproj/argo-rollouts/rollout  -count 100
ok  	github.com/argoproj/argo-rollouts/rollout	21.187s
```