### PR TITLE
docs: update examples to remove deprecated APIs in k8s 1.25

### DIFF
--- a/examples/notifications/rollout-canary.yaml
+++ b/examples/notifications/rollout-canary.yaml
@@ -15,21 +15,24 @@ spec:
   selector:
     app: rollout-canary
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: rollouts-demo-stable
   annotations:
     kubernetes.io/ingress.class: nginx
+  name: rollouts-demo-stable
 spec:
   rules:
-    - http:
-        paths:
-          - path: /
-            backend:
-              # Reference to a Service name, also specified in the Rollout spec.strategy.canary.stableService field
-              serviceName: rollouts-canary
-              servicePort: 8080
+  - http:
+      paths:
+      - backend:
+          service:
+            # Reference to a Service name, also specified in the Rollout spec.strategy.canary.stableService field
+            name: rollouts-canary
+            port:
+              number: 8080
+        path: /
+        pathType: ImplementationSpecific
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout

--- a/examples/traffic-routing-experiment-step/rollout-alb-experiment-step.yaml
+++ b/examples/traffic-routing-experiment-step/rollout-alb-experiment-step.yaml
@@ -40,20 +40,23 @@ spec:
   selector:
     app: alb-rollout
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: alb-rollout-ingress
   annotations:
     kubernetes.io/ingress.class: alb
+  name: alb-rollout-ingress
 spec:
   rules:
-    - http:
-        paths:
-          - path: /*
-            backend:
-              serviceName: alb-rollout-root
-              servicePort: use-annotation
+  - http:
+      paths:
+      - backend:
+          service:
+            name: alb-rollout-root
+            port:
+              name: use-annotation
+        path: /*
+        pathType: ImplementationSpecific
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout

--- a/examples/traffic-routing-experiment-step/rollout-smi-experiment-step.yaml
+++ b/examples/traffic-routing-experiment-step/rollout-smi-experiment-step.yaml
@@ -28,22 +28,25 @@ spec:
     # This selector will be updated with the pod-template-hash of the stable ReplicaSet. e.g.:
     # rollouts-pod-template-hash: 789746c88d
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: rollout-smi-experiment-stable
   annotations:
     kubernetes.io/ingress.class: nginx
+  name: rollout-smi-experiment-stable
 spec:
   rules:
-    - host: rollout-smi-experiment.local
-      http:
-        paths:
-          - path: /
-            backend:
-              # Reference to a Service name, also specified in the Rollout spec.strategy.canary.stableService field
-              serviceName: rollout-smi-experiment-stable
-              servicePort: 80
+  - host: rollout-smi-experiment.local
+    http:
+      paths:
+      - backend:
+          service:
+            # Reference to a Service name, also specified in the Rollout spec.strategy.canary.stableService field
+            name: rollout-smi-experiment-stable
+            port:
+              number: 80
+        path: /
+        pathType: ImplementationSpecific
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-rollouts/issues/2350

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).