### PR TITLE
build: copy proto files from GOPATH so we can clone outside of GOPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ k8s-proto: go-mod-vendor $(TYPES)
 		--proto-import $(CURDIR)/vendor \
 		--proto-import=${DIST_DIR}/protoc-include
 	touch pkg/apis/rollouts/v1alpha1/generated.proto
-	cp -R ${GOPATH}/src/github.com/argoproj/argo-rollouts/pkg .
+	cp -R ${GOPATH}/src/github.com/argoproj/argo-rollouts/pkg . | true
 
 
 # generates *.pb.go, *.pb.gw.go, swagger from .proto files

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,8 @@ k8s-proto: go-mod-vendor $(TYPES)
 		--proto-import $(CURDIR)/vendor \
 		--proto-import=${DIST_DIR}/protoc-include
 	touch pkg/apis/rollouts/v1alpha1/generated.proto
+	cp -R ${GOPATH}/src/github.com/argoproj/argo-rollouts/pkg .
+
 
 # generates *.pb.go, *.pb.gw.go, swagger from .proto files
 .PHONY: api-proto


### PR DESCRIPTION
This will allow the argo rollouts repo to live outside the  GOPATH directory.

Signed-off-by: zachaller <zachaller@users.noreply.github.com>