### PR TITLE
fix: Failed to process: Object 'Kind' is missing in Errors with rollouts notification

### DIFF
--- a/rollout/controller.go
+++ b/rollout/controller.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"reflect"
 	"strconv"
 	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts"
 	smiclientset "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/split/clientset/versioned"

--- a/rollout/controller.go
+++ b/rollout/controller.go
@@ -426,7 +426,7 @@ func (c *Controller) writeBackToInformer(ro *v1alpha1.Rollout) {
 	// which the notification controller expects when it converts rolloutobject to toUnstructured and if not present
 	// and that throws an error "Failed to process: Object 'Kind' is missing in ..."
 	// Fixing this here as the informer is shared by notification controller by updating typemetafileds.
-	// TODO: Ned to revisit this in the future and maybe we should have a dedicated informer for notification
+	// TODO: Need to revisit this in the future and maybe we should have a dedicated informer for notification
 	gvk := un.GetObjectKind().GroupVersionKind()
 	if len(gvk.Version) == 0 || len(gvk.Group) == 0 || len(gvk.Kind) == 0 {
 		un.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{

--- a/rollout/controller.go
+++ b/rollout/controller.go
@@ -422,6 +422,11 @@ func (c *Controller) writeBackToInformer(ro *v1alpha1.Rollout) {
 		return
 	}
 	un := unstructured.Unstructured{Object: obj}
+	// With code-gen tools the argoclientset is generated and the update method here is removing typemetafields
+	// which the notification controller expects when it converts rolloutobject to toUnstructured and if not present
+	// and that throws an error "Failed to process: Object 'Kind' is missing in ..."
+	// Fixing this here as the informer is shared by notification controller by updating typemetafileds.
+	// TODO: Ned to revisit this in the future and maybe we should have a dedicated informer for notification
 	gvk := un.GetObjectKind().GroupVersionKind()
 	if len(gvk.Version) == 0 || len(gvk.Group) == 0 || len(gvk.Kind) == 0 {
 		un.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{


### PR DESCRIPTION
Signed-off-by: Ravi Hari <ravireliable@gmail.com>
fixes: #1720 
Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [X] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [X] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My builds are green. Try syncing with master if they are not. 
* [X] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).