### PR TITLE
docs: fix typo in helm Argo rollouts

### DIFF
--- a/docs/features/traffic-management/alb.md
+++ b/docs/features/traffic-management/alb.md
@@ -138,7 +138,7 @@ spec:
 By default, a rollout will inject the `alb.ingress.kubernetes.io/actions.<SERVICE-NAME>` annotation
 using the service/action name specified under `spec.strategy.canary.stableService`. However, it may
 be desirable to specify an explicit service/action name different from the `stableService`. For
-example, [one pattern](/best-practices/#ingress-desiredstable-host-routes) is to use a single
+example, [one pattern](/argo-rollouts/best-practices/#ingress-desiredstable-host-routes) is to use a single
 Ingress containing three different rules to reach the canary, stable, and root service separately
 (e.g. for testing purposes). In this case, you may want to specify a "root" service as the
 service/action name instead of stable. To do so, reference a service under `rootService` under the

--- a/examples/helm-blue-green/README.md
+++ b/examples/helm-blue-green/README.md
@@ -5,7 +5,7 @@ regardless of the event source. If you package your manifest
 with the Helm package manager you can perform Progressive Delivery deployments with Helm
 
 1. Install the Argo Rollouts controller in your cluster: https://github.com/argoproj/argo-rollouts#installation
-2. Instal the `helm` executable locally: https://helm.sh/docs/intro/install/
+2. Install the `helm` executable locally: https://helm.sh/docs/intro/install/
 
 ## Deploying the initial version
 


### PR DESCRIPTION
fixing docs typo in Helm Argo Rollouts. `Instal` -> `Install`

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).