### PR TITLE
chore: sign container images and checksum assets

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -98,24 +98,29 @@ jobs:
         with:
           cosign-release: 'v1.13.0'
 
-      - name: Sign Argo Rollout latest controller-image
+      - name: Sign Argo Rollouts latest controller-image
         run: |
           cosign sign --key env://COSIGN_PRIVATE_KEY ${TAGS}
-          # Displays the public key to share.
-          cosign public-key --key env://COSIGN_PRIVATE_KEY
         env:
           TAGS: ${{ steps.controller-meta.outputs.tags }}
           COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
           COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
         if: ${{ github.event_name == 'push' }}
 
-      - name: Sign Argo Rollout latest plugin-image
+      - name: Sign Argo Rollouts latest plugin-image
         run: |
           cosign sign --key env://COSIGN_PRIVATE_KEY ${TAGS}
-          # Displays the public key to share.
-          cosign public-key --key env://COSIGN_PRIVATE_KEY
         env:
           TAGS: ${{ steps.plugin-meta.outputs.tags }}
+          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
+          COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
+        if: ${{ github.event_name == 'push' }}
+
+      - name: Display the public key to share.
+        run: |
+          # Displays the public key to share
+          cosign public-key --key env://COSIGN_PRIVATE_KEY
+        env:
           COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
           COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -99,22 +99,36 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@main
         with:
-          cosign-release: 'v1.13.0'
+          cosign-release: 'v1.13.1'
 
-      - name: Sign Argo Rollouts latest controller-image
-        run: |
-          cosign sign --key env://COSIGN_PRIVATE_KEY ${TAGS}
-        env:
-          TAGS: ${{ steps.controller-meta.outputs.tags }}
-          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
-          COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
-        if: ${{ github.event_name == 'push' }}
+      - name: Install crane to get digest of image
+        uses: imjasonh/setup-crane@v0.1
 
-      - name: Sign Argo Rollouts latest plugin-image
+      - name: Get digest of controller-image
         run: |
-          cosign sign --key env://COSIGN_PRIVATE_KEY ${TAGS}
+          if [[ "${{ github.ref == 'refs/heads/master' }}" ]]
+          then
+            echo "CONTROLLER_DIGEST=$(crane digest quay.io/argoproj/argo-rollouts:latest)" >> $GITHUB_ENV
+          fi
+          if [[ "${{ github.ref != 'refs/heads/master' }}" ]]
+            echo "CONTROLLER_DIGEST=$(crane digest ${{ steps.controller-meta.outputs.tags }})" >> $GITHUB_ENV
+          fi
+
+      - name: Get digest of plugin-image
+        run: |
+          if [[ "${{ github.ref == 'refs/heads/master' }}" ]]
+          then
+            echo "PLUGIN_DIGEST=$(crane digest quay.io/argoproj/kubectl-argo-rollouts:latest)" >> $GITHUB_ENV
+          fi
+          if [[ "${{ github.ref != 'refs/heads/master' }}" ]]
+            echo "PLUGIN_DIGEST=$(crane digest ${{ steps.plugin-meta.outputs.tags }})" >> $GITHUB_ENV
+          fi
+
+      - name: Sign Argo Rollouts Images
+        run: |
+          cosign sign --key env://COSIGN_PRIVATE_KEY quay.io/argoproj/argo-rollouts@${{ env.CONTROLLER_DIGEST }}
+          cosign sign --key env://COSIGN_PRIVATE_KEY quay.io/argoproj/kubectl-argo-rollouts@${{ env.PLUGIN_DIGEST }}
         env:
-          TAGS: ${{ steps.plugin-meta.outputs.tags }}
           COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
           COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -111,6 +111,7 @@ jobs:
             echo "CONTROLLER_DIGEST=$(crane digest quay.io/argoproj/argo-rollouts:latest)" >> $GITHUB_ENV
           fi
           if [[ "${{ github.ref != 'refs/heads/master' }}" ]]
+          then
             echo "CONTROLLER_DIGEST=$(crane digest ${{ steps.controller-meta.outputs.tags }})" >> $GITHUB_ENV
           fi
 
