### PR TITLE
docs: add available configuration options for rollouts controller. Fixes #1914

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,6 +26,23 @@ This will create a new namespace, `argo-rollouts`, where Argo Rollouts controlle
 You can find released container images of the controller at [Quay.io](https://quay.io/repository/argoproj/argo-rollouts?tab=tags). There are also old releases
 at Dockerhub, but since the introduction of rate limiting, the Argo project has moved to Quay.
 
+### Configuration Options
+
+For instance, logging format can be easily set as `json` via passing the following additional command-line argument in ArgoRollouts controller deployment:
+
+````yaml
+      containers:
+      - image: "quay.io/argoproj/argo-rollouts:v1.2.0"
+        args:
+        - --logformat=json
+````
+
+You can list all the available CLI options for the rollouts controller using the following command:
+
+```shell
+docker run --rm -it quay.io/argoproj/argo-rollouts:v1.2.0 -h
+```
+
 ## Kubectl Plugin Installation
 
 The kubectl plugin is optional, but is convenient for managing and visualizing rollouts from the 


### PR DESCRIPTION
It seems that docs are not listing available configuration options for the controller, this is a just simple attempt to list options as in ArgoCD Server Configuration Parameters docs.

Refs: #1914
Signed-off-by: Celal Öner <celal.oner@trendyol.com>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).