### PR TITLE
ci: bump api limit on pr/issue action

### DIFF
--- a/.github/workflows/stale-issues-pr.yml
+++ b/.github/workflows/stale-issues-pr.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - uses: actions/stale@v6
         with:
+          operations-per-run: 250
           stale-issue-message: 'This issue is stale because it has been open 60 days with no activity.'
           stale-pr-message: 'This PR is stale because it has been open 90 days with no activity.'
           close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'

--- a/.github/workflows/waiting-issues.yml
+++ b/.github/workflows/waiting-issues.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - uses: actions/stale@v6
         with:
+          operations-per-run: 250
           stale-issue-message: 'This issue is stale because it has awaiting-response label for 5 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           stale-pr-message: 'This PR is stale because it has awaiting-response label for 10 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity and has the awaiting-response label.'


### PR DESCRIPTION
This change is required becuase we are not fully updating all our issues/PR's becuase we are so far behind since turning on this workflow.

Docs on change param:
https://github.com/actions/stale#operations-per-run

Signed-off-by: zachaller <zachaller@users.noreply.github.com>