### PR TITLE
fix(dashboard): correct mime type is returned. Fixes: #2290

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -2,13 +2,9 @@ package server
 
 import (
 	"context"
-	"embed"
 	"fmt"
-	"io/fs"
 	"net"
 	"net/http"
-	"path"
-	"regexp"
 	"strings"
 	"time"
 
@@ -47,9 +43,6 @@ import (
 	versionutils "github.com/argoproj/argo-rollouts/utils/version"
 )
 
-//go:embed static/*
-var static embed.FS //nolint
-
 var backoff = wait.Backoff{
 	Steps:    5,
 	Duration: 500 * time.Millisecond,
@@ -81,13 +74,6 @@ func NewServer(o ServerOptions) *ArgoRolloutsServer {
 	return &ArgoRolloutsServer{Options: o}
 }
 
-var re = regexp.MustCompile(`<base href=".*".*/>`)
-
-func withRootPath(fileContent []byte, rootpath string) []byte {
-	var temp = re.ReplaceAllString(string(fileContent), `<base href="`+path.Clean("/"+rootpath)+`/" />`)
-	return []byte(temp)
-}
-
 func (s *ArgoRolloutsServer) newHTTPServer(ctx context.Context, port int) *http.Server {
 	mux := http.NewServeMux()
 	endpoint := fmt.Sprintf("0.0.0.0:%d", port)
@@ -117,107 +103,11 @@ func (s *ArgoRolloutsServer) newHTTPServer(ctx context.Context, port int) *http.
 		panic(err)
 	}
 
-	var handler http.Handler = gwmux
-
-	mux.Handle("/api/", handler)
-
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		requestedURI := path.Clean(r.RequestURI)
-		rootPath := path.Clean("/" + s.Options.RootPath)
-
-		if requestedURI == "/" {
-			http.Redirect(w, r, rootPath+"/", http.StatusFound)
-			return
-		}
-
-		//If the rootPath is not in the prefix 404
-		if !strings.HasPrefix(requestedURI, rootPath) {
-			http.NotFound(w, r)
-			return
-		}
-		//If the rootPath is the requestedURI, serve index.html
-		if requestedURI == rootPath {
-			fileBytes, openErr := s.readIndexHtml()
-			if openErr != nil {
-				log.Errorf("Error opening file index.html: %v", openErr)
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
-			w.Write(fileBytes)
-			return
-		}
-
-		embedPath := path.Join("static", strings.TrimPrefix(requestedURI, rootPath))
-		file, openErr := static.Open(embedPath)
-		if openErr != nil {
-			fErr := openErr.(*fs.PathError)
-			//If the file is not found, serve index.html
-			if fErr.Err == fs.ErrNotExist {
-				fileBytes, openErr := s.readIndexHtml()
-				if openErr != nil {
-					log.Errorf("Error opening file index.html: %v", openErr)
-					w.WriteHeader(http.StatusInternalServerError)
-					return
-				}
-				w.Write(fileBytes)
-				return
-			} else {
-				log.Errorf("Error opening file %s: %v", embedPath, openErr)
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
-		}
-		defer file.Close()
-
-		stat, statErr := file.Stat()
-		if statErr != nil {
-			log.Errorf("Failed to stat file or dir %s: %v", embedPath, err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
-		fileBytes := make([]byte, stat.Size())
-		_, err = file.Read(fileBytes)
-		if err != nil {
-			log.Errorf("Failed to read file %s: %v", embedPath, err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
-		w.Write(fileBytes)
-	})
+	var apiHandler http.Handler = gwmux
+	mux.Handle("/api/", apiHandler)
+	mux.HandleFunc("/", s.staticFileHttpHandler)
 
 	return &httpS
-}
-
-func (s *ArgoRolloutsServer) readIndexHtml() ([]byte, error) {
-	file, err := static.Open("static/index.html")
-	if err != nil {
-		log.Errorf("Failed to open file %s: %v", "static/index.html", err)
-		return nil, err
-	}
-	defer func() {
-		if file != nil {
-			if err := file.Close(); err != nil {
-				log.Errorf("Error closing file: %v", err)
-			}
-		}
-	}()
-
-	stat, err := file.Stat()
-	if err != nil {
-		log.Errorf("Failed to stat file or dir %s: %v", "static/index.html", err)
-		return nil, err
-	}
-
-	fileBytes := make([]byte, stat.Size())
-	_, err = file.Read(fileBytes)
-	if err != nil {
-		log.Errorf("Failed to read file %s: %v", "static/index.html", err)
-		return nil, err
-	}
-
-	return withRootPath(fileBytes, s.Options.RootPath), nil
 }
 
 func (s *ArgoRolloutsServer) newGRPCServer() *grpc.Server {

--- a/server/server_static.go
+++ b/server/server_static.go
@@ -51,12 +51,14 @@ func (s *ArgoRolloutsServer) staticFileHttpHandler(w http.ResponseWriter, r *htt
 	fileBytes, err := static.ReadFile(embedPath)
 	if err != nil {
 		if fileNotExistsOrIsDirectoryError(err) {
-			http.NotFound(w, r)
+			// send index.html, because UI will use path based router in React
+			fileBytes, _ = static.ReadFile(IndexHtmlFile)
+			embedPath = IndexHtmlFile
+		} else {
+			log.Errorf("Error reading file %s: %v", embedPath, err)
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		log.Errorf("Error reading file %s: %v", embedPath, err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
 	}
 
 	if embedPath == IndexHtmlFile {

--- a/server/server_static.go
+++ b/server/server_static.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"embed"
+	"errors"
+	"io/fs"
+	"mime"
+	"net/http"
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	//go:embed static/*
+	static         embed.FS //nolint
+	staticBasePath = "static"
+	IndexHtmlFile  = staticBasePath + "/index.html"
+)
+
+const (
+	ContentType   = "Content-Type"
+	ContentLength = "Content-Length"
+)
+
+func (s *ArgoRolloutsServer) staticFileHttpHandler(w http.ResponseWriter, r *http.Request) {
+	requestedURI := path.Clean(r.RequestURI)
+	rootPath := path.Clean("/" + s.Options.RootPath)
+
+	if requestedURI == "/" {
+		http.Redirect(w, r, rootPath+"/", http.StatusFound)
+		return
+	}
+
+	//If the rootPath is not in the prefix 404
+	if !strings.HasPrefix(requestedURI, rootPath) {
+		http.NotFound(w, r)
+		return
+	}
+
+	embedPath := path.Join(staticBasePath, strings.TrimPrefix(requestedURI, rootPath))
+
+	//If the rootPath is the requestedURI, serve index.html
+	if requestedURI == rootPath {
+		embedPath = IndexHtmlFile
+	}
+
+	fileBytes, err := static.ReadFile(embedPath)
+	if err != nil {
+		if fileNotExistsOrIsDirectoryError(err) {
+			http.NotFound(w, r)
+			return
+		}
+		log.Errorf("Error reading file %s: %v", embedPath, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if embedPath == IndexHtmlFile {
+		fileBytes = withRootPath(fileBytes, s.Options.RootPath)
+	}
+
+	w.Header().Set(ContentType, determineMimeType(embedPath))
+	w.Header().Set(ContentLength, strconv.Itoa(len(fileBytes)))
+	w.WriteHeader(http.StatusOK)
+	_, err = w.Write(fileBytes)
+	if err != nil {
+		log.Errorf("Error writing response: %v", err)
+	}
+}
+
+func fileNotExistsOrIsDirectoryError(err error) bool {
+	if errors.Is(err, fs.ErrNotExist) {
+		return true
+	}
+	pathErr, isPathError := err.(*fs.PathError)
+	return isPathError && strings.Contains(pathErr.Error(), "is a directory")
+}
+
+func determineMimeType(fileName string) string {
+	idx := strings.LastIndex(fileName, ".")
+	if idx >= 0 {
+		mimeType := mime.TypeByExtension(fileName[idx:])
+		if len(mimeType) > 0 {
+			return mimeType
+		}
+	}
+	return "text/plain"
+}
+
+var re = regexp.MustCompile(`<base href=".*".*/>`)
+
+func withRootPath(fileContent []byte, rootpath string) []byte {
+	var temp = re.ReplaceAllString(string(fileContent), `<base href="`+path.Clean("/"+rootpath)+`/" />`)
+	return []byte(temp)
+}

--- a/server/server_static.go
+++ b/server/server_static.go
@@ -18,7 +18,7 @@ var (
 	//go:embed static/*
 	static         embed.FS //nolint
 	staticBasePath = "static"
-	IndexHtmlFile  = staticBasePath + "/index.html"
+	indexHtmlFile  = staticBasePath + "/index.html"
 )
 
 const (
@@ -45,15 +45,15 @@ func (s *ArgoRolloutsServer) staticFileHttpHandler(w http.ResponseWriter, r *htt
 
 	//If the rootPath is the requestedURI, serve index.html
 	if requestedURI == rootPath {
-		embedPath = IndexHtmlFile
+		embedPath = indexHtmlFile
 	}
 
 	fileBytes, err := static.ReadFile(embedPath)
 	if err != nil {
 		if fileNotExistsOrIsDirectoryError(err) {
 			// send index.html, because UI will use path based router in React
-			fileBytes, _ = static.ReadFile(IndexHtmlFile)
-			embedPath = IndexHtmlFile
+			fileBytes, _ = static.ReadFile(indexHtmlFile)
+			embedPath = indexHtmlFile
 		} else {
 			log.Errorf("Error reading file %s: %v", embedPath, err)
 			w.WriteHeader(http.StatusInternalServerError)
@@ -61,7 +61,7 @@ func (s *ArgoRolloutsServer) staticFileHttpHandler(w http.ResponseWriter, r *htt
 		}
 	}
 
-	if embedPath == IndexHtmlFile {
+	if embedPath == indexHtmlFile {
 		fileBytes = withRootPath(fileBytes, s.Options.RootPath)
 	}
 

--- a/server/server_static_test.go
+++ b/server/server_static_test.go
@@ -1,0 +1,122 @@
+package server
+
+import (
+	"embed"
+	"io"
+	"mime"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tj/assert"
+)
+
+const TestRootPath = "/test-root"
+
+var (
+	//go:embed static_test/*
+	staticTestData embed.FS //nolint
+	mockServer     ArgoRolloutsServer
+)
+
+func init() {
+	static = staticTestData
+	staticBasePath = "static_test"
+	IndexHtmlFile = staticBasePath + "/index.html"
+	mockServer = mockArgoRolloutServer()
+}
+
+func TestIndexHtmlIsServed(t *testing.T) {
+	tests := []struct {
+		requestPath string
+	}{
+		{"/"},
+		{"/index.html"},
+		{"/nonsense/../index.html"},
+		{"/test-dir/test.css"},
+	}
+	for _, test := range tests {
+		t.Run(test.requestPath, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, TestRootPath+test.requestPath, nil)
+			w := httptest.NewRecorder()
+			mockServer.staticFileHttpHandler(w, req)
+			res := w.Result()
+			defer res.Body.Close()
+			data, err := io.ReadAll(res.Body)
+			assert.NoError(t, err)
+			assert.Equal(t, res.StatusCode, http.StatusOK)
+			if strings.HasSuffix(test.requestPath, ".css") {
+				assert.Equal(t, res.Header.Get(ContentType), mime.TypeByExtension(".css"))
+				assert.Contains(t, string(data), "empty by intent")
+			} else {
+				assert.Equal(t, res.Header.Get(ContentType), mime.TypeByExtension(".html"))
+				assert.Contains(t, string(data), "<title>index-title</title>")
+			}
+		})
+	}
+}
+
+func TestInvalidFileAndExistingDirectoryReturns404(t *testing.T) {
+	tests := []struct {
+		requestPath string
+	}{
+		{"/test-dir"},
+		{"/invalid-file.html"},
+	}
+	for _, test := range tests {
+		t.Run(test.requestPath, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, TestRootPath+test.requestPath, nil)
+			w := httptest.NewRecorder()
+			mockServer.staticFileHttpHandler(w, req)
+			res := w.Result()
+			defer res.Body.Close()
+			_, err := io.ReadAll(res.Body)
+			assert.NoError(t, err)
+			assert.Equal(t, res.StatusCode, http.StatusNotFound)
+		})
+	}
+}
+
+func TestSlashWillBeRedirectedToRootPath(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	mockServer.staticFileHttpHandler(w, req)
+	res := w.Result()
+	defer res.Body.Close()
+	_, err := io.ReadAll(res.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, res.StatusCode, http.StatusFound)
+	assert.Contains(t, res.Header.Get("Location"), TestRootPath)
+}
+
+func TestInvalidFilesOrHackingAttemptReturn404(t *testing.T) {
+	tests := []struct {
+		requestPath string
+	}{
+		{"/index.html"}, // should fail, because not prefixed with Option.RootPath
+		{"/etc/passwd"},
+		{TestRootPath + "/../etc/passwd"},
+		{TestRootPath + "/../../etc/passwd"},
+		{TestRootPath + "/../../../etc/passwd"},
+	}
+	for _, test := range tests {
+		t.Run(test.requestPath, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, test.requestPath, nil)
+			w := httptest.NewRecorder()
+			mockServer.staticFileHttpHandler(w, req)
+			res := w.Result()
+			defer res.Body.Close()
+			assert.Equal(t, res.StatusCode, http.StatusNotFound)
+		})
+	}
+}
+
+func mockArgoRolloutServer() ArgoRolloutsServer {
+	s := ArgoRolloutsServer{
+		Options: ServerOptions{
+			RootPath: TestRootPath,
+		},
+	}
+	return s
+}

--- a/server/server_static_test.go
+++ b/server/server_static_test.go
@@ -23,7 +23,7 @@ var (
 func init() {
 	static = staticTestData
 	staticBasePath = "static_test"
-	IndexHtmlFile = staticBasePath + "/index.html"
+	indexHtmlFile = staticBasePath + "/index.html"
 	mockServer = mockArgoRolloutServer()
 }
 

--- a/server/server_static_test.go
+++ b/server/server_static_test.go
@@ -31,14 +31,14 @@ func TestIndexHtmlIsServed(t *testing.T) {
 	tests := []struct {
 		requestPath string
 	}{
-		{"/"},
-		{"/index.html"},
-		{"/nonsense/../index.html"},
-		{"/test-dir/test.css"},
+		{TestRootPath + "/"},
+		{TestRootPath + "/index.html"},
+		{TestRootPath + "/nonsense/../index.html"},
+		{TestRootPath + "/test-dir/test.css"},
 	}
 	for _, test := range tests {
 		t.Run(test.requestPath, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodGet, TestRootPath+test.requestPath, nil)
+			req := httptest.NewRequest(http.MethodGet, test.requestPath, nil)
 			w := httptest.NewRecorder()
 			mockServer.staticFileHttpHandler(w, req)
 			res := w.Result()
@@ -57,25 +57,16 @@ func TestIndexHtmlIsServed(t *testing.T) {
 	}
 }
 
-func TestInvalidFileAndExistingDirectoryReturns404(t *testing.T) {
-	tests := []struct {
-		requestPath string
-	}{
-		{"/test-dir"},
-		{"/invalid-file.html"},
-	}
-	for _, test := range tests {
-		t.Run(test.requestPath, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodGet, TestRootPath+test.requestPath, nil)
-			w := httptest.NewRecorder()
-			mockServer.staticFileHttpHandler(w, req)
-			res := w.Result()
-			defer res.Body.Close()
-			_, err := io.ReadAll(res.Body)
-			assert.NoError(t, err)
-			assert.Equal(t, res.StatusCode, http.StatusNotFound)
-		})
-	}
+func TestWhenFileNotFoundSendIndexPageForUiReactRouter(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, TestRootPath+"/namespace-default", nil)
+	w := httptest.NewRecorder()
+	mockServer.staticFileHttpHandler(w, req)
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, res.StatusCode, http.StatusOK)
+	assert.Contains(t, string(data), "<title>index-title</title>")
 }
 
 func TestSlashWillBeRedirectedToRootPath(t *testing.T) {

--- a/server/static_test/index.html
+++ b/server/static_test/index.html
@@ -1,4 +1,5 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
   <title>index-title</title>
 </head>

--- a/server/static_test/index.html
+++ b/server/static_test/index.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+  <title>index-title</title>
+</head>
+<body>
+index-body
+</body>
+</html>

--- a/server/static_test/test-dir/test.css
+++ b/server/static_test/test-dir/test.css
@@ -1,0 +1,1 @@
+/* empty by intent */


### PR DESCRIPTION
## comments about this PR

I did refactor the code for static file serving into its own file.
Overall, I also did simplify the code and fixed former issues (see below).
Golang's mime package comes to the rescue when determining the correct mime type.

- add: tests for static files serving
- fix: when request /index.html, the base path was not modified
- fix: wrong 'err' variable used when log.Errorf("Failed to stat file or dir %s: %v"...) was printed

relates to #2290

PS: I would like to participate the hacktoberfest and would appreciated the 'hacktoberfest-accepted' label, IF you're OK with it :)
PPS: any feedback is welcome.

## Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).