### PR TITLE
chore: Improve image build speed

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -87,8 +87,6 @@ jobs:
           platforms: ${{ steps.platform-matrix.outputs.platform-matrix }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.controller-meta.outputs.tags }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Build and push (plugin-image)
         uses: docker/build-push-action@v2
@@ -97,8 +95,6 @@ jobs:
           platforms: ${{ steps.platform-matrix.outputs.platform-matrix }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.plugin-meta.outputs.tags }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
 
         # Temp fix
         # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,13 +23,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+      # - name: Cache Docker layers
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: /tmp/.buildx-cache
+      #     key: ${{ runner.os }}-buildx-${{ github.sha }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-buildx-
 
       - name: Docker meta (controller)
         id: controller-meta
@@ -99,7 +99,7 @@ jobs:
         # Temp fix
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      # - name: Move cache
+      #   run: |
+      #     rm -rf /tmp/.buildx-cache
+      #     mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
Signed-off-by: Justin Marquis <34fathombelow@protonmail.com>

Disabled cache, it is configured to only cache the export layers that are in the final build stages.  Not taking advantage of the cache on disk for the second run of the `kubectl-argo-rollouts` image  This will reduce build times by **half**.  I recommend a second PR to cleanup the existing cache steps from the docker-publish.yml as they are not needed anymore.

I have tested these builds locally.  I'm expecting the complete Workflow should be complete in approximately 20-25 minutes on GitHub runners.

The flowchart below shows how the Dockerfile is processed using cross-compilation. Orange nodes are x86_64 and opaque orange nodes are arm64.

```mermaid
flowchart TB

id1([builder]) --> id2([argo-rollouts-ui]) --> id3([argo-rollouts-build]) --> id4([kubectl-argo-rollouts]) --> id5([x86_64 Final_image])
id3([argo-rollouts-build]) --> id6([kubectl-argo-rollouts]) --> id7([arm64 Final_Image])


style id6 fill:#5C74C6,stroke:#333,stroke-width:2px,color:#ffffff
classDef x86 fill:#EF7B4D,stroke:#EF7B4D,stroke-width:2px,color:#ffffff
classDef arm64 fill:#FCE5DB,stroke:#EF7B4D,stroke-width:2px,color:#EF7B4D
class id1,id2,id3,id4,id5 x86
class id6,id7,id8 arm64

```

Checklist:

* [x] Either ~~(a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or~~ (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).