### PR TITLE
fix: Traffic weight error after last step. Fixes #1734

### DIFF
--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -118,7 +118,8 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 		}
 
 		if rolloututil.IsFullyPromoted(c.rollout) {
-			// when we are fully promoted. desired canary weight should be 0
+			// when we are fully promoted. desired canary weight should be 100
+			desiredWeight = 100
 		} else if c.pauseContext.IsAborted() {
 			// when aborted, desired canary weight should be 0 (100% to stable), *unless* we
 			// are using dynamic stable scaling. In that case, we can only decrease canary weight


### PR DESCRIPTION
After finish the last step in destinationrule stableRS=oldRS、canaryRS=newRS, but rollouts.Status.StableRS==rollouts.Status.CurrentPodHash,  DesiredWeight=0 causes traffic to request oldRS.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).