### PR TITLE
fix(analysis): Avoid Infinite Error Message Append For Failed Dry-Run Metrics

### DIFF
--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -510,12 +510,7 @@ func (c *Controller) assessRunStatus(run *v1alpha1.AnalysisRun, metrics []v1alph
 				} else {
 					// Update metric result message
 					if message != "" {
-						failureMessage := fmt.Sprintf("Metric assessed %s due to %s", metricStatus, message)
-						if result.Message != "" {
-							result.Message = fmt.Sprintf("%s: \"Error Message: %s\"", failureMessage, result.Message)
-						} else {
-							result.Message = failureMessage
-						}
+						result.Message = fmt.Sprintf("Metric assessed %s due to %s", metricStatus, message)
 						analysisutil.SetResult(run, *result)
 					}
 					// Update DryRun Summary


### PR DESCRIPTION
### Description

A small fix to only include the most recent error message for the dry-run metric failures. If we don't do this and there are other wet-metrics in progress then the error message keeps getting appended infinitely. 

### Checklist

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

---
Signed-off-by: Rohit Agrawal <rohit.agrawal@databricks.com>