### PR TITLE
fix(analysis): Fix Analysis Terminal Decision For Dry-Run Metrics

### DIFF
--- a/utils/analysis/helpers.go
+++ b/utils/analysis/helpers.go
@@ -85,11 +85,15 @@ func IsTerminating(run *v1alpha1.AnalysisRun) bool {
 		return true
 	}
 	for _, res := range run.Status.MetricResults {
+		// If this metric is running in the dryRun mode then we don't care about the failures and hence the terminal
+		// decision shouldn't be affected.
+		if res.DryRun {
+			continue
+		}
+
 		switch res.Phase {
 		case v1alpha1.AnalysisPhaseFailed, v1alpha1.AnalysisPhaseError, v1alpha1.AnalysisPhaseInconclusive:
-			// If this metric is running in the dryRun mode then we don't care about the failures and hence the terminal
-			// decision shouldn't be affected.
-			return !res.DryRun
+			return true
 		}
 	}
 	return false

--- a/utils/analysis/helpers_test.go
+++ b/utils/analysis/helpers_test.go
@@ -67,6 +67,10 @@ func TestIsFastFailTerminating(t *testing.T) {
 					Phase:  v1alpha1.AnalysisPhaseRunning,
 					DryRun: true,
 				},
+				{
+					Name:  "yet-another-metric",
+					Phase: v1alpha1.AnalysisPhaseRunning,
+				},
 			},
 		},
 	}
@@ -78,6 +82,11 @@ func TestIsFastFailTerminating(t *testing.T) {
 	dryRunMetricResult.Phase = v1alpha1.AnalysisPhaseError
 	run.Status.MetricResults[2] = dryRunMetricResult
 	assert.False(t, IsTerminating(run))
+	// Verify that a wet run metric failure/error which is executed after a dry-run metric results in terminal decision.
+	yetAnotherMetric := run.Status.MetricResults[3]
+	yetAnotherMetric.Phase = v1alpha1.AnalysisPhaseError
+	run.Status.MetricResults[3] = yetAnotherMetric
+	assert.True(t, IsTerminating(run))
 	// Verify that a wet run metric failure/error results in terminal decision.
 	successRate.Phase = v1alpha1.AnalysisPhaseError
 	run.Status.MetricResults[1] = successRate


### PR DESCRIPTION
## Description

We recently came across a bug in the Analysis Run with both the Dry as well as Wet metrics where the terminal decision was being made based on the metric ordering and since we are simply returning in case of a Dry-Run metric failure, it was shadowing the Wet-Run failures by not correctly terminating the Analysis Run.

The fix is to simply continue the loop and keep looking for any Wet-Run metric failures by ignoring the failures from Dry-Run metrics inside `IsTerminating(...)`.

## Checklist

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).