@@ -121,6 +122,7 @@ jobs:
             echo "PLUGIN_DIGEST=$(crane digest quay.io/argoproj/kubectl-argo-rollouts:latest)" >> $GITHUB_ENV
           fi
           if [[ "${{ github.ref != 'refs/heads/master' }}" ]]
+          then
             echo "PLUGIN_DIGEST=$(crane digest ${{ steps.plugin-meta.outputs.tags }})" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -114,6 +114,7 @@ jobs:
           then
             echo "CONTROLLER_DIGEST=$(crane digest ${{ steps.controller-meta.outputs.tags }})" >> $GITHUB_ENV
           fi
+        if: github.event_name != 'pull_request'
 
       - name: Get digest of plugin-image
         run: |
@@ -125,6 +126,7 @@ jobs:
           then
             echo "PLUGIN_DIGEST=$(crane digest ${{ steps.plugin-meta.outputs.tags }})" >> $GITHUB_ENV
           fi
+        if: github.event_name != 'pull_request'
 
       - name: Sign Argo Rollouts Images
         run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -92,3 +92,31 @@ jobs:
           platforms: ${{ steps.platform-matrix.outputs.platform-matrix }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.plugin-meta.outputs.tags }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v1.13.0'
+
+      - name: Sign Argo Rollout latest controller-image
+        run: |
+          cosign sign --key env://COSIGN_PRIVATE_KEY ${TAGS}
+          # Displays the public key to share.
+          cosign public-key --key env://COSIGN_PRIVATE_KEY
+        env:
+          TAGS: ${{ steps.controller-meta.outputs.tags }}
+          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
+          COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
+        if: ${{ github.event_name == 'push' }}
+
+      - name: Sign Argo Rollout latest plugin-image
+        run: |
+          cosign sign --key env://COSIGN_PRIVATE_KEY ${TAGS}
+          # Displays the public key to share.
+          cosign public-key --key env://COSIGN_PRIVATE_KEY
+        env:
+          TAGS: ${{ steps.plugin-meta.outputs.tags }}
+          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
+          COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
+        if: ${{ github.event_name == 'push' }}
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -144,6 +144,40 @@ jobs:
 
           cd /tmp && tar -zcf sbom.tar.gz *.spdx
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v1.13.0'
+
+      - name: Sign Argo Rollout controller-image
+        run: |
+          cosign sign --key env://COSIGN_PRIVATE_KEY ${TAGS}
+          # Displays the public key to share.
+          cosign public-key --key env://COSIGN_PRIVATE_KEY
+        env:
+          TAGS: ${{ steps.controller-meta.outputs.tags }}
+          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
+          COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
+
+      - name: Sign Argo Rollout plugin-image
+        run: |
+          cosign sign --key env://COSIGN_PRIVATE_KEY ${TAGS}
+          # Displays the public key to share.
+          cosign public-key --key env://COSIGN_PRIVATE_KEY
+        env:
+          TAGS: ${{ steps.plugin-meta.outputs.tags }}
+          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
+          COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
+
+      - name: Sign Argo Rollout assets
+        run: |
+          cosign sign-blob --key env://COSIGN_PRIVATE_KEY dist/argo-rollouts-checksums.txt > dist/argo-rollouts-checksums.sig
+          # Displays the public key to share.
+          cosign public-key --key env://COSIGN_PRIVATE_KEY
+        env:
+          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
+          COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
+
       - name: Draft release
         uses: softprops/action-gh-release@v1
         with:
@@ -156,6 +190,7 @@ jobs:
             dist/kubectl-argo-rollouts-darwin-arm64
             dist/kubectl-argo-rollouts-windows-amd64
             dist/argo-rollouts-checksums.txt
+            dist/argo-rollouts-checksums.sig
             manifests/dashboard-install.yaml
             manifests/install.yaml
             manifests/namespace-install.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -149,29 +149,26 @@ jobs:
         with:
           cosign-release: 'v1.13.0'
 
-      - name: Sign Argo Rollout controller-image
+      - name: Sign Argo Rollouts controller-image
         run: |
           cosign sign --key env://COSIGN_PRIVATE_KEY ${TAGS}
-          # Displays the public key to share.
-          cosign public-key --key env://COSIGN_PRIVATE_KEY
         env:
           TAGS: ${{ steps.controller-meta.outputs.tags }}
           COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
           COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
 
