### PR TITLE
ci: create stable tag for docs

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - master
+  workflow_run:
+    workflows: [ "Release" ]
+    types:
+      - completed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -183,6 +183,12 @@ jobs:
           COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
           COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
 
+      - name: update stable tag for docs
+        run: |
+          git tag -f -m "" stable ${{ github.event.inputs.tag }}
+          git push -f origin stable
+        
+
       - name: Draft release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
Create a stable tag so that docs do not track latest causing confusion for end users on what features are available.

Signed-off-by: zachaller <zachaller@users.noreply.github.com>

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).