### PR TITLE
docs: Remove duplicate sentence 

### DIFF
--- a/docs/features/analysis.md
+++ b/docs/features/analysis.md
@@ -633,8 +633,7 @@ Metric Results:
 
 ### Dry-Run Rollouts
 
-If a rollout wants to dry run its analysis, it simply needs to specify the `dryRun` field to its `analysis` stanza. If a
-rollout wants to dry run its analysis, it simply needs to specify the `dryRun` field to its `analysis` stanza. In the 
+If a rollout wants to dry run its analysis, it simply needs to specify the `dryRun` field to its `analysis` stanza. In the 
 following example, all the metrics from `random-fail` and `always-pass` get merged and executed in the dry-run mode.
 
 ```yaml hl_lines="9 10"


### PR DESCRIPTION
This removes a duplicate sentence in dry-run docs

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).