### PR TITLE
fix: Use actual weight from status field on rollout object

### DIFF
--- a/pkg/kubectl-argo-rollouts/info/info_test.go
+++ b/pkg/kubectl-argo-rollouts/info/info_test.go
@@ -48,6 +48,7 @@ func TestCanaryRolloutInfoWeights(t *testing.T) {
 	}
 	assert.Equal(t, rolloutObjs.Rollouts[4].Status.Canary.Weights.Canary.Weight, int32(actualWeightStringInt32))
 
+	//This test has a no canary weight object in the status field so we fall back to using SetWeight value
 	roInfo = NewRolloutInfo(rolloutObjs.Rollouts[5], rolloutObjs.ReplicaSets, rolloutObjs.Pods, rolloutObjs.Experiments, rolloutObjs.AnalysisRuns, nil)
 	assert.Equal(t, roInfo.SetWeight, roInfo.ActualWeight)
 }

--- a/pkg/kubectl-argo-rollouts/info/info_test.go
+++ b/pkg/kubectl-argo-rollouts/info/info_test.go
@@ -36,17 +36,6 @@ func TestCanaryRolloutInfo(t *testing.T) {
 			Tags:  []string{InfoTagStable},
 		},
 	})
-
-	roInfo = NewRolloutInfo(rolloutObjs.Rollouts[4], rolloutObjs.ReplicaSets, rolloutObjs.Pods, rolloutObjs.Experiments, rolloutObjs.AnalysisRuns, nil)
-	actualWeightString := roInfo.ActualWeight
-	actualWeightStringInt32, err := strconv.ParseInt(actualWeightString, 10, 32)
-	if err != nil {
-		t.Error(err)
-	}
-	assert.Equal(t, rolloutObjs.Rollouts[4].Status.Canary.Weights.Canary.Weight, int32(actualWeightStringInt32))
-
-	roInfo = NewRolloutInfo(rolloutObjs.Rollouts[5], rolloutObjs.ReplicaSets, rolloutObjs.Pods, rolloutObjs.Experiments, rolloutObjs.AnalysisRuns, nil)
-	assert.Equal(t, roInfo.SetWeight, roInfo.ActualWeight)
 }
 
 func TestCanaryRolloutInfoWeights(t *testing.T) {

--- a/pkg/kubectl-argo-rollouts/info/info_test.go
+++ b/pkg/kubectl-argo-rollouts/info/info_test.go
@@ -49,6 +49,20 @@ func TestCanaryRolloutInfo(t *testing.T) {
 	assert.Equal(t, roInfo.SetWeight, roInfo.ActualWeight)
 }
 
+func TestCanaryRolloutInfoWeights(t *testing.T) {
+	rolloutObjs := testdata.NewCanaryRollout()
+	roInfo := NewRolloutInfo(rolloutObjs.Rollouts[4], rolloutObjs.ReplicaSets, rolloutObjs.Pods, rolloutObjs.Experiments, rolloutObjs.AnalysisRuns, nil)
+	actualWeightString := roInfo.ActualWeight
+	actualWeightStringInt32, err := strconv.ParseInt(actualWeightString, 10, 32)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, rolloutObjs.Rollouts[4].Status.Canary.Weights.Canary.Weight, int32(actualWeightStringInt32))
+
+	roInfo = NewRolloutInfo(rolloutObjs.Rollouts[5], rolloutObjs.ReplicaSets, rolloutObjs.Pods, rolloutObjs.Experiments, rolloutObjs.AnalysisRuns, nil)
+	assert.Equal(t, roInfo.SetWeight, roInfo.ActualWeight)
+}
+
 func TestPingPongCanaryRolloutInfo(t *testing.T) {
 	rolloutObjs := testdata.NewCanaryRollout()
 	roInfo := NewRolloutInfo(rolloutObjs.Rollouts[3], rolloutObjs.ReplicaSets, rolloutObjs.Pods, rolloutObjs.Experiments, rolloutObjs.AnalysisRuns, nil)

--- a/pkg/kubectl-argo-rollouts/info/info_test.go
+++ b/pkg/kubectl-argo-rollouts/info/info_test.go
@@ -1,6 +1,7 @@
 package info
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -35,6 +36,17 @@ func TestCanaryRolloutInfo(t *testing.T) {
 			Tags:  []string{InfoTagStable},
 		},
 	})
