### PR TITLE
fix: When Degraded state, canary-service doesn't have any endpoints

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -41,3 +41,4 @@ Organizations below are **officially** using Argo Rollouts. Please send a PR wit
 1. [Ubie](https://ubie.life/)
 1. [VISITS Technologies](https://visits.world/en)
 1. [Yotpo](https://www.yotpo.com/)
+1. [Nike](https://nike.com)

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -403,7 +403,6 @@ func (c *rolloutContext) syncRolloutStatusCanary() error {
 			}
 		}
 		newStatus = c.calculateRolloutConditions(newStatus)
-		println("Here in aborted")
 		return c.persistRolloutStatus(&newStatus)
 	}
 

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -71,6 +71,13 @@ func (c *rolloutContext) rolloutCanary() error {
 		return err
 	}
 
+	//Reset the Canary service to have stableRS pod selector in event of failed analysis run or failed experiment
+	//to expose network endpoints to route traffic without any interruption.
+	err = c.reconcileStableAndCanaryService()
+	if err != nil {
+		return err
+	}
+
 	noScalingOccurred, err := c.reconcileCanaryReplicaSets()
 	if err != nil {
 		return err
@@ -396,6 +403,7 @@ func (c *rolloutContext) syncRolloutStatusCanary() error {
 			}
 		}
 		newStatus = c.calculateRolloutConditions(newStatus)
+		println("Here in aborted")
 		return c.persistRolloutStatus(&newStatus)
 	}
 

--- a/rollout/service.go
+++ b/rollout/service.go
@@ -54,12 +54,10 @@ func generatePatch(service *corev1.Service, newRolloutUniqueLabelValue string, r
 
 // switchSelector switch the selector on an existing service to a new value
 func (c rolloutContext) switchServiceSelector(service *corev1.Service, newRolloutUniqueLabelValue string, r *v1alpha1.Rollout) error {
-	print("here in init")
 	ctx := context.TODO()
 	if service.Spec.Selector == nil {
 		service.Spec.Selector = make(map[string]string)
 	}
-	print("here in init")
 	_, hasManagedRollout := serviceutil.HasManagedByAnnotation(service)
 	print("hasManagedRollout " + strconv.FormatBool(hasManagedRollout))
 	oldPodHash, ok := service.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey]

--- a/rollout/service.go
+++ b/rollout/service.go
@@ -3,6 +3,7 @@ package rollout
 import (
 	"context"
 	"fmt"
+
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/rollout/trafficrouting"
 	"github.com/argoproj/argo-rollouts/utils/annotations"

--- a/rollout/service.go
+++ b/rollout/service.go
@@ -3,8 +3,6 @@ package rollout
 import (
 	"context"
 	"fmt"
-	"strconv"
-
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/rollout/trafficrouting"
 	"github.com/argoproj/argo-rollouts/utils/annotations"
@@ -59,9 +57,7 @@ func (c rolloutContext) switchServiceSelector(service *corev1.Service, newRollou
 		service.Spec.Selector = make(map[string]string)
 	}
 	_, hasManagedRollout := serviceutil.HasManagedByAnnotation(service)
-	print("hasManagedRollout " + strconv.FormatBool(hasManagedRollout))
 	oldPodHash, ok := service.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey]
-	print("old " + oldPodHash)
 	if ok && oldPodHash == newRolloutUniqueLabelValue && hasManagedRollout {
 		return nil
 	}
@@ -265,16 +261,13 @@ func (c *rolloutContext) reconcileStableAndCanaryService() error {
 		err := c.ensureSVCTargets(c.rollout.Spec.Strategy.Canary.StableService, c.stableRS, true)
 		if err != nil {
 			return err
-		} else {
-			err = c.ensureSVCTargets(c.rollout.Spec.Strategy.Canary.CanaryService, c.newRS, true)
-			if err != nil {
-				return err
-			}
-			return nil
+		}
+		err = c.ensureSVCTargets(c.rollout.Spec.Strategy.Canary.CanaryService, c.newRS, true)
+		if err != nil {
+			return err
 		}
 	}
 	return nil
-
 }
 
 // ensureSVCTargets updates the service with the given name to point to the given ReplicaSet,

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -893,6 +893,7 @@ func TestDynamicScalingDontIncreaseWeightWhenAborted(t *testing.T) {
 	f.objects = append(f.objects, r2)
 
 	f.expectPatchRolloutAction(r2)
+	f.expectPatchServiceAction(canarySvc, rs1PodHash)
 
 	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
 	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -964,6 +965,7 @@ func TestDynamicScalingDecreaseWeightAccordingToStableAvailabilityWhenAborted(t 
 	f.objects = append(f.objects, r2)
 
 	f.expectPatchRolloutAction(r2)
+	f.expectPatchServiceAction(canarySvc, rs1PodHash)
 
 	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
 	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)


### PR DESCRIPTION
When Degraded state, canary-service doesn't have any endpoints resulting in traefik unable to route requests in failed state.

Signed-off-by: Kalyan Inampudi <Kalyan.Inampudi@nike.com>

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).