### PR TITLE
fix: build/lint is broken due to dependencies changes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-          uses: actions/setup-go@v3
-          with:
-            go-version: ${{ env.GOLANG_VERSION }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Run golangci-lint

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,18 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.30
+          version: v1.45.2
           args: --timeout 5m
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.17
         id: go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,15 +7,23 @@ on:
   pull_request:
     branches:
       - "master"
+env:
+  # Golang version to use across CI steps
+  GOLANG_VERSION: '1.17'
+
 jobs:
   lint-go:
     name: Lint Go code
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go
+          uses: actions/setup-go@v3
+          with:
+            go-version: ${{ env.GOLANG_VERSION }}
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.45.2
           args: --timeout 5m
@@ -26,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: ${{ env.GOLANG_VERSION }}
         id: go
 
       - name: Check out code into the Go module directory
@@ -70,7 +78,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v1
         with:
-          go-version: 1.17.6
+          go-version: ${{ env.GOLANG_VERSION }}
       # k8s codegen generates files into GOPATH location instead of the GitHub git checkout location
       # This symlink is necessary to ensure that `git diff` detects changes
       - name: Create symlink in GOPATH


### PR DESCRIPTION
We ran into this same issue with argo cd the fix is found [here](https://github.com/argoproj/argo-cd/pull/8988) for ArgoCD