### PR TITLE
docs: fix ambassador-api-version flag

### DIFF
--- a/docs/getting-started/ambassador/index.md
+++ b/docs/getting-started/ambassador/index.md
@@ -9,7 +9,7 @@ This tutorial will walk you through the process of configuring Argo Rollouts to 
 
 ---
 **Note**
-If using Ambassador Edge Stack or Emissary-ingress 2.0+, you will need to install Argo-Rollouts version v1.1+, and you will need to supply `--ambassador-api-version x.getambassador.io/v3alpha1` to your `argo-rollouts` deployment.
+If using Ambassador Edge Stack or Emissary-ingress 2.0+, you will need to install Argo-Rollouts version v1.1+, and you will need to supply `--ambassador-api-version getambassador.io/v3alpha1` to your `argo-rollouts` deployment.
 ---
 
 ## 1. Install and configure Ambassador Edge Stack


### PR DESCRIPTION
I went through an Ambassador Edge Stack upgrade a few months ago, going from 1.x to 3.x. Got stuck for quite awhile because the ambassador-api-version flag indicated wasn't valid. @zachaller identified that it is the `x.` part that is no longer valid so this removes that text.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).