### PR TITLE
fix: traffic routed canary would flap traffic to stable after last step

### DIFF
--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -140,16 +140,16 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 						break
 					}
 				}
+				weightDestinations = append(weightDestinations, c.calculateWeightDestinationsFromExperiment()...)
 			} else if *index != int32(len(c.rollout.Spec.Strategy.Canary.Steps)) {
-				// This if statement prevents the desiredWeight from being set to 100
-				// when the rollout has progressed through all the steps. The rollout
-				// should send all traffic to the stable service by using a weight of
-				// 0. If the rollout is progressing through the steps, the desired
+				// If the rollout is progressing through the steps, the desired
 				// weight of the traffic routing service should be at the value of the
 				// last setWeight step, which is set by GetCurrentSetWeight.
 				desiredWeight = replicasetutil.GetCurrentSetWeight(c.rollout)
+				weightDestinations = append(weightDestinations, c.calculateWeightDestinationsFromExperiment()...)
+			} else {
+				desiredWeight = 100
 			}
-			weightDestinations = append(weightDestinations, c.calculateWeightDestinationsFromExperiment()...)
 		}
 
 		err = reconciler.UpdateHash(canaryHash, stableHash, weightDestinations...)


### PR DESCRIPTION
Signed-off-by: Andrii Perenesenko <andrii.perenesenko@gmail.com>

Fix: https://github.com/argoproj/argo-rollouts/issues/1718

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).