### PR TITLE
ci: fix some github actions warnings

### DIFF
--- a/.github/workflows/e2e-test-results.yml
+++ b/.github/workflows/e2e-test-results.yml
@@ -1,3 +1,4 @@
+# use separate workflow to support fork repositories and dependabot branches when publishing test results: see https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories-and-dependabot-branches
 name: Test Results
 
 on:
@@ -18,6 +19,7 @@ jobs:
       actions: read
     steps:
       - name: Download and Extract Artifacts
+        # TODO repace with native actions/download-artifact once it supports downloading from another workflow: https://github.com/actions/download-artifact/issues/3
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |

--- a/.github/workflows/e2e-test-results.yml
+++ b/.github/workflows/e2e-test-results.yml
@@ -39,7 +39,7 @@ jobs:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json
           event_name: ${{ github.event.workflow_run.event }}
-          files: "artifacts/**/*.xml"
+          junit_files: "artifacts/**/junit.xml"
           compare_to_earlier_commit: false
           test_changes_limit: 0
           fail_on: "errors"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -90,7 +90,7 @@ jobs:
           path: coverage.out
 
       - name: Upload code coverage information to codecov.io
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v3.1.1
         with:
           file: coverage.out
 


### PR DESCRIPTION
superseeds #1973 and #2251

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).