### PR TITLE
fix(plugin): Fixes arm64 compatibility to plugin docker image. Fixes #1728

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,8 +128,11 @@ jobs:
           draft: true
           files: |
             dist/kubectl-argo-rollouts-linux-amd64
+            dist/kubectl-argo-rollouts-linux-arm64
             dist/kubectl-argo-rollouts-darwin-amd64
+            dist/kubectl-argo-rollouts-darwin-arm64
             dist/kubectl-argo-rollouts-windows-amd64
+            dist/kubectl-argo-rollouts-windows-arm64
             manifests/dashboard-install.yaml
             manifests/install.yaml
             manifests/namespace-install.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,11 +1,9 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: Git tag to build release from
-        required: true
+  push:
+    tags:
+      - 'v*.*.*'  
 
 jobs:
   release-images:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            quay.io/argoproj/argo-rollouts
+            quay.io/cguertin14/argo-rollouts
           # ghcr.io/argoproj/argo-rollouts
           tags: |
             type=semver,pattern={{version}},prefix=v,value=${{ github.event.inputs.tag }}
@@ -55,7 +55,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            quay.io/argoproj/kubectl-argo-rollouts
+            quay.io/cguertin14/kubectl-argo-rollouts
           #  ghcr.io/argoproj/kubectl-argo-rollouts
           tags: |
             type=semver,pattern={{version}},prefix=v,value=${{ github.event.inputs.tag }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,9 +128,7 @@ jobs:
             dist/kubectl-argo-rollouts-linux-amd64
             dist/kubectl-argo-rollouts-linux-arm64
             dist/kubectl-argo-rollouts-darwin-amd64
-            dist/kubectl-argo-rollouts-darwin-arm64
             dist/kubectl-argo-rollouts-windows-amd64
-            dist/kubectl-argo-rollouts-windows-arm64
             manifests/dashboard-install.yaml
             manifests/install.yaml
             manifests/namespace-install.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,10 +1,11 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'  
-
+  workflow_dispatch:                                                                                                         
+    inputs:                                                                                                                  
+      tag:                                                                                                                   
+        description: Git tag to build release from                                                                           
+        required: true  
 jobs:
   release-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            quay.io/cguertin14/argo-rollouts
+            quay.io/argoproj/argo-rollouts
           # ghcr.io/argoproj/argo-rollouts
           tags: |
             type=semver,pattern={{version}},prefix=v,value=${{ github.event.inputs.tag }}
@@ -53,7 +53,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            quay.io/cguertin14/kubectl-argo-rollouts
+            quay.io/argoproj/kubectl-argo-rollouts
           #  ghcr.io/argoproj/kubectl-argo-rollouts
           tags: |
             type=semver,pattern={{version}},prefix=v,value=${{ github.event.inputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN touch ui/dist/node_modules.marker && \
     touch ui/dist/app/index.html && \
     find ui/dist
 
-ARG MAKE_TARGET="controller plugin-linux plugin-darwin plugin-windows"
+ARG MAKE_TARGET="controller plugin plugin-linux plugin-darwin plugin-windows"
 RUN make ${MAKE_TARGET}
 
 ####################################################################################################
@@ -71,7 +71,7 @@ RUN make ${MAKE_TARGET}
 ####################################################################################################
 FROM docker.io/library/ubuntu:20.10 as kubectl-argo-rollouts
 
-COPY --from=argo-rollouts-build /go/src/github.com/argoproj/argo-rollouts/dist/kubectl-argo-rollouts-linux-amd64 /bin/kubectl-argo-rollouts
+COPY --from=argo-rollouts-build /go/src/github.com/argoproj/argo-rollouts/dist/kubectl-argo-rollouts /bin/kubectl-argo-rollouts
 
 USER 999
 

--- a/Makefile
+++ b/Makefile
@@ -197,13 +197,11 @@ plugin-linux: ui/dist
 plugin-darwin: ui/dist
 	cp -r ui/dist/app/* server/static
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${PLUGIN_CLI_NAME}-darwin-amd64 ./cmd/kubectl-argo-rollouts
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${PLUGIN_CLI_NAME}-darwin-arm64 ./cmd/kubectl-argo-rollouts
 
 .PHONY: plugin-windows
 plugin-windows: ui/dist
 	cp -r ui/dist/app/* server/static
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${PLUGIN_CLI_NAME}-windows-amd64 ./cmd/kubectl-argo-rollouts
-	CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${PLUGIN_CLI_NAME}-windows-arm64 ./cmd/kubectl-argo-rollouts
 
 .PHONY: docs
 docs:

--- a/Makefile
+++ b/Makefile
@@ -191,16 +191,19 @@ ui/dist:
 plugin-linux: ui/dist
 	cp -r ui/dist/app/* server/static
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${PLUGIN_CLI_NAME}-linux-amd64 ./cmd/kubectl-argo-rollouts
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${PLUGIN_CLI_NAME}-linux-arm64 ./cmd/kubectl-argo-rollouts
 
 .PHONY: plugin-darwin
 plugin-darwin: ui/dist
 	cp -r ui/dist/app/* server/static
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${PLUGIN_CLI_NAME}-darwin-amd64 ./cmd/kubectl-argo-rollouts
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${PLUGIN_CLI_NAME}-darwin-arm64 ./cmd/kubectl-argo-rollouts
 
 .PHONY: plugin-windows
 plugin-windows: ui/dist
 	cp -r ui/dist/app/* server/static
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${PLUGIN_CLI_NAME}-windows-amd64 ./cmd/kubectl-argo-rollouts
+	CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${PLUGIN_CLI_NAME}-windows-arm64 ./cmd/kubectl-argo-rollouts
 
 .PHONY: docs
 docs:

--- a/hack/build-release-plugins.sh
+++ b/hack/build-release-plugins.sh
@@ -10,7 +10,7 @@ docker build --iidfile ${rollout_iid_file} --target argo-rollouts-build .
 rollout_iid=$(cat ${rollout_iid_file})
 container_id=$(docker create ${rollout_iid})
 
-for plat in linux-amd64 darwin-amd64 windows-amd64; do
+for plat in linux-amd64 linux-arm64 darwin-amd64 windows-amd64; do
     docker cp ${container_id}:/go/src/github.com/argoproj/argo-rollouts/dist/kubectl-argo-rollouts-${plat} ${SRCROOT}/dist
 done
 docker rm -v ${container_id}


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

## What's accomplished

The `quay.io/argoproj/kubectl-argo-rollouts` can now run on arm64 :D.
Closes #1728, which contains all the important details about this.

## Demo of the new fix

Wrote a quick demo using the new docker image which I pushed to my own Quay account for testing. We can see in the screenshot that the new Docker image runs smoothly on arm64 and the old one does not.

![image](https://user-images.githubusercontent.com/23645771/147586112-954781e4-be88-48db-87e3-5c380183f9ba.png)
