### PR TITLE
docs: fix missing links for getting started documentation Fixes #2511

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -176,6 +176,7 @@ Follow one of the traffic routing guides to see how Argo Rollouts can leverage a
 provider to achieve more advanced traffic shaping.
 
 * [ALB Guide](getting-started/alb/index.md)
+* [App Mesh Guide](getting-started/appmesh/index.md)
 * [Ambassador Guide](getting-started/ambassador/index.md)
 * [Istio Guide](getting-started/istio/index.md)
 * [Multiple Providers Guide](getting-started/mixed/index.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,9 +23,11 @@ nav:
   - Basic Usage: getting-started.md
   - Ambassador: getting-started/ambassador/index.md
   - AWS ALB: getting-started/alb/index.md
+  - AWS App Mesh: getting-started/appmesh/index.md
   - Istio: getting-started/istio/index.md
   - NGINX: getting-started/nginx/index.md
   - SMI: getting-started/smi/index.md
+  - Multiple Providers: getting-started/mixed/index.md
 - Dashboard: dashboard.md
 - Rollout:
   - Deployment Strategies:


### PR DESCRIPTION
Signed-off-by: Jiacheng Xu <xjcmaxwellcjx@gmail.com>
Fixes: #2511
- Getting started menu:
<img width="229" alt="Screenshot 2023-02-03 at 01 25 57" src="https://user-images.githubusercontent.com/18415314/216399253-c692a13f-a8c8-478e-b010-6d2666c9ceac.png">

- Links at the bottom of the getting started page:
<img width="753" alt="Screenshot 2023-02-03 at 01 27 05" src="https://user-images.githubusercontent.com/18415314/216399271-252fc47b-123f-4f35-ac9d-8de14c61b842.png">
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).