### PR TITLE
build: set GOPATH in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ E2E_INSTANCE_ID ?= argo-rollouts-e2e
 E2E_TEST_OPTIONS ?= 
 E2E_PARALLEL ?= 1
 E2E_WAIT_TIMEOUT ?= 120
+GOPATH ?= $(shell go env GOPATH)
 
 override LDFLAGS += \
   -X ${PACKAGE}/utils/version.version=${VERSION} \


### PR DESCRIPTION
We currently assume that GOPATH is set within the developers environment go has some defaults that get used when no GOPATH is defined. If we use `go env GOPATH` to set the env var for the Makefile we will then also fall back to golang defaults which help contributior experiance.

Signed-off-by: zachaller <zachaller@users.noreply.github.com>

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).