### PR TITLE
fix: plugin did not set deployment image when using workloadRef

### DIFF
--- a/manifests/dashboard-install.yaml
+++ b/manifests/dashboard-install.yaml
@@ -53,6 +53,13 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - deployments
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - apps
+  resources:
   - replicasets
   verbs:
   - get

--- a/manifests/dashboard-install/dashboard-clusterrole.yaml
+++ b/manifests/dashboard-install/dashboard-clusterrole.yaml
@@ -43,6 +43,13 @@ rules:
   - apiGroups:
       - apps
     resources:
+      - deployments
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - apps
+    resources:
       - replicasets
     verbs:
       - get

--- a/pkg/kubectl-argo-rollouts/cmd/set/set_image.go
+++ b/pkg/kubectl-argo-rollouts/cmd/set/set_image.go
@@ -9,6 +9,7 @@ import (
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
@@ -44,8 +45,10 @@ func NewCmdSetImage(o *options.ArgoRolloutsOptions) *cobra.Command {
 			container := imageSplit[0]
 			image := imageSplit[1]
 
+			var un *unstructured.Unstructured
+			var err error
 			for attempt := 0; attempt < maxAttempts; attempt++ {
-				err := SetImage(o.DynamicClientset(), o.Namespace(), rollout, container, image)
+				un, err = SetImage(o.DynamicClientset(), o.Namespace(), rollout, container, image)
 				if err != nil {
 					if k8serr.IsConflict(err) && attempt < maxAttempts {
 						continue
@@ -54,33 +57,56 @@ func NewCmdSetImage(o *options.ArgoRolloutsOptions) *cobra.Command {
 				}
 				break
 			}
-			fmt.Fprintf(o.Out, "rollout \"%s\" image updated\n", rollout)
+			fmt.Fprintf(o.Out, "%s \"%s\" image updated\n", strings.ToLower(un.GetKind()), un.GetName())
 			return nil
 		},
 	}
 	return cmd
 }
 
+var deploymentGVR = schema.GroupVersionResource{
+	Group:    "apps",
+	Version:  "v1",
+	Resource: "deployments",
+}
+
 // SetImage updates a rollout's container image
 // We use a dynamic clientset instead of a rollout clientset in order to allow an older plugin
 // to still work with a newer version of Rollouts (without dropping newly introduced fields during
 // the marshalling)
-func SetImage(dynamicClient dynamic.Interface, namespace, rollout, container, image string) error {
+func SetImage(dynamicClient dynamic.Interface, namespace, rollout, container, image string) (*unstructured.Unstructured, error) {
 	ctx := context.TODO()
 	rolloutIf := dynamicClient.Resource(v1alpha1.RolloutGVR).Namespace(namespace)
 	ro, err := rolloutIf.Get(ctx, rollout, metav1.GetOptions{})
 	if err != nil {
-		return err
+		return nil, err
 	}
-	newRo, err := newRolloutSetImage(ro, container, image)
+	workloadRef, ok, err := unstructured.NestedMap(ro.Object, "spec", "workloadRef")
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = rolloutIf.Update(ctx, newRo, metav1.UpdateOptions{})
-	if err != nil {
-		return err
+	if ok {
+		deployIf := dynamicClient.Resource(deploymentGVR).Namespace(namespace)
+		deployName, ok := workloadRef["name"].(string)
+		if !ok {
+			return nil, fmt.Errorf("spec.workloadRef.name is not a string: %v", workloadRef["name"])
+		}
+		deployUn, err := deployIf.Get(ctx, deployName, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		newDeploy, err := newRolloutSetImage(deployUn, container, image)
+		if err != nil {
+			return nil, err
+		}
+		return deployIf.Update(ctx, newDeploy, metav1.UpdateOptions{})
+	} else {
+		newRo, err := newRolloutSetImage(ro, container, image)
+		if err != nil {
+			return nil, err
+		}
+		return rolloutIf.Update(ctx, newRo, metav1.UpdateOptions{})
 	}
-	return nil
 }
 
 func newRolloutSetImage(orig *unstructured.Unstructured, container string, image string) (*unstructured.Unstructured, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -397,7 +397,10 @@ func (s *ArgoRolloutsServer) getRollout(namespace string, name string) (*v1alpha
 
 func (s *ArgoRolloutsServer) SetRolloutImage(ctx context.Context, q *rollout.SetImageRequest) (*v1alpha1.Rollout, error) {
 	imageString := fmt.Sprintf("%s:%s", q.GetImage(), q.GetTag())
-	set.SetImage(s.Options.DynamicClientset, q.GetNamespace(), q.GetRollout(), q.GetContainer(), imageString)
+	_, err := set.SetImage(s.Options.DynamicClientset, q.GetNamespace(), q.GetRollout(), q.GetContainer(), imageString)
+	if err != nil {
+		return nil, err
+	}
 	return s.getRollout(q.GetNamespace(), q.GetRollout())
 }
 


### PR DESCRIPTION
When running: `kubectl argo rollouts set image` against a Rollout which is using the workloadRef feature, the CLI does not properly set the image on the workload (the Deployment). This change detects if the rollout is referencing a Deployment, then sets the image on the referenced Deployment.

Resolves https://github.com/argoproj/argo-rollouts/issues/1537

Signed-off-by: Jesse Suen <jesse@akuity.io>
