### PR TITLE
fix: plugin panic while watching progress

### DIFF
--- a/pkg/kubectl-argo-rollouts/cmd/status/status_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/status/status_test.go
@@ -120,7 +120,7 @@ func TestWatchAbortedRollout(t *testing.T) {
 	assert.Error(t, err)
 	stdout := o.Out.(*bytes.Buffer).String()
 	stderr := o.ErrOut.(*bytes.Buffer).String()
-	assert.Equal(t, "Degraded\n", stdout)
+	assert.Equal(t, "Degraded - RolloutAborted: metric \"web\" assessed Failed due to failed (1) > failureLimit (0)\n", stdout)
 	assert.Equal(t, "Error: The rollout is in a degraded state with message: RolloutAborted: metric \"web\" assessed Failed due to failed (1) > failureLimit (0)\n", stderr)
 }
 

--- a/pkg/kubectl-argo-rollouts/viewcontroller/viewcontroller.go
+++ b/pkg/kubectl-argo-rollouts/viewcontroller/viewcontroller.go
@@ -144,6 +144,7 @@ func (c *viewController) Run(ctx context.Context) error {
 		}
 	}, time.Second, ctx.Done())
 	<-ctx.Done()
+	c.DeregisterCallbacks()
 	return nil
 }
 
@@ -166,6 +167,10 @@ func (c *viewController) processNextWorkItem() bool {
 		c.prevObj = newObj
 	}
 	return true
+}
+
+func (c *viewController) DeregisterCallbacks() {
+	c.callbacks = nil
 }
 
 func (c *RolloutViewController) GetRolloutInfo() (*rollout.RolloutInfo, error) {


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/1747

Fixes a panic introduced in v1.1.0 plugin which closed a channel prematurely while the sender (view controller) was still sending on it. This change prevents this by deferring the channel close, and also niling out the view controller's callback list when the view controller stops, so that it will not attempt to perform any callbacks when finished.

As part of this fix, I made the plugin less chatty and only showed status changes. Previously, it would print out the phase and message on every rollout change, even if it was the same as before. Example output:

```
$ kubectl-argo-rollouts status my-rollout -w
Progressing - more replicas need to be updated
Paused - CanaryPauseStep
Progressing - more replicas need to be updated
Progressing - updated replicas are still becoming available
Healthy
```

Signed-off-by: Jesse Suen <jesse@akuity.io>
