### PR TITLE
fix: add patch verb to deployment resource

### DIFF
--- a/manifests/dashboard-install.yaml
+++ b/manifests/dashboard-install.yaml
@@ -59,6 +59,7 @@ rules:
   - update
   - list
   - watch
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/manifests/dashboard-install/dashboard-clusterrole.yaml
+++ b/manifests/dashboard-install/dashboard-clusterrole.yaml
@@ -49,6 +49,7 @@ rules:
       - update
       - list
       - watch
+      - patch
   - apiGroups:
       - apps
     resources:


### PR DESCRIPTION
Dashboard fails with ```failed restoring revision 21: deployments.apps "ourapp" is forbidden: User "system:serviceaccount:argo-rollouts:argo-rollouts-dashboard" cannot patch resource "deployments" in API group "apps" in the namespace "ournamespace"``` when trying to rollback `Rollout` defined using existing `Deployment` and `workloadRef` config. Adding `patch` verb for `deployments` should fix it.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).