### PR TITLE
Example Analysis template fails without a value for "count".

### DIFF
--- a/docs/analysis/datadog.md
+++ b/docs/analysis/datadog.md
@@ -16,6 +16,7 @@ spec:
   metrics:
   - name: error-rate
     interval: 5m
+    count: 3
     successCondition: result <= 0.01
     failureLimit: 3
     provider:


### PR DESCRIPTION
Error without a value for count: "AnalysisTemplate  has metrict which runs indefinitely"

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).