### PR TITLE
docs: commit generated docs for readthedocs.org

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -138,8 +138,6 @@ jobs:
         run: |
           make go-mod-vendor
           make codegen
-          make manifests
-          make docs
 
       - name: Ensure nothing changed
         run: git diff --exit-code

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,6 @@ junit.xml
 rerunreport.txt
 site/
 vendor/
-# generated
-docs/generated
 # static
 server/static/*
 !server/static/.gitkeep

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ install-toolchain: install-go-tools-local install-protoc-local
 
 # generates all auto-generated code
 .PHONY: codegen
-codegen: go-mod-vendor gen-proto gen-k8scodegen gen-openapi gen-mocks gen-crd manifests
+codegen: go-mod-vendor gen-proto gen-k8scodegen gen-openapi gen-mocks gen-crd manifests docs
 
 # generates all files related to proto files
 .PHONY: gen-proto

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts.md
@@ -1,0 +1,76 @@
+# Rollouts
+
+Manage argo rollouts
+
+## Synopsis
+
+This command consists of multiple subcommands which can be used to manage Argo Rollouts.
+
+```shell
+kubectl argo rollouts COMMAND [flags]
+```
+
+## Examples
+
+```shell
+# Get guestbook rollout and watch progress
+kubectl argo rollouts get rollout guestbook -w
+
+# Pause the guestbook rollout
+kubectl argo rollouts pause guestbook
+
+# Promote the guestbook rollout
+kubectl argo rollouts promote guestbook
+
+# Abort the guestbook rollout
+kubectl argo rollouts abort guestbook
+
+# Retry the guestbook rollout
+kubectl argo rollouts retry guestbook
+```
+
+## Options
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+  -h, --help                           help for kubectl-argo-rollouts
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## Available Commands
+
+* [rollouts abort](kubectl-argo-rollouts_abort.md)	 - Abort a rollout
+* [rollouts completion](kubectl-argo-rollouts_completion.md)	 - Generate completion script
+* [rollouts create](kubectl-argo-rollouts_create.md)	 - Create a Rollout, Experiment, AnalysisTemplate, ClusterAnalysisTemplate, or AnalysisRun resource
+* [rollouts dashboard](kubectl-argo-rollouts_dashboard.md)	 - Start UI dashboard
+* [rollouts get](kubectl-argo-rollouts_get.md)	 - Get details about rollouts and experiments
+* [rollouts lint](kubectl-argo-rollouts_lint.md)	 - Lint and validate a Rollout
+* [rollouts list](kubectl-argo-rollouts_list.md)	 - List rollouts or experiments
+* [rollouts notifications](kubectl-argo-rollouts_notifications.md)	 - Set of CLI commands that helps manage notifications settings
+* [rollouts pause](kubectl-argo-rollouts_pause.md)	 - Pause a rollout
+* [rollouts promote](kubectl-argo-rollouts_promote.md)	 - Promote a rollout
+* [rollouts restart](kubectl-argo-rollouts_restart.md)	 - Restart the pods of a rollout
+* [rollouts retry](kubectl-argo-rollouts_retry.md)	 - Retry a rollout or experiment
+* [rollouts set](kubectl-argo-rollouts_set.md)	 - Update various values on resources
+* [rollouts status](kubectl-argo-rollouts_status.md)	 - Show the status of a rollout
+* [rollouts terminate](kubectl-argo-rollouts_terminate.md)	 - Terminate an AnalysisRun or Experiment
+* [rollouts undo](kubectl-argo-rollouts_undo.md)	 - Undo a rollout
+* [rollouts version](kubectl-argo-rollouts_version.md)	 - Print version
+

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts.md
@@ -35,7 +35,7 @@ kubectl argo rollouts retry guestbook
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_abort.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_abort.md
@@ -1,0 +1,55 @@
+# Rollouts Abort
+
+Abort a rollout
+
+## Synopsis
+
+This command stops progressing the current rollout and reverts all steps. The previous ReplicaSet will be active.
+
+Note the 'spec.template' still represents the new rollout version. If the Rollout leaves the aborted state, it will try to go to the new version. 
+Updating the 'spec.template' back to the previous version will fully revert the rollout.
+
+```shell
+kubectl argo rollouts abort ROLLOUT_NAME [flags]
+```
+
+## Examples
+
+```shell
+# Abort a rollout
+kubectl argo rollouts abort guestbook
+```
+
+## Options
+
+```
+  -h, --help   help for abort
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## See Also
+
+* [rollouts](kubectl-argo-rollouts.md)	 - Manage argo rollouts

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_abort.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_abort.md
@@ -32,7 +32,7 @@ kubectl argo rollouts abort guestbook
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_completion.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_completion.md
@@ -1,0 +1,83 @@
+# Rollouts Completion
+
+Generate completion script
+
+## Synopsis
+
+To load completions:
+	
+	Bash:
+	
+	  $ source <(yourprogram completion bash)
+	
+	  # To load completions for each session, execute once:
+	  # Linux:
+	  $ yourprogram completion bash > /etc/bash_completion.d/yourprogram
+	  # macOS:
+	  $ yourprogram completion bash > /usr/local/etc/bash_completion.d/yourprogram
+	
+	Zsh:
+	
+	  # If shell completion is not already enabled in your environment,
+	  # you will need to enable it.  You can execute the following once:
+	
+	  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+	
+	  # To load completions for each session, execute once:
+	  $ yourprogram completion zsh > "${fpath[1]}/_yourprogram"
+	
+	  # You will need to start a new shell for this setup to take effect.
+	
+	fish:
+	
+	  $ yourprogram completion fish | source
+	
+	  # To load completions for each session, execute once:
+	  $ yourprogram completion fish > ~/.config/fish/completions/yourprogram.fish
+	
+	PowerShell:
+	
+	  PS> yourprogram completion powershell | Out-String | Invoke-Expression
+	
+	  # To load completions for every new session, run:
+	  PS> yourprogram completion powershell > yourprogram.ps1
+	  # and source this file from your PowerShell profile.
+	
+
+```shell
+kubectl argo rollouts completion [bash|zsh|fish|powershell]
+```
+
+## Options
+
+```
+  -h, --help   help for completion
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## See Also
+
+* [rollouts](kubectl-argo-rollouts.md)	 - Manage argo rollouts

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_completion.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_completion.md
@@ -60,7 +60,7 @@ kubectl argo rollouts completion [bash|zsh|fish|powershell]
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_create.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_create.md
@@ -32,7 +32,7 @@ kubectl argo rollouts create -f my-experiment.yaml -w
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_create.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_create.md
@@ -1,0 +1,59 @@
+# Rollouts Create
+
+Create a Rollout, Experiment, AnalysisTemplate, ClusterAnalysisTemplate, or AnalysisRun resource
+
+## Synopsis
+
+This command creates a new Rollout, Experiment, AnalysisTemplate, ClusterAnalysisTemplate, or AnalysisRun resource from a file.
+
+```shell
+kubectl argo rollouts create [flags]
+```
+
+## Examples
+
+```shell
+# Create an experiment and watch it
+kubectl argo rollouts create -f my-experiment.yaml -w
+```
+
+## Options
+
+```
+  -f, --filename stringArray   Files to use to create the resource
+  -h, --help                   help for create
+      --no-color               Do not colorize output
+  -w, --watch                  Watch live updates to the resource after creating
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## Available Commands
+
+* [rollouts create analysisrun](kubectl-argo-rollouts_create_analysisrun.md)	 - Create an AnalysisRun from an AnalysisTemplate or a ClusterAnalysisTemplate
+
+## See Also
+
+* [rollouts](kubectl-argo-rollouts.md)	 - Manage argo rollouts

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_create_analysisrun.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_create_analysisrun.md
@@ -45,7 +45,7 @@ kubectl argo rollouts create analysisrun --global --from my-analysis-cluster-tem
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_create_analysisrun.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_create_analysisrun.md
@@ -1,0 +1,68 @@
+# Rollouts Create Analysisrun
+
+Create an AnalysisRun from an AnalysisTemplate or a ClusterAnalysisTemplate
+
+## Synopsis
+
+This command creates a new AnalysisRun from an existing AnalysisTemplate resources or from an AnalysisTemplate file.
+
+```shell
+kubectl argo rollouts create analysisrun [flags]
+```
+
+## Examples
+
+```shell
+# Create an AnalysisRun from a local AnalysisTemplate file
+kubectl argo rollouts create analysisrun --from-file my-analysis-template.yaml
+
+# Create an AnalysisRun from a AnalysisTemplate in the cluster
+kubectl argo rollouts create analysisrun --from my-analysis-template
+
+# Create an AnalysisRun from a local ClusterAnalysisTemplate file
+kubectl argo rollouts create analysisrun --global --from my-analysis-cluster-template.yaml
+
+# Create an AnalysisRun from a ClusterAnalysisTemplate in the cluster
+kubectl argo rollouts create analysisrun --global --from my-analysis-cluster-template
+```
+
+## Options
+
+```
+  -a, --argument stringArray   Arguments to the parameter template
+      --from string            Create an AnalysisRun from an AnalysisTemplate or ClusterAnalysisTemplate in the cluster
+      --from-file string       Create an AnalysisRun from an AnalysisTemplate or ClusterAnalysisTemplate in a local file
+      --generate-name string   Use the specified generateName for the run
+      --global                 Use a ClusterAnalysisTemplate instead of a AnalysisTemplate
+  -h, --help                   help for analysisrun
+      --instance-id string     Instance-ID for the AnalysisRun
+      --name string            Use the specified name for the run
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## See Also
+
+* [rollouts create](kubectl-argo-rollouts_create.md)	 - Create a Rollout, Experiment, AnalysisTemplate, ClusterAnalysisTemplate, or AnalysisRun resource

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_dashboard.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_dashboard.md
@@ -24,7 +24,7 @@ kubectl argo rollouts dashboard [flags]
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_dashboard.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_dashboard.md
@@ -1,0 +1,47 @@
+# Rollouts Dashboard
+
+Start UI dashboard
+
+## Synopsis
+
+Start UI dashboard
+
+```shell
+kubectl argo rollouts dashboard [flags]
+```
+
+## Options
+
+```
+  -h, --help               help for dashboard
+  -p, --port int           port to listen on (default 3100)
+      --root-path string   changes the root path of the dashboard (default "rollouts")
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## See Also
+
+* [rollouts](kubectl-argo-rollouts.md)	 - Manage argo rollouts

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_get.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_get.md
@@ -1,0 +1,63 @@
+# Rollouts Get
+
+Get details about rollouts and experiments
+
+## Synopsis
+
+This command consists of multiple subcommands which can be used to get extended information about a rollout or experiment.
+
+```shell
+kubectl argo rollouts get <rollout|experiment> RESOURCE_NAME [flags]
+```
+
+## Examples
+
+```shell
+# Get a rollout
+kubectl argo rollouts get rollout guestbook
+
+# Watch a rollouts progress
+kubectl argo rollouts get rollout guestbook -w
+
+# Get an experiment
+kubectl argo rollouts get experiment my-experiment
+```
+
+## Options
+
+```
+  -h, --help   help for get
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## Available Commands
+
+* [rollouts get experiment](kubectl-argo-rollouts_get_experiment.md)	 - Get details about an Experiment
+* [rollouts get rollout](kubectl-argo-rollouts_get_rollout.md)	 - Get details about a rollout
+
+## See Also
+
+* [rollouts](kubectl-argo-rollouts.md)	 - Manage argo rollouts

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_get.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_get.md
@@ -35,7 +35,7 @@ kubectl argo rollouts get experiment my-experiment
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_get_experiment.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_get_experiment.md
@@ -1,0 +1,69 @@
+# Rollouts Get Experiment
+
+Get details about an Experiment
+
+## Synopsis
+
+Get details about and visual representation of a experiment. It returns a bunch of metadata on a resource and a tree view of the child resources created by the parent.
+	
+Tree view icons
+
+| Icon | Kind |
+|:----:|:-----------:|
+| ⟳ | Rollout |
+| Σ | Experiment |
+| α | AnalysisRun |
+| # | Revision |
+| ⧉ | ReplicaSet |
+| □ | Pod |
+| ⊞ | Job |
+
+```shell
+kubectl argo rollouts get experiment EXPERIMENT_NAME [flags]
+```
+
+## Examples
+
+```shell
+# Get an experiment
+kubectl argo rollouts get experiment my-experiment
+
+# Watch experiment progress
+kubectl argo rollouts get experiment my-experiment -w
+```
+
+## Options
+
+```
+  -h, --help       help for experiment
+      --no-color   Do not colorize output
+  -w, --watch      Watch live updates to the rollout
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## See Also
+
+* [rollouts get](kubectl-argo-rollouts_get.md)	 - Get details about rollouts and experiments

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_get_experiment.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_get_experiment.md
@@ -46,7 +46,7 @@ kubectl argo rollouts get experiment my-experiment -w
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_get_rollout.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_get_rollout.md
@@ -1,0 +1,70 @@
+# Rollouts Get Rollout
+
+Get details about a rollout
+
+## Synopsis
+
+Get details about and visual representation of a rollout. It returns a bunch of metadata on a resource and a tree view of the child resources created by the parent.
+	
+Tree view icons
+
+| Icon | Kind |
+|:----:|:-----------:|
+| ⟳ | Rollout |
+| Σ | Experiment |
+| α | AnalysisRun |
+| # | Revision |
+| ⧉ | ReplicaSet |
+| □ | Pod |
+| ⊞ | Job |
+
+```shell
+kubectl argo rollouts get rollout ROLLOUT_NAME [flags]
+```
+
+## Examples
+
+```shell
+# Get a rollout
+kubectl argo rollouts get rollout guestbook
+
+# Watch progress of a rollout
+kubectl argo rollouts get rollout guestbook -w
+```
+
+## Options
+
+```
+  -h, --help                  help for rollout
+      --no-color              Do not colorize output
+      --timeout-seconds int   Timeout after specified seconds
+  -w, --watch                 Watch live updates to the rollout
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## See Also
+
+* [rollouts get](kubectl-argo-rollouts_get.md)	 - Get details about rollouts and experiments

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_get_rollout.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_get_rollout.md
@@ -47,7 +47,7 @@ kubectl argo rollouts get rollout guestbook -w
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_lint.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_lint.md
@@ -1,0 +1,53 @@
+# Rollouts Lint
+
+Lint and validate a Rollout
+
+## Synopsis
+
+This command lints and validates a new Rollout resource from a file.
+
+```shell
+kubectl argo rollouts lint [flags]
+```
+
+## Examples
+
+```shell
+# Lint a rollout
+kubectl argo rollouts lint -f my-rollout.yaml
+```
+
+## Options
+
+```
+  -f, --filename string   File to lint
+  -h, --help              help for lint
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## See Also
+
+* [rollouts](kubectl-argo-rollouts.md)	 - Manage argo rollouts

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_lint.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_lint.md
@@ -30,7 +30,7 @@ kubectl argo rollouts lint -f my-rollout.yaml
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_list.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_list.md
@@ -1,0 +1,61 @@
+# Rollouts List
+
+List rollouts or experiments
+
+## Synopsis
+
+This command consists of multiple subcommands which can be used to lists all of the 
+rollouts or experiments for a specified namespace (uses current namespace context if namespace not specified).
+
+```shell
+kubectl argo rollouts list <rollout|experiment> [flags]
+```
+
+## Examples
+
+```shell
+# List rollouts
+kubectl argo rollouts list rollouts
+
+# List experiments
+kubectl argo rollouts list experiments
+```
+
+## Options
+
+```
+  -h, --help   help for list
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## Available Commands
+
+* [rollouts list experiments](kubectl-argo-rollouts_list_experiments.md)	 - List experiments
+* [rollouts list rollouts](kubectl-argo-rollouts_list_rollouts.md)	 - List rollouts
+
+## See Also
+
+* [rollouts](kubectl-argo-rollouts.md)	 - Manage argo rollouts

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_list.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_list.md
@@ -33,7 +33,7 @@ kubectl argo rollouts list experiments
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_list_experiments.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_list_experiments.md
@@ -36,7 +36,7 @@ kubectl argo rollouts list experiments --watch
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_list_experiments.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_list_experiments.md
@@ -1,0 +1,59 @@
+# Rollouts List Experiments
+
+List experiments
+
+## Synopsis
+
+This command lists all of the experiments for a specified namespace (uses current namespace context if namespace not specified).
+
+```shell
+kubectl argo rollouts list experiments [flags]
+```
+
+## Examples
+
+```shell
+# List rollouts
+kubectl argo rollouts list experiments
+
+# List rollouts from all namespaces
+kubectl argo rollouts list experiments --all-namespaces
+
+# List rollouts and watch for changes
+kubectl argo rollouts list experiments --watch
+```
+
+## Options
+
+```
+      --all-namespaces   Include all namespaces
+  -h, --help             help for experiments
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## See Also
+
+* [rollouts list](kubectl-argo-rollouts_list.md)	 - List rollouts or experiments

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_list_rollouts.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_list_rollouts.md
@@ -1,0 +1,62 @@
+# Rollouts List Rollouts
+
+List rollouts
+
+## Synopsis
+
+This command lists all of the rollouts for a specified namespace (uses current namespace context if namespace not specified).
+
+```shell
+kubectl argo rollouts list rollouts [flags]
+```
+
+## Examples
+
+```shell
+# List rollouts
+kubectl argo rollouts list rollouts
+
+# List rollouts from all namespaces
+kubectl argo rollouts list rollouts --all-namespaces
+
+# List rollouts and watch for changes
+kubectl argo rollouts list rollouts --watch
+```
+
+## Options
+
+```
+  -A, --all-namespaces   Include all namespaces
+  -h, --help             help for rollouts
+      --name string      Only show rollout with specified name
+      --timestamps       Print timestamps on updates
+  -w, --watch            Watch for changes
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## See Also
+
+* [rollouts list](kubectl-argo-rollouts_list.md)	 - List rollouts or experiments

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_list_rollouts.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_list_rollouts.md
@@ -39,7 +39,7 @@ kubectl argo rollouts list rollouts --watch
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications.md
@@ -1,0 +1,55 @@
+# Rollouts Notifications
+
+Set of CLI commands that helps manage notifications settings
+
+## Synopsis
+
+Set of CLI commands that helps manage notifications settings
+
+```shell
+kubectl argo rollouts notifications [flags]
+```
+
+## Options
+
+```
+      --as string                      Username to impersonate for the operation
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --config-map string              argo-rollouts-notification-configmap.yaml file path
+      --context string                 The name of the kubeconfig context to use
+  -h, --help                           help for notifications
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string              Path to a kube config. Only required if out-of-cluster
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --password string                Password for basic authentication to the API server
+      --proxy-url string               If provided, this URL will be used to connect via proxy
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+      --secret string                  argo-rollouts-notification-secret.yaml file path. Use empty secret if provided value is ':empty'
+      --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+      --username string                Username for basic authentication to the API server
+```
+
+## Options inherited from parent commands
+
+```
+      --cache-dir string   Default cache directory (default "/Users/zaller/.kube/cache")
+  -v, --kloglevel int      Log level for kubernetes client library
+      --loglevel string    Log level for kubectl argo rollouts (default "info")
+```
+
+## Available Commands
+
+* [rollouts notifications template](kubectl-argo-rollouts_notifications_template.md)	 - Notification templates related commands
+* [rollouts notifications trigger](kubectl-argo-rollouts_notifications_trigger.md)	 - Notification triggers related commands
+
+## See Also
+
+* [rollouts](kubectl-argo-rollouts.md)	 - Manage argo rollouts

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications.md
@@ -40,7 +40,7 @@ kubectl argo rollouts notifications [flags]
 ## Options inherited from parent commands
 
 ```
-      --cache-dir string   Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string   Default cache directory (default "$HOME/.kube/cache")
   -v, --kloglevel int      Log level for kubernetes client library
       --loglevel string    Log level for kubectl argo rollouts (default "info")
 ```

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_template.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_template.md
@@ -22,7 +22,7 @@ kubectl argo rollouts notifications template [flags]
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_template.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_template.md
@@ -1,0 +1,55 @@
+# Rollouts Notifications Template
+
+Notification templates related commands
+
+## Synopsis
+
+Notification templates related commands
+
+```shell
+kubectl argo rollouts notifications template [flags]
+```
+
+## Options
+
+```
+  -h, --help   help for template
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --config-map string              argo-rollouts-notification-configmap.yaml file path
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to a kube config. Only required if out-of-cluster
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --password string                Password for basic authentication to the API server
+      --proxy-url string               If provided, this URL will be used to connect via proxy
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+      --secret string                  argo-rollouts-notification-secret.yaml file path. Use empty secret if provided value is ':empty'
+      --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+      --username string                Username for basic authentication to the API server
+```
+
+## Available Commands
+
+* [rollouts notifications template get](kubectl-argo-rollouts_notifications_template_get.md)	 - Prints information about configured templates
+* [rollouts notifications template notify](kubectl-argo-rollouts_notifications_template_notify.md)	 - Generates notification using the specified template and send it to specified recipients
+
+## See Also
+
+* [rollouts notifications](kubectl-argo-rollouts_notifications.md)	 - Set of CLI commands that helps manage notifications settings

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_template_get.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_template_get.md
@@ -34,7 +34,7 @@ kubectl argo rollouts notifications template get app-sync-succeeded -o=yaml
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_template_get.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_template_get.md
@@ -1,0 +1,62 @@
+# Rollouts Notifications Template Get
+
+Prints information about configured templates
+
+## Synopsis
+
+Prints information about configured templates
+
+```shell
+kubectl argo rollouts notifications template get [flags]
+```
+
+## Examples
+
+```shell
+
+# prints all templates
+kubectl argo rollouts notifications template get
+# print YAML formatted app-sync-succeeded template definition
+kubectl argo rollouts notifications template get app-sync-succeeded -o=yaml
+
+```
+
+## Options
+
+```
+  -h, --help            help for get
+  -o, --output string   Output format. One of:json|yaml|wide|name (default "wide")
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --config-map string              argo-rollouts-notification-configmap.yaml file path
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to a kube config. Only required if out-of-cluster
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --password string                Password for basic authentication to the API server
+      --proxy-url string               If provided, this URL will be used to connect via proxy
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+      --secret string                  argo-rollouts-notification-secret.yaml file path. Use empty secret if provided value is ':empty'
+      --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+      --username string                Username for basic authentication to the API server
+```
+
+## See Also
+
+* [rollouts notifications template](kubectl-argo-rollouts_notifications_template.md)	 - Notification templates related commands

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_template_notify.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_template_notify.md
@@ -1,0 +1,63 @@
+# Rollouts Notifications Template Notify
+
+Generates notification using the specified template and send it to specified recipients
+
+## Synopsis
+
+Generates notification using the specified template and send it to specified recipients
+
+```shell
+kubectl argo rollouts notifications template notify NAME RESOURCE_NAME [flags]
+```
+
+## Examples
+
+```shell
+
+# Trigger notification using in-cluster config map and secret
+kubectl argo rollouts notifications template notify app-sync-succeeded guestbook --recipient slack:my-slack-channel
+
+# Render notification render generated notification in console
+kubectl argo rollouts notifications template notify app-sync-succeeded guestbook
+
+```
+
+## Options
+
+```
+  -h, --help                    help for notify
+      --recipient stringArray   List of recipients (default [console:stdout])
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --config-map string              argo-rollouts-notification-configmap.yaml file path
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to a kube config. Only required if out-of-cluster
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --password string                Password for basic authentication to the API server
+      --proxy-url string               If provided, this URL will be used to connect via proxy
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+      --secret string                  argo-rollouts-notification-secret.yaml file path. Use empty secret if provided value is ':empty'
+      --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+      --username string                Username for basic authentication to the API server
+```
+
+## See Also
+
+* [rollouts notifications template](kubectl-argo-rollouts_notifications_template.md)	 - Notification templates related commands

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_template_notify.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_template_notify.md
@@ -35,7 +35,7 @@ kubectl argo rollouts notifications template notify app-sync-succeeded guestbook
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_trigger.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_trigger.md
@@ -1,0 +1,55 @@
+# Rollouts Notifications Trigger
+
+Notification triggers related commands
+
+## Synopsis
+
+Notification triggers related commands
+
+```shell
+kubectl argo rollouts notifications trigger [flags]
+```
+
+## Options
+
+```
+  -h, --help   help for trigger
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --config-map string              argo-rollouts-notification-configmap.yaml file path
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to a kube config. Only required if out-of-cluster
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --password string                Password for basic authentication to the API server
+      --proxy-url string               If provided, this URL will be used to connect via proxy
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+      --secret string                  argo-rollouts-notification-secret.yaml file path. Use empty secret if provided value is ':empty'
+      --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+      --username string                Username for basic authentication to the API server
+```
+
+## Available Commands
+
+* [rollouts notifications trigger get](kubectl-argo-rollouts_notifications_trigger_get.md)	 - Prints information about configured triggers
+* [rollouts notifications trigger run](kubectl-argo-rollouts_notifications_trigger_run.md)	 - Evaluates specified trigger condition and prints the result
+
+## See Also
+
+* [rollouts notifications](kubectl-argo-rollouts_notifications.md)	 - Set of CLI commands that helps manage notifications settings

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_trigger.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_trigger.md
@@ -22,7 +22,7 @@ kubectl argo rollouts notifications trigger [flags]
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_trigger_get.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_trigger_get.md
@@ -1,0 +1,62 @@
+# Rollouts Notifications Trigger Get
+
+Prints information about configured triggers
+
+## Synopsis
+
+Prints information about configured triggers
+
+```shell
+kubectl argo rollouts notifications trigger get [flags]
+```
+
+## Examples
+
+```shell
+
+# prints all triggers
+kubectl argo rollouts notifications trigger get
+# print YAML formatted on-sync-failed trigger definition
+kubectl argo rollouts notifications trigger get on-sync-failed -o=yaml
+
+```
+
+## Options
+
+```
+  -h, --help            help for get
+  -o, --output string   Output format. One of:json|yaml|wide|name (default "wide")
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --config-map string              argo-rollouts-notification-configmap.yaml file path
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to a kube config. Only required if out-of-cluster
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --password string                Password for basic authentication to the API server
+      --proxy-url string               If provided, this URL will be used to connect via proxy
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+      --secret string                  argo-rollouts-notification-secret.yaml file path. Use empty secret if provided value is ':empty'
+      --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+      --username string                Username for basic authentication to the API server
+```
+
+## See Also
+
+* [rollouts notifications trigger](kubectl-argo-rollouts_notifications_trigger.md)	 - Notification triggers related commands

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_trigger_get.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_trigger_get.md
@@ -34,7 +34,7 @@ kubectl argo rollouts notifications trigger get on-sync-failed -o=yaml
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_trigger_run.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_trigger_run.md
@@ -1,0 +1,62 @@
+# Rollouts Notifications Trigger Run
+
+Evaluates specified trigger condition and prints the result
+
+## Synopsis
+
+Evaluates specified trigger condition and prints the result
+
+```shell
+kubectl argo rollouts notifications trigger run NAME RESOURCE_NAME [flags]
+```
+
+## Examples
+
+```shell
+
+# Execute trigger configured in 'argocd-notification-cm' ConfigMap
+kubectl argo rollouts notifications trigger run on-sync-status-unknown ./sample-app.yaml
+
+# Execute trigger using my-config-map.yaml instead of 'argo-rollouts-notification-configmap' ConfigMap
+kubectl argo rollouts notifications trigger run on-sync-status-unknown ./sample-app.yaml \
+--config-map ./my-config-map.yaml
+```
+
+## Options
+
+```
+  -h, --help   help for run
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --config-map string              argo-rollouts-notification-configmap.yaml file path
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to a kube config. Only required if out-of-cluster
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --password string                Password for basic authentication to the API server
+      --proxy-url string               If provided, this URL will be used to connect via proxy
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+      --secret string                  argo-rollouts-notification-secret.yaml file path. Use empty secret if provided value is ':empty'
+      --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+      --username string                Username for basic authentication to the API server
+```
+
+## See Also
+
+* [rollouts notifications trigger](kubectl-argo-rollouts_notifications_trigger.md)	 - Notification triggers related commands

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_trigger_run.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_notifications_trigger_run.md
@@ -34,7 +34,7 @@ kubectl argo rollouts notifications trigger run on-sync-status-unknown ./sample-
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_pause.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_pause.md
@@ -29,7 +29,7 @@ kubectl argo rollouts pause guestbook
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_pause.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_pause.md
@@ -1,0 +1,52 @@
+# Rollouts Pause
+
+Pause a rollout
+
+## Synopsis
+
+Set the rollout paused state to 'true'
+
+```shell
+kubectl argo rollouts pause ROLLOUT_NAME [flags]
+```
+
+## Examples
+
+```shell
+# Pause a rollout
+kubectl argo rollouts pause guestbook
+```
+
+## Options
+
+```
+  -h, --help   help for pause
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## See Also
+
+* [rollouts](kubectl-argo-rollouts.md)	 - Manage argo rollouts

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_promote.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_promote.md
@@ -36,7 +36,7 @@ kubectl argo rollouts promote guestbook --full
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_promote.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_promote.md
@@ -1,0 +1,59 @@
+# Rollouts Promote
+
+Promote a rollout
+
+## Synopsis
+
+Promote a rollout
+
+Promotes a rollout paused at a canary step, or a paused blue-green pre-promotion.
+To skip analysis, pauses and steps entirely, use '--full' to fully promote the rollout
+
+```shell
+kubectl argo rollouts promote ROLLOUT_NAME [flags]
+```
+
+## Examples
+
+```shell
+# Promote a paused rollout
+kubectl argo rollouts promote guestbook
+
+# Fully promote a rollout to desired version, skipping analysis, pauses, and steps
+kubectl argo rollouts promote guestbook --full
+```
+
+## Options
+
+```
+      --full   Perform a full promotion, skipping analysis, pauses, and steps
+  -h, --help   help for promote
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## See Also
+
+* [rollouts](kubectl-argo-rollouts.md)	 - Manage argo rollouts

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_restart.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_restart.md
@@ -1,0 +1,56 @@
+# Rollouts Restart
+
+Restart the pods of a rollout
+
+## Synopsis
+
+Restart the pods of a rollout
+
+```shell
+kubectl argo rollouts restart ROLLOUT [flags]
+```
+
+## Examples
+
+```shell
+# Restart the pods of a rollout in now
+kubectl argo rollouts restart ROLLOUT_NAME
+
+# Restart the pods of a rollout in ten seconds
+kubectl argo rollouts restart ROLLOUT_NAME --in 10s
+```
+
+## Options
+
+```
+  -h, --help        help for restart
+  -i, --in string   Amount of time before a restart. (e.g. 30s, 5m, 1h)
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## See Also
+
+* [rollouts](kubectl-argo-rollouts.md)	 - Manage argo rollouts

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_restart.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_restart.md
@@ -33,7 +33,7 @@ kubectl argo rollouts restart ROLLOUT_NAME --in 10s
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_retry.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_retry.md
@@ -1,0 +1,60 @@
+# Rollouts Retry
+
+Retry a rollout or experiment
+
+## Synopsis
+
+This command consists of multiple subcommands which can be used to restart an aborted rollout or a failed experiment.
+
+```shell
+kubectl argo rollouts retry <rollout|experiment> RESOURCE_NAME [flags]
+```
+
+## Examples
+
+```shell
+# Retry an aborted rollout
+kubectl argo rollouts retry rollout guestbook
+
+# Retry a failed experiment
+kubectl argo rollouts retry experiment my-experiment
+```
+
+## Options
+
+```
+  -h, --help   help for retry
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## Available Commands
+
+* [rollouts retry experiment](kubectl-argo-rollouts_retry_experiment.md)	 - Retry an experiment
+* [rollouts retry rollout](kubectl-argo-rollouts_retry_rollout.md)	 - Retry an aborted rollout
+
+## See Also
+
+* [rollouts](kubectl-argo-rollouts.md)	 - Manage argo rollouts

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_retry.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_retry.md
@@ -32,7 +32,7 @@ kubectl argo rollouts retry experiment my-experiment
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_retry_experiment.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_retry_experiment.md
@@ -29,7 +29,7 @@ kubectl argo rollouts retry experiment my-experiment
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_retry_experiment.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_retry_experiment.md
@@ -1,0 +1,52 @@
+# Rollouts Retry Experiment
+
+Retry an experiment
+
+## Synopsis
+
+Retry a failed experiment.
+
+```shell
+kubectl argo rollouts retry experiment EXPERIMENT_NAME [flags]
+```
+
+## Examples
+
+```shell
+# Retry an experiment
+kubectl argo rollouts retry experiment my-experiment
+```
+
+## Options
+
+```
+  -h, --help   help for experiment
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## See Also
+
+* [rollouts retry](kubectl-argo-rollouts_retry.md)	 - Retry a rollout or experiment

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_retry_rollout.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_retry_rollout.md
@@ -1,0 +1,52 @@
+# Rollouts Retry Rollout
+
+Retry an aborted rollout
+
+## Synopsis
+
+Retry an aborted rollout
+
+```shell
+kubectl argo rollouts retry rollout ROLLOUT_NAME [flags]
+```
+
+## Examples
+
+```shell
+# Retry an aborted rollout
+kubectl argo rollouts retry rollout guestbook
+```
+
+## Options
+
+```
+  -h, --help   help for rollout
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## See Also
+
+* [rollouts retry](kubectl-argo-rollouts_retry.md)	 - Retry a rollout or experiment

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_retry_rollout.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_retry_rollout.md
@@ -29,7 +29,7 @@ kubectl argo rollouts retry rollout guestbook
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_set.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_set.md
@@ -1,0 +1,56 @@
+# Rollouts Set
+
+Update various values on resources
+
+## Synopsis
+
+This command consists of multiple subcommands which can be used to update rollout resources.
+
+```shell
+kubectl argo rollouts set COMMAND [flags]
+```
+
+## Examples
+
+```shell
+# Set rollout image
+kubectl argo rollouts set image my-rollout demo=argoproj/rollouts-demo:yellow
+```
+
+## Options
+
+```
+  -h, --help   help for set
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## Available Commands
+
+* [rollouts set image](kubectl-argo-rollouts_set_image.md)	 - Update the image of a rollout
+
+## See Also
+
+* [rollouts](kubectl-argo-rollouts.md)	 - Manage argo rollouts

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_set.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_set.md
@@ -29,7 +29,7 @@ kubectl argo rollouts set image my-rollout demo=argoproj/rollouts-demo:yellow
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_set_image.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_set_image.md
@@ -29,7 +29,7 @@ kubectl argo rollouts set image my-rollout www=image:v2
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_set_image.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_set_image.md
@@ -1,0 +1,52 @@
+# Rollouts Set Image
+
+Update the image of a rollout
+
+## Synopsis
+
+Update the image of a rollout
+
+```shell
+kubectl argo rollouts set image ROLLOUT_NAME CONTAINER=IMAGE [flags]
+```
+
+## Examples
+
+```shell
+# Set rollout image
+kubectl argo rollouts set image my-rollout www=image:v2
+```
+
+## Options
+
+```
+  -h, --help   help for image
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## See Also
+
+* [rollouts set](kubectl-argo-rollouts_set.md)	 - Update various values on resources

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_status.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_status.md
@@ -1,0 +1,59 @@
+# Rollouts Status
+
+Show the status of a rollout
+
+## Synopsis
+
+Watch rollout until it finishes or the timeout is exceeded. Returns success if
+the rollout is healthy upon completion and an error otherwise.
+
+```shell
+kubectl argo rollouts status ROLLOUT_NAME [flags]
+```
+
+## Examples
+
+```shell
+# Watch the rollout until it succeeds
+kubectl argo rollouts status guestbook
+
+# Watch the rollout until it succeeds, fail if it takes more than 60 seconds
+kubectl argo rollouts status --timeout 60s guestbook
+
+```
+
+## Options
+
+```
+  -h, --help               help for status
+  -t, --timeout duration   The length of time to watch before giving up. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). Zero means wait forever
+  -w, --watch              Watch the status of the rollout until it's done (default true)
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## See Also
+
+* [rollouts](kubectl-argo-rollouts.md)	 - Manage argo rollouts

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_status.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_status.md
@@ -36,7 +36,7 @@ kubectl argo rollouts status --timeout 60s guestbook
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_terminate.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_terminate.md
@@ -32,7 +32,7 @@ kubectl argo rollouts terminate experiment my-experiment
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_terminate.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_terminate.md
@@ -1,0 +1,60 @@
+# Rollouts Terminate
+
+Terminate an AnalysisRun or Experiment
+
+## Synopsis
+
+This command consists of multiple subcommands which can be used to terminate an AnalysisRun or Experiment that is in progress.
+
+```shell
+kubectl argo rollouts terminate <analysisrun|experiment> RESOURCE_NAME [flags]
+```
+
+## Examples
+
+```shell
+# Terminate an analysisRun
+kubectl argo rollouts terminate analysisrun guestbook-877894d5b-4-success-rate.1
+
+# Terminate a failed experiment
+kubectl argo rollouts terminate experiment my-experiment
+```
+
+## Options
+
+```
+  -h, --help   help for terminate
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## Available Commands
+
+* [rollouts terminate analysisrun](kubectl-argo-rollouts_terminate_analysisrun.md)	 - Terminate an AnalysisRun
+* [rollouts terminate experiment](kubectl-argo-rollouts_terminate_experiment.md)	 - Terminate an experiment
+
+## See Also
+
+* [rollouts](kubectl-argo-rollouts.md)	 - Manage argo rollouts

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_terminate_analysisrun.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_terminate_analysisrun.md
@@ -29,7 +29,7 @@ kubectl argo rollouts terminate analysis guestbook-877894d5b-4-success-rate.1
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_terminate_analysisrun.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_terminate_analysisrun.md
@@ -1,0 +1,52 @@
+# Rollouts Terminate Analysisrun
+
+Terminate an AnalysisRun
+
+## Synopsis
+
+This command terminates an AnalysisRun.
+
+```shell
+kubectl argo rollouts terminate analysisrun ANALYSISRUN_NAME [flags]
+```
+
+## Examples
+
+```shell
+# Terminate an AnalysisRun
+kubectl argo rollouts terminate analysis guestbook-877894d5b-4-success-rate.1
+```
+
+## Options
+
+```
+  -h, --help   help for analysisrun
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## See Also
+
+* [rollouts terminate](kubectl-argo-rollouts_terminate.md)	 - Terminate an AnalysisRun or Experiment

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_terminate_experiment.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_terminate_experiment.md
@@ -29,7 +29,7 @@ kubectl argo rollouts terminate experiment my-experiment
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_terminate_experiment.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_terminate_experiment.md
@@ -1,0 +1,52 @@
+# Rollouts Terminate Experiment
+
+Terminate an experiment
+
+## Synopsis
+
+This command terminates an Experiment.
+
+```shell
+kubectl argo rollouts terminate experiment EXPERIMENT_NAME [flags]
+```
+
+## Examples
+
+```shell
+# Terminate an experiment
+kubectl argo rollouts terminate experiment my-experiment
+```
+
+## Options
+
+```
+  -h, --help   help for experiment
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## See Also
+
+* [rollouts terminate](kubectl-argo-rollouts_terminate.md)	 - Terminate an AnalysisRun or Experiment

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_undo.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_undo.md
@@ -1,0 +1,56 @@
+# Rollouts Undo
+
+Undo a rollout
+
+## Synopsis
+
+Rollback to the previous rollout.
+
+```shell
+kubectl argo rollouts undo ROLLOUT_NAME [flags]
+```
+
+## Examples
+
+```shell
+# Undo a rollout
+kubectl argo rollouts undo guestbook
+
+# Undo a rollout revision 3
+kubectl argo rollouts undo guestbook --to-revision=3
+```
+
+## Options
+
+```
+  -h, --help              help for undo
+      --to-revision int   The revision to rollback to. Default to 0 (last revision).
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## See Also
+
+* [rollouts](kubectl-argo-rollouts.md)	 - Manage argo rollouts

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_undo.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_undo.md
@@ -33,7 +33,7 @@ kubectl argo rollouts undo guestbook --to-revision=3
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_version.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_version.md
@@ -33,7 +33,7 @@ kubectl argo rollouts version --short
       --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_version.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_version.md
@@ -1,0 +1,56 @@
+# Rollouts Version
+
+Print version
+
+## Synopsis
+
+Show the version and build information of the Argo Rollouts plugin.
+
+```shell
+kubectl argo rollouts version [flags]
+```
+
+## Examples
+
+```shell
+# Get full version info
+kubectl argo rollouts version
+
+# Get just plugin version number
+kubectl argo rollouts version --short
+```
+
+## Options
+
+```
+  -h, --help    help for version
+      --short   print just the version number
+```
+
+## Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "/Users/zaller/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -v, --kloglevel int                  Log level for kubernetes client library
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loglevel string                Log level for kubectl argo rollouts (default "info")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+## See Also
+
+* [rollouts](kubectl-argo-rollouts.md)	 - Manage argo rollouts

--- a/docs/generated/notification-services/alertmanager.md
+++ b/docs/generated/notification-services/alertmanager.md
@@ -1,0 +1,164 @@
+# Alertmanager
+
+## Parameters
+
+The notification service is used to push events to [Alertmanager](https://github.com/prometheus/alertmanager), and the following settings need to be specified:
+
+* `targets` - the alertmanager service address, array type
+* `scheme` - optional, default is "http", e.g. http or https
+* `apiPath` - optional, default is "/api/v2/alerts"
+* `insecureSkipVerify` - optional, default is "false", when scheme is https whether to skip the verification of ca
+* `basicAuth` - optional, server auth
+* `bearerToken` - optional, server auth
+* `timeout` - optional, the timeout in seconds used when sending alerts, default is "3 seconds"
+
+`basicAuth` or `bearerToken` is used for authentication, you can choose one. If the two are set at the same time, `basicAuth` takes precedence over `bearerToken`.
+
+## Example
+
+### Prometheus Alertmanager config
+
+```yaml
+global:
+  resolve_timeout: 5m
+
+route:
+  group_by: ['alertname']
+  group_wait: 10s
+  group_interval: 10s
+  repeat_interval: 1h
+  receiver: 'default'
+receivers:
+- name: 'default'
+  webhook_configs:
+  - send_resolved: false
+    url: 'http://10.5.39.39:10080/api/alerts/webhook'
+```
+
+You should turn off "send_resolved" or you will receive unnecessary recovery notifications after "resolve_timeout".
+
+### Send one alertmanager without auth
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.alertmanager: |
+    targets:
+    - 10.5.39.39:9093
+```
+
+### Send alertmanager cluster with custom api path
+
+If your alertmanager has changed the default api, you can customize "apiPath".
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.alertmanager: |
+    targets:
+    - 10.5.39.39:443
+    scheme: https
+    apiPath: /api/events
+    insecureSkipVerify: true
+```
+
+### Send high availability alertmanager with auth
+
+Store auth token in `argocd-notifications-secret` Secret and use configure in `argocd-notifications-cm` ConfigMap.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <secret-name>
+stringData:
+  alertmanager-username: <username>
+  alertmanager-password: <password>
+  alertmanager-bearer-token: <token>
+```
+
+- with basicAuth
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.alertmanager: |
+    targets:
+    - 10.5.39.39:19093
+    - 10.5.39.39:29093
+    - 10.5.39.39:39093
+    scheme: https
+    apiPath: /api/v2/alerts
+    insecureSkipVerify: true
+    basicAuth:
+      username: $alertmanager-username
+      password: $alertmanager-password   
+```
+
+- with bearerToken
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.alertmanager: |
+    targets:
+    - 10.5.39.39:19093
+    - 10.5.39.39:29093
+    - 10.5.39.39:39093
+    scheme: https
+    apiPath: /api/v2/alerts
+    insecureSkipVerify: true
+    bearerToken: $alertmanager-bearer-token
+```
+
+## Templates
+
+* `labels` - at least one label pair required, implement different notification strategies according to alertmanager routing
+* `annotations` - optional, specifies a set of information labels, which can be used to store longer additional information, but only for display
+* `generatorURL` - optional, default is '{{.app.spec.source.repoURL}}', backlink used to identify the entity that caused this alert in the client
+
+the `label` or `annotations` or `generatorURL` values can be templated.
+
+```yaml
+context: |
+  argocdUrl: https://example.com/argocd
+
+template.app-deployed: |
+  message: Application {{.app.metadata.name}} has been healthy.
+  alertmanager:
+    labels:
+      fault_priority: "P5"
+      event_bucket: "deploy"
+      event_status: "succeed"
+      recipient: "{{.recipient}}"
+    annotations:
+      application: '<a href="{{.context.argocdUrl}}/applications/{{.app.metadata.name}}">{{.app.metadata.name}}</a>'
+      author: "{{(call .repo.GetCommitMetadata .app.status.sync.revision).Author}}"
+      message: "{{(call .repo.GetCommitMetadata .app.status.sync.revision).Message}}"
+```
+
+You can do targeted push on [Alertmanager](https://github.com/prometheus/alertmanager) according to labels.
+
+```yaml
+template.app-deployed: |
+  message: Application {{.app.metadata.name}} has been healthy.
+  alertmanager:
+    labels:
+      alertname: app-deployed
+      fault_priority: "P5"
+      event_bucket: "deploy"
+```
+
+There is a special label `alertname`. If you don’t set its value, it will be equal to the template name by default.

--- a/docs/generated/notification-services/email.md
+++ b/docs/generated/notification-services/email.md
@@ -1,0 +1,63 @@
+# Email
+
+## Parameters
+
+The Email notification service sends email notifications using SMTP protocol and requires specifying the following settings:
+
+* `host` - the SMTP server host name
+* `port` - the SMTP server port
+* `username` - username
+* `password` - password
+* `from` - from email address
+* `html` - optional bool, true or false
+* `insecure_skip_verify` - optional bool, true or false
+
+## Example
+
+The following snippet contains sample Gmail service configuration:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.email.gmail: |
+    username: $email-username
+    password: $email-password
+    host: smtp.gmail.com
+    port: 465
+    from: $email-username
+```
+
+Without authentication:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.email.example: |
+    host: smtp.example.com
+    port: 587
+    from: $email-username
+```
+
+## Template
+
+Notification templates support specifying subject for email notifications:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  template.app-sync-succeeded: |
+    email:
+      subject: Application {{.app.metadata.name}} has been successfully synced.
+    message: |
+      {{if eq .serviceType "slack"}}:white_check_mark:{{end}} Application {{.app.metadata.name}} has been successfully synced at {{.app.status.operationState.finishedAt}}.
+      Sync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .
+```

--- a/docs/generated/notification-services/github.md
+++ b/docs/generated/notification-services/github.md
@@ -1,0 +1,76 @@
+# GitHub
+
+## Parameters
+
+The GitHub notification service changes commit status using [GitHub Apps](https://docs.github.com/en/developers/apps) and requires specifying the following settings:
+
+* `appID` - the app id
+* `installationID` - the app installation id
+* `privateKey` - the app private key
+* `enterpriseBaseURL` - optional URL, e.g. https://git.example.com/
+
+## Configuration
+
+1. Create a GitHub Apps using https://github.com/settings/apps/new
+2. Change repository permissions to enable write commit statuses
+![2](https://user-images.githubusercontent.com/18019529/108397381-3ca57980-725b-11eb-8d17-5b8992dc009e.png)
+3. Generate a private key, and download it automatically
+![3](https://user-images.githubusercontent.com/18019529/108397926-d4a36300-725b-11eb-83fe-74795c8c3e03.png)
+4. Install app to account
+5. Store privateKey in `argocd-notifications-secret` Secret and configure GitHub integration
+in `argocd-notifications-cm` ConfigMap
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.github: |
+    appID: <app-id>
+    installationID: <installation-id>
+    privateKey: $github-privateKey
+```
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <secret-name>
+stringData:
+  github-privateKey: |
+    -----BEGIN RSA PRIVATE KEY-----
+    (snip)
+    -----END RSA PRIVATE KEY-----
+```
+
+6. Create subscription for your GitHub integration
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.<trigger-name>.github: ""
+```
+
+## Templates
+
+![](https://user-images.githubusercontent.com/18019529/108520497-168ce180-730e-11eb-93cb-b0b91f99bdc5.png)
+
+```yaml
+template.app-deployed: |
+  message: |
+    Application {{.app.metadata.name}} is now running new version of deployments manifests.
+  github:
+    repoURLPath: "{{.app.spec.source.repoURL}}"
+    revisionPath: "{{.app.status.operationState.syncResult.revision}}"
+    status:
+      state: success
+      label: "continuous-delivery/{{.app.metadata.name}}"
+      targetURL: "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"
+```
+
+**Notes**:
+- If the message is set to 140 characters or more, it will be truncated.
+- If `github.repoURLPath` and `github.revisionPath` are same as above, they can be omitted.

--- a/docs/generated/notification-services/googlechat.md
+++ b/docs/generated/notification-services/googlechat.md
@@ -1,0 +1,92 @@
+# Google Chat
+
+## Parameters
+
+The Google Chat notification service send message notifications to a google chat webhook. This service uses the following settings:
+
+* `webhooks` - a map of the form `webhookName: webhookUrl`
+
+## Configuration
+
+1. Open `Google chat` and go to the space to which you want to send messages
+2. From the menu at the top of the page, select **Configure Webhooks**
+3. Under **Incoming Webhooks**, click **Add Webhook**
+4. Give a name to the webhook, optionally add an image and click **Save**
+5. Copy the URL next to your webhook
+6. Store the URL in `argocd-notification-secret` and declare it in `argocd-notifications-cm`
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.googlechat: |
+    webhooks:
+      spaceName: $space-webhook-url
+```
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <secret-name>
+stringData:
+  space-webhook-url: https://chat.googleapis.com/v1/spaces/<space_id>/messages?key=<key>&token=<token>  
+```
+
+6. Create a subscription for your space
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-succeeded.googlechat: spaceName
+```
+
+## Templates
+
+You can send [simple text](https://developers.google.com/chat/reference/message-formats/basic) or [card messages](https://developers.google.com/chat/reference/message-formats/cards) to a Google Chat space. A simple text message template can be defined as follows:
+
+```yaml
+template.app-sync-succeeded: |
+  message: The app {{ .app.metadata.name }} has successfully synced!
+```
+
+A card message can be defined as follows:
+
+```yaml
+template.app-sync-succeeded: |
+  googlechat:
+    cards: |
+      - header:
+          title: ArgoCD Bot Notification
+        sections:
+          - widgets:
+              - textParagraph:
+                  text: The app {{ .app.metadata.name }} has successfully synced!
+          - widgets:
+              - keyValue:
+                  topLabel: Repository
+                  content: {{ call .repo.RepoURLToHTTPS .app.spec.source.repoURL }}
+              - keyValue:
+                  topLabel: Revision
+                  content: {{ .app.spec.source.targetRevision }}
+              - keyValue:
+                  topLabel: Author
+                  content: {{ (call .repo.GetCommitMetadata .app.status.sync.revision).Author }}
+```
+
+The card message can be written in JSON too.
+
+## Chat Threads
+
+It is possible send both simple text and card messages in a chat thread by specifying a unique key for the thread. The thread key can be defined as follows:
+
+```yaml
+template.app-sync-succeeded: |
+  message: The app {{ .app.metadata.name }} has succesfully synced!
+  googlechat:
+    threadKey: {{ .app.metadata.name }}
+```

--- a/docs/generated/notification-services/grafana.md
+++ b/docs/generated/notification-services/grafana.md
@@ -1,0 +1,45 @@
+# Grafana
+
+To be able to create Grafana annotation with argocd-notifications you have to create an [API Key](https://grafana.com/docs/grafana/latest/http_api/auth/#create-api-key) inside your [Grafana](https://grafana.com).
+
+![sample](https://user-images.githubusercontent.com/18019529/112024976-0f106080-8b78-11eb-9658-7663305899be.png)
+
+1. Login to your Grafana instance as `admin`
+2. On the left menu, go to Configuration / API Keys
+3. Click "Add API Key" 
+4. Fill the Key with name `ArgoCD Notification`, role `Editor` and Time to Live `10y` (for example)
+5. Click on Add button
+6. Store apiKey in `argocd-notifications-secret` Secret and Copy your API Key and define it in `argocd-notifications-cm` ConfigMap
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.grafana: |
+    apiUrl: https://grafana.example.com/api
+    apiKey: $grafana-api-key
+```
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <secret-name>
+stringData:
+  grafana-api-key: api-key
+```
+
+7. Create subscription for your Grafana integration
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.<trigger-name>.grafana: tag1|tag2 # list of tags separated with |
+```
+
+8. Change the annotations settings
+![8](https://user-images.githubusercontent.com/18019529/112022083-47fb0600-8b75-11eb-849b-d25d41925909.png)

--- a/docs/generated/notification-services/mattermost.md
+++ b/docs/generated/notification-services/mattermost.md
@@ -1,0 +1,78 @@
+# Mattermost
+
+## Parameters
+
+* `apiURL` - the server url, e.g. https://mattermost.example.com
+* `token` - the bot token
+* `insecureSkipVerify` - optional bool, true or false
+
+## Configuration
+
+1. Create a bot account and copy token after creating it
+![1](https://user-images.githubusercontent.com/18019529/111499520-62ed0500-8786-11eb-88b0-d0aade61fed4.png)
+2. Invite team
+![2](https://user-images.githubusercontent.com/18019529/111500197-1229dc00-8787-11eb-98e5-587ee36c94a9.png)
+3. Store token in `argocd-notifications-secret` Secret and configure Mattermost integration
+in `argocd-notifications-cm` ConfigMap
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.mattermost: |
+    apiURL: <api-url>
+    token: $mattermost-token
+```
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <secret-name>
+stringData:
+  mattermost-token: token
+```
+
+4. Copy channel id
+![4](https://user-images.githubusercontent.com/18019529/111501289-333efc80-8788-11eb-9731-8353170cd73a.png)
+
+5. Create subscription for your Mattermost integration
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.<trigger-name>.mattermost: <channel-id>
+```
+
+## Templates
+
+![](https://user-images.githubusercontent.com/18019529/111502636-5fa74880-8789-11eb-97c5-5eac22c00a37.png)
+
+You can reuse the template of slack.  
+Mattermost is compatible with attachments of Slack. See [Mattermost Integration Guide](https://docs.mattermost.com/developer/message-attachments.html).
+
+```yaml
+template.app-deployed: |
+  message: |
+    Application {{.app.metadata.name}} is now running new version of deployments manifests.
+  mattermost:
+    attachments: |
+      [{
+        "title": "{{.app.metadata.name}}",
+        "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+        "color": "#18be52",
+        "fields": [{
+          "title": "Sync Status",
+          "value": "{{.app.status.sync.status}}",
+          "short": true
+        }, {
+          "title": "Repository",
+          "value": "{{.app.spec.source.repoURL}}",
+          "short": true
+        }]
+      }]
+```

--- a/docs/generated/notification-services/newrelic.md
+++ b/docs/generated/notification-services/newrelic.md
@@ -1,0 +1,61 @@
+# NewRelic
+
+## Parameters
+
+* `apiURL` - the api server url, e.g. https://api.newrelic.com
+* `apiKey` - a [NewRelic ApiKey](https://docs.newrelic.com/docs/apis/rest-api-v2/get-started/introduction-new-relic-rest-api-v2/#api_key)
+
+## Configuration
+
+1. Create a NewRelic [Api Key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#user-api-key)
+2. Store apiKey in `argocd-notifications-secret` Secret and configure NewRelic integration in `argocd-notifications-cm` ConfigMap
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.newrelic: |
+    apiURL: <api-url>
+    apiKey: $newrelic-apiKey
+```
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <secret-name>
+stringData:
+  newrelic-apiKey: apiKey
+```
+
+3. Copy [Application ID](https://docs.newrelic.com/docs/apis/rest-api-v2/get-started/get-app-other-ids-new-relic-one/#apm)
+4. Create subscription for your NewRelic integration
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.<trigger-name>.newrelic: <app-id>
+```
+
+## Templates
+
+* `description` - __optional__, high-level description of this deployment, visible in the [Summary](https://docs.newrelic.com/docs/apm/applications-menu/monitoring/apm-overview-page) page and on the [Deployments](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page) page when you select an individual deployment.
+  * Defaults to `message`
+* `changelog` - __optional__, A summary of what changed in this deployment, visible in the [Deployments](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page) page when you select (selected deployment) > Change log.
+  * Defaults to `{{(call .repo.GetCommitMetadata .app.status.sync.revision).Message}}`
+* `user` - __optional__, A username to associate with the deployment, visible in the [Summary](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page) and on the [Deployments](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page).
+  * Defaults to `{{(call .repo.GetCommitMetadata .app.status.sync.revision).Author}}`
+
+```yaml
+context: |
+  argocdUrl: https://example.com/argocd
+
+template.app-deployed: |
+  message: Application {{.app.metadata.name}} has successfully deployed.
+  newrelic:
+    description: Application {{.app.metadata.name}} has successfully deployed
+```

--- a/docs/generated/notification-services/opsgenie.md
+++ b/docs/generated/notification-services/opsgenie.md
@@ -1,0 +1,28 @@
+# Opsgenie
+
+To be able to send notifications with argocd-notifications you have to create an [API Integration](https://docs.opsgenie.com/docs/integrations-overview) inside your [Opsgenie Team](https://docs.opsgenie.com/docs/teams).
+
+1. Login to Opsgenie at https://app.opsgenie.com or https://app.eu.opsgenie.com (if you have an account in the european union)
+2. Make sure you already have a team, if not follow this guide https://docs.opsgenie.com/docs/teams
+3. Click "Teams" in the Menu on the left
+4. Select the team that you want to notify
+5. In the teams configuration menu select "Integrations"
+6. click "Add Integration" in the top right corner
+7. Select "API" integration
+8. Give your integration a name, copy the "API key" and safe it somewhere for later
+9. Make sure the checkboxes for "Create and Update Access" and "enable" are selected, disable the other checkboxes to remove unnecessary permissions
+10. Click "Safe Integration" at the bottom
+11. Check your browser for the correct server apiURL. If it is "app.opsgenie.com" then use the us/international api url `api.opsgenie.com` in the next step, otherwise use `api.eu.opsgenie.com` (european api). 
+12. You are finished with configuring opsgenie. Now you need to configure argocd-notifications. Use the apiUrl, the team name and the apiKey to configure the opsgenie integration in the `argocd-notifications-secret` secret. 
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.opsgenie: |
+    apiUrl: <api-url>
+    apiKeys:
+      <your-team>: <integration-api-key>
+```

--- a/docs/generated/notification-services/overview.md
+++ b/docs/generated/notification-services/overview.md
@@ -1,0 +1,53 @@
+The notification services represent integration with services such as slack, email or custom webhook. Services are configured in `argocd-notifications-cm` ConfigMap
+using `service.<type>.(<custom-name>)` keys and might reference sensitive data from `argocd-notifications-secret` Secret. Following example demonstrates slack
+service configuration:
+
+```yaml
+  service.slack: |
+    token: $slack-token
+```
+
+
+The `slack` indicates that service sends slack notification; name is missing and defaults to `slack`.
+
+## Sensitive Data
+
+Sensitive data like authentication tokens should be stored in `<secret-name>` Secret and can be referenced in
+service configuration using `$<secret-key>` format. For example `$slack-token` referencing value of key `slack-token` in
+`<secret-name>` Secret.
+
+## Custom Names
+
+Service custom names allow configuring two instances of the same service type.
+
+```yaml
+  service.slack.workspace1: |
+    token: $slack-token-workspace1
+  service.slack.workspace2: |
+    token: $slack-token-workspace2
+```
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-succeeded.workspace1: my-channel
+    notifications.argoproj.io/subscribe.on-sync-succeeded.workspace2: my-channel
+```
+
+## Service Types
+
+* [Email](./email.md)
+* [GitHub](./github.md)
+* [Slack](./slack.md)
+* [Mattermost](./mattermost.md)
+* [Opsgenie](./opsgenie.md)
+* [Grafana](./grafana.md)
+* [Webhook](./webhook.md)
+* [Telegram](./telegram.md)
+* [Teams](./teams.md)
+* [Google Chat](./googlechat.md)
+* [Rocket.Chat](./rocketchat.md)
+* [Pushover](./pushover.md)
+* [Alertmanager](./alertmanager.md)

--- a/docs/generated/notification-services/pagerduty.md
+++ b/docs/generated/notification-services/pagerduty.md
@@ -1,0 +1,66 @@
+# Pagerduty
+
+## Parameters
+
+The Pagerduty notification service is used to create pagerduty incidents and requires specifying the following settings:
+
+* `pagerdutyToken` - the pagerduty auth token
+* `from` - email address of a valid user associated with the account making the request.
+* `serviceID` - The ID of the resource.
+
+
+## Example
+
+The following snippet contains sample Pagerduty service configuration:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <secret-name>
+stringData:
+  pagerdutyToken: <pd-api-token>
+```
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.pagerduty: |
+    token: $pagerdutyToken
+    from: <emailid>
+```
+
+## Template
+
+Notification templates support specifying subject for pagerduty notifications:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  template.rollout-aborted: |
+    message: Rollout {{.rollout.metadata.name}} is aborted.
+    pagerduty:
+      title: "Rollout {{.rollout.metadata.name}}"
+      urgency: "high"
+      body: "Rollout {{.rollout.metadata.name}} aborted "
+      priorityID: "<priorityID of incident>"
+```
+
+NOTE: A Priority is a label representing the importance and impact of an incident. This is only available on Standard and Enterprise plans of pagerduty.
+
+## Annotation
+
+Annotation sample for pagerduty notifications:
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-rollout-aborted.pagerduty: "<serviceID for Pagerduty>"
+```

--- a/docs/generated/notification-services/pushover.md
+++ b/docs/generated/notification-services/pushover.md
@@ -1,0 +1,33 @@
+# Pushover
+
+1. Create an app at [pushover.net](https://pushover.net/apps/build).
+2. Store the API key in `<secret-name>` Secret and define the secret name in `<config-map-name>` ConfigMap:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.pushover: |
+    token: $pushover-token
+```
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <secret-name>
+stringData:
+  pushover-token: avtc41pn13asmra6zaiyf7dh6cgx97
+```
+
+3. Add your user key to your Application resource:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-succeeded.pushover: uumy8u4owy7bgkapp6mc5mvhfsvpcd
+```

--- a/docs/generated/notification-services/rocketchat.md
+++ b/docs/generated/notification-services/rocketchat.md
@@ -1,0 +1,96 @@
+# Rocket.Chat
+
+## Parameters
+
+The Rocket.Chat notification service configuration includes following settings:
+
+* `email` - the Rocker.Chat user's email
+* `password` - the Rocker.Chat user's password
+* `alias` - optional alias that should be used to post message
+* `icon` - optional message icon
+* `avatar` - optional message avatar
+* `serverUrl` - optional Rocket.Chat server url
+
+## Configuration
+
+1. Login to your RocketChat instance
+2. Go to user management
+
+![2](https://user-images.githubusercontent.com/15252187/115824993-7ccad900-a411-11eb-89de-6a0c4438ffdf.png)
+
+3. Add new user with `bot` role. Also note that `Require password change` checkbox mus be not checked
+
+![3](https://user-images.githubusercontent.com/15252187/115825174-b4d21c00-a411-11eb-8f20-cda48cea9fad.png)
+
+4. Copy username and password that you was created for bot user
+5. Create a public or private channel, or a team, for this example `my_channel`
+6. Add your bot to this channel **otherwise it won't work**
+7. Store email and password in argocd_notifications-secret Secret
+ 
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <secret-name>
+stringData:
+  rocketchat-email: <email>
+  rocketchat-password: <password>
+```
+
+8. Finally, use these credentials to configure the RocketChat integration in the `argocd-configmap` config map: 
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.rocketchat: |
+    email: $rocketchat-email
+    password: $rocketchat-password
+```
+
+9. Create a subscription for your Rocket.Chat integration:
+
+*Note: channel, team or user must be prefixed with # or @ elsewhere we will be interpretative destination as a room ID*
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-succeeded.rocketchat: #my_channel
+```
+
+## Templates
+
+Notification templates can be customized with RocketChat [attachments](https://developer.rocket.chat/api/rest-api/methods/chat/postmessage#attachments-detail).
+
+*Note: Attachments structure in Rocketchat is same with Slack attachments [feature](https://api.slack.com/messaging/composing/layouts).*
+
+<!-- TODO: @sergeyshevch Need to add screenshot with RocketChat attachments -->
+
+The message attachments can be specified in `attachments` string fields under `rocketchat` field:
+
+```yaml
+template.app-sync-status: |
+  message: |
+    Application {{.app.metadata.name}} sync is {{.app.status.sync.status}}.
+    Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
+  rocketchat:
+    attachments: |
+      [{
+        "title": "{{.app.metadata.name}}",
+        "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+        "color": "#18be52",
+        "fields": [{
+          "title": "Sync Status",
+          "value": "{{.app.status.sync.status}}",
+          "short": true
+        }, {
+          "title": "Repository",
+          "value": "{{.app.spec.source.repoURL}}",
+          "short": true
+        }]
+      }]
+```

--- a/docs/generated/notification-services/slack.md
+++ b/docs/generated/notification-services/slack.md
@@ -1,0 +1,169 @@
+# Slack
+
+If you want to send message using incoming webhook, you can use [webhook](./webhook.md#send-slack).
+
+## Parameters
+
+The Slack notification service configuration includes following settings:
+
+* `token` - the app token
+* `apiURL` - optional, the server url, e.g. https://example.com/api
+* `username` - optional, the app username
+* `icon` - optional, the app icon, e.g. :robot_face: or https://example.com/image.png
+* `insecureSkipVerify` - optional bool, true or false
+
+## Configuration
+
+1. Create Slack Application using https://api.slack.com/apps?new_app=1
+![1](https://user-images.githubusercontent.com/426437/73604308-4cb0c500-4543-11ea-9092-6ca6bae21cbb.png)
+1. Once application is created navigate to `Enter OAuth & Permissions`
+![2](https://user-images.githubusercontent.com/426437/73604309-4d495b80-4543-11ea-9908-4dea403d3399.png)
+1. Click `Permissions` under `Add features and functionality` section and add `chat:write` scope. To use the optional username and icon overrides in the Slack notification service also add the `chat:write.customize` scope.
+![3](https://user-images.githubusercontent.com/426437/73604310-4d495b80-4543-11ea-8576-09cd91aea0e5.png)
+1. Scroll back to the top, click 'Install App to Workspace' button and confirm the installation.
+![4](https://user-images.githubusercontent.com/426437/73604311-4d495b80-4543-11ea-9155-9d216b20ec86.png)
+1. Once installation is completed copy the OAuth token.
+![5](https://user-images.githubusercontent.com/426437/73604312-4d495b80-4543-11ea-832b-a9d9d5e4bc29.png)
+
+1. Create a public or private channel, for this example `my_channel`
+1. Invite your slack bot to this channel **otherwise slack bot won't be able to deliver notifications to this channel**
+1. Store Oauth access token in `argocd-notifications-secret` secret
+
+```yaml
+  apiVersion: v1
+  kind: Secret
+  metadata:
+      name: <secret-name>
+  stringData:
+      slack-token: <Oauth-access-token>
+```
+
+1. Define service type slack in data section of `argocd-notifications-cm` configmap:
+
+```yaml
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: <config-map-name>
+  data:
+    service.slack: |
+      token: $slack-token
+```
+
+1. Add annotation in application yaml file to enable notifications for specific argocd app
+
+```yaml
+  apiVersion: argoproj.io/v1alpha1
+  kind: Application
+  metadata:
+    annotations:
+      notifications.argoproj.io/subscribe.on-sync-succeeded.slack: my_channel
+```
+
+1. Annotation with more than one trigger multiple of destinations and recipients
+
+```yaml
+  apiVersion: argoproj.io/v1alpha1
+  kind: Application
+  metadata:
+    annotations:
+      notifications.argoproj.io/subscriptions: |
+        - trigger: [on-scaling-replica-set, on-rollout-updated, on-rollout-step-completed]
+          destinations:
+            - service: slack
+              recipients: [my-channel-1, my-channel-2]
+            - service: email
+              recipients: [recipient-1, recipient-2, recipient-3 ]
+        - trigger: [on-rollout-aborted, on-analysis-run-failed, on-analysis-run-error]
+          destinations:
+            - service: slack
+              recipients: [my-channel-21, my-channel-22]
+```
+
+## Templates
+
+Notification templates can be customized to leverage slack message blocks and attachments
+[feature](https://api.slack.com/messaging/composing/layouts).
+
+![](https://user-images.githubusercontent.com/426437/72776856-6dcef880-3bc8-11ea-8e3b-c72df16ee8e6.png)
+
+The message blocks and attachments can be specified in `blocks` and `attachments` string fields under `slack` field:
+
+```yaml
+template.app-sync-status: |
+  message: |
+    Application {{.app.metadata.name}} sync is {{.app.status.sync.status}}.
+    Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
+  slack:
+    attachments: |
+      [{
+        "title": "{{.app.metadata.name}}",
+        "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+        "color": "#18be52",
+        "fields": [{
+          "title": "Sync Status",
+          "value": "{{.app.status.sync.status}}",
+          "short": true
+        }, {
+          "title": "Repository",
+          "value": "{{.app.spec.source.repoURL}}",
+          "short": true
+        }]
+      }]
+```
+
+The messages can be aggregated to the slack threads by grouping key which can be specified in a `groupingKey` string field under `slack` field.
+`groupingKey` is used across each template and works independently on each slack channel.
+When multiple applications will be updated at the same time or frequently, the messages in slack channel can be easily read by aggregating with git commit hash, application name, etc.
+Furthermore, the messages can be broadcast to the channel at the specific template by `notifyBroadcast` field.
+
+```yaml
+template.app-sync-status: |
+  message: |
+    Application {{.app.metadata.name}} sync is {{.app.status.sync.status}}.
+    Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
+  slack:
+    attachments: |
+      [{
+        "title": "{{.app.metadata.name}}",
+        "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+        "color": "#18be52",
+        "fields": [{
+          "title": "Sync Status",
+          "value": "{{.app.status.sync.status}}",
+          "short": true
+        }, {
+          "title": "Repository",
+          "value": "{{.app.spec.source.repoURL}}",
+          "short": true
+        }]
+      }]
+    # Aggregate the messages to the thread by git commit hash
+    groupingKey: "{{.app.status.sync.revision}}"
+    notifyBroadcast: false
+template.app-sync-failed: |
+  message: |
+    Application {{.app.metadata.name}} sync is {{.app.status.sync.status}}.
+    Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
+  slack:
+    attachments: |
+      [{
+        "title": "{{.app.metadata.name}}",
+        "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+        "color": "#ff0000",
+        "fields": [{
+          "title": "Sync Status",
+          "value": "{{.app.status.sync.status}}",
+          "short": true
+        }, {
+          "title": "Repository",
+          "value": "{{.app.spec.source.repoURL}}",
+          "short": true
+        }]
+      }]
+    # Aggregate the messages to the thread by git commit hash
+    groupingKey: "{{.app.status.sync.revision}}"
+    notifyBroadcast: true
+```
+
+The message is sent according to the `deliveryPolicy` string field under the `slack` field. The available modes are `Post` (default), `PostAndUpdate`, and `Update`. The `PostAndUpdate` and `Update` settings require `groupingKey` to be set.

--- a/docs/generated/notification-services/teams.md
+++ b/docs/generated/notification-services/teams.md
@@ -1,0 +1,126 @@
+# Teams
+
+## Parameters
+
+The Teams notification service send message notifications using Teams bot and requires specifying the following settings:
+
+* `recipientUrls` - the webhook url map, e.g. `channelName: https://example.com`
+
+## Configuration
+
+1. Open `Teams` and goto `Apps`
+2. Find `Incoming Webhook` microsoft app and click on it
+3. Press `Add to a team` -> select team and channel -> press `Set up a connector`
+4. Enter webhook name and upload image (optional)
+5. Press `Create` then copy webhook url and store it in `argocd-notifications-secret` and define it in `argocd-notifications-cm`
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.teams: |
+    recipientUrls:
+      channelName: $channel-teams-url
+```
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <secret-name>
+stringData:
+  channel-teams-url: https://example.com
+```
+
+6. Create subscription for your Teams integration:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-succeeded.teams: channelName
+```
+
+## Templates
+
+![](https://user-images.githubusercontent.com/18019529/114271500-9d2b8880-9a4c-11eb-85c1-f6935f0431d5.png)
+
+Notification templates can be customized to leverage teams message sections, facts, themeColor, summary and potentialAction [feature](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using).
+
+```yaml
+template.app-sync-succeeded: |
+  teams:
+    themeColor: "#000080"
+    sections: |
+      [{
+        "facts": [
+          {
+            "name": "Sync Status",
+            "value": "{{.app.status.sync.status}}"
+          },
+          {
+            "name": "Repository",
+            "value": "{{.app.spec.source.repoURL}}"
+          }
+        ]
+      }]
+    potentialAction: |-
+      [{
+        "@type":"OpenUri",
+        "name":"Operation Details",
+        "targets":[{
+          "os":"default",
+          "uri":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"
+        }]
+      }]
+    title: Application {{.app.metadata.name}} has been successfully synced
+    text: Application {{.app.metadata.name}} has been successfully synced at {{.app.status.operationState.finishedAt}}.
+    summary: "{{.app.metadata.name}} sync succeeded"
+```
+
+### facts field
+
+You can use `facts` field instead of `sections` field.
+
+```yaml
+template.app-sync-succeeded: |
+  teams:
+    facts: |
+      [{
+        "name": "Sync Status",
+        "value": "{{.app.status.sync.status}}"
+      },
+      {
+        "name": "Repository",
+        "value": "{{.app.spec.source.repoURL}}"
+      }]
+```
+
+### theme color field
+
+You can set theme color as hex string for the message.
+
+![](https://user-images.githubusercontent.com/1164159/114864810-0718a900-9e24-11eb-8127-8d95da9544c1.png)
+
+```yaml
+template.app-sync-succeeded: |
+  teams:
+    themeColor: "#000080"
+```
+
+### summary field
+
+You can set a summary of the message that will be shown on Notifcation & Activity Feed 
+
+![](https://user-images.githubusercontent.com/6957724/116587921-84c4d480-a94d-11eb-9da4-f365151a12e7.jpg)
+
+![](https://user-images.githubusercontent.com/6957724/116588002-99a16800-a94d-11eb-807f-8626eb53b980.jpg)
+
+```yaml
+template.app-sync-succeeded: |
+  teams:
+    summary: "Sync Succeeded"
+```

--- a/docs/generated/notification-services/telegram.md
+++ b/docs/generated/notification-services/telegram.md
@@ -1,0 +1,35 @@
+# Telegram
+
+1. Get an API token using [@Botfather](https://t.me/Botfather).
+2. Store token in `<secret-name>` Secret and configure telegram integration
+in `<config-map-name>` ConfigMap:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.telegram: |
+    token: $telegram-token
+```
+
+3. Create new Telegram [channel](https://telegram.org/blog/channels).
+4. Add your bot as an administrator.
+5. Use this channel `username` (public channel) or `chatID` (private channel) in the subscription for your Telegram integration:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-succeeded.telegram: username
+```
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-succeeded.telegram: -1000000000000
+```

--- a/docs/generated/notification-services/webex.md
+++ b/docs/generated/notification-services/webex.md
@@ -1,0 +1,41 @@
+# Webex Teams
+
+## Parameters
+
+The Webex Teams notification service configuration includes following settings:
+
+* `token` - the app token
+
+## Configuration
+
+1. Create a Webex [Bot](https://developer.webex.com/docs/bots)
+1. Copy the bot access [token](https://developer.webex.com/my-apps) and store it in the `argocd-notifications-secret` Secret and configure Webex Teams integration in `argocd-notifications-cm` ConfigMap
+
+    ``` yaml
+    apiVersion: v1
+    kind: Secret
+    metadata:
+    name: <secret-name>
+    stringData:
+    webex-token: <bot access token>
+    ```
+
+    ``` yaml
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+    name: <config-map-name>
+    data:
+    service.webex: |
+        token: $webex-token
+    ```
+
+1. Create subscription for your Webex Teams integration
+
+    ``` yaml
+    apiVersion: argoproj.io/v1alpha1
+    kind: Application
+    metadata:
+    annotations:
+        notifications.argoproj.io/subscribe.<trigger-name>.webex: <personal email or room id>
+    ```

--- a/docs/generated/notification-services/webhook.md
+++ b/docs/generated/notification-services/webhook.md
@@ -1,0 +1,189 @@
+# Webhook
+
+The webhook notification service allows sending a generic HTTP request using the templatized request body and URL.
+Using Webhook you might trigger a Jenkins job, update Github commit status.
+
+## Parameters
+
+The Webhook notification service configuration includes following settings:
+
+- `url` - the url to send the webhook to
+- `headers` - optional, the headers to pass along with the webhook
+- `basicAuth` - optional, the basic authentication to pass along with the webook
+- `insecureSkipVerify` - optional bool, true or false
+
+## Configuration
+
+Use the following steps to configure webhook:
+
+1 Register webhook in `argocd-notifications-cm` ConfigMap:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.webhook.<webhook-name>: |
+    url: https://<hostname>/<optional-path>
+    headers: #optional headers
+    - name: <header-name>
+      value: <header-value>
+    basicAuth: #optional username password
+      username: <username>
+      password: <api-key>
+    insecureSkipVerify: true #optional bool
+```
+
+2 Define template that customizes webhook request method, path and body:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  template.github-commit-status: |
+    webhook:
+      <webhook-name>:
+        method: POST # one of: GET, POST, PUT, PATCH. Default value: GET 
+        path: <optional-path-template>
+        body: |
+          <optional-body-template>
+  trigger.<trigger-name>: |
+    - when: app.status.operationState.phase in ['Succeeded']
+      send: [github-commit-status]
+```
+
+3 Create subscription for webhook integration:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.<trigger-name>.<webhook-name>: ""
+```
+
+## Examples
+
+### Set Github commit status
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.webhook.github: |
+    url: https://api.github.com
+    headers: #optional headers
+    - name: Authorization
+      value: token $github-token
+```
+
+2 Define template that customizes webhook request method, path and body:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.webhook.github: |
+    url: https://api.github.com
+    headers: #optional headers
+    - name: Authorization
+      value: token $github-token
+
+  template.github-commit-status: |
+    webhook:
+      github:
+        method: POST
+        path: /repos/{{call .repo.FullNameByRepoURL .app.spec.source.repoURL}}/statuses/{{.app.status.operationState.operation.sync.revision}}
+        body: |
+          {
+            {{if eq .app.status.operationState.phase "Running"}} "state": "pending"{{end}}
+            {{if eq .app.status.operationState.phase "Succeeded"}} "state": "success"{{end}}
+            {{if eq .app.status.operationState.phase "Error"}} "state": "error"{{end}}
+            {{if eq .app.status.operationState.phase "Failed"}} "state": "error"{{end}},
+            "description": "ArgoCD",
+            "target_url": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+            "context": "continuous-delivery/{{.app.metadata.name}}"
+          }
+```
+
+### Start Jenkins Job
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.webhook.jenkins: |
+    url: http://<jenkins-host>/job/<job-name>/build?token=<job-secret>
+    basicAuth:
+      username: <username>
+      password: <api-key>
+
+type: Opaque
+```
+
+### Send form-data
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.webhook.form: |
+    url: https://form.example.com
+    headers:
+    - name: Content-Type
+      value: application/x-www-form-urlencoded
+
+  template.form-data: |
+    webhook:
+      form:
+        method: POST
+        body: key1=value1&key2=value2
+```
+
+### Send Slack
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.webhook.slack_webhook: |
+    url: https://hooks.slack.com/services/xxxxx
+    headers:
+    - name: Content-Type
+      value: application/json
+
+  template.send-slack: |
+    webhook:
+      slack_webhook:
+        method: POST
+        body: |
+          {
+            "attachments": [{
+              "title": "{{.app.metadata.name}}",
+              "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+              "color": "#18be52",
+              "fields": [{
+                "title": "Sync Status",
+                "value": "{{.app.status.sync.status}}",
+                "short": true
+              }, {
+                "title": "Repository",
+                "value": "{{.app.spec.source.repoURL}}",
+                "short": true
+              }]
+            }]
+          }
+```

--- a/hack/gen-docs/main.go
+++ b/hack/gen-docs/main.go
@@ -21,7 +21,6 @@ import (
 )
 
 func main() {
-	os.Setenv("KUBECACHEDIR", "/home/user")
 	generateNotificationsDocs()
 	generatePluginsDocs()
 }

--- a/hack/gen-docs/main.go
+++ b/hack/gen-docs/main.go
@@ -21,6 +21,7 @@ import (
 )
 
 func main() {
+	os.Setenv("KUBECACHEDIR", "/home/user")
 	generateNotificationsDocs()
 	generatePluginsDocs()
 }
@@ -41,8 +42,14 @@ func generateNotificationsDocs() {
 
 func generatePluginsDocs() {
 	tf, o := options.NewFakeArgoRolloutsOptions()
+
+	//Set static config dir so that gen docs dose not change depending on what machine it is ran on
+	configDir := "$HOME/.kube/cache"
+	o.ConfigFlags.CacheDir = &configDir
+
 	defer tf.Cleanup()
 	cmd := cmd.NewCmdArgoRollouts(o)
+
 	os.RemoveAll("./docs/generated/kubectl-argo-rollouts")
 	os.MkdirAll("./docs/generated/kubectl-argo-rollouts/", 0755)
 	files, err := GenMarkdownTree(cmd, "./docs/generated/kubectl-argo-rollouts")

--- a/hack/gen-docs/main.go
+++ b/hack/gen-docs/main.go
@@ -42,7 +42,7 @@ func generateNotificationsDocs() {
 func generatePluginsDocs() {
 	tf, o := options.NewFakeArgoRolloutsOptions()
 
-	//Set static config dir so that gen docs dose not change depending on what machine it is ran on
+	//Set static config dir so that gen docs does not change depending on what machine it is ran on
 	configDir := "$HOME/.kube/cache"
 	o.ConfigFlags.CacheDir = &configDir
 


### PR DESCRIPTION
If we do not commit the docs all the autogenerated docs do not show or work on argo-rollouts.readthedocs.org this also brings the pattern in line with and is probably why argocd does the same.

https://cloud-native.slack.com/archives/C01U781DW2E/p1674574980825679
https://cloud-native.slack.com/archives/C01U781DW2E/p1674579723986039

<img width="919" alt="Screenshot 2023-01-24 at 12 13 31 PM" src="https://user-images.githubusercontent.com/201390/214374465-6b7e0704-4f4c-4d1a-807e-0c19682998ba.png">

vs

https://argo-rollouts.readthedocs.io/en/fix-docs-version/features/kubectl-plugin/

I also feel it makes sense to have these committed for things like different versions which is why readthedocs needs them as well

Signed-off-by: zachaller <zachaller@users.noreply.github.com>