### PR TITLE
fix(analysis): Make AnalysisRun end when only Dry-Run metrics are defined. Fixes: #2151

### DIFF
--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -508,6 +508,11 @@ func (c *Controller) assessRunStatus(run *v1alpha1.AnalysisRun, metrics []v1alph
 						runSummary.Successful++
 					}
 				} else {
+					// We don't really care about the failures from dry-runs and hence, if there is no current status
+					// found then we just set it to `AnalysisPhaseSuccessful`
+					if worstStatus == "" {
+						worstStatus = v1alpha1.AnalysisPhaseSuccessful
+					}
 					// Update metric result message
 					if message != "" {
 						result.Message = fmt.Sprintf("Metric assessed %s due to %s", metricStatus, message)


### PR DESCRIPTION
## Description

This PR fixes the issue defined in https://github.com/argoproj/argo-rollouts/issues/2151 where `AnalysisRun` doesn't transition to `Successful` from `Running` when only Dry-Run metrics are defined and being evaluated. As per the current logic, we don't set the decision while evaluating the Dry-Run metrics but the proper fix is to set it to `Successful` at least if nothing is set.

## Checklist

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).