### PR TITLE
feat(analysis): Add Measurements Length Option for Dry-Run Metrics

### DIFF
--- a/controller/metrics/analysis.go
+++ b/controller/metrics/analysis.go
@@ -91,12 +91,16 @@ func collectAnalysisRuns(ch chan<- prometheus.Metric, ar *v1alpha1.AnalysisRun) 
 		if metricResult != nil {
 			calculatedPhase = metricResult.Phase
 		}
-		addGauge(MetricAnalysisRunMetricPhase, boolFloat64(calculatedPhase == v1alpha1.AnalysisPhasePending || calculatedPhase == ""), metric.Name, metricType, fmt.Sprint(dryRunMetricsMap[metric.Name]), string(v1alpha1.AnalysisPhasePending))
-		addGauge(MetricAnalysisRunMetricPhase, boolFloat64(calculatedPhase == v1alpha1.AnalysisPhaseError), metric.Name, metricType, fmt.Sprint(dryRunMetricsMap[metric.Name]), string(v1alpha1.AnalysisPhaseError))
-		addGauge(MetricAnalysisRunMetricPhase, boolFloat64(calculatedPhase == v1alpha1.AnalysisPhaseFailed), metric.Name, metricType, fmt.Sprint(dryRunMetricsMap[metric.Name]), string(v1alpha1.AnalysisPhaseFailed))
-		addGauge(MetricAnalysisRunMetricPhase, boolFloat64(calculatedPhase == v1alpha1.AnalysisPhaseSuccessful), metric.Name, metricType, fmt.Sprint(dryRunMetricsMap[metric.Name]), string(v1alpha1.AnalysisPhaseSuccessful))
-		addGauge(MetricAnalysisRunMetricPhase, boolFloat64(calculatedPhase == v1alpha1.AnalysisPhaseRunning), metric.Name, metricType, fmt.Sprint(dryRunMetricsMap[metric.Name]), string(v1alpha1.AnalysisPhaseRunning))
-		addGauge(MetricAnalysisRunMetricPhase, boolFloat64(calculatedPhase == v1alpha1.AnalysisPhaseInconclusive), metric.Name, metricType, fmt.Sprint(dryRunMetricsMap[metric.Name]), string(v1alpha1.AnalysisPhaseInconclusive))
+		isDryRunMetric := "No"
+		if dryRunMetricsMap[metric.Name] != nil {
+			isDryRunMetric = "Yes"
+		}
+		addGauge(MetricAnalysisRunMetricPhase, boolFloat64(calculatedPhase == v1alpha1.AnalysisPhasePending || calculatedPhase == ""), metric.Name, metricType, fmt.Sprint(isDryRunMetric), string(v1alpha1.AnalysisPhasePending))
+		addGauge(MetricAnalysisRunMetricPhase, boolFloat64(calculatedPhase == v1alpha1.AnalysisPhaseError), metric.Name, metricType, fmt.Sprint(isDryRunMetric), string(v1alpha1.AnalysisPhaseError))
+		addGauge(MetricAnalysisRunMetricPhase, boolFloat64(calculatedPhase == v1alpha1.AnalysisPhaseFailed), metric.Name, metricType, fmt.Sprint(isDryRunMetric), string(v1alpha1.AnalysisPhaseFailed))
+		addGauge(MetricAnalysisRunMetricPhase, boolFloat64(calculatedPhase == v1alpha1.AnalysisPhaseSuccessful), metric.Name, metricType, fmt.Sprint(isDryRunMetric), string(v1alpha1.AnalysisPhaseSuccessful))
+		addGauge(MetricAnalysisRunMetricPhase, boolFloat64(calculatedPhase == v1alpha1.AnalysisPhaseRunning), metric.Name, metricType, fmt.Sprint(isDryRunMetric), string(v1alpha1.AnalysisPhaseRunning))
+		addGauge(MetricAnalysisRunMetricPhase, boolFloat64(calculatedPhase == v1alpha1.AnalysisPhaseInconclusive), metric.Name, metricType, fmt.Sprint(isDryRunMetric), string(v1alpha1.AnalysisPhaseInconclusive))
 	}
 }
 

--- a/controller/metrics/analysis_test.go
+++ b/controller/metrics/analysis_test.go
@@ -22,13 +22,21 @@ metadata:
   name: http-benchmark-test-tr8rn
   namespace: jesse-test
 spec:
+  dryRun:
+  - metricName: web-metric-2
   metrics:
-  - name: webmetric
+  - name: web-metric-1
     provider:
       web:
         jsonPath: .
         url: https://www.google.com
     successCondition: "true"
