### PR TITLE
feat: Expose metric for rollout abort with analysisrun failure

### DIFF
--- a/controller/metrics/metrics.go
+++ b/controller/metrics/metrics.go
@@ -28,6 +28,7 @@ type MetricsServer struct {
 	errorAnalysisRunCounter       *prometheus.CounterVec
 	successNotificationCounter    *prometheus.CounterVec
 	errorNotificationCounter      *prometheus.CounterVec
+	rolloutInfoCounter            *prometheus.CounterVec
 	sendNotificationRunHistogram  *prometheus.HistogramVec
 	k8sRequestsCounter            *K8sRequestsCountProvider
 }
@@ -72,6 +73,7 @@ func NewMetricsServer(cfg ServerConfig, isPrimary bool) *MetricsServer {
 	cfg.K8SRequestProvider.MustRegister(reg)
 	reg.MustRegister(MetricRolloutReconcile)
 	reg.MustRegister(MetricRolloutReconcileError)
+	reg.MustRegister(MetricRolloutInfoTotal)
 	reg.MustRegister(MetricRolloutEventsTotal)
 	reg.MustRegister(MetricExperimentReconcile)
 	reg.MustRegister(MetricExperimentReconcileError)
@@ -104,6 +106,7 @@ func NewMetricsServer(cfg ServerConfig, isPrimary bool) *MetricsServer {
 		successNotificationCounter:    MetricNotificationSuccessTotal,
 		errorNotificationCounter:      MetricNotificationFailedTotal,
 		sendNotificationRunHistogram:  MetricNotificationSend,
+		rolloutInfoCounter:            MetricRolloutInfoTotal,
 
 		k8sRequestsCounter: cfg.K8SRequestProvider,
 	}
@@ -134,6 +137,11 @@ func (m *MetricsServer) IncError(namespace, name string, kind string) {
 	case log.ExperimentKey:
 		m.errorExperimentCounter.WithLabelValues(namespace, name).Inc()
 	}
+}
+
+// IncAnalysisFailed increments rolloutInfoCounter counter for a rollout
+func (m *MetricsServer) IncAnalysisFailed(namespace, name string, reason string) {
+	m.rolloutInfoCounter.WithLabelValues(namespace, name, reason).Inc()
 }
 
 func boolFloat64(b bool) float64 {

--- a/controller/metrics/prommetrics.go
+++ b/controller/metrics/prommetrics.go
@@ -37,6 +37,14 @@ var (
 		nil,
 	)
 
+	MetricRolloutInfoTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "rollout_info_total",
+			Help: "Information about rollout status.",
+		},
+		append(namespaceNameLabels, "reason"),
+	)
+
 	MetricRolloutInfoReplicasAvailable = prometheus.NewDesc(
 		"rollout_info_replicas_available",
 		"The number of available replicas per rollout.",

--- a/rollout/context.go
+++ b/rollout/context.go
@@ -3,6 +3,8 @@ package rollout
 import (
 	"time"
 
+	"github.com/argoproj/argo-rollouts/controller/metrics"
+
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -39,8 +41,9 @@ type rolloutContext struct {
 	currentEx *v1alpha1.Experiment
 	otherExs  []*v1alpha1.Experiment
 
-	newStatus    v1alpha1.RolloutStatus
-	pauseContext *pauseContext
+	metricsServer *metrics.MetricsServer
+	newStatus     v1alpha1.RolloutStatus
+	pauseContext  *pauseContext
 
 	// targetsVerified indicates if the pods targets have been verified with underlying LoadBalancer.
 	// This is used in pod-aware flat networks where LoadBalancers target Pods and not Nodes.

--- a/rollout/controller.go
+++ b/rollout/controller.go
@@ -473,6 +473,7 @@ func (c *Controller) newRolloutContext(rollout *v1alpha1.Rollout) (*rolloutConte
 			log:     logCtx,
 		},
 		reconcilerBase: c.reconcilerBase,
+		metricsServer:  c.metricsServer,
 	}
 	// carry over existing recorded weights
 	roCtx.newStatus.Canary.Weights = rollout.Status.Canary.Weights

--- a/utils/conditions/conditions.go
+++ b/utils/conditions/conditions.go
@@ -73,6 +73,8 @@ const (
 	RolloutAbortedReason = "RolloutAborted"
 	// RolloutAbortedMessage indicates that the rollout was aborted
 	RolloutAbortedMessage = "Rollout aborted update to revision %d"
+	// RolloutAbortedWithAnalysisFailure indicates that the rollout was aborted with analysis failure
+	RolloutAbortedWithAnalysisFailure = "RolloutAbortedWithAnalysisFailure"
 
 	// RolloutRetryReason indicates that the rollout is retrying after being aborted
 	RolloutRetryReason = "RolloutRetry"


### PR DESCRIPTION
Signed-off-by: Ravi Hari <ravireliable@gmail.com>

fixes: #2087 

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [X] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [X] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My builds are green. Try syncing with master if they are not. 
* [X] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).