### PR TITLE
chore: disable docker sbom and attestations

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -82,19 +82,23 @@ jobs:
           echo "::set-output name=platform-matrix::$PLATFORM_MATRIX"
 
       - name: Build and push (controller-image)
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 # v3.3.0
         with:
           platforms: ${{ steps.platform-matrix.outputs.platform-matrix }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.controller-meta.outputs.tags }}
+          provenance: false
+          sbom: false
 
       - name: Build and push (plugin-image)
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 # v3.3.0
         with:
           target: kubectl-argo-rollouts
           platforms: ${{ steps.platform-matrix.outputs.platform-matrix }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.plugin-meta.outputs.tags }}
+          provenance: false
+          sbom: false
 
       - name: Install cosign
         uses: sigstore/cosign-installer@main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,21 +84,25 @@ jobs:
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
       - name: Build and push (controller-image)
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 # v3.3.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.controller-meta.outputs.tags }}
+          provenance: false
+          sbom: false
 
       - name: Build and push (plugin-image)
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 # v3.3.0
         with:
           context: .
           target: kubectl-argo-rollouts
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.plugin-meta.outputs.tags }}
+          provenance: false
+          sbom: false
 
 
   release-artifacts:


### PR DESCRIPTION
Signed-off-by: Justin Marquis <34fathombelow@protonmail.com>

The newer [BuildKit v0.11](https://www.docker.com/blog/highlights-buildkit-v0-11-release/) now enables a provenance attestation by default. These attestations are stored as a manifest object of `unknown on unknown` attached to the root image index object.  `"To prevent container runtimes from accidentally pulling or running the image described in the manifest, the platform property of the attestation manifest will be set to unknown/unknown"`  This prevents our current Sbom generation from working properly.  

This PR is a workaround by disabling attestations and sboms by default. These new inputs for the `docker build and push action` require the newer version of build and push.

Note:  I have tested this workaround  locally. 