### PR TITLE
docs: Fixed read-the-docs rendering

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,5 @@ mkdocs==1.2.3
 mkdocs-material==8.1.9
 markdown_include==0.6.0
 pygments==2.11.2
+jinja2==3.0.3
+markdown==3.3.7


### PR DESCRIPTION
Signed-off-by: Kostis Kapelonis <kostis@codefresh.io>

[Read the docs rendering](https://argo-rollouts.readthedocs.io/en/latest/) as well as the drop-down version menu are broken because of https://github.com/readthedocs/readthedocs.org/issues/9064 and https://github.com/mkdocs/mkdocs/issues/2799

I fixed the issue by pinning the same versions mentioned in the [argocd github repo](https://github.com/argoproj/argo-cd/blob/master/docs/requirements.txt)

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [X] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [X] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).