### PR TITLE
fix: Add pagination to FindLoadBalancerByDNSName

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/antonmedv/expr v1.9.0
 	github.com/argoproj/notifications-engine v0.3.1-0.20220129012210-32519f8f68ec
 	github.com/argoproj/pkg v0.9.0
+	github.com/aws/aws-sdk-go-v2 v1.13.0
 	github.com/aws/aws-sdk-go-v2/config v1.13.1
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.15.0
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.16.0
@@ -66,7 +67,6 @@ require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/RocketChat/Rocket.Chat.Go.SDK v0.0.0-20210112200207-10ab4d695d60 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.13.0 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.8.0 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.10.0 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.4 // indirect

--- a/utils/aws/aws.go
+++ b/utils/aws/aws.go
@@ -131,7 +131,7 @@ func FakeNewClientFunc(elbClient ELBv2APIClient) func() (Client, error) {
 
 func (c *ClientAdapter) FindLoadBalancerByDNSName(ctx context.Context, dnsName string) (*elbv2types.LoadBalancer, error) {
 	paginator := elbv2.NewDescribeLoadBalancersPaginator(c.ELBV2, &elbv2.DescribeLoadBalancersInput{
-		PageSize: aws.Int32(300),
+		PageSize: aws.Int32(defaults.DefaultAwsLoadBalancerPageSize),
 	})
 	for paginator.HasMorePages() {
 		output, err := paginator.NextPage(ctx)

--- a/utils/aws/aws.go
+++ b/utils/aws/aws.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
 
 	"github.com/argoproj/argo-rollouts/utils/defaults"
 	"github.com/aws/aws-sdk-go-v2/config"

--- a/utils/defaults/defaults.go
+++ b/utils/defaults/defaults.go
@@ -40,6 +40,8 @@ const (
 	DefaultQPS float32 = 40.0
 	// DefaultBurst is the default value for Burst for client side throttling to the K8s API server
 	DefaultBurst int = 80
+	// DefaultAwsLoadBalancerPageSize is the default page size used when calling aws to get load balancers by DNS name
+	DefaultAwsLoadBalancerPageSize = int32(300)
 )
 
 const (


### PR DESCRIPTION
This adds pagination to the FindLoadBalancerByDNSName function this
should allow argo rollouts to work with any number of loadbalancers.

closes issue #1963

Signed-off-by: zachaller <zachaller@hotmail.com>