### PR TITLE
chore: Improve image build speed #1919

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,14 +22,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-
-      # - name: Cache Docker layers
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: /tmp/.buildx-cache
-      #     key: ${{ runner.os }}-buildx-${{ github.sha }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-buildx-
+        with:
+          config-inline: |
+            [worker.oci]
+            gc = false
 
       - name: Docker meta (controller)
         id: controller-meta
@@ -95,11 +91,3 @@ jobs:
           platforms: ${{ steps.platform-matrix.outputs.platform-matrix }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.plugin-meta.outputs.tags }}
-
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-      # - name: Move cache
-      #   run: |
-      #     rm -rf /tmp/.buildx-cache
-      #     mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -72,7 +72,8 @@ jobs:
         id: platform-matrix
         run: |
           PLATFORM_MATRIX=linux/amd64
-          if [ ${{ github.event_name != 'pull_request' }} = true ]; then
+          if [[ "${{ github.event_name }}" == "push" || "${{ contains(github.event.pull_request.labels.*.name, 'test-arm-image') }}" == "true" ]]
+          then
             PLATFORM_MATRIX=$PLATFORM_MATRIX,linux/arm64
           fi
           echo "::set-output name=platform-matrix::$PLATFORM_MATRIX"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,12 +25,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-
-      - name: Cache Docker layers
-        uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ steps.get-sha.outputs.sha }}
+          config-inline: |
+            [worker.oci]
+            gc = false
 
       - name: Print Disk Usage
         run: |
@@ -84,8 +82,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.controller-meta.outputs.tags }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Build and push (plugin-image)
         uses: docker/build-push-action@v2
@@ -95,16 +91,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.plugin-meta.outputs.tags }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
 
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   release-artifacts:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN touch ui/dist/node_modules.marker && \
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG MAKE_TARGET="controller plugin plugin-linux plugin-darwin plugin-windows"
+ARG MAKE_TARGET="controller plugin"
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH make ${MAKE_TARGET}
 
 ####################################################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,8 @@ RUN touch ui/dist/node_modules.marker && \
     touch ui/dist/app/index.html && \
     find ui/dist
 
-ARG TARGETOS TARGETARCH
+ARG TARGETOS
+ARG TARGETARCH
 ARG MAKE_TARGET="controller plugin plugin-linux plugin-darwin plugin-windows"
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH make ${MAKE_TARGET}
 

--- a/Makefile
+++ b/Makefile
@@ -175,22 +175,22 @@ docs:
 
 .PHONY: builder-image
 builder-image:
-	docker build  -t $(IMAGE_PREFIX)argo-rollouts-ci-builder:$(IMAGE_TAG) --target builder .
+	DOCKER_BUILDKIT=1 docker build  -t $(IMAGE_PREFIX)argo-rollouts-ci-builder:$(IMAGE_TAG) --target builder .
 		@if [ "$(DOCKER_PUSH)" = "true" ] ; then docker push $(IMAGE_PREFIX)argo-rollouts:$(IMAGE_TAG) ; fi
 
 .PHONY: image
 image:
 ifeq ($(DEV_IMAGE), true)
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/rollouts-controller-linux-amd64 ./cmd/rollouts-controller
-	docker build -t $(IMAGE_PREFIX)argo-rollouts:$(IMAGE_TAG) -f Dockerfile.dev ${DIST_DIR}
+	DOCKER_BUILDKIT=1 docker build -t $(IMAGE_PREFIX)argo-rollouts:$(IMAGE_TAG) -f Dockerfile.dev ${DIST_DIR}
 else
-	docker build -t $(IMAGE_PREFIX)argo-rollouts:$(IMAGE_TAG)  .
+	DOCKER_BUILDKIT=1 docker build -t $(IMAGE_PREFIX)argo-rollouts:$(IMAGE_TAG)  .
 endif
 	@if [ "$(DOCKER_PUSH)" = "true" ] ; then docker push $(IMAGE_PREFIX)argo-rollouts:$(IMAGE_TAG) ; fi
 
 .PHONY: plugin-image
 plugin-image:
-	docker build --target kubectl-argo-rollouts -t $(IMAGE_PREFIX)kubectl-argo-rollouts:$(IMAGE_TAG) .
+	DOCKER_BUILDKIT=1 docker build --target kubectl-argo-rollouts -t $(IMAGE_PREFIX)kubectl-argo-rollouts:$(IMAGE_TAG) .
 	if [ "$(DOCKER_PUSH)" = "true" ] ; then docker push $(IMAGE_PREFIX)kubectl-argo-rollouts:$(IMAGE_TAG) ; fi
 
 .PHONY: lint

--- a/hack/build-release-plugins.sh
+++ b/hack/build-release-plugins.sh
@@ -6,7 +6,8 @@ SRCROOT="$( CDPATH='' cd -- "$(dirname "$0")/.." && pwd -P )"
 mkdir -p ${SRCROOT}/dist
 
 rollout_iid_file=$(mktemp -d "${SRCROOT}/dist/rollout_iid.XXXXXXXXX")
-docker build --iidfile ${rollout_iid_file} --target argo-rollouts-build .
+DOCKER_BUILDKIT=1 docker build --iidfile ${rollout_iid_file} --build-arg MAKE_TARGET="plugin-linux plugin-darwin plugin-windows" \
+--target argo-rollouts-build .
 rollout_iid=$(cat ${rollout_iid_file})
 container_id=$(docker create ${rollout_iid})
 


### PR DESCRIPTION
Signed-off-by: Justin Marquis <34fathombelow@protonmail.com>

This is a follow-up to PR#1919.  Cache created from the `controller-image` should be used to build the `plugin-image`.  Buildx uses Buildkit under the hood and uses "Automatic garbage collection" which has a [default policy of 10% of free disk space](https://github.com/moby/moby/blob/master/builder/builder-next/worker/gc_unix.go).  Disabling the garbage collection ensures that the cache is temporarily stored for the duration of the runner.  

I also made a small change to the Dockerfile to provide support for older versions of Docker and Podman which do not support multiple args on a single line.

Checklist:

* [x] Either ~~(a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or~~ (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).