### PR TITLE
fix: flakey TestWriteBackToInformer test

### DIFF
--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -1955,11 +1955,9 @@ func TestWriteBackToInformer(t *testing.T) {
 	// *v1alpha1.Rollout the underlying cause is not fully known.
 	//un, ok := obj.(*unstructured.Unstructured)
 	//assert.True(t, ok)
-	var mapObj map[string]interface{}
-	inrec, err := json.Marshal(obj)
+	unObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	assert.NoError(t, err)
-	json.Unmarshal(inrec, &mapObj)
-	un := &unstructured.Unstructured{Object: mapObj}
+	un := unstructured.Unstructured{Object: unObj}
 
 	stableRS, _, _ := unstructured.NestedString(un.Object, "status", "stableRS")
 	assert.NotEmpty(t, stableRS)

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -1949,12 +1949,9 @@ func TestWriteBackToInformer(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, exists)
 
-	// Want to keep this code for future reference, this commented code would randomly fail to do the type cast
-	// using json marshalling to convert to a map[string]interface{} fixes the issue. The type returned from
-	// c.rolloutsIndexer.GetByKey is not always the same type it switches between *unstructured.Unstructured and
-	// *v1alpha1.Rollout the underlying cause is not fully known.
-	//un, ok := obj.(*unstructured.Unstructured)
-	//assert.True(t, ok)
+	// The type returned from c.rolloutsIndexer.GetByKey is not always the same type it switches between
+	// *unstructured.Unstructured and *v1alpha1.Rollout the underlying cause is not fully known. We use the
+	// runtime.DefaultUnstructuredConverter to account for this.
 	unObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	assert.NoError(t, err)
 

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -1957,9 +1957,8 @@ func TestWriteBackToInformer(t *testing.T) {
 	//assert.True(t, ok)
 	unObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	assert.NoError(t, err)
-	un := unstructured.Unstructured{Object: unObj}
 
-	stableRS, _, _ := unstructured.NestedString(un.Object, "status", "stableRS")
+	stableRS, _, _ := unstructured.NestedString(unObj, "status", "stableRS")
 	assert.NotEmpty(t, stableRS)
 	assert.Equal(t, rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey], stableRS)
 }

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -1948,8 +1948,19 @@ func TestWriteBackToInformer(t *testing.T) {
 	obj, exists, err := c.rolloutsIndexer.GetByKey(roKey)
 	assert.NoError(t, err)
 	assert.True(t, exists)
-	un, ok := obj.(*unstructured.Unstructured)
-	assert.True(t, ok)
+
+	// Want to keep this code for future reference, this commented code would randomly fail to do the type cast
+	// using json marshalling to convert to a map[string]interface{} instead seems to fix the issue when I test
+	// this function in a loop. I want to keep this code because it seems really strange that the type cast would
+	// randomly fail.
+	//un, ok := obj.(*unstructured.Unstructured)
+	//assert.True(t, ok)
+	var mapObj map[string]interface{}
+	inrec, err := json.Marshal(obj)
+	assert.NoError(t, err)
+	json.Unmarshal(inrec, &mapObj)
+	un := &unstructured.Unstructured{Object: mapObj}
+
 	stableRS, _, _ := unstructured.NestedString(un.Object, "status", "stableRS")
 	assert.NotEmpty(t, stableRS)
 	assert.Equal(t, rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey], stableRS)

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -1950,9 +1950,9 @@ func TestWriteBackToInformer(t *testing.T) {
 	assert.True(t, exists)
 
 	// Want to keep this code for future reference, this commented code would randomly fail to do the type cast
-	// using json marshalling to convert to a map[string]interface{} instead seems to fix the issue when I test
-	// this function in a loop. I want to keep this code because it seems really strange that the type cast would
-	// randomly fail.
+	// using json marshalling to convert to a map[string]interface{} fixes the issue. The type returned from
+	// c.rolloutsIndexer.GetByKey is not always the same type it switches between *unstructured.Unstructured and
+	// *v1alpha1.Rollout the underlying cause is not fully known.
 	//un, ok := obj.(*unstructured.Unstructured)
 	//assert.True(t, ok)
 	var mapObj map[string]interface{}


### PR DESCRIPTION
This fixes the flakey unit test  `TestWriteBackToInformer` I was able to easily reproduce the flake buy putting the test into a loop, when I switched out the code to use json marshaling it 3000 iterations passed.

This is possibly somewhat a hack solution for how we are using the fake client with informers. There could also be a bug upstream in k8s fake client.