### PR TITLE
fix: Change behavior of rollout to not check for availability during rollout and fix flakey e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ DEV_IMAGE=false
 E2E_INSTANCE_ID ?= argo-rollouts-e2e
 E2E_TEST_OPTIONS ?= 
 E2E_PARALLEL ?= 4
+E2E_WAIT_TIMEOUT ?= 90
 
 override LDFLAGS += \
   -X ${PACKAGE}/utils/version.version=${VERSION} \

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -758,6 +758,7 @@ spec:
       - pause: {}
 `).
 		WaitForRolloutStatus("Paused").
+		WaitForRolloutAvailableReplicas(2).
 		Then().
 		ExpectReplicaCounts(2, 2, 1, 2, 2). // desired, current, updated, ready, available
 		ExpectServiceSelector("bluegreen-to-canary", map[string]string{"app": "bluegreen-to-canary"}, false)

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -644,7 +644,8 @@ spec:
       maxUnavailable: 0
       steps:
       - setWeight: 50
-      - pause: {}
+      - pause:
+          duration: 5s
   selector:
     matchLabels:
       app: bad2good-setweight
@@ -671,10 +672,10 @@ spec:
       containers:
       - name: bad2good-setweight
         command: null`).
-		WaitForRolloutStatus("Progressing").
-		WaitForRolloutStatus("Degraded").
+		WaitForRolloutStatus("Healthy").
 		Then().
-		ExpectCanaryStablePodCount(2, 2)
+		ExpectRevisionPodCount("2", 4).
+		ExpectRevisionPodCount("1", 0)
 }
 
 // TestBlueGreenUpdate

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -758,7 +758,6 @@ spec:
       - pause: {}
 `).
 		WaitForRolloutStatus("Paused").
-		WaitForRolloutAvailableReplicas(2).
 		Then().
 		ExpectReplicaCounts(2, 2, 1, 2, 2). // desired, current, updated, ready, available
 		ExpectServiceSelector("bluegreen-to-canary", map[string]string{"app": "bluegreen-to-canary"}, false)

--- a/test/fixtures/e2e_suite.go
+++ b/test/fixtures/e2e_suite.go
@@ -36,7 +36,7 @@ import (
 const (
 	// E2E_INSTANCE_ID is the instance id label attached to objects created by the e2e tests
 	EnvVarE2EInstanceID = "E2E_INSTANCE_ID"
-	// E2E_WAIT_TIMEOUT is a timeout in seconds when waiting for a test condition (default: 60)
+	// E2E_WAIT_TIMEOUT is a timeout in seconds when waiting for a test condition (default: 90)
 	EnvVarE2EWaitTimeout = "E2E_WAIT_TIMEOUT"
 	// E2E_POD_DELAY slows down pod startup and shutdown by the value in seconds (default: 0)
 	// Used humans slow down rollout activity during a test
@@ -52,7 +52,7 @@ const (
 )
 
 var (
-	E2EWaitTimeout time.Duration = time.Second * 60
+	E2EWaitTimeout time.Duration = time.Second * 90
 	E2EPodDelay                  = 0
 
 	E2EALBIngressAnnotations map[string]string

--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -21,6 +21,10 @@ func allDesiredAreAvailable(rs *appsv1.ReplicaSet, desired int32) bool {
 	return rs != nil && desired == *rs.Spec.Replicas && desired == rs.Status.AvailableReplicas
 }
 
+func allDesiredAreCreated(rs *appsv1.ReplicaSet, desired int32) bool {
+	return rs != nil && desired == *rs.Spec.Replicas
+}
+
 func AtDesiredReplicaCountsForCanary(ro *v1alpha1.Rollout, newRS, stableRS *appsv1.ReplicaSet, olderRSs []*appsv1.ReplicaSet, weights *v1alpha1.TrafficWeights) bool {
 	var desiredNewRSReplicaCount, desiredStableRSReplicaCount int32
 	if ro.Spec.Strategy.Canary.TrafficRouting == nil {
@@ -32,7 +36,7 @@ func AtDesiredReplicaCountsForCanary(ro *v1alpha1.Rollout, newRS, stableRS *apps
 		return false
 	}
 	if ro.Spec.Strategy.Canary.TrafficRouting == nil || !ro.Spec.Strategy.Canary.DynamicStableScale {
-		if !allDesiredAreAvailable(stableRS, desiredStableRSReplicaCount) {
+		if !allDesiredAreCreated(stableRS, desiredStableRSReplicaCount) {
 			// only check stable RS if we are not using dynamic stable scaling
 			return false
 		}

--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -22,7 +22,7 @@ func allDesiredAreAvailable(rs *appsv1.ReplicaSet, desired int32) bool {
 }
 
 func allDesiredAreCreated(rs *appsv1.ReplicaSet, desired int32) bool {
-	return rs != nil && desired == *rs.Spec.Replicas
+	return rs != nil && desired == *rs.Spec.Replicas && desired == rs.Status.Replicas
 }
 
 func AtDesiredReplicaCountsForCanary(ro *v1alpha1.Rollout, newRS, stableRS *appsv1.ReplicaSet, olderRSs []*appsv1.ReplicaSet, weights *v1alpha1.TrafficWeights) bool {


### PR DESCRIPTION
This PR changes the behavior such that we now do not check the stable replicate sets pod availability during a rollout and instead just insure the the replica set has the correct number of replica pods set which would put them in the created or creating state. Fixes issue #995

This implements the logic found in this [comment](https://github.com/argoproj/argo-rollouts/issues/995#issuecomment-1083602885) . 

- [x] Handle roll forward case
- [x] Handle rollback case


NOTES: on e2e changes

The changes for the timing config for e2e test has greatly improved the flakey nature of the e2e test both on github runners and while running locally. At 60 seconds I was never really able to reliably get e2e tests to run with the default of 60 seconds. I think to help with onboarding and have good defaults bumping to to 90 seconds makes sense.

I also did some tests on github found [here](https://github.com/zachaller/argo-rollouts/actions) where I ran test set at 60 seconds and 90 seconds. I did 5 of each and at 60 seconds 1/5 where successful and at 90 seconds 4/5 where successful. The one failure at 90 seconds I think was not related to the time setting but possibly another type of race.

Screen shot for history test 31 is 90 seconds and test 32 is 60 seconds and they continue to alternate:
<img width="965" alt="Screen Shot 2022-04-05 at 9 58 24 AM" src="https://user-images.githubusercontent.com/201390/161783552-7abcd399-2ecc-4335-8ae5-04fe809fa087.png">
