### PR TITLE
fix: delay service injection of selector labels until ReplicaSet available

### DIFF
--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -220,10 +220,9 @@ func (c *rolloutContext) scaleDownOldReplicaSetsForCanary(oldRSs []*appsv1.Repli
 					// It is safe to scale the intermediate RS down, if no traffic is directed to it.
 					c.log.Infof("scaling down intermediate RS '%s'", targetRS.Name)
 				} else {
-					c.log.Infof("DEBUG CANNOT scaling down intermediate RS '%s'", targetRS.Name)
-					// The current and stable ReplicaSets have not reached readiness. This implies
-					// we might not have shifted traffic away from this ReplicaSet so we need to
-					// keep this scaled up.
+					c.log.Infof("Skip scaling down intermediate RS '%s': still referenced by service", targetRS.Name)
+					// This ReplicaSet is still referenced by the service. It is not safe to scale
+					// this down.
 					continue
 				}
 			}

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -1186,13 +1186,13 @@ func TestCanaryRolloutWithCanaryService(t *testing.T) {
 func TestCanarySVCSelectors(t *testing.T) {
 	for _, tc := range []struct {
 		canaryReplicas      int32
-		canaryReadyReplicas int32
+		canaryAvailReplicas int32
 
 		shouldTargetNewRS bool
 	}{
 		{0, 0, false},
 		{2, 0, false},
-		{2, 1, false},
+		{2, 1, true},
 		{2, 2, true},
 	} {
 		namespace := "namespace"
@@ -1247,7 +1247,7 @@ func TestCanarySVCSelectors(t *testing.T) {
 					Replicas: pointer.Int32Ptr(tc.canaryReplicas),
 				},
 				Status: v1.ReplicaSetStatus{
-					ReadyReplicas: tc.canaryReadyReplicas,
+					AvailableReplicas: tc.canaryAvailReplicas,
 				},
 			},
 			stableRS: &v1.ReplicaSet{
@@ -1267,12 +1267,12 @@ func TestCanarySVCSelectors(t *testing.T) {
 		assert.NoError(t, err, "unable to get updated canary service")
 		if tc.shouldTargetNewRS {
 			assert.Equal(t, selectorNewRSVal, updatedCanarySVC.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey],
-				"canary SVC should have newRS selector label when newRS has %d replicas and %d ReadyReplicas",
-				tc.canaryReplicas, tc.canaryReadyReplicas)
+				"canary SVC should have newRS selector label when newRS has %d replicas and %d AvailableReplicas",
+				tc.canaryReplicas, tc.canaryAvailReplicas)
 		} else {
 			assert.Empty(t, updatedCanarySVC.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey],
-				"canary SVC should not have newRS selector label when newRS has %d replicas and %d ReadyReplicas",
-				tc.canaryReplicas, tc.canaryReadyReplicas)
+				"canary SVC should not have newRS selector label when newRS has %d replicas and %d AvailableReplicas",
+				tc.canaryReplicas, tc.canaryAvailReplicas)
 		}
 	}
 }

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -1192,7 +1192,7 @@ func TestCanarySVCSelectors(t *testing.T) {
 	}{
 		{0, 0, false},
 		{2, 0, false},
-		{2, 1, true},
+		{2, 1, false},
 		{2, 2, true},
 	} {
 		namespace := "namespace"

--- a/rollout/service.go
+++ b/rollout/service.go
@@ -240,16 +240,15 @@ func (c *rolloutContext) reconcileStableAndCanaryService() error {
 	if err != nil {
 		return err
 	}
-
-	if replicasetutil.IsReplicaSetReady(c.newRS) {
-		err = c.ensureSVCTargets(c.rollout.Spec.Strategy.Canary.CanaryService, c.newRS)
-		if err != nil {
-			return err
-		}
+	err = c.ensureSVCTargets(c.rollout.Spec.Strategy.Canary.CanaryService, c.newRS)
+	if err != nil {
+		return err
 	}
 	return nil
 }
 
+// ensureSVCTargets updates the service with the given name to point to the given ReplicaSet,
+// but only if that ReplicaSet has availability.
 func (c *rolloutContext) ensureSVCTargets(svcName string, rs *appsv1.ReplicaSet) error {
 	if rs == nil || svcName == "" {
 		return nil
@@ -258,8 +257,16 @@ func (c *rolloutContext) ensureSVCTargets(svcName string, rs *appsv1.ReplicaSet)
 	if err != nil {
 		return err
 	}
-	if svc.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey] != rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] {
-		err = c.switchServiceSelector(svc, rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey], c.rollout)
+	currSelector := svc.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey]
+	desiredSelector := rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	if currSelector != desiredSelector {
+		// ensure we have available replicas, otherwise we will point the service to nothing
+		if rs.Status.AvailableReplicas == 0 {
+			logCtx := c.log.WithField(logutil.ServiceKey, svc.Name)
+			logCtx.Infof("delaying service switch from %s to %s: ReplicaSet not yet available", currSelector, desiredSelector)
+			return nil
+		}
+		err = c.switchServiceSelector(svc, desiredSelector, c.rollout)
 		if err != nil {
 			return err
 		}

--- a/rollout/service.go
+++ b/rollout/service.go
@@ -248,7 +248,7 @@ func (c *rolloutContext) reconcileStableAndCanaryService() error {
 }
 
 // ensureSVCTargets updates the service with the given name to point to the given ReplicaSet,
-// but only if that ReplicaSet has availability.
+// but only if that ReplicaSet has full availability.
 func (c *rolloutContext) ensureSVCTargets(svcName string, rs *appsv1.ReplicaSet) error {
 	if rs == nil || svcName == "" {
 		return nil
@@ -260,10 +260,10 @@ func (c *rolloutContext) ensureSVCTargets(svcName string, rs *appsv1.ReplicaSet)
 	currSelector := svc.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey]
 	desiredSelector := rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 	if currSelector != desiredSelector {
-		// ensure we have available replicas, otherwise we will point the service to nothing
-		if rs.Status.AvailableReplicas == 0 {
+		// ensure ReplicaSet is fully available, otherwise we will point the service to nothing or an underprovisioned ReplicaSet
+		if !replicasetutil.IsReplicaSetAvailable(rs) {
 			logCtx := c.log.WithField(logutil.ServiceKey, svc.Name)
-			logCtx.Infof("delaying service switch from %s to %s: ReplicaSet not yet available", currSelector, desiredSelector)
+			logCtx.Infof("delaying service switch from %s to %s: ReplicaSet not fully available", currSelector, desiredSelector)
 			return nil
 		}
 		err = c.switchServiceSelector(svc, desiredSelector, c.rollout)

--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -623,12 +623,12 @@ func GetPodsOwnedByReplicaSet(ctx context.Context, client kubernetes.Interface, 
 	return podOwnedByRS, nil
 }
 
-// IsReplicaSetReady returns if a ReplicaSet is scaled up and its ready count is >= desired count
-func IsReplicaSetReady(rs *appsv1.ReplicaSet) bool {
+// IsReplicaSetAvailable returns if a ReplicaSet is scaled up and its ready count is >= desired count
+func IsReplicaSetAvailable(rs *appsv1.ReplicaSet) bool {
 	if rs == nil {
 		return false
 	}
 	replicas := rs.Spec.Replicas
-	readyReplicas := rs.Status.ReadyReplicas
-	return replicas != nil && *replicas != 0 && readyReplicas != 0 && *replicas <= readyReplicas
+	availableReplicas := rs.Status.AvailableReplicas
+	return replicas != nil && *replicas != 0 && availableReplicas != 0 && *replicas <= availableReplicas
 }

--- a/utils/replicaset/replicaset_test.go
+++ b/utils/replicaset/replicaset_test.go
@@ -1249,9 +1249,9 @@ spec:
 	assert.True(t, PodTemplateEqualIgnoreHash(&live, &desired))
 }
 
-func TestIsReplicaSetReady(t *testing.T) {
+func TestIsReplicaSetAvailable(t *testing.T) {
 	{
-		assert.False(t, IsReplicaSetReady(nil))
+		assert.False(t, IsReplicaSetAvailable(nil))
 	}
 	{
 		rs := appsv1.ReplicaSet{
@@ -1259,10 +1259,11 @@ func TestIsReplicaSetReady(t *testing.T) {
 				Replicas: pointer.Int32Ptr(1),
 			},
 			Status: appsv1.ReplicaSetStatus{
-				ReadyReplicas: 0,
+				ReadyReplicas:     0,
+				AvailableReplicas: 0,
 			},
 		}
-		assert.False(t, IsReplicaSetReady(&rs))
+		assert.False(t, IsReplicaSetAvailable(&rs))
 	}
 	{
 		rs := appsv1.ReplicaSet{
@@ -1270,10 +1271,11 @@ func TestIsReplicaSetReady(t *testing.T) {
 				Replicas: pointer.Int32Ptr(1),
 			},
 			Status: appsv1.ReplicaSetStatus{
-				ReadyReplicas: 1,
+				ReadyReplicas:     1,
+				AvailableReplicas: 1,
 			},
 		}
-		assert.True(t, IsReplicaSetReady(&rs))
+		assert.True(t, IsReplicaSetAvailable(&rs))
 	}
 	{
 		rs := appsv1.ReplicaSet{
@@ -1281,10 +1283,11 @@ func TestIsReplicaSetReady(t *testing.T) {
 				Replicas: pointer.Int32Ptr(1),
 			},
 			Status: appsv1.ReplicaSetStatus{
-				ReadyReplicas: 2,
+				ReadyReplicas:     2,
+				AvailableReplicas: 2,
 			},
 		}
-		assert.True(t, IsReplicaSetReady(&rs))
+		assert.True(t, IsReplicaSetAvailable(&rs))
 	}
 	{
 		rs := appsv1.ReplicaSet{
@@ -1292,10 +1295,23 @@ func TestIsReplicaSetReady(t *testing.T) {
 				Replicas: pointer.Int32Ptr(0),
 			},
 			Status: appsv1.ReplicaSetStatus{
-				ReadyReplicas: 0,
+				ReadyReplicas:     0,
+				AvailableReplicas: 0,
 			},
 		}
-		// NOTE: currently consider scaled down replicas as not ready
-		assert.False(t, IsReplicaSetReady(&rs))
+		// NOTE: currently consider scaled down replicas as not available
+		assert.False(t, IsReplicaSetAvailable(&rs))
+	}
+	{
+		rs := appsv1.ReplicaSet{
+			Spec: appsv1.ReplicaSetSpec{
+				Replicas: pointer.Int32Ptr(0),
+			},
+			Status: appsv1.ReplicaSetStatus{
+				ReadyReplicas:     1,
+				AvailableReplicas: 0,
+			},
+		}
+		assert.False(t, IsReplicaSetAvailable(&rs))
 	}
 }


### PR DESCRIPTION
This change delays the updating of the stable service selector unless the stable replicaset is ~ready~ available. This helps ensure we don't prematurely point the stable service to nothing in the event we are taking over a Service in the migration case, potentially causing downtime.

Resolves https://github.com/argoproj/argo-rollouts/issues/1731

Signed-off-by: Jesse Suen <jesse@akuity.io>
