### PR TITLE
chore: Add example for istio-subset-split

### DIFF
--- a/examples/istio/istio-subset-split.yaml
+++ b/examples/istio/istio-subset-split.yaml
@@ -1,0 +1,89 @@
+# This examples sets up istio-subset-split
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-subset-split
+spec:
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app: istio-subset-split
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: istio-subset-split-vsvc
+spec:
+  hosts:
+  - istio-subset-split
+  http:
+  - name: primary
+    route:
+    - destination:
+        host: istio-subset-split
+        subset: stable
+      weight: 100
+    - destination:
+        host: istio-subset-split
+        subset: canary
+      weight: 0
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: istio-subset-split-destrule
+spec:
+  host: istio-subset-split
+  subsets:
+  - name: stable
+    labels:
+      app: istio-subset-split
+  - name: canary
+    labels:
+      app: istio-subset-split
+
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: istio-subset-split
+spec:
+  strategy:
+    canary:
+      trafficRouting:
+        istio:
+          virtualService: 
+            name: istio-subset-split-vsvc
+            routes:
+            - primary
+          destinationRule:
+            name: istio-subset-split-destrule
+            canarySubsetName: canary
+            stableSubsetName: stable
+      steps:
+      - setWeight: 10
+      - pause: {}
+  selector:
+    matchLabels:
+      app: istio-subset-split
+  template:
+    metadata:
+      labels:
+        app: istio-subset-split
+    spec:
+      containers:
+      - name: istio-subset-split
+        image: nginx:1.19-alpine
+        ports:
+        - name: http
+          containerPort: 80
+          protocol: TCP
+        resources:
+          requests:
+            memory: 16Mi
+            cpu: 5m


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

While trying out istio with rollouts, I could not find any examples for `istio-subset-split`. However, there is an example for `istio-mirroring`. 

This example would help someone who is starting with  `istio` as traffic manager for `argo-rollouts`.