### PR TITLE
docs: updated rollout_phase metrics details for rollout objects

### DIFF
--- a/docs/features/controller-metrics.md
+++ b/docs/features/controller-metrics.md
@@ -50,7 +50,7 @@ The Argo Rollouts controller publishes the following prometheus metrics about Ar
 | `rollout_info`                      | Information about rollout. |
 | `rollout_info_replicas_available`   | The number of available replicas per rollout. |
 | `rollout_info_replicas_unavailable` | The number of unavailable replicas per rollout. |
-| `rollout_phase`                     | Information on the state of the rollout. |
+| `rollout_phase`                     | [**DEPRECATED - use rollout_info**] Information on the state of the rollout. |
 | `rollout_reconcile`                 | Rollout reconciliation performance. |
 | `rollout_reconcile_error`           | Error occurring during the rollout. |
 | `experiment_info`                   | Information about Experiment. |


### PR DESCRIPTION
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

Issue: https://github.com/argoproj/argo-rollouts/issues/2377
Description: Updated documentation for rollout object.rollout_phase is marked deprecated in code but not in the docs