### PR TITLE
fix(RBAC): Add watch verb to clusterRole for pods. Fixes #1960

### DIFF
--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -14430,6 +14430,7 @@ rules:
   verbs:
   - list
   - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -14430,6 +14430,7 @@ rules:
   verbs:
   - list
   - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/manifests/role/argo-rollouts-clusterrole.yaml
+++ b/manifests/role/argo-rollouts-clusterrole.yaml
@@ -107,6 +107,7 @@ rules:
   verbs:
   - list
   - update
+  - watch
 # pods eviction needed for restart
 - apiGroups:
   - ""


### PR DESCRIPTION
Need pod watch argo rollouts get rollouts
Fixes https://github.com/argoproj/argo-rollouts/issues/1960
Checklist:

* [x] this is a bug fix
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).