### PR TITLE
fix: Rollback change on service creation with weightless experiments

### DIFF
--- a/docs/features/experiment.md
+++ b/docs/features/experiment.md
@@ -6,7 +6,7 @@ The Experiment CRD allows users to have ephemeral runs of one or more ReplicaSet
 running ephemeral ReplicaSets, the Experiment CRD can launch AnalysisRuns alongside the ReplicaSets.
 Generally, those AnalysisRun is used to confirm that new ReplicaSets are running as expected.
 
-A Service routing traffic to the Experiment ReplicaSet is also generated.
+A Service routing traffic to the Experiment ReplicaSet is also generated if a weight for that experiment is set.
 
 ## Use cases of Experiments
 
@@ -245,7 +245,7 @@ to `experiment-baseline`, leaving the remaining 90% of traffic to the old stack.
 
 !!! note
     When a weighted experiment step with traffic routing is used, a
-    Service is auto-created for each experiment template. The traffic routers use
+    service is auto-created for each experiment template. The traffic routers use
     this service to send traffic to the experiment pods.
 
 By default, the generated Service has the name of the ReplicaSet and inherits

--- a/rollout/experiment.go
+++ b/rollout/experiment.go
@@ -64,7 +64,9 @@ func GetExperimentFromTemplate(r *v1alpha1.Rollout, stableRS, newRS *appsv1.Repl
 			Name:     templateStep.Name,
 			Replicas: templateStep.Replicas,
 		}
-		template.Service = &v1alpha1.TemplateService{}
+		if templateStep.Weight != nil {
+			template.Service = &v1alpha1.TemplateService{}
+		}
 		templateRS := &appsv1.ReplicaSet{}
 		switch templateStep.SpecRef {
 		case v1alpha1.CanarySpecRef:

--- a/rollout/experiment_test.go
+++ b/rollout/experiment_test.go
@@ -791,7 +791,7 @@ func TestRolloutCreateExperimentWithService(t *testing.T) {
 					Replicas: pointer.Int32Ptr(1),
 					Weight:   pointer.Int32Ptr(5),
 				},
-				// Service should also be created for "canary-template"
+				// Service should NOT be created for "canary-template"
 				{
 					Name:     "canary-template",
 					SpecRef:  v1alpha1.CanarySpecRef,
@@ -818,5 +818,5 @@ func TestRolloutCreateExperimentWithService(t *testing.T) {
 	assert.NotNil(t, ex.Spec.Templates[0].Service)
 
 	assert.Equal(t, "canary-template", ex.Spec.Templates[1].Name)
-	assert.NotNil(t, ex.Spec.Templates[1].Service)
+	assert.Nil(t, ex.Spec.Templates[1].Service)
 }


### PR DESCRIPTION
closes: #2622 

possible fix for: https://github.com/argoproj/argo-rollouts/issues/2608

This rolls back the change introduced in #2397 which allows experiments with no weights to still create services. We want it so that services won't be created if there is no weight set for the experiments.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).