### PR TITLE
fix(analysis): Fix Analysis Terminal Decision For Dry-Run Metrics

### DIFF
--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -1500,7 +1500,7 @@ func TestAssessRunStatusErrorMessageAnalysisPhaseFail(t *testing.T) {
 
 func TestAssessRunStatusErrorMessageAnalysisPhaseFailInDryRunMode(t *testing.T) {
 	status, message, dryRunSummary := StartAssessRunStatusErrorMessageAnalysisPhaseFail(t, true)
-	assert.Equal(t, v1alpha1.AnalysisPhaseSuccessful, status)
+	assert.Equal(t, v1alpha1.AnalysisPhaseRunning, status)
 	assert.Equal(t, "", message)
 	expectedDryRunSummary := v1alpha1.RunSummary{
 		Count:        2,
@@ -1545,7 +1545,7 @@ func TestAssessRunStatusErrorMessageFromProvider(t *testing.T) {
 func TestAssessRunStatusErrorMessageFromProviderInDryRunMode(t *testing.T) {
 	providerMessage := "Provider Error"
 	status, message, dryRunSummary := StartAssessRunStatusErrorMessageFromProvider(t, providerMessage, true)
-	assert.Equal(t, v1alpha1.AnalysisPhaseSuccessful, status)
+	assert.Equal(t, v1alpha1.AnalysisPhaseRunning, status)
 	assert.Equal(t, "", message)
 	expectedDryRunSummary := v1alpha1.RunSummary{
 		Count:        2,
@@ -1587,7 +1587,7 @@ func TestAssessRunStatusMultipleFailures(t *testing.T) {
 
 func TestAssessRunStatusMultipleFailuresInDryRunMode(t *testing.T) {
 	status, message, dryRunSummary := StartAssessRunStatusMultipleFailures(t, true)
-	assert.Equal(t, v1alpha1.AnalysisPhaseSuccessful, status)
+	assert.Equal(t, v1alpha1.AnalysisPhaseRunning, status)
 	assert.Equal(t, "", message)
 	expectedDryRunSummary := v1alpha1.RunSummary{
 		Count:        2,
@@ -1623,7 +1623,7 @@ func TestAssessRunStatusWorstMessageInReconcileAnalysisRun(t *testing.T) {
 
 func TestAssessRunStatusWorstMessageInReconcileAnalysisRunInDryRunMode(t *testing.T) {
 	newRun := StartAssessRunStatusWorstMessageInReconcileAnalysisRun(t, true)
-	assert.Equal(t, v1alpha1.AnalysisPhaseSuccessful, newRun.Status.Phase)
+	assert.Equal(t, v1alpha1.AnalysisPhaseRunning, newRun.Status.Phase)
 	assert.Equal(t, "", newRun.Status.Message)
 	expectedDryRunSummary := v1alpha1.RunSummary{
 		Count:        2,

--- a/utils/analysis/helpers.go
+++ b/utils/analysis/helpers.go
@@ -87,7 +87,9 @@ func IsTerminating(run *v1alpha1.AnalysisRun) bool {
 	for _, res := range run.Status.MetricResults {
 		switch res.Phase {
 		case v1alpha1.AnalysisPhaseFailed, v1alpha1.AnalysisPhaseError, v1alpha1.AnalysisPhaseInconclusive:
-			return true
+			// If this metric is running in the dryRun mode then we don't care about the failures and hence the terminal
+			// decision shouldn't be affected.
+			return !res.DryRun
 		}
 	}
 	return false

--- a/utils/analysis/helpers_test.go
+++ b/utils/analysis/helpers_test.go
@@ -62,20 +62,34 @@ func TestIsFastFailTerminating(t *testing.T) {
 					Name:  "success-rate",
 					Phase: v1alpha1.AnalysisPhaseRunning,
 				},
+				{
+					Name:   "dry-run-metric",
+					Phase:  v1alpha1.AnalysisPhaseRunning,
+					DryRun: true,
+				},
 			},
 		},
 	}
+	// Verify that when the metric is not failing or in the error state then we don't terminate.
 	successRate := run.Status.MetricResults[1]
 	assert.False(t, IsTerminating(run))
+	// Metric failing in the dryRun mode shouldn't impact the terminal decision.
+	dryRunMetricResult := run.Status.MetricResults[2]
+	dryRunMetricResult.Phase = v1alpha1.AnalysisPhaseError
+	run.Status.MetricResults[2] = dryRunMetricResult
+	assert.False(t, IsTerminating(run))
+	// Verify that a wet run metric failure/error results in terminal decision.
 	successRate.Phase = v1alpha1.AnalysisPhaseError
 	run.Status.MetricResults[1] = successRate
 	assert.True(t, IsTerminating(run))
 	successRate.Phase = v1alpha1.AnalysisPhaseFailed
 	run.Status.MetricResults[1] = successRate
 	assert.True(t, IsTerminating(run))
+	// Verify that an inconclusive wet run metric results in terminal decision.
 	successRate.Phase = v1alpha1.AnalysisPhaseInconclusive
 	run.Status.MetricResults[1] = successRate
 	assert.True(t, IsTerminating(run))
+	// Verify that we don't terminate when there are no metric results or when the status is empty.
 	run.Status.MetricResults = nil
 	assert.False(t, IsTerminating(run))
 	run.Status = v1alpha1.AnalysisRunStatus{}


### PR DESCRIPTION
## Description

Metrics running in the Dry-Run mode shouldn't impact the terminal decision even if they error out or fail but currently we ignore the metric state which results in the analysis run being terminated earlier in case there are any Dry-Run failures.

Expected behavior is to take into account the status of the metric i.e. Dry-Run or Wet-Run while making the terminal decision inside `IsTerminating(...)`.

## Checklist

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).