+  - name: web-metric-2
+    provider:
+      web:
+        jsonPath: .
+        url: https://www.msn.com
+    successCondition: "false"
 status:
   metricResults:
   - consecutiveError: 5
@@ -39,7 +47,17 @@ status:
         of value'
       phase: Error
       startedAt: "2020-03-16T20:02:14Z"
-    name: webmetric
+    name: web-metric-1
+    phase: Error
+  - consecutiveError: 5
+    error: 5
+    measurements:
+    - finishedAt: "2020-03-16T20:02:15Z"
+      message: 'Could not parse JSON body: invalid character ''<'' looking for beginning
+        of value'
+      phase: Error
+      startedAt: "2020-03-16T20:02:14Z"
+    name: web-metric-2
     phase: Error
   phase: Error
   startedAt: "2020-03-16T20:02:15Z"
@@ -53,6 +71,8 @@ metadata:
   name: http-benchmark-test
   namespace: jesse-test
 spec:
+  dryRun:
+  - metricName: web-metric-2
   metrics:
   - name: web-metric-1
     provider:
@@ -61,7 +81,6 @@ spec:
         url: https://www.google.com
     successCondition: "true"
   - name: web-metric-2
-    dryRun: true
     provider:
       web:
         jsonPath: .
@@ -76,6 +95,8 @@ metadata:
   creationTimestamp: "2020-03-16T20:01:13Z"
   name: http-benchmark-cluster-test
 spec:
+  dryRun:
+  - metricName: web-metric-2
   metrics:
   - name: web-metric-1
     provider:
@@ -84,7 +105,6 @@ spec:
         url: https://www.google.com
     successCondition: "true"
   - name: web-metric-2
-    dryRun: true
     provider:
       web:
         jsonPath: .
