### PR TITLE
docs: correct syntax of canary setMirrorRoute's value

### DIFF
--- a/docs/features/specification.md
+++ b/docs/features/specification.md
@@ -307,8 +307,8 @@ spec:
                 prefix: "POST"
               path: # What HTTP url paths to match.
                 exact: "/test"
-                regex: ""/test/.*"
-                prefix: ""/"
+                regex: "/test/.*"
+                prefix: "/"
               headers:
                 agent-1b: # What HTTP header name to use in the match.
                   exact: "firefox"


### PR DESCRIPTION
Fix wrong syntax of
spec.strategy.canary.steps[setMirrorRoute].match.path.regex and spec.strategy.canary.steps[setMirrorRoute].match.path.prefix

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).