### PR TITLE
fix: return an error when we cannot swap the replicaset hashes fixes #2050

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -38,3 +38,4 @@ Organizations below are **officially** using Argo Rollouts. Please send a PR wit
 1. [Twilio SendGrid](https://sendgrid.com)
 1. [Ubie](https://ubie.life/)
 1. [VISITS Technologies](https://visits.world/en)
+1. [Plaid](https://plaid.com)

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -1,6 +1,7 @@
 package rollout
 
 import (
+	"errors"
 	"sort"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -50,6 +51,11 @@ func (c *rolloutContext) rolloutCanary() error {
 	}
 
 	if err := c.reconcileStableAndCanaryService(); err != nil {
+		// if we cannot reconcile the stable and canary services then
+		// we should not continue to adjust traffic routing
+		if errors.Is(err, DelayServiceSelectorSwapError) {
+			return nil
+		}
 		return err
 	}
 

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -1,7 +1,6 @@
 package rollout
 
 import (
-	"errors"
 	"sort"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -51,11 +50,6 @@ func (c *rolloutContext) rolloutCanary() error {
 	}
 
 	if err := c.reconcileStableAndCanaryService(); err != nil {
-		// if we cannot reconcile the stable and canary services then
-		// we should not continue to adjust traffic routing
-		if errors.Is(err, DelayServiceSelectorSwapError) {
-			return nil
-		}
 		return err
 	}
 

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -1391,13 +1391,7 @@ func TestCanarySVCSelectors(t *testing.T) {
 		informers.Start(stopchan)
 		informers.WaitForCacheSync(stopchan)
 		err := rc.reconcileStableAndCanaryService()
-		// There is an error returned here because we could not reconcile
-		// unhealthy services.
-		if tc.shouldTargetNewRS {
-			assert.NoError(t, err, "unable to reconcileStableAndCanaryService")
-		} else {
-			assert.Error(t, err, "able to reconcileStableAndCanaryService for unhealthy replicas")
-		}
+		assert.NoError(t, err, "unable to reconcileStableAndCanaryService")
 		updatedCanarySVC, err := servicesLister.Services(rc.rollout.Namespace).Get(canaryService.Name)
 		assert.NoError(t, err, "unable to get updated canary service")
 		if tc.shouldTargetNewRS {

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -1271,7 +1271,13 @@ func TestCanarySVCSelectors(t *testing.T) {
 		informers.Start(stopchan)
 		informers.WaitForCacheSync(stopchan)
 		err := rc.reconcileStableAndCanaryService()
-		assert.NoError(t, err, "unable to reconcileStableAndCanaryService")
+		// There is an error returned here because we could not reconcile
+		// unhealthy services.
+		if tc.shouldTargetNewRS {
+			assert.NoError(t, err, "unable to reconcileStableAndCanaryService")
+		} else {
+			assert.Error(t, err, "able to reconcileStableAndCanaryService for unhealthy replicas")
+		}
 		updatedCanarySVC, err := servicesLister.Services(rc.rollout.Namespace).Get(canaryService.Name)
 		assert.NoError(t, err, "unable to get updated canary service")
 		if tc.shouldTargetNewRS {

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -129,8 +129,9 @@ func TestCanaryRollout(t *testing.T) {
 			Spec: v1alpha1.RolloutSpec{
 				Strategy: v1alpha1.RolloutStrategy{
 					Canary: &v1alpha1.CanaryStrategy{
-						StableService: stableService.Name,
-						CanaryService: canaryService.Name,
+						DynamicStableScale: true,
+						StableService:      stableService.Name,
+						CanaryService:      canaryService.Name,
 					},
 				},
 			},

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -63,6 +63,7 @@ func bumpVersion(rollout *v1alpha1.Rollout) *v1alpha1.Rollout {
 }
 
 func TestCanaryRollout(t *testing.T) {
+	newrsVal := "new-rs-xxx"
 	for _, tc := range []struct {
 		canaryReplicas      int32
 		canaryAvailReplicas int32
@@ -75,7 +76,7 @@ func TestCanaryRollout(t *testing.T) {
 		{2, 2, true},
 	} {
 		namespace := "namespace"
-		selectorNewRSVal := "new-rs-xxx"
+		selectorNewRSVal := newrsVal
 		stableService := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "stable",
@@ -141,7 +142,7 @@ func TestCanaryRollout(t *testing.T) {
 		if tc.shouldRouteTraffic {
 			trafficRouter.On("Type").Return("mock")
 			trafficRouter.On("RemoveManagedRoutes").Return(nil)
-			trafficRouter.On("UpdateHash", "new-rs-xxx", "").Return(nil)
+			trafficRouter.On("UpdateHash", newrsVal, "").Return(nil)
 			trafficRouter.On("SetWeight", int32(0)).Return(nil)
 			trafficRouter.On("VerifyWeight", int32(0)).Return(nil, nil)
 		}

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
+	"github.com/argoproj/argo-rollouts/rollout/mocks"
+	"github.com/argoproj/argo-rollouts/rollout/trafficrouting"
 	"github.com/argoproj/argo-rollouts/utils/annotations"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
 	"github.com/argoproj/argo-rollouts/utils/hash"
@@ -58,6 +60,123 @@ func bumpVersion(rollout *v1alpha1.Rollout) *v1alpha1.Rollout {
 	newRollout.Status.CurrentStepHash = conditions.ComputeStepHash(newRollout)
 	newRollout.Status.Phase, newRollout.Status.Message = rolloututil.CalculateRolloutPhase(newRollout.Spec, newRollout.Status)
 	return newRollout
+}
+
+func TestCanaryRollout(t *testing.T) {
+	for _, tc := range []struct {
+		canaryReplicas      int32
+		canaryAvailReplicas int32
+
+		shouldRouteTraffic bool
+	}{
+		{0, 0, false},
+		{2, 0, false},
+		{2, 1, false},
+		{2, 2, true},
+	} {
+		namespace := "namespace"
+		selectorNewRSVal := "new-rs-xxx"
+		stableService := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "stable",
+				Namespace: namespace,
+			},
+		}
+		canaryService := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "canary",
+				Namespace: namespace,
+			},
+		}
+		canaryReplicaset := &v1.ReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "canary",
+				Namespace: namespace,
+				Labels: map[string]string{
+					v1alpha1.DefaultRolloutUniqueLabelKey: selectorNewRSVal,
+				},
+			},
+			Spec: v1.ReplicaSetSpec{
+				Replicas: pointer.Int32Ptr(tc.canaryReplicas),
+			},
+			Status: v1.ReplicaSetStatus{
+				AvailableReplicas: tc.canaryAvailReplicas,
+			},
+		}
+
+		stableReplicaset := &v1.ReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "stable",
+				Namespace: namespace,
+			},
+			Spec: v1.ReplicaSetSpec{
+				Replicas: pointer.Int32Ptr(0),
+			},
+		}
+
+		fake := fake.Clientset{}
+		kubeclient := k8sfake.NewSimpleClientset(
+			stableService, canaryService, canaryReplicaset, stableReplicaset)
+		informers := k8sinformers.NewSharedInformerFactory(kubeclient, 0)
+		servicesLister := informers.Core().V1().Services().Lister()
+
+		rollout := &v1alpha1.Rollout{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "selector-labels-test",
+				Namespace: namespace,
+			},
+			Spec: v1alpha1.RolloutSpec{
+				Strategy: v1alpha1.RolloutStrategy{
+					Canary: &v1alpha1.CanaryStrategy{
+						StableService: stableService.Name,
+						CanaryService: canaryService.Name,
+					},
+				},
+			},
+		}
+
+		rollout.Status.CurrentStepHash = conditions.ComputeStepHash(rollout)
+		haveRoutedTraffic := false
+		trafficRouter := mocks.NewTrafficRoutingReconciler(t)
+		if tc.shouldRouteTraffic {
+			trafficRouter.On("Type").Return("mock")
+			trafficRouter.On("RemoveManagedRoutes").Return(nil)
+			trafficRouter.On("UpdateHash", "new-rs-xxx", "").Return(nil)
+			trafficRouter.On("SetWeight", int32(0)).Return(nil)
+			trafficRouter.On("VerifyWeight", int32(0)).Return(nil, nil)
+		}
+		mocks.NewTrafficRoutingReconciler(t)
+		rc := rolloutContext{
+			log: logutil.WithRollout(rollout),
+			reconcilerBase: reconcilerBase{
+				argoprojclientset: &fake,
+				servicesLister:    servicesLister,
+				kubeclientset:     kubeclient,
+				recorder:          record.NewFakeEventRecorder(),
+
+				newTrafficRoutingReconciler: func(roCtx *rolloutContext) ([]trafficrouting.TrafficRoutingReconciler, error) {
+					haveRoutedTraffic = true
+					return []trafficrouting.TrafficRoutingReconciler{
+						trafficRouter,
+					}, nil
+				},
+			},
+
+			rollout: rollout,
+			pauseContext: &pauseContext{
+				rollout: rollout,
+			},
+			newRS:    canaryReplicaset,
+			stableRS: stableReplicaset,
+		}
+		stopchan := make(chan struct{})
+		defer close(stopchan)
+		informers.Start(stopchan)
+		informers.WaitForCacheSync(stopchan)
+		err := rc.rolloutCanary()
+		assert.NoError(t, err)
+		assert.Equal(t, tc.shouldRouteTraffic, haveRoutedTraffic, " the traffic routing reconciler was called even though we are not ready to route traffic")
+	}
 }
 
 // TestCanaryRolloutBumpVersion verifies we correctly bump revision of Rollout and new ReplicaSet

--- a/rollout/context.go
+++ b/rollout/context.go
@@ -49,6 +49,10 @@ type rolloutContext struct {
 	// (e.g. a setWeight step, after a blue-green active switch, after stable service switch),
 	// since we do not want to continually verify weight in case it could incur rate-limiting or other expenses.
 	targetsVerified *bool
+
+	// skippedSelectorSwap indicates that we have skipped swapping selectors
+	// and are not ready to perform any final actions of moving to 100%
+	skippedSelectorSwap *bool
 }
 
 func (c *rolloutContext) reconcile() error {

--- a/rollout/service.go
+++ b/rollout/service.go
@@ -290,8 +290,10 @@ func (c *rolloutContext) ensureSVCTargets(svcName string, rs *appsv1.ReplicaSet,
 		if checkRsAvailability && !replicasetutil.IsReplicaSetAvailable(rs) {
 			logCtx := c.log.WithField(logutil.ServiceKey, svc.Name)
 			logCtx.Infof("delaying service switch from %s to %s: ReplicaSet not fully available", currSelector, desiredSelector)
-			return DelayServiceSelectorSwapError
+			c.skippedSelectorSwap = pointer.BoolPtr(true)
+			return nil
 		}
+		c.skippedSelectorSwap = pointer.BoolPtr(false)
 		err = c.switchServiceSelector(svc, desiredSelector, c.rollout)
 		if err != nil {
 			return err

--- a/rollout/service.go
+++ b/rollout/service.go
@@ -45,14 +45,6 @@ const (
 }`
 )
 
-type delayServiceSelectorSwapError struct{}
-
-func (e delayServiceSelectorSwapError) Error() string {
-	return "Selectors cannot be swapped yet because not all pods are ready"
-}
-
-var DelayServiceSelectorSwapError = delayServiceSelectorSwapError{}
-
 func generatePatch(service *corev1.Service, newRolloutUniqueLabelValue string, r *v1alpha1.Rollout) string {
 	if _, ok := service.Annotations[v1alpha1.ManagedByRolloutsKey]; !ok {
 		return fmt.Sprintf(switchSelectorAndAddManagedByPatch, r.Name, newRolloutUniqueLabelValue)

--- a/rollout/service_test.go
+++ b/rollout/service_test.go
@@ -806,3 +806,8 @@ func TestDelayCanaryStableServiceLabelInjection(t *testing.T) {
 	}
 
 }
+
+func TestDelayServiceSelectorSwapError(t *testing.T) {
+	assert.Error(t, DelayServiceSelectorSwapError)
+	assert.NotEqual(t, DelayServiceSelectorSwapError.Error(), "")
+}

--- a/rollout/service_test.go
+++ b/rollout/service_test.go
@@ -781,12 +781,16 @@ func TestDelayCanaryStableServiceLabelInjection(t *testing.T) {
 		roCtx.stableRS = newReplicaSetWithStatus(ro2, 3, 0)
 
 		err = roCtx.reconcileStableAndCanaryService()
-		// an error is returned because we are delaying
-		assert.Equal(t, err, DelayServiceSelectorSwapError)
+		assert.NoError(t, err)
 		_, canaryInjected := canarySvc.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey]
 		assert.False(t, canaryInjected)
 		_, stableInjected := stableSvc.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey]
 		assert.False(t, stableInjected)
+
+		assert.NotNil(t, roCtx.skippedSelectorSwap)
+		if roCtx.skippedSelectorSwap != nil {
+			assert.True(t, *roCtx.skippedSelectorSwap)
+		}
 	}
 	{
 		// next ensure we do update service because new/stable are now available
@@ -805,9 +809,4 @@ func TestDelayCanaryStableServiceLabelInjection(t *testing.T) {
 		assert.True(t, stableInjected)
 	}
 
-}
-
-func TestDelayServiceSelectorSwapError(t *testing.T) {
-	assert.Error(t, DelayServiceSelectorSwapError)
-	assert.NotEqual(t, DelayServiceSelectorSwapError.Error(), "")
 }

--- a/rollout/service_test.go
+++ b/rollout/service_test.go
@@ -781,7 +781,8 @@ func TestDelayCanaryStableServiceLabelInjection(t *testing.T) {
 		roCtx.stableRS = newReplicaSetWithStatus(ro2, 3, 0)
 
 		err = roCtx.reconcileStableAndCanaryService()
-		assert.NoError(t, err)
+		// an error is returned because we are delaying
+		assert.Equal(t, err, DelayServiceSelectorSwapError)
 		_, canaryInjected := canarySvc.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey]
 		assert.False(t, canaryInjected)
 		_, stableInjected := stableSvc.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey]

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -220,8 +220,11 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			return err
 		}
 
-		if c.skippedSelectorSwap != nil && *c.skippedSelectorSwap {
-			c.log.Infof("Skipping selector swap (%v)", c.skippedSelectorSwap)
+		// if we haven't swapped selectors and dynamic stable scale is set then
+		// we might switch weights to a set of pods that are not ready (importantly this is the case
+		// where canary: 100, stable: 0 -> canary: 0, stable: 100).
+		if c.skippedSelectorSwap != nil && *c.skippedSelectorSwap && c.rollout.Spec.Strategy.Canary.DynamicStableScale {
+			c.log.Infof("Skipping weight changes since replica set is not ready and dynamicStableScale is set")
 			return nil
 		}
 

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -220,6 +220,10 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			return err
 		}
 
+		if c.skippedSelectorSwap != nil && *c.skippedSelectorSwap {
+			continue
+		}
+
 		err = reconciler.SetWeight(desiredWeight, weightDestinations...)
 		if err != nil {
 			c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: "TrafficRoutingError"}, err.Error())

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -221,7 +221,8 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 		}
 
 		if c.skippedSelectorSwap != nil && *c.skippedSelectorSwap {
-			continue
+			c.log.Infof("Skipping selector swap (%v)", c.skippedSelectorSwap)
+			return nil
 		}
 
 		err = reconciler.SetWeight(desiredWeight, weightDestinations...)


### PR DESCRIPTION
This fixes #2050 by ensuring that, if a rollout needs to delay swapping the replicaset hashes, we do not continue reconciling.

If we were to continue reconciling then we would end up moving the `stable` (which should be the `canary`) to 100% and the `canary` (which should be the `stable`) to 0%. Importantly, if this is at the end of a rollout where the stable set has been spun down then this will cause a traffic outage because the `stable` set will have 0 replicas available.

To illustrate the failure mode it would be:
1. We are at the end of a rollout and start to run reconciliation
2. We see that the canary replicaset is unhealthy so we do not swap the selectors
3. We continue to reconcile and set the canary replicaset to 0 and the stable replicaset to 100 (if pods have been removed during this process then this means the stable replicaset could be overwhelmed)
4. On a subsequent reconciliation we see that the canary replicaset is healthy
5. We swap the canary and stable selectors
6. This makes traffic on the correct stable replicaset (the former canary replicaset) 100

The troublesome bit here is step 3 which can be catastrophic if the canary replicaset continues to be unhealthy for an indeterminate period of time. Returning an error would only extend the period at which we are at then end of the rollout but have not completed yet.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).