### PR TITLE
feat: add metric for rolloutabort with analysisrun failure

### DIFF
--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -561,13 +561,27 @@ func (c *rolloutContext) calculateRolloutConditions(newStatus v1alpha1.RolloutSt
 
 	if isAborted {
 		revision, _ := replicasetutil.Revision(c.rollout)
+		var analysisRunStatusCanaryStep, analysisRunStatusCanaryBackground, analysisRunStatus v1alpha1.AnalysisPhase
+		if c.currentArs.CanaryStep != nil {
+			analysisRunStatusCanaryStep = c.currentArs.CanaryStep.Status.Phase
+		}
+		if c.currentArs.CanaryBackground != nil {
+			analysisRunStatusCanaryBackground = c.currentArs.CanaryBackground.Status.Phase
+		}
+		if analysisRunStatusCanaryStep == "Failed" || analysisRunStatusCanaryBackground == "Failed" {
+			analysisRunStatus = "Failed"
+		}
 		message := fmt.Sprintf(conditions.RolloutAbortedMessage, revision)
 		if c.pauseContext.abortMessage != "" {
 			message = fmt.Sprintf("%s: %s", message, c.pauseContext.abortMessage)
 		}
 		condition := conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionFalse, conditions.RolloutAbortedReason, message)
 		if conditions.SetRolloutCondition(&newStatus, *condition) {
-			c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: conditions.RolloutAbortedReason}, message)
+			if analysisRunStatus == "Failed" {
+				c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: conditions.RolloutAbortedWithAnalysisFailure}, message)
+			} else {
+				c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: conditions.RolloutAbortedReason}, message)
+			}
 		}
 	}
 

--- a/utils/conditions/conditions.go
+++ b/utils/conditions/conditions.go
@@ -71,6 +71,8 @@ const (
 
 	// RolloutAbortedReason indicates that the rollout was aborted
 	RolloutAbortedReason = "RolloutAborted"
+	// RolloutAbortedReason indicates that the rollout was aborted
+	RolloutAbortedWithAnalysisFailure = "RolloutAbortedWithAnalysisFailure"
 	// RolloutAbortedMessage indicates that the rollout was aborted
 	RolloutAbortedMessage = "Rollout aborted update to revision %d"
 


### PR DESCRIPTION
Signed-off-by: Ravi Hari <ravireliable@gmail.com>

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [X] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [X] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My builds are green. Try syncing with master if they are not. 
* [X] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).



<img width="1061" alt="image" src="https://user-images.githubusercontent.com/7333720/159768490-3672540b-f225-48c6-9624-d90f1e916950.png">

```
Events:
  Type     Reason                             Age                From                 Message
  ----     ------                             ----               ----                 -------
  Normal   RolloutUpdated                     67s                rollouts-controller  Rollout updated to revision 1
  Normal   NewReplicaSetCreated               67s                rollouts-controller  Created ReplicaSet rollouts-demo-659bd4d4c8 (revision 1)
  Normal   ScalingReplicaSet                  67s                rollouts-controller  Scaled up ReplicaSet rollouts-demo-659bd4d4c8 (revision 1) from 0 to 5
  Normal   RolloutCompleted                   67s                rollouts-controller  Rollout completed update to revision 1 (659bd4d4c8): Initial deploy
  Normal   RolloutUpdated                     39s                rollouts-controller  Rollout updated to revision 2
  Normal   NewReplicaSetCreated               39s                rollouts-controller  Created ReplicaSet rollouts-demo-98447df77 (revision 2)
  Normal   ScalingReplicaSet                  39s                rollouts-controller  Scaled down ReplicaSet rollouts-demo-659bd4d4c8 (revision 1) from 5 to 4
  Normal   AnalysisRunSuccessful              39s                rollouts-controller  Background Analysis Run 'rollouts-demo-98447df77-2' Status New: 'Successful' Previous: ''
  Normal   ScalingReplicaSet                  39s                rollouts-controller  Scaled up ReplicaSet rollouts-demo-98447df77 (revision 2) from 0 to 1
  Normal   RolloutStepCompleted               37s                rollouts-controller  Rollout step 1/7 completed (setWeight: 20)
  Normal   RolloutPaused                      37s                rollouts-controller  Rollout is paused (CanaryPauseStep)
  Normal   ScalingReplicaSet                  27s                rollouts-controller  Scaled up ReplicaSet rollouts-demo-98447df77 (revision 2) from 1 to 3
  Normal   RolloutResumed                     27s                rollouts-controller  Rollout is resumed
  Normal   ScalingReplicaSet                  27s                rollouts-controller  Scaled down ReplicaSet rollouts-demo-659bd4d4c8 (revision 1) from 4 to 3
  Normal   RolloutStepCompleted               27s                rollouts-controller  Rollout step 2/7 completed (pause: 10)
  Normal   ScalingReplicaSet                  26s                rollouts-controller  Scaled down ReplicaSet rollouts-demo-659bd4d4c8 (revision 1) from 3 to 2
  Normal   RolloutStepCompleted               25s                rollouts-controller  Rollout step 3/7 completed (setWeight: 60)
  Warning  AnalysisRunFailed                  25s                rollouts-controller  Step Analysis Run 'rollouts-demo-98447df77-2-3' Status New: 'Failed' Previous: ''


  Warning  RolloutAbortedWithAnalysisFailure  25s                rollouts-controller  Rollout aborted update to revision 2: Metric "success-rate" assessed Failed due to failed (1) > failureLimit (0)


  Normal   ScalingReplicaSet                  25s                rollouts-controller  Scaled up ReplicaSet rollouts-demo-659bd4d4c8 (revision 1) from 2 to 4
  Normal   ScalingReplicaSet                  25s                rollouts-controller  Scaled down ReplicaSet rollouts-demo-98447df77 (revision 2) from 3 to 2
  Normal   ScalingReplicaSet                  25s                rollouts-controller  Scaled up ReplicaSet rollouts-demo-659bd4d4c8 (revision 1) from 4 to 5
  Normal   ScalingReplicaSet                  23s (x2 over 24s)  rollouts-controller  (combined from similar events): Scaled down ReplicaSet rollouts-demo-98447df77 (revision 2) from 1 to 0
```