### PR TITLE
docs: update contributions.md to include k3d as recommended cluster, add details on e2e test setup, and update kubectl install link. Fixes #1750

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Install:
 
 * [docker](https://docs.docker.com/install/#supported-platforms)
 * [golang](https://golang.org/)
-* [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+* [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
 * [kustomize](https://github.com/kubernetes-sigs/kustomize/releases)
 * [k3d](https://k3d.io/) recommended
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Install:
 * [golang](https://golang.org/)
 * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 * [kustomize](https://github.com/kubernetes-sigs/kustomize/releases)
-* [minikube](https://kubernetes.io/docs/setup/minikube/) or Docker for Desktop
+* [k3d](https://k3d.io/) recommended
 
 Kustomize is required for unit tests (`make test` is using it), so you [must install it](https://kubectl.docs.kubernetes.io/installation/kustomize/)
 locally if you wish to make code contributions to Argo Rollouts.
@@ -33,7 +33,7 @@ go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 Brew users can quickly install the lot:
 
 ```bash
-brew install go kubectl kustomize golangci-lint protobuf swagger-codegen
+brew install go kubectl kustomize golangci-lint protobuf swagger-codegen k3d
 ```
 
 Set up environment variables (e.g. is `~/.bashrc`):

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -87,6 +87,15 @@ running. The rollout controller can be started with the command:
 make start-e2e
 ```
 
+Start and prepare your cluster for e2e tests:
+
+```
+k3d cluster create
+kubectl create ns argo-rollouts
+kubectl apply -k manifests/crds
+kubectl apply -f test/e2e/crds
+```
+
 Then run the e2e tests:
 
 ```


### PR DESCRIPTION
Closes #1750 

Also documents some cluster setup steps under running e2e test section and updates kubectl install link.

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).