-      - name: Sign Argo Rollout plugin-image
+      - name: Sign Argo Rollouts plugin-image
         run: |
           cosign sign --key env://COSIGN_PRIVATE_KEY ${TAGS}
-          # Displays the public key to share.
-          cosign public-key --key env://COSIGN_PRIVATE_KEY
         env:
           TAGS: ${{ steps.plugin-meta.outputs.tags }}
           COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
           COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
 
-      - name: Sign Argo Rollout assets
+      - name: Sign checksums and create public key for release assets
         run: |
           cosign sign-blob --key env://COSIGN_PRIVATE_KEY dist/argo-rollouts-checksums.txt > dist/argo-rollouts-checksums.sig
+          cosign public-key --key env://COSIGN_PRIVATE_KEY > ./dist/argo-rollouts-cosign.pub
           # Displays the public key to share.
           cosign public-key --key env://COSIGN_PRIVATE_KEY
         env:
@@ -191,6 +188,7 @@ jobs:
             dist/kubectl-argo-rollouts-windows-amd64
             dist/argo-rollouts-checksums.txt
             dist/argo-rollouts-checksums.sig
+            dist/argo-rollouts-cosign.pub
             manifests/dashboard-install.yaml
             manifests/install.yaml
             manifests/namespace-install.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -152,21 +152,24 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@main
         with:
-          cosign-release: 'v1.13.0'
+          cosign-release: 'v1.13.1'
 
-      - name: Sign Argo Rollouts controller-image
-        run: |
-          cosign sign --key env://COSIGN_PRIVATE_KEY ${TAGS}
-        env:
-          TAGS: ${{ steps.controller-meta.outputs.tags }}
-          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
-          COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
+      - name: Install crane to get digest of image
+        uses: imjasonh/setup-crane@v0.1
 
-      - name: Sign Argo Rollouts plugin-image
+      - name: Get digest of controller-image
         run: |
-          cosign sign --key env://COSIGN_PRIVATE_KEY ${TAGS}
+          echo "CONTROLLER_DIGEST=$(crane digest ${{ steps.controller-meta.outputs.tags }})" >> $GITHUB_ENV
+
+      - name: Get digest of plugin-image
+        run: |
+          echo "PLUGIN_DIGEST=$(crane digest ${{ steps.plugin-meta.outputs.tags }})" >> $GITHUB_ENV
+
+      - name: Sign Argo Rollouts Images
+        run: |
+          cosign sign --key env://COSIGN_PRIVATE_KEY quay.io/argoproj/argo-rollouts@${{ env.CONTROLLER_DIGEST }}
+          cosign sign --key env://COSIGN_PRIVATE_KEY quay.io/argoproj/kubectl-argo-rollouts@${{ env.PLUGIN_DIGEST }}
         env:
-          TAGS: ${{ steps.plugin-meta.outputs.tags }}
           COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
           COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
 


### PR DESCRIPTION
Signed-off-by: Justin Marquis <34fathombelow@protonmail.com>
Closes #2330 

This PR implements container images and ```argo-rollouts-checksums.txt``` to be signed using ```sigstore/cosign```  

#### Three GitHub secrets will need to be created before this PR is merged. The process to do this is listed below.

TLDR: https://docs.sigstore.dev/cosign/git_support

1. [Install Cosign](https://docs.sigstore.dev/cosign/installation) on your workstation. Linux, Homebrew, and container options are available.  Execute the command ```cosign --version``` to verified it has been installed correctly.
2. Create or have a valid GitHub PAT token available.
3. Export your PAT as the environment variable "GITHUB_TOKEN"
4. Execute ```cosign generate-key-pair github://argoproj/argo-rollouts``` This will start the process of creating the GitHub Secrets automatically for you, and prompt you to enter a password.  This Password will be stored as the Github secret ```COSIGN_PASSWORD``` I would recommend to use well respected password generator such as KeePassXC or Bitwarden and use a paranoid level of characters of at least 32. 
5. Three GitHub secretes should have been created, please verify.  ```COSIGN_PASSWORD``` ```COSIGN_PRIVATE_KEY``` & ```COSIGN_PUBLIC_KEY```
6. Please comment on this PR with the newly created public key (cosign.pub)