@@ -97,15 +117,22 @@ const expectedAnalysisRunResponse = `# HELP analysis_run_info Information about 
 analysis_run_info{name="http-benchmark-test-tr8rn",namespace="jesse-test",phase="Error"} 1
 # HELP analysis_run_metric_phase Information on the duration of a specific metric in the Analysis Run
 # TYPE analysis_run_metric_phase gauge
-analysis_run_metric_phase{dry_run="false",metric="webmetric",name="http-benchmark-test-tr8rn",namespace="jesse-test",phase="Error",type="Web"} 1
-analysis_run_metric_phase{dry_run="false",metric="webmetric",name="http-benchmark-test-tr8rn",namespace="jesse-test",phase="Failed",type="Web"} 0
-analysis_run_metric_phase{dry_run="false",metric="webmetric",name="http-benchmark-test-tr8rn",namespace="jesse-test",phase="Inconclusive",type="Web"} 0
-analysis_run_metric_phase{dry_run="false",metric="webmetric",name="http-benchmark-test-tr8rn",namespace="jesse-test",phase="Pending",type="Web"} 0
-analysis_run_metric_phase{dry_run="false",metric="webmetric",name="http-benchmark-test-tr8rn",namespace="jesse-test",phase="Running",type="Web"} 0
-analysis_run_metric_phase{dry_run="false",metric="webmetric",name="http-benchmark-test-tr8rn",namespace="jesse-test",phase="Successful",type="Web"} 0
+analysis_run_metric_phase{dry_run="No",metric="web-metric-1",name="http-benchmark-test-tr8rn",namespace="jesse-test",phase="Error",type="Web"} 1
+analysis_run_metric_phase{dry_run="No",metric="web-metric-1",name="http-benchmark-test-tr8rn",namespace="jesse-test",phase="Failed",type="Web"} 0
+analysis_run_metric_phase{dry_run="No",metric="web-metric-1",name="http-benchmark-test-tr8rn",namespace="jesse-test",phase="Inconclusive",type="Web"} 0
+analysis_run_metric_phase{dry_run="No",metric="web-metric-1",name="http-benchmark-test-tr8rn",namespace="jesse-test",phase="Pending",type="Web"} 0
+analysis_run_metric_phase{dry_run="No",metric="web-metric-1",name="http-benchmark-test-tr8rn",namespace="jesse-test",phase="Running",type="Web"} 0
+analysis_run_metric_phase{dry_run="No",metric="web-metric-1",name="http-benchmark-test-tr8rn",namespace="jesse-test",phase="Successful",type="Web"} 0
+analysis_run_metric_phase{dry_run="Yes",metric="web-metric-2",name="http-benchmark-test-tr8rn",namespace="jesse-test",phase="Error",type="Web"} 1
+analysis_run_metric_phase{dry_run="Yes",metric="web-metric-2",name="http-benchmark-test-tr8rn",namespace="jesse-test",phase="Failed",type="Web"} 0
+analysis_run_metric_phase{dry_run="Yes",metric="web-metric-2",name="http-benchmark-test-tr8rn",namespace="jesse-test",phase="Inconclusive",type="Web"} 0
+analysis_run_metric_phase{dry_run="Yes",metric="web-metric-2",name="http-benchmark-test-tr8rn",namespace="jesse-test",phase="Pending",type="Web"} 0
+analysis_run_metric_phase{dry_run="Yes",metric="web-metric-2",name="http-benchmark-test-tr8rn",namespace="jesse-test",phase="Running",type="Web"} 0
+analysis_run_metric_phase{dry_run="Yes",metric="web-metric-2",name="http-benchmark-test-tr8rn",namespace="jesse-test",phase="Successful",type="Web"} 0
 # HELP analysis_run_metric_type Information on the type of a specific metric in the Analysis Runs
 # TYPE analysis_run_metric_type gauge
-analysis_run_metric_type{metric="webmetric",name="http-benchmark-test-tr8rn",namespace="jesse-test",type="Web"} 1
+analysis_run_metric_type{metric="web-metric-1",name="http-benchmark-test-tr8rn",namespace="jesse-test",type="Web"} 1
+analysis_run_metric_type{metric="web-metric-2",name="http-benchmark-test-tr8rn",namespace="jesse-test",type="Web"} 1
 # HELP analysis_run_phase Information on the state of the Analysis Run (DEPRECATED - use analysis_run_info)
 # TYPE analysis_run_phase gauge
 analysis_run_phase{name="http-benchmark-test-tr8rn",namespace="jesse-test",phase="Error"} 1

--- a/docs/features/analysis.md
+++ b/docs/features/analysis.md
@@ -554,9 +554,13 @@ out as inconclusive.
 The following example queries prometheus every 5 minutes to get the total number of 4XX and 5XX errors, and even if the
 evaluation of the metric to monitor the 5XX error-rate fail, the analysis run will pass.
 
-```yaml hl_lines="1 2"
+```yaml hl_lines="1 2 3 4 5 6"
   dryRun:
   - metricName: total-5xx-errors
+    # `measurementsLength` can be used to retain more than ten results for the metrics running in the dry-run mode. 
+    # Setting it to `0` will disable this option and, the controller will revert to the existing behavior of retaining 
+    # the latest ten measurements.
+    measurementsLength: 25
   metrics:
   - name: total-5xx-errors
     interval: 5m
@@ -713,7 +717,7 @@ A use case for having `Inconclusive` analysis runs are to enable Argo Rollouts t
 whether or not measurement value is acceptable and decide to proceed or abort.
 
 ## Delay Analysis Runs
-If the analysis run does not need to start immediately (i.e give the metric provider time to collect
+If the analysis run does not need to start immediately (i.e. give the metric provider time to collect
 metrics on the canary version), Analysis Runs can delay the specific metric analysis. Each metric
 can be configured to have a different delay. In additional to the metric specific delays, the rollouts
 with background analysis can delay creating an analysis run until a certain step is reached

--- a/manifests/crds/analysis-run-crd.yaml
+++ b/manifests/crds/analysis-run-crd.yaml
@@ -71,6 +71,8 @@ spec:
               dryRun:
                 items:
                   properties:
+                    measurementsLength:
+                      type: integer
                     metricName:
                       type: string
                   required:

--- a/manifests/crds/analysis-template-crd.yaml
+++ b/manifests/crds/analysis-template-crd.yaml
@@ -67,6 +67,8 @@ spec:
               dryRun:
                 items:
                   properties:
+                    measurementsLength:
+                      type: integer
                     metricName:
                       type: string
                   required:

--- a/manifests/crds/cluster-analysis-template-crd.yaml
+++ b/manifests/crds/cluster-analysis-template-crd.yaml
@@ -67,6 +67,8 @@ spec:
               dryRun:
                 items:
                   properties:
+                    measurementsLength:
+                      type: integer
                     metricName:
                       type: string
                   required:

--- a/manifests/crds/experiment-crd.yaml
+++ b/manifests/crds/experiment-crd.yaml
@@ -87,6 +87,8 @@ spec:
               dryRun:
                 items:
                   properties:
+                    measurementsLength:
+                      type: integer
                     metricName:
                       type: string
                   required:

--- a/manifests/crds/rollout-crd.yaml
+++ b/manifests/crds/rollout-crd.yaml
@@ -173,6 +173,8 @@ spec:
                           dryRun:
                             items:
                               properties:
+                                measurementsLength:
+                                  type: integer
                                 metricName:
                                   type: string
                               required:
@@ -217,6 +219,8 @@ spec:
                           dryRun:
                             items:
                               properties:
+                                measurementsLength:
+                                  type: integer
                                 metricName:
                                   type: string
                               required:
@@ -291,6 +295,8 @@ spec:
                           dryRun:
                             items:
                               properties:
+                                measurementsLength:
+                                  type: integer
                                 metricName:
                                   type: string
                               required:
@@ -398,6 +404,8 @@ spec:
                                 dryRun:
                                   items:
                                     properties:
+                                      measurementsLength:
+                                        type: integer
                                       metricName:
                                         type: string
                                     required:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -72,6 +72,8 @@ spec:
               dryRun:
                 items:
                   properties:
+                    measurementsLength:
+                      type: integer
                     metricName:
                       type: string
                   required:
@@ -2809,6 +2811,8 @@ spec:
               dryRun:
                 items:
                   properties:
+                    measurementsLength:
+                      type: integer
                     metricName:
                       type: string
                   required:
@@ -5436,6 +5440,8 @@ spec:
               dryRun:
                 items:
                   properties:
+                    measurementsLength:
+                      type: integer
                     metricName:
                       type: string
                   required:
@@ -8083,6 +8089,8 @@ spec:
               dryRun:
                 items:
                   properties:
+                    measurementsLength:
+                      type: integer
                     metricName:
                       type: string
                   required:
@@ -10645,6 +10653,8 @@ spec:
                           dryRun:
                             items:
                               properties:
+                                measurementsLength:
+                                  type: integer
                                 metricName:
                                   type: string
                               required:
@@ -10689,6 +10699,8 @@ spec:
                           dryRun:
                             items:
                               properties:
+                                measurementsLength:
+                                  type: integer
                                 metricName:
                                   type: string
                               required:
@@ -10763,6 +10775,8 @@ spec:
                           dryRun:
                             items:
                               properties:
+                                measurementsLength:
+                                  type: integer
                                 metricName:
                                   type: string
                               required:
@@ -10870,6 +10884,8 @@ spec:
                                 dryRun:
                                   items:
                                     properties:
+                                      measurementsLength:
+                                        type: integer
                                       metricName:
                                         type: string
                                     required:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -72,6 +72,8 @@ spec:
               dryRun:
                 items:
                   properties:
+                    measurementsLength:
+                      type: integer
                     metricName:
                       type: string
                   required:
@@ -2809,6 +2811,8 @@ spec:
               dryRun:
                 items:
                   properties:
+                    measurementsLength:
+                      type: integer
                     metricName:
                       type: string
                   required:
@@ -5436,6 +5440,8 @@ spec:
               dryRun:
                 items:
                   properties:
+                    measurementsLength:
+                      type: integer
                     metricName:
                       type: string
                   required:
@@ -8083,6 +8089,8 @@ spec:
               dryRun:
                 items:
                   properties:
+                    measurementsLength:
+                      type: integer
                     metricName:
                       type: string
                   required:
@@ -10645,6 +10653,8 @@ spec:
                           dryRun:
                             items:
                               properties:
+                                measurementsLength:
+                                  type: integer
                                 metricName:
                                   type: string
                               required:
@@ -10689,6 +10699,8 @@ spec:
                           dryRun:
                             items:
                               properties:
+                                measurementsLength:
+                                  type: integer
                                 metricName:
                                   type: string
                               required:
@@ -10763,6 +10775,8 @@ spec:
                           dryRun:
                             items:
                               properties:
+                                measurementsLength:
+                                  type: integer
                                 metricName:
                                   type: string
                               required:
@@ -10870,6 +10884,8 @@ spec:
                                 dryRun:
                                   items:
                                     properties:
+                                      measurementsLength:
+                                        type: integer
                                       metricName:
                                         type: string
                                     required:

--- a/pkg/apiclient/rollout/rollout.swagger.json
+++ b/pkg/apiclient/rollout/rollout.swagger.json
@@ -839,6 +839,11 @@
         "metricName": {
           "type": "string",
           "description": "Name of the metric which needs to be evaluated in the Dry-Run mode. Wildcard '*' is supported and denotes all\nthe available metrics."
+        },
+        "measurementsLength": {
+          "type": "string",
+          "format": "int64",
+          "description": "MeasurementsLength indicates how many measurements to retain for this metric when it's running in the Dry-Run\nmode."
         }
       },
       "description": "DryRun defines the settings for running the analysis in Dry-Run mode."

--- a/pkg/apis/rollouts/v1alpha1/analysis_types.go
+++ b/pkg/apis/rollouts/v1alpha1/analysis_types.go
@@ -118,6 +118,9 @@ type DryRun struct {
 	// Name of the metric which needs to be evaluated in the Dry-Run mode. Wildcard '*' is supported and denotes all
 	// the available metrics.
 	MetricName string `json:"metricName" protobuf:"bytes,1,opt,name=metricName"`
+	// MeasurementsLength indicates how many measurements to retain for this metric when it's running in the Dry-Run
+	// mode.
+	MeasurementsLength int `json:"measurementsLength,omitempty" protobuf:"varint,2,opt,name=measurementsLength"`
 }
 
 // EffectiveCount is the effective count based on whether or not count/interval is specified

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -1760,8 +1760,17 @@ func TestWriteBackToInformer(t *testing.T) {
 
 	// Verify the informer was updated with the new unstructured object after reconciliation
 	obj, _, _ := c.rolloutsIndexer.GetByKey(roKey)
-	un := obj.(*unstructured.Unstructured)
-	stableRS, _, _ := unstructured.NestedString(un.Object, "status", "stableRS")
+	stableRS := ""
+	switch objType := obj.(type) {
+	case *unstructured.Unstructured:
+		un := obj.(*unstructured.Unstructured)
+		stableRS, _, _ = unstructured.NestedString(un.Object, "status", "stableRS")
+	case *v1alpha1.Rollout:
+		rollout := obj.(*v1alpha1.Rollout)
+		stableRS = rollout.Status.StableRS
+	default:
+		fmt.Println("Unknown Type:", objType)
+	}
 	assert.NotEmpty(t, stableRS)
 	assert.Equal(t, rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey], stableRS)
 }

--- a/utils/analysis/helpers.go
+++ b/utils/analysis/helpers.go
@@ -94,8 +94,8 @@ func IsTerminating(run *v1alpha1.AnalysisRun) bool {
 }
 
 // GetDryRunMetrics returns an array of metric names matching the RegEx rules from the Dry-Run metrics.
-func GetDryRunMetrics(dryRunMetrics []v1alpha1.DryRun, metrics []v1alpha1.Metric) (map[string]bool, error) {
-	metricsMap := make(map[string]bool)
+func GetDryRunMetrics(dryRunMetrics []v1alpha1.DryRun, metrics []v1alpha1.Metric) (map[string]*v1alpha1.DryRun, error) {
+	metricsMap := make(map[string]*v1alpha1.DryRun)
 	if len(dryRunMetrics) == 0 {
 		return metricsMap, nil
 	}
@@ -104,7 +104,7 @@ func GetDryRunMetrics(dryRunMetrics []v1alpha1.DryRun, metrics []v1alpha1.Metric
 		matchCount := 0
 		for _, metric := range metrics {
 			if matched, _ := regexp.MatchString(dryRunObject.MetricName, metric.Name); matched {
-				metricsMap[metric.Name] = true
+				metricsMap[metric.Name] = &dryRunObject
 				matchCount++
 			}
 		}

--- a/utils/analysis/helpers_test.go
+++ b/utils/analysis/helpers_test.go
@@ -838,7 +838,7 @@ func TestGetDryRunMetrics(t *testing.T) {
 		}
 		dryRunMetricNamesMap, err := GetDryRunMetrics(spec.DryRun, spec.Metrics)
 		assert.Nil(t, err)
-		assert.True(t, dryRunMetricNamesMap["success-rate"])
+		assert.NotNil(t, dryRunMetricNamesMap["success-rate"])
 	})
 	t.Run("GetDryRunMetrics handles the RegEx rules", func(t *testing.T) {
 		failureLimit := intstr.FromInt(2)


### PR DESCRIPTION
# Description

It could be very useful to retain the maximum data points while running an analysis in the dry-run mode to understand what caused a particular metric to error out or why the final result came out as inconclusive. 

Currently, the controller only retains the ten latest measurements and it's not possible to configure/change this value as its hard-coded in the code.

# Changes

This PR adds a new option called `measurementsLength` in the `dryRun` which can be used to retain other than the latest ten results for the metrics running in the dry-run mode. Setting this option to `0` would disable it and, the controller will revert back to the existing behavior of retaining the latest ten measurements.

# Checklist

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [X] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [X] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My builds are green. Try syncing with master if they are not. 
* [X] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

---
**Signed-off-by:** Rohit Agrawal <rohit.agrawal@databricks.com>