### PR TITLE
fix: client can detect if rollout is in the process of unpausing

### DIFF
--- a/pkg/apiclient/rollout/rollout.swagger.json
+++ b/pkg/apiclient/rollout/rollout.swagger.json
@@ -1300,7 +1300,7 @@
           "items": {
             "$ref": "#/definitions/github.com.argoproj.argo_rollouts.pkg.apis.rollouts.v1alpha1.PauseCondition"
           },
-          "title": "PauseConditions indicates why the rollout is currently paused"
+          "title": "PauseConditions is a list of reasons why rollout became automatically paused (e.g.\nCanaryPauseStep, BlueGreenPause, InconclusiveAnalysis). The items in this list are populated\nby the controller but are cleared by the user (e.g. plugin, argo-cd resume action) when they\nwish to unpause. If pause conditions is empty, but controllerPause is true, it indicates\nthe user manually unpaused the Rollout"
         },
         "controllerPause": {
           "type": "boolean",

--- a/pkg/apis/rollouts/v1alpha1/generated.proto
+++ b/pkg/apis/rollouts/v1alpha1/generated.proto
@@ -1207,7 +1207,11 @@ message RolloutStatus {
   // Abort cancel the current rollout progression
   optional bool abort = 1;
 
-  // PauseConditions indicates why the rollout is currently paused
+  // PauseConditions is a list of reasons why rollout became automatically paused (e.g.
+  // CanaryPauseStep, BlueGreenPause, InconclusiveAnalysis). The items in this list are populated
+  // by the controller but are cleared by the user (e.g. plugin, argo-cd resume action) when they
+  // wish to unpause. If pause conditions is empty, but controllerPause is true, it indicates
+  // the user manually unpaused the Rollout
   repeated PauseCondition pauseConditions = 2;
 
   // ControllerPause indicates the controller has paused the rollout. It is set to true when

--- a/pkg/apis/rollouts/v1alpha1/openapi_generated.go
+++ b/pkg/apis/rollouts/v1alpha1/openapi_generated.go
@@ -3661,7 +3661,7 @@ func schema_pkg_apis_rollouts_v1alpha1_RolloutStatus(ref common.ReferenceCallbac
 					},
 					"pauseConditions": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PauseConditions indicates why the rollout is currently paused",
+							Description: "PauseConditions is a list of reasons why rollout became automatically paused (e.g. CanaryPauseStep, BlueGreenPause, InconclusiveAnalysis). The items in this list are populated by the controller but are cleared by the user (e.g. plugin, argo-cd resume action) when they wish to unpause. If pause conditions is empty, but controllerPause is true, it indicates the user manually unpaused the Rollout",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -684,7 +684,11 @@ const (
 type RolloutStatus struct {
 	// Abort cancel the current rollout progression
 	Abort bool `json:"abort,omitempty" protobuf:"varint,1,opt,name=abort"`
-	// PauseConditions indicates why the rollout is currently paused
+	// PauseConditions is a list of reasons why rollout became automatically paused (e.g.
+	// CanaryPauseStep, BlueGreenPause, InconclusiveAnalysis). The items in this list are populated
+	// by the controller but are cleared by the user (e.g. plugin, argo-cd resume action) when they
+	// wish to unpause. If pause conditions is empty, but controllerPause is true, it indicates
+	// the user manually unpaused the Rollout
 	PauseConditions []PauseCondition `json:"pauseConditions,omitempty" protobuf:"bytes,2,rep,name=pauseConditions"`
 	// ControllerPause indicates the controller has paused the rollout. It is set to true when
 	// the controller adds a pause condition. This field helps to discern the scenario where a

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 package e2e
@@ -288,10 +289,6 @@ func (s *IstioSuite) TestIstioAbortUpdateDeleteAllCanaryPods() {
 		WaitForRolloutStatus("Paused").
 		Then().
 		ExpectRevisionPodCount("2", 2).
-		When().
-		PromoteRollout().
-		WaitForRolloutStatus("Paused").
-		Then().
 		When().
 		PromoteRollout().
 		WaitForRolloutStatus("Paused").

--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -436,7 +436,7 @@ func GetCurrentCanaryStep(rollout *v1alpha1.Rollout) (*v1alpha1.CanaryStep, *int
 
 // GetCanaryReplicasOrWeight either returns a static set of replicas or a weight percentage
 func GetCanaryReplicasOrWeight(rollout *v1alpha1.Rollout) (*int32, int32) {
-	if rollout.Status.PromoteFull || rollout.Status.CurrentPodHash == rollout.Status.StableRS {
+	if rollout.Status.PromoteFull || rollout.Status.StableRS == "" || rollout.Status.CurrentPodHash == rollout.Status.StableRS {
 		return nil, 100
 	}
 	if scs := UseSetCanaryScale(rollout); scs != nil {

--- a/utils/rollout/rolloututil_test.go
+++ b/utils/rollout/rolloututil_test.go
@@ -394,3 +394,23 @@ func TestCanaryStepString(t *testing.T) {
 		assert.Equal(t, test.expectedString, CanaryStepString(test.step))
 	}
 }
+
+func TestIsUnpausing(t *testing.T) {
+	ro := newCanaryRollout()
+	ro.Status.Phase = v1alpha1.RolloutPhasePaused
+	ro.Status.Message = "canary pause"
+	ro.Status.PauseConditions = []v1alpha1.PauseCondition{
+		{
+			Reason: v1alpha1.PauseReasonCanaryPauseStep,
+		},
+	}
+	ro.Status.ControllerPause = true
+	status, message := GetRolloutPhase(ro)
+	assert.Equal(t, v1alpha1.RolloutPhasePaused, status)
+	assert.Equal(t, "canary pause", message)
+
+	ro.Status.PauseConditions = nil
+	status, message = GetRolloutPhase(ro)
+	assert.Equal(t, v1alpha1.RolloutPhaseProgressing, status)
+	assert.Equal(t, "waiting for rollout to unpause", message)
+}


### PR DESCRIPTION
While debugging e2e flakiness, I determined that **_some_** of the flakiness is actually caused by a bug where the client does not properly detect that the rollout is still in the process of being unpaused. This is probably a rare event but is exacerbated when the client is aggressively monitoring rollout status (such as in e2e tests which are performing watches against the rollout). The scenario is this:

1. rollout becomes automatically paused (e.g. canary pause step). Status becomes:

```yaml
status:
  phase: Paused
  pauseConditions:
  - reason: CanaryPauseStep
  controllerPause: true
```

2. client (plugin) unpauses the rollout (by nilling out pauseConditions). Status becomes:

```yaml
status:
  phase: Paused
  controllerPause: true
```

3. Before the controller has time to update status to `Progressing`, the client examines the rollout and sees that the phase is `Paused`, despite the fact that the controller is unpausing the rollout and hasn't yet updated the status. In this situation checking `metadata.generation` and `status.observedGeneration` does not help because Kubernetes status changes to not increment `metadata.generation`.

To fix this, we need a client side check similar to `observedGeneration` such that the client looks at both the `controllerPause` and `pauseConditions` to detect if the controller has not yet reacted to the unpause, and then considers the rollout as `Progressing` despite the `status.phase` being `Paused`.

Signed-off-by: Jesse Suen <jesse@akuity.io>
