### PR TITLE
chore: fix spdx ci

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -136,7 +136,7 @@ jobs:
           # managers (gomod, yarn, npm).
           PROJECT_FOLDERS: ".,./ui" 
           # full qualified name of the docker image to be inspected
-          DOCKER_IMAGE: quay.io/argoproj/argo-rollouts:v${{ github.event.inputs.tag }}
+          DOCKER_IMAGE: quay.io/argoproj/argo-rollouts:${{ github.event.inputs.tag }}
 
         run: |
           yarn install --cwd ./ui


### PR DESCRIPTION
Release process failed with:

```
INFO[2022-02-05T02:33:23Z] Plugin yarn generated output at /tmp/bom-yarn.spdx 
level=info msg="Generating SPDX Bill of Materials"
level=info msg="Processing image reference: quay.io/argoproj/argo-rollouts:vv1.2.0-rc1"
level=fatal msg="generating doc: creating SPDX document: generating SPDX package from image ref quay.io/argoproj/argo-rollouts:vv1.2.0-rc1: while downloading images to archive: fetching remote descriptor: GET https://quay.io/v2/argoproj/argo-rollouts/manifests/vv1.2.0-rc1: MANIFEST_UNKNOWN: manifest unknown; map[]"
Error: Process completed with exit code 1.
```

Signed-off-by: Jesse Suen <jesse@akuity.io>
