### PR TITLE
chore: move dependencies to dev dependencies

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -3,16 +3,6 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@testing-library/jest-dom": "^5.11.4",
-        "@testing-library/react": "^11.1.0",
-        "@testing-library/user-event": "^12.1.10",
-        "@types/classnames": "2.2.9",
-        "@types/jest": "^26.0.15",
-        "@types/node": "^12.0.0",
-        "@types/react": "^16.9.3",
-        "@types/react-dom": "^16.9.3",
-        "@types/react-helmet": "^6.1.0",
-        "@types/react-router-dom": "^5.1.7",
         "argo-ui": "git+https://github.com/argoproj/argo-ui.git",
         "classnames": "2.2.6",
         "moment": "^2.29.1",
@@ -24,11 +14,9 @@
         "react-hot-loader": "^3.1.3",
         "react-keyhooks": "^0.2.3",
         "react-router-dom": "5.2.0",
-        "react-scripts": "4.0.3",
         "rxjs": "^6.6.6",
         "typescript": "4.3.5",
-        "web-vitals": "^1.0.1",
-        "webpack-dev-server": "^3.11.2"
+        "web-vitals": "^1.0.1"
     },
     "scripts": {
         "start": "webpack serve --config ./src/app/webpack.dev.js",
@@ -56,13 +44,25 @@
         ]
     },
     "devDependencies": {
+        "@testing-library/jest-dom": "^5.11.4",
+        "@testing-library/react": "^11.1.0",
+        "@testing-library/user-event": "^12.1.10",
+        "@types/classnames": "2.2.9",
+        "@types/jest": "^26.0.15",
+        "@types/node": "^12.0.0",
+        "@types/react": "^16.9.3",
+        "@types/react-dom": "^16.9.3",
+        "@types/react-helmet": "^6.1.0",
+        "@types/react-router-dom": "^5.1.7",
         "copy-webpack-plugin": "^6.3.2",
         "mini-css-extract-plugin": "^1.3.9",
         "raw-loader": "^4.0.2",
+        "react-scripts": "4.0.3",
         "sass": "^1.32.8",
         "ts-loader": "^8.0.17",
         "webpack-bundle-analyzer": "^4.4.0",
         "webpack-cli": "^4.5.0",
+        "webpack-dev-server": "^3.11.2",
         "webpack-merge": "^5.7.3"
     },
     "resolutions": {


### PR DESCRIPTION
Moving some dependencies to devDependencies, because they're causing false-positives for vulnerabilities in Snyk.