### PR TITLE
fix: canary replicas/weight could flap during abort with dynamic scaling

### DIFF
--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -103,9 +103,8 @@ type fixture struct {
 	unfreezeTime    func() error
 
 	// events holds all the K8s Event Reasons emitted during the run
-	events                   []string
-	fakeTrafficRouting       []*mocks.TrafficRoutingReconciler
-	fakeSingleTrafficRouting *mocks.TrafficRoutingReconciler
+	events             []string
+	fakeTrafficRouting *mocks.TrafficRoutingReconciler
 }
 
 func newFixture(t *testing.T) *fixture {
@@ -121,8 +120,7 @@ func newFixture(t *testing.T) *fixture {
 		return nil
 	}
 
-	f.fakeTrafficRouting = newFakeTrafficRoutingReconciler()
-	f.fakeSingleTrafficRouting = newFakeSingleTrafficRoutingReconciler()
+	f.fakeTrafficRouting = newFakeSingleTrafficRoutingReconciler()
 	return f
 }
 
@@ -570,7 +568,7 @@ func (f *fixture) newController(resync resyncFunc) (*Controller, informers.Share
 			return nil, nil
 		}
 		var reconcilers = []trafficrouting.TrafficRoutingReconciler{}
-		reconcilers = append(reconcilers, f.fakeSingleTrafficRouting)
+		reconcilers = append(reconcilers, f.fakeTrafficRouting)
 		return reconcilers, nil
 	}
 

--- a/rollout/restart.go
+++ b/rollout/restart.go
@@ -143,6 +143,13 @@ func maxInt(left, right int32) int32 {
 	return right
 }
 
+func minInt(left, right int32) int32 {
+	if left < right {
+		return left
+	}
+	return right
+}
+
 // getRolloutPods returns all pods associated with a rollout
 func (p *RolloutPodRestarter) getRolloutPods(ctx context.Context, ro *v1alpha1.Rollout, allRSs []*appsv1.ReplicaSet) ([]*corev1.Pod, error) {
 	pods, err := p.client.CoreV1().Pods(ro.Namespace).List(ctx, metav1.ListOptions{

--- a/rollout/trafficrouting/smi/smi.go
+++ b/rollout/trafficrouting/smi/smi.go
@@ -215,11 +215,7 @@ func (r *Reconciler) SetWeight(desiredWeight int32, additionalDestinations ...v1
 	if !isControlledBy {
 		return fmt.Errorf("Rollout does not own TrafficSplit `%s`", trafficSplitName)
 	}
-	err = r.patchTrafficSplit(existingTrafficSplit, trafficSplits)
-	if err == nil {
-		r.cfg.Recorder.Eventf(r.cfg.Rollout, record.EventOptions{EventReason: "TrafficSplitModified"}, "TrafficSplit `%s` modified", trafficSplitName)
-	}
-	return err
+	return r.patchTrafficSplit(existingTrafficSplit, trafficSplits)
 }
 
 func (r *Reconciler) generateTrafficSplits(trafficSplitName string, desiredWeight int32, additionalDestinations ...v1alpha1.WeightDestination) VersionedTrafficSplits {

--- a/utils/conditions/conditions.go
+++ b/utils/conditions/conditions.go
@@ -99,12 +99,13 @@ const (
 	// rollout that paused amidst a rollout and are bounded by a deadline.
 	RolloutResumedMessage = "Rollout is resumed"
 
-	// ResumedRolloutReason is added in a rollout when it is resumed. Useful for not failing accidentally
-	// rollout that paused amidst a rollout and are bounded by a deadline.
-	RolloutStepCompletedReason = "RolloutStepCompleted"
-	// ResumeRolloutMessage is added in a rollout when it is resumed. Useful for not failing accidentally
-	// rollout that paused amidst a rollout and are bounded by a deadline.
+	// RolloutStepCompleted indicates when a canary step has completed
+	RolloutStepCompletedReason  = "RolloutStepCompleted"
 	RolloutStepCompletedMessage = "Rollout step %d/%d completed (%s)"
+
+	// TrafficWeightUpdated is emitted any time traffic weight is modified
+	TrafficWeightUpdatedReason  = "TrafficWeightUpdated"
+	TrafficWeightUpdatedMessage = "Traffic weight updated %s"
 
 	// NewRSAvailableReason is added in a rollout when its newest replica set is made available
 	// ie. the number of new pods that have passed readiness checks and run for at least minReadySeconds


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/1665
Resolves https://github.com/argoproj/argo-rollouts/issues/1701

When using dynamicStableScaling, and the rollout was aborted, we would incorrectly increase the weight of the canary if the available stable replicas was flapping. This fix ensures that when we are aborting, we are only ever *decreasing* the weight and never increasing this. 

While testing this fix, I also discovered that a portion of the traffic routing unit tests was not functioning properly because the expected mock functions were not executed properly (Issue https://github.com/argoproj/argo-rollouts/issues/1701)

Signed-off-by: Jesse Suen <jesse@akuity.io>
