### PR TITLE
docs: fix !important block typo in canary doc

### DIFF
--- a/docs/features/canary.md
+++ b/docs/features/canary.md
@@ -83,8 +83,7 @@ match the traffic weight. Some use cases for this:
 
 
 !!! important
-  Setting canary scale is only available when using the canary strategy with a traffic router, since
-  the basic canary needs to control canary scale in order to approximate canary weight.
+    Setting canary scale is only available when using the canary strategy with a traffic router, since the basic canary needs to control canary scale in order to approximate canary weight.
 
 To control canary scales and weights during steps, use the `setCanaryScale` step and indicate which scale the
 the canary should use:


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).