### PR TITLE
chore: bump node version and set openssl-legacy-provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN cd ${GOPATH}/src/dummy && \
 ####################################################################################################
 # UI build stage
 ####################################################################################################
-FROM --platform=$BUILDPLATFORM docker.io/library/node:12.18.4 as argo-rollouts-ui
+FROM --platform=$BUILDPLATFORM docker.io/library/node:18 as argo-rollouts-ui
 
 WORKDIR /src
 ADD ["ui/package.json", "ui/yarn.lock", "./"]

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,7 +21,7 @@
     },
     "scripts": {
         "start": "webpack serve --config ./src/app/webpack.dev.js",
-        "build": "rm -rf dist && webpack --config ./src/app/webpack.prod.js",
+        "build": "rm -rf dist && NODE_OPTIONS=--openssl-legacy-provider webpack --config ./src/app/webpack.prod.js",
         "test": "react-scripts test",
         "eject": "react-scripts eject",
         "protogen": "../hack/swagger-codegen.sh generate -i ../pkg/apiclient/rollout/rollout.swagger.json -l typescript-fetch -o src/models/rollout/generated"


### PR DESCRIPTION
This PR fixes the build pipeline again because of changes in github runners that upgrade node to version 18 https://github.com/actions/runner-images/issues/7002 this caused 
isses with hash generation functions that were depricated.

This turns on the legacy hash until I can spend time debugging front end deps.

Created an issue to track fixing this all properly https://github.com/argoproj/argo-rollouts/issues/2609

This was the error from pipeline

```
$ rm -rf dist && webpack --config ./src/app/webpack.prod.js
/home/runner/work/argo-rollouts/argo-rollouts/ui/node_modules/loader-runner/lib/LoaderRunner.js:133
		if(isError) throw e;
		            ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at module.exports (/home/runner/work/argo-rollouts/argo-rollouts/ui/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/home/runner/work/argo-rollouts/argo-rollouts/ui/node_modules/webpack/lib/NormalModule.js:417:16)
    at handleParseError (/home/runner/work/argo-rollouts/argo-rollouts/ui/node_modules/webpack/lib/NormalModule.js:471:10)
    at /home/runner/work/argo-rollouts/argo-rollouts/ui/node_modules/webpack/lib/NormalModule.js:503:5
    at /home/runner/work/argo-rollouts/argo-rollouts/ui/node_modules/webpack/lib/NormalModule.js:358:12
    at /home/runner/work/argo-rollouts/argo-rollouts/ui/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (/home/runner/work/argo-rollouts/argo-rollouts/ui/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at iterateNormalLoaders (/home/runner/work/argo-rollouts/argo-rollouts/ui/node_modules/loader-runner/lib/LoaderRunner.js:221:10)
    at /home/runner/work/argo-rollouts/argo-rollouts/ui/node_modules/loader-runner/lib/LoaderRunner.js:236:3
    at context.callback (/home/runner/work/argo-rollouts/argo-rollouts/ui/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at makeSourceMapAndFinish (/home/runner/work/argo-rollouts/argo-rollouts/ui/node_modules/ts-loader/dist/index.js:58:5)
    at successLoader (/home/runner/work/argo-rollouts/argo-rollouts/ui/node_modules/ts-loader/dist/index.js:40:5)
    at Object.loader (/home/runner/work/argo-rollouts/argo-rollouts/ui/node_modules/ts-loader/dist/index.js:23:5)
    at LOADER_EXECUTION (/home/runner/work/argo-rollouts/argo-rollouts/ui/node_modules/loader-runner/lib/LoaderRunner.js:119:14) {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}
```