### PR TITLE
feat: Implement Issue #1779: add --canary-min-replicas command-line flag

### DIFF
--- a/cmd/rollouts-controller/main.go
+++ b/cmd/rollouts-controller/main.go
@@ -60,6 +60,7 @@ func newCommand() *cobra.Command {
 		analysisThreads      int
 		serviceThreads       int
 		ingressThreads       int
+		canaryMinReplicas    int
 		istioVersion         string
 		trafficSplitVersion  string
 		ambassadorVersion    string
@@ -95,6 +96,7 @@ func newCommand() *cobra.Command {
 			defaults.SetAmbassadorAPIVersion(ambassadorVersion)
 			defaults.SetSMIAPIVersion(trafficSplitVersion)
 			defaults.SetAppMeshCRDVersion(appmeshCRDVersion)
+			defaults.SetDefaultCanaryMinReplicas(canaryMinReplicas)
 
 			config, err := clientConfig.ClientConfig()
 			checkError(err)
@@ -225,6 +227,7 @@ func newCommand() *cobra.Command {
 	command.Flags().IntVar(&analysisThreads, "analysis-threads", controller.DefaultAnalysisThreads, "Set the number of worker threads for the Experiment controller")
 	command.Flags().IntVar(&serviceThreads, "service-threads", controller.DefaultServiceThreads, "Set the number of worker threads for the Service controller")
 	command.Flags().IntVar(&ingressThreads, "ingress-threads", controller.DefaultIngressThreads, "Set the number of worker threads for the Ingress controller")
+	command.Flags().IntVar(&canaryMinReplicas, "canary-min-replicas", defaults.DefaultCanaryMinReplicas, "Set the minimum number of replicas for Canary ReplicaSets")
 	command.Flags().StringVar(&istioVersion, "istio-api-version", defaults.DefaultIstioVersion, "Set the default Istio apiVersion that controller should look when manipulating VirtualServices.")
 	command.Flags().StringVar(&ambassadorVersion, "ambassador-api-version", defaults.DefaultAmbassadorVersion, "Set the Ambassador apiVersion that controller should look when manipulating Ambassador Mappings.")
 	command.Flags().StringVar(&trafficSplitVersion, "traffic-split-api-version", defaults.DefaultSMITrafficSplitVersion, "Set the default TrafficSplit apiVersion that controller uses when creating TrafficSplits.")

--- a/cmd/rollouts-controller/main.go
+++ b/cmd/rollouts-controller/main.go
@@ -60,7 +60,7 @@ func newCommand() *cobra.Command {
 		analysisThreads      int
 		serviceThreads       int
 		ingressThreads       int
-		canaryMinReplicas    int
+		canaryMinReplicas    int32
 		istioVersion         string
 		trafficSplitVersion  string
 		ambassadorVersion    string
@@ -227,7 +227,7 @@ func newCommand() *cobra.Command {
 	command.Flags().IntVar(&analysisThreads, "analysis-threads", controller.DefaultAnalysisThreads, "Set the number of worker threads for the Experiment controller")
 	command.Flags().IntVar(&serviceThreads, "service-threads", controller.DefaultServiceThreads, "Set the number of worker threads for the Service controller")
 	command.Flags().IntVar(&ingressThreads, "ingress-threads", controller.DefaultIngressThreads, "Set the number of worker threads for the Ingress controller")
-	command.Flags().IntVar(&canaryMinReplicas, "canary-min-replicas", defaults.DefaultCanaryMinReplicas, "Set the minimum number of replicas for Canary ReplicaSets")
+	command.Flags().Int32Var(&canaryMinReplicas, "canary-min-replicas", defaults.DefaultCanaryMinReplicas, "Set the minimum number of replicas for Canary ReplicaSets")
 	command.Flags().StringVar(&istioVersion, "istio-api-version", defaults.DefaultIstioVersion, "Set the default Istio apiVersion that controller should look when manipulating VirtualServices.")
 	command.Flags().StringVar(&ambassadorVersion, "ambassador-api-version", defaults.DefaultAmbassadorVersion, "Set the Ambassador apiVersion that controller should look when manipulating Ambassador Mappings.")
 	command.Flags().StringVar(&trafficSplitVersion, "traffic-split-api-version", defaults.DefaultSMITrafficSplitVersion, "Set the default TrafficSplit apiVersion that controller uses when creating TrafficSplits.")

--- a/utils/defaults/defaults.go
+++ b/utils/defaults/defaults.go
@@ -321,6 +321,7 @@ func GetMetricCleanupDelaySeconds() time.Duration {
 func SetMetricCleanupDelaySeconds(seconds int32) {
 	defaultMetricCleanupDelay = seconds
 }
+
 // GetDefaultCanaryMinReplicas returns the minimum pods in a Replicaset for Canary traffic routing
 func GetDefaultCanaryMinReplicas() int32 {
 	return defaultCanaryMinReplicas

--- a/utils/defaults/defaults.go
+++ b/utils/defaults/defaults.go
@@ -45,6 +45,8 @@ const (
 	// DefaultMetricCleanupDelay is the default time to delay metrics removal upon object removal, gives time for metrics
 	// to be collected
 	DefaultMetricCleanupDelay = int32(65)
+	// DefaultCanaryMinReplicas is the minimum pods in a Replicaset for Canary traffic routing
+	DefaultCanaryMinReplicas = int32(1)
 )
 
 const (
@@ -66,6 +68,7 @@ var (
 	targetGroupBindingAPIVersion = DefaultTargetGroupBindingAPIVersion
 	appmeshCRDVersion            = DefaultAppMeshCRDVersion
 	defaultMetricCleanupDelay    = DefaultMetricCleanupDelay
+	defaultCanaryMinReplicas     = DefaultCanaryMinReplicas
 )
 
 const (
@@ -317,4 +320,13 @@ func GetMetricCleanupDelaySeconds() time.Duration {
 // SetMetricCleanupDelaySeconds sets the metric cleanup delay in seconds
 func SetMetricCleanupDelaySeconds(seconds int32) {
 	defaultMetricCleanupDelay = seconds
+}
+// GetDefaultCanaryMinReplicas returns the minimum pods in a Replicaset for Canary traffic routing
+func GetDefaultCanaryMinReplicas() int32 {
+	return defaultCanaryMinReplicas
+}
+
+// SetDefaultCanaryMinReplicas sets the minimum pods in a Replicaset for Canary traffic routing
+func SetDefaultCanaryMinReplicas(replicas int32) {
+	defaultCanaryMinReplicas = replicas
 }

--- a/utils/replicaset/canary_test.go
+++ b/utils/replicaset/canary_test.go
@@ -821,6 +821,14 @@ func TestCalculateReplicaCountsForCanaryWithMinPods(t *testing.T) {
 	newRSReplicaCount, stableRSReplicaCount = CalculateReplicaCountsForTrafficRoutedCanary(rollout, rollout.Status.Canary.Weights)
 	assert.Equal(t, int32(2), newRSReplicaCount)
 	assert.Equal(t, int32(10), stableRSReplicaCount)
+
+	// Test that we don't use minPods when desired replicas < minPods
+	rollout = newRollout(1, 1, intstr.FromInt(0), intstr.FromInt(1), "canary", "stable", nil, nil)
+	rollout.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
+	newRSReplicaCount, stableRSReplicaCount = CalculateReplicaCountsForTrafficRoutedCanary(rollout, rollout.Status.Canary.Weights)
+	assert.Equal(t, int32(1), newRSReplicaCount)
+	assert.Equal(t, int32(1), stableRSReplicaCount)
+
 	defaults.SetDefaultCanaryMinReplicas(minPods) // Restore initial value
 }
 

--- a/utils/replicaset/canary_test.go
+++ b/utils/replicaset/canary_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/argoproj/argo-rollouts/utils/defaults"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
-	"github.com/argoproj/argo-rollouts/utils/defaults"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 )
@@ -800,7 +800,7 @@ func TestCalculateReplicaCountsForCanaryTrafficRouting(t *testing.T) {
 }
 
 func TestCalculateReplicaCountsForCanaryWithMinPods(t *testing.T) {
-	minPods := defaults.GetDefaultCanaryMinReplicas()  // Save initial value
+	minPods := defaults.GetDefaultCanaryMinReplicas() // Save initial value
 	rollout := newRollout(10, 1, intstr.FromInt(0), intstr.FromInt(1), "canary", "stable", nil, nil)
 
 	// first test Basic Canary without minPods
@@ -821,7 +821,7 @@ func TestCalculateReplicaCountsForCanaryWithMinPods(t *testing.T) {
 	newRSReplicaCount, stableRSReplicaCount = CalculateReplicaCountsForTrafficRoutedCanary(rollout, rollout.Status.Canary.Weights)
 	assert.Equal(t, int32(2), newRSReplicaCount)
 	assert.Equal(t, int32(10), stableRSReplicaCount)
-	defaults.SetDefaultCanaryMinReplicas(minPods)  // Restore initial value
+	defaults.SetDefaultCanaryMinReplicas(minPods) // Restore initial value
 }
 
 func TestCalculateReplicaCountsForCanaryTrafficRoutingDynamicScale(t *testing.T) {

--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -285,7 +285,7 @@ func NewRSNewReplicas(rollout *v1alpha1.Rollout, allRSs []*appsv1.ReplicaSet, ne
 		} else {
 			newRSReplicaCount, _ = CalculateReplicaCountsForTrafficRoutedCanary(rollout, weights)
 		}
-		return newRSReplicaCount, nil
+		return max(newRSReplicaCount, defaults.GetDefaultCanaryMinReplicas()), nil
 	}
 	return 0, fmt.Errorf("no rollout strategy provided")
 }

--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -285,9 +285,6 @@ func NewRSNewReplicas(rollout *v1alpha1.Rollout, allRSs []*appsv1.ReplicaSet, ne
 		} else {
 			newRSReplicaCount, _ = CalculateReplicaCountsForTrafficRoutedCanary(rollout, weights)
 		}
-		if newRSReplicaCount > 0 {
-			newRSReplicaCount = max(newRSReplicaCount, defaults.GetDefaultCanaryMinReplicas())
-		}
 		return newRSReplicaCount, nil
 	}
 	return 0, fmt.Errorf("no rollout strategy provided")

--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -285,7 +285,10 @@ func NewRSNewReplicas(rollout *v1alpha1.Rollout, allRSs []*appsv1.ReplicaSet, ne
 		} else {
 			newRSReplicaCount, _ = CalculateReplicaCountsForTrafficRoutedCanary(rollout, weights)
 		}
-		return max(newRSReplicaCount, defaults.GetDefaultCanaryMinReplicas()), nil
+		if newRSReplicaCount > 0 {
+			newRSReplicaCount = max(newRSReplicaCount, defaults.GetDefaultCanaryMinReplicas())
+		}
+		return newRSReplicaCount, nil
 	}
 	return 0, fmt.Errorf("no rollout strategy provided")
 }


### PR DESCRIPTION
Implements issue https://github.com/argoproj/argo-rollouts/issues/1779
See https://github.com/argoproj/argo-rollouts/issues/1779 for Use Cases

Based on https://github.com/argoproj/argo-rollouts/issues/1779#issuecomment-1314690329

This replaces https://github.com/argoproj/argo-rollouts/pull/1938

@alexef @zachaller 