### PR TITLE
fix(trafficrouting): dont let traffic router update routes if  the replicaset is not available

### DIFF
--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -143,7 +143,7 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			if !replicasetutil.IsReplicaSetAvailable(c.newRS) {
 				// We are in the middle of a rollout, but the newRS is not available yet so let's bail on reconciling traffic
 				// routers but we want to continue reconciling the rollout so we return nil
-				fmt.Errorf("canary service %s is not ready to switch traffic from %s to %s, aborting traffic router reconcile", c.rollout.Spec.Strategy.Canary.CanaryService, stableHash, canaryHash)
+				fmt.Sprintf("canary service %s is not ready to switch traffic from %s to %s, aborting traffic router reconcile", c.rollout.Spec.Strategy.Canary.CanaryService, stableHash, canaryHash)
 				return nil
 			}
 		}

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -143,7 +143,7 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			if !replicasetutil.IsReplicaSetAvailable(c.newRS) {
 				// We are in the middle of a rollout, but the newRS is not available yet so let's bail on reconciling traffic
 				// routers but we want to continue reconciling the rollout so we return nil
-				fmt.Sprintf("canary service %s is not ready to switch traffic from %s to %s, aborting traffic router reconcile", c.rollout.Spec.Strategy.Canary.CanaryService, stableHash, canaryHash)
+				c.log.Infof("canary service %s is not ready to switch traffic from %s to %s, aborting traffic router reconcile", c.rollout.Spec.Strategy.Canary.CanaryService, stableHash, canaryHash)
 				return nil
 			}
 		}


### PR DESCRIPTION
Signed-off-by: zachaller <zachaller@users.noreply.github.com>

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).