### PR TITLE
chore: upgrade default smi version

### DIFF
--- a/rollout/trafficrouting/smi/smi_test.go
+++ b/rollout/trafficrouting/smi/smi_test.go
@@ -180,6 +180,8 @@ func TestReconcilePatchExistingTrafficSplit(t *testing.T) {
 	t.Run("v1alpha1", func(t *testing.T) {
 		ts1 := trafficSplitV1Alpha1(ro, objectMeta, "root-service", int32(10))
 		client := fake.NewSimpleClientset(ts1)
+		defaults.SetSMIAPIVersion("v1alpha1")
+		defer defaults.SetSMIAPIVersion(defaults.DefaultSMITrafficSplitVersion)
 		r, err := NewReconciler(ReconcilerConfig{
 			Rollout:        ro,
 			Client:         client,
@@ -246,8 +248,6 @@ func TestReconcilePatchExistingTrafficSplit(t *testing.T) {
 	t.Run("v1alpha3", func(t *testing.T) {
 		ts3 := trafficSplitV1Alpha3(ro, objectMeta, "root-service", int32(10))
 		client := fake.NewSimpleClientset(ts3)
-		defaults.SetSMIAPIVersion("v1alpha3")
-		defer defaults.SetSMIAPIVersion(defaults.DefaultSMITrafficSplitVersion)
 		r, err := NewReconciler(ReconcilerConfig{
 			Rollout:        ro,
 			Client:         client,
@@ -282,6 +282,8 @@ func TestReconcilePatchExistingTrafficSplitNoChange(t *testing.T) {
 		objMeta := objectMeta("traffic-split-v1alpha1", ro, schema.GroupVersionKind{})
 		ts1 := trafficSplitV1Alpha1(ro, objMeta, "root-service", int32(10))
 		client := fake.NewSimpleClientset(ts1)
+		defaults.SetSMIAPIVersion("v1alpha1")
+		defer defaults.SetSMIAPIVersion(defaults.DefaultSMITrafficSplitVersion)
 		r, err := NewReconciler(ReconcilerConfig{
 			Rollout:        ro,
 			Client:         client,
@@ -331,8 +333,6 @@ func TestReconcilePatchExistingTrafficSplitNoChange(t *testing.T) {
 		objMeta := objectMeta("traffic-split-v1alpha3", ro, schema.GroupVersionKind{})
 		ts3 := trafficSplitV1Alpha3(ro, objMeta, "root-service", int32(10))
 		client := fake.NewSimpleClientset(ts3)
-		defaults.SetSMIAPIVersion("v1alpha3")
-		defer defaults.SetSMIAPIVersion(defaults.DefaultSMITrafficSplitVersion)
 		r, err := NewReconciler(ReconcilerConfig{
 			Rollout:        ro,
 			Client:         client,

--- a/rollout/trafficrouting/smi/smi_test.go
+++ b/rollout/trafficrouting/smi/smi_test.go
@@ -381,6 +381,8 @@ func TestReconcileRolloutDoesNotOwnTrafficSplitError(t *testing.T) {
 		ts1.OwnerReferences = nil
 
 		client := fake.NewSimpleClientset(ts1)
+		defaults.SetSMIAPIVersion("v1alpha1")
+		defer defaults.SetSMIAPIVersion(defaults.DefaultSMITrafficSplitVersion)
 		r, err := NewReconciler(ReconcilerConfig{
 			Rollout:        ro,
 			Client:         client,
@@ -415,8 +417,6 @@ func TestReconcileRolloutDoesNotOwnTrafficSplitError(t *testing.T) {
 	t.Run("v1alpha3", func(t *testing.T) {
 		ts3 := trafficSplitV1Alpha3(ro, objMeta, "root-service", int32(10))
 		ts3.OwnerReferences = nil
-		defaults.SetSMIAPIVersion("v1alpha3")
-		defer defaults.SetSMIAPIVersion(defaults.DefaultSMITrafficSplitVersion)
 
 		client := fake.NewSimpleClientset(ts3)
 		r, err := NewReconciler(ReconcilerConfig{
@@ -449,6 +449,8 @@ func TestCreateTrafficSplitForMultipleBackends(t *testing.T) {
 
 	t.Run("v1alpha1", func(t *testing.T) {
 		client := fake.NewSimpleClientset()
+		defaults.SetSMIAPIVersion("v1alpha1")
+		defer defaults.SetSMIAPIVersion(defaults.DefaultSMITrafficSplitVersion)
 		r, err := NewReconciler(ReconcilerConfig{
 			Rollout:        ro,
 			Client:         client,
@@ -533,8 +535,6 @@ func TestCreateTrafficSplitForMultipleBackends(t *testing.T) {
 	})
 
 	t.Run("v1alpha3", func(t *testing.T) {
-		defaults.SetSMIAPIVersion("v1alpha3")
-		defer defaults.SetSMIAPIVersion(defaults.DefaultSMITrafficSplitVersion)
 
 		client := fake.NewSimpleClientset()
 		r, err := NewReconciler(ReconcilerConfig{

--- a/utils/defaults/defaults.go
+++ b/utils/defaults/defaults.go
@@ -48,7 +48,7 @@ const (
 	DefaultAmbassadorAPIGroup           = "getambassador.io"
 	DefaultAmbassadorVersion            = "getambassador.io/v2"
 	DefaultIstioVersion                 = "v1alpha3"
-	DefaultSMITrafficSplitVersion       = "v1alpha1"
+	DefaultSMITrafficSplitVersion       = "v1alpha3"
 	DefaultTargetGroupBindingAPIVersion = "elbv2.k8s.aws/v1beta1"
 	DefaultAppMeshCRDVersion            = "v1beta2"
 	DefaultTraefikAPIGroup              = "traefik.containo.us"


### PR DESCRIPTION
This is a breaking change so we would want to make a note of it in upgrade docs.

Signed-off-by: zachaller <zachaller@hotmail.com>