### PR TITLE
docs: Use new Google Analytics 4 site tag

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,7 @@
+extra:
+  analytics:
+    property: G-5Z1VTPDL73
+    provider: google
 extra_css:
 - assets/versions.css
 extra_javascript:


### PR DESCRIPTION
- Contributes to https://github.com/argoproj/argo-site/issues/102
- As mentioned in that umbrella issue, the UA site tag originally assigned to the site (which hasn't been active since 2021/07/03) is now [connected] from the new GA4 site tag and so will continue receiving events. In fact, it will start receiving consolidated events forwarded from the GA4 site tag.

/cc @alexmt @alexec 

[connected]: https://support.google.com/analytics/answer/9973999

---

Note that analytics for `UA-105170809-3` was disabled in July 2021 (inadvertently?) via:

- #1321, specifically https://github.com/argoproj/argo-rollouts/pull/1321/files#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2L10-L12