### PR TITLE
Replaces an incorrect substitution in configIdLookupURLFormat string

### DIFF
--- a/metricproviders/kayenta/kayenta.go
+++ b/metricproviders/kayenta/kayenta.go
@@ -68,7 +68,7 @@ func (p *Provider) GetMetadata(metric v1alpha1.Metric) map[string]string {
 
 func getCanaryConfigId(metric v1alpha1.Metric, p *Provider) (string, error) {
 
-	configIdLookupURL := fmt.Sprintf(configIdLookupURLFormat, metric.Provider.Kayenta.Address, metric.Provider.Kayenta.Application, metric.Provider.Kayenta.StorageAccountName)
+	configIdLookupURL := fmt.Sprintf(configIdLookupURLFormat, metric.Provider.Kayenta.Address, metric.Provider.Kayenta.Application, metric.Provider.Kayenta.ConfigurationAccountName)
 
 	response, err := p.client.Get(configIdLookupURL)
 	if err != nil || response.Body == nil || response.StatusCode != 200 {


### PR DESCRIPTION
configIdLookupURLFormat string refers to a configurationAccountName, but StorageAccountName is provided.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).