+
+	roInfo = NewRolloutInfo(rolloutObjs.Rollouts[4], rolloutObjs.ReplicaSets, rolloutObjs.Pods, rolloutObjs.Experiments, rolloutObjs.AnalysisRuns, nil)
+	actualWeightString := roInfo.ActualWeight
+	actualWeightStringInt32, err := strconv.ParseInt(actualWeightString, 10, 32)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, rolloutObjs.Rollouts[4].Status.Canary.Weights.Canary.Weight, int32(actualWeightStringInt32))
+
+	roInfo = NewRolloutInfo(rolloutObjs.Rollouts[5], rolloutObjs.ReplicaSets, rolloutObjs.Pods, rolloutObjs.Experiments, rolloutObjs.AnalysisRuns, nil)
+	assert.Equal(t, roInfo.SetWeight, roInfo.ActualWeight)
 }
 
 func TestPingPongCanaryRolloutInfo(t *testing.T) {

--- a/pkg/kubectl-argo-rollouts/info/info_test.go
+++ b/pkg/kubectl-argo-rollouts/info/info_test.go
@@ -40,17 +40,26 @@ func TestCanaryRolloutInfo(t *testing.T) {
 
 func TestCanaryRolloutInfoWeights(t *testing.T) {
 	rolloutObjs := testdata.NewCanaryRollout()
-	roInfo := NewRolloutInfo(rolloutObjs.Rollouts[4], rolloutObjs.ReplicaSets, rolloutObjs.Pods, rolloutObjs.Experiments, rolloutObjs.AnalysisRuns, nil)
-	actualWeightString := roInfo.ActualWeight
-	actualWeightStringInt32, err := strconv.ParseInt(actualWeightString, 10, 32)
-	if err != nil {
-		t.Error(err)
-	}
-	assert.Equal(t, rolloutObjs.Rollouts[4].Status.Canary.Weights.Canary.Weight, int32(actualWeightStringInt32))
 
-	//This test has a no canary weight object in the status field so we fall back to using SetWeight value
-	roInfo = NewRolloutInfo(rolloutObjs.Rollouts[5], rolloutObjs.ReplicaSets, rolloutObjs.Pods, rolloutObjs.Experiments, rolloutObjs.AnalysisRuns, nil)
-	assert.Equal(t, roInfo.SetWeight, roInfo.ActualWeight)
+	t.Run("TestActualWeightWithExistingWeight", func(t *testing.T) {
+		t.Run("will test that actual weight for info object is set from rollout status", func(t *testing.T) {
+			roInfo := NewRolloutInfo(rolloutObjs.Rollouts[4], rolloutObjs.ReplicaSets, rolloutObjs.Pods, rolloutObjs.Experiments, rolloutObjs.AnalysisRuns, nil)
+			actualWeightString := roInfo.ActualWeight
+			actualWeightStringInt32, err := strconv.ParseInt(actualWeightString, 10, 32)
+			if err != nil {
+				t.Error(err)
+			}
+			assert.Equal(t, rolloutObjs.Rollouts[4].Status.Canary.Weights.Canary.Weight, int32(actualWeightStringInt32))
+		})
+	})
+
+	t.Run("TestActualWeightWithoutExistingWeight", func(t *testing.T) {
+		t.Run("will test that actual weight is set to SetWeight when status field dose not exist", func(t *testing.T) {
+			//This test has a no canary weight object in the status field so we fall back to using SetWeight value
+			roInfo := NewRolloutInfo(rolloutObjs.Rollouts[5], rolloutObjs.ReplicaSets, rolloutObjs.Pods, rolloutObjs.Experiments, rolloutObjs.AnalysisRuns, nil)
+			assert.Equal(t, roInfo.SetWeight, roInfo.ActualWeight)
+		})
+	})
 }
 
 func TestPingPongCanaryRolloutInfo(t *testing.T) {

--- a/pkg/kubectl-argo-rollouts/info/info_test.go
+++ b/pkg/kubectl-argo-rollouts/info/info_test.go
@@ -54,7 +54,7 @@ func TestCanaryRolloutInfoWeights(t *testing.T) {
 	})
 
 	t.Run("TestActualWeightWithoutExistingWeight", func(t *testing.T) {
-		t.Run("will test that actual weight is set to SetWeight when status field dose not exist", func(t *testing.T) {
+		t.Run("will test that actual weight is set to SetWeight when status field does not exist", func(t *testing.T) {
 			//This test has a no canary weight object in the status field so we fall back to using SetWeight value
 			roInfo := NewRolloutInfo(rolloutObjs.Rollouts[5], rolloutObjs.ReplicaSets, rolloutObjs.Pods, rolloutObjs.Experiments, rolloutObjs.AnalysisRuns, nil)
 			assert.Equal(t, roInfo.SetWeight, roInfo.ActualWeight)

--- a/pkg/kubectl-argo-rollouts/info/rollout_info.go
+++ b/pkg/kubectl-argo-rollouts/info/rollout_info.go
@@ -68,7 +68,7 @@ func NewRolloutInfo(
 				if ro.Status.Canary.Weights != nil {
 					roInfo.ActualWeight = fmt.Sprintf("%d", ro.Status.Canary.Weights.Canary.Weight)
 				} else {
-					roInfo.ActualWeight = "n/a"
+					roInfo.ActualWeight = roInfo.SetWeight
 				}
 			}
 		}

--- a/pkg/kubectl-argo-rollouts/info/rollout_info.go
+++ b/pkg/kubectl-argo-rollouts/info/rollout_info.go
@@ -65,7 +65,11 @@ func NewRolloutInfo(
 					}
 				}
 			} else {
-				roInfo.ActualWeight = roInfo.SetWeight
+				if ro.Status.Canary.Weights != nil {
+					roInfo.ActualWeight = fmt.Sprintf("%d", ro.Status.Canary.Weights.Canary.Weight)
+				} else {
+					roInfo.ActualWeight = "n/a"
+				}
 			}
 		}
 	} else if ro.Spec.Strategy.BlueGreen != nil {

--- a/pkg/kubectl-argo-rollouts/info/testdata/canary/canary-rollout5.yaml
+++ b/pkg/kubectl-argo-rollouts/info/testdata/canary/canary-rollout5.yaml
@@ -6,12 +6,12 @@ metadata:
   creationTimestamp: "2019-10-25T06:07:18Z"
   generation: 429
   labels:
-    app: canary-demo
+    app: canary-demo-weights
     app.kubernetes.io/instance: jesse-test
-  name: canary-demo
+  name: canary-demo-weights
   namespace: jesse-test
   resourceVersion: "28253567"
-  selfLink: /apis/argoproj.io/v1alpha1/namespaces/jesse-test/rollouts/canary-demo
+  selfLink: /apis/argoproj.io/v1alpha1/namespaces/jesse-test/rollouts/canary-demo-weights
   uid: b350ba76-f6ed-11e9-a15b-42010aa80033
 spec:
   progressDeadlineSeconds: 30

--- a/pkg/kubectl-argo-rollouts/info/testdata/canary/canary-rollout5.yaml
+++ b/pkg/kubectl-argo-rollouts/info/testdata/canary/canary-rollout5.yaml
@@ -19,7 +19,7 @@ spec:
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: canary-demo
+      app: canary-demo-weights
   strategy:
     canary:
       canaryService: canary-demo-preview
@@ -44,7 +44,7 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
-        app: canary-demo
+        app: canary-demo-weights
     spec:
       containers:
       - image: argoproj/rollouts-demo:does-not-exist
@@ -92,5 +92,5 @@ status:
   observedGeneration: "429"
   readyReplicas: 5
   replicas: 6
-  selector: app=canary-demo
+  selector: app=canary-demo-weights
   updatedReplicas: 1

--- a/pkg/kubectl-argo-rollouts/info/testdata/canary/canary-rollout5.yaml
+++ b/pkg/kubectl-argo-rollouts/info/testdata/canary/canary-rollout5.yaml
@@ -1,0 +1,96 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  annotations:
+    rollout.argoproj.io/revision: "31"
+  creationTimestamp: "2019-10-25T06:07:18Z"
+  generation: 429
+  labels:
+    app: canary-demo
+    app.kubernetes.io/instance: jesse-test
+  name: canary-demo
+  namespace: jesse-test
+  resourceVersion: "28253567"
+  selfLink: /apis/argoproj.io/v1alpha1/namespaces/jesse-test/rollouts/canary-demo
+  uid: b350ba76-f6ed-11e9-a15b-42010aa80033
+spec:
+  progressDeadlineSeconds: 30
+  replicas: 5
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: canary-demo
+  strategy:
+    canary:
+      canaryService: canary-demo-preview
+      stableService: canary-demo-stable
+      trafficRouting:
+        smi:
+          rootService: root-svc # optional
+          trafficSplitName: rollout-example-traffic-split # optional
+      steps:
+      - setWeight: 20
+      - pause: {}
+      - setWeight: 40
+      - pause:
+          duration: 10s
+      - setWeight: 60
+      - pause:
+          duration: 10s
+      - setWeight: 80
+      - pause:
+          duration: 10s
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: canary-demo
+    spec:
+      containers:
+      - image: argoproj/rollouts-demo:does-not-exist
+        imagePullPolicy: Always
+        name: canary-demo
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 5m
+            memory: 32Mi
+status:
+  HPAReplicas: 6
+  availableReplicas: 5
+  blueGreen: {}
+  canary:
+    weights:
+      canary:
+        podTemplateHash: 868d98998a
+        serviceName: canary-demo
+        weight: 20
+      stable:
+        podTemplateHash: 877894d5b
+        serviceName: canary-demo
+        weight: 60
+  stableRS: 877894d5b
+  conditions:
+  - lastTransitionTime: "2019-10-25T06:07:29Z"
+    lastUpdateTime: "2019-10-25T06:07:29Z"
+    message: Rollout has minimum availability
+    reason: AvailableReason
+    status: "True"
+    type: Available
+  - lastTransitionTime: "2019-10-28T04:52:55Z"
+    lastUpdateTime: "2019-10-28T04:52:55Z"
+    message: ReplicaSet "canary-demo-65fb5ffc84" has timed out progressing.
+    reason: ProgressDeadlineExceeded
+    status: "False"
+    type: Progressing
+  currentPodHash: 65fb5ffc84
+  currentStepHash: f64cdc9d
+  currentStepIndex: 0
+  observedGeneration: "429"
+  readyReplicas: 5
+  replicas: 6
+  selector: app=canary-demo
+  updatedReplicas: 1

--- a/pkg/kubectl-argo-rollouts/info/testdata/canary/canary-rollout6.yaml
+++ b/pkg/kubectl-argo-rollouts/info/testdata/canary/canary-rollout6.yaml
@@ -1,0 +1,87 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  annotations:
+    rollout.argoproj.io/revision: "31"
+  creationTimestamp: "2019-10-25T06:07:18Z"
+  generation: 429
+  labels:
+    app: canary-demo
+    app.kubernetes.io/instance: jesse-test
+  name: canary-demo
+  namespace: jesse-test
+  resourceVersion: "28253567"
+  selfLink: /apis/argoproj.io/v1alpha1/namespaces/jesse-test/rollouts/canary-demo
+  uid: b350ba76-f6ed-11e9-a15b-42010aa80033
+spec:
+  progressDeadlineSeconds: 30
+  replicas: 5
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: canary-demo
+  strategy:
+    canary:
+      canaryService: canary-demo-preview
+      stableService: canary-demo-stable
+      trafficRouting:
+        smi:
+          rootService: root-svc # optional
+          trafficSplitName: rollout-example-traffic-split # optional
+      steps:
+      - setWeight: 20
+      - pause: {}
+      - setWeight: 40
+      - pause:
+          duration: 10s
+      - setWeight: 60
+      - pause:
+          duration: 10s
+      - setWeight: 80
+      - pause:
+          duration: 10s
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: canary-demo
+    spec:
+      containers:
+      - image: argoproj/rollouts-demo:does-not-exist
+        imagePullPolicy: Always
+        name: canary-demo
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 5m
+            memory: 32Mi
+status:
+  HPAReplicas: 6
+  availableReplicas: 5
+  blueGreen: {}
+  canary: {}
+  stableRS: 877894d5b
+  conditions:
+  - lastTransitionTime: "2019-10-25T06:07:29Z"
+    lastUpdateTime: "2019-10-25T06:07:29Z"
+    message: Rollout has minimum availability
+    reason: AvailableReason
+    status: "True"
+    type: Available
+  - lastTransitionTime: "2019-10-28T04:52:55Z"
+    lastUpdateTime: "2019-10-28T04:52:55Z"
+    message: ReplicaSet "canary-demo-65fb5ffc84" has timed out progressing.
+    reason: ProgressDeadlineExceeded
+    status: "False"
+    type: Progressing
+  currentPodHash: 65fb5ffc84
+  currentStepHash: f64cdc9d
+  currentStepIndex: 0
+  observedGeneration: "429"
+  readyReplicas: 5
+  replicas: 6
+  selector: app=canary-demo
+  updatedReplicas: 1

--- a/pkg/kubectl-argo-rollouts/info/testdata/canary/canary-rollout6.yaml
+++ b/pkg/kubectl-argo-rollouts/info/testdata/canary/canary-rollout6.yaml
@@ -19,7 +19,7 @@ spec:
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: canary-demo
+      app: canary-demo-weights-na
   strategy:
     canary:
       canaryService: canary-demo-preview
@@ -44,7 +44,7 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
-        app: canary-demo
+        app: canary-demo-weights-na
     spec:
       containers:
       - image: argoproj/rollouts-demo:does-not-exist
@@ -83,5 +83,5 @@ status:
   observedGeneration: "429"
   readyReplicas: 5
   replicas: 6
-  selector: app=canary-demo
+  selector: app=canary-demo-weights-na
   updatedReplicas: 1

--- a/pkg/kubectl-argo-rollouts/info/testdata/canary/canary-rollout6.yaml
+++ b/pkg/kubectl-argo-rollouts/info/testdata/canary/canary-rollout6.yaml
@@ -6,12 +6,12 @@ metadata:
   creationTimestamp: "2019-10-25T06:07:18Z"
   generation: 429
   labels:
-    app: canary-demo
+    app: canary-demo-weights-na
     app.kubernetes.io/instance: jesse-test
-  name: canary-demo
+  name: canary-demo-weights-na
   namespace: jesse-test
   resourceVersion: "28253567"
-  selfLink: /apis/argoproj.io/v1alpha1/namespaces/jesse-test/rollouts/canary-demo
+  selfLink: /apis/argoproj.io/v1alpha1/namespaces/jesse-test/rollouts/canary-demo-weights-na
   uid: b350ba76-f6ed-11e9-a15b-42010aa80033
 spec:
   progressDeadlineSeconds: 30


### PR DESCRIPTION
This fixes #1812 by pulling the actual weight from the status field instead
of the SetWeight.

Signed-off-by: zachaller <zachaller@hotmail.com>