### PR TITLE
chore: fix golangci-lint to 1.44 to fix build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,7 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install golangci-lint
-RUN wget https://install.goreleaser.com/github.com/golangci/golangci-lint.sh  && \
-    chmod +x ./golangci-lint.sh && \
-    ./golangci-lint.sh -b $GOPATH/bin && \
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.0 && \
     golangci-lint linters
 
 COPY .golangci.yml ${GOPATH}/src/dummy/.golangci.yml


### PR DESCRIPTION
Latest 1.45 version causes this failure in CI (I think due to multi-arch build on arm64):

```
#22 0.471 golangci/golangci-lint info checking GitHub for tag 'v1.45.0'
#22 0.834 golangci/golangci-lint info found version: 1.45.0 for v1.45.0/linux/arm64
#22 2.684 golangci/golangci-lint info installed /go/bin/golangci-lint
#22 14.16 panic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt
#22 14.16
#22 14.16 goroutine 1 [running]:
#22 14.16 github.com/go-critic/go-critic/checkers.init.22()
#22 14.16       github.com/go-critic/go-critic@v0.6.2/checkers/embedded_rules.go:46 +0x488
```

Signed-off-by: Jesse Suen <jesse@akuity.io>
