### PR TITLE
WIP ci: run e2e tests on multiple kubernetes versions

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -34,6 +34,12 @@ jobs:
           name: Event File
           path: ${{ github.event_path }}
   test-e2e:
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes-minor-version:
+          - v1.23
+          - v1.24
     name: Run end-to-end tests
     runs-on: ubuntu-latest
     steps:
@@ -43,6 +49,8 @@ jobs:
           go-version: 1.19
       - uses: actions/checkout@v3.1.0
       - name: Setup k3s
+        env:
+          INSTALL_K3S_CHANNEL: v${{ matrix.kubernetes-minor-version }}
         run: |
           curl -sfL https://get.k3s.io | sh -
           sudo mkdir ~/.kube
@@ -77,12 +85,12 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: E2E Test Results
+          name: E2E Test Results on kubernetes ${{ matrix.kubernetes-minor-version }}
           path: |
             junit.xml
       - name: Upload e2e-controller logs
         uses: actions/upload-artifact@v2
         with:
-          name: e2e-controller-k8s.log
+          name: e2e-controller-k8s-${{ matrix.kubernetes-minor-version }}.log
           path: /tmp/e2e-controller.log
         if: ${{ failure() }}


### PR DESCRIPTION
closes #2171

WIP, see discussion there

Use k3s release channel per kubernetes minor version (see https://get.k3s.io/ `INSTALL_K3S_CHANNEL_URL` & `INSTALL_K3S_CHANNEL`)

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).