### PR TITLE
chore: update e2e k8s versions

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -40,6 +40,8 @@ jobs:
         kubernetes-minor-version:
           - 1.23
           - 1.24
+          - 1.25
+          - 1.26
     name: Run end-to-end tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -76,10 +76,10 @@ jobs:
         run: make start-e2e 2>&1 | sed -r "s/[[:cntrl:]]\[[0-9]{1,3}m//g" > /tmp/e2e-controller.log &
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled}}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled == 'true'}}
       - name: Run e2e tests
         run: make test-e2e
-        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled) }}
+        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled == 'true') }}
       - name: Output Rerun Overview
         run: |
           [[ -f rerunreport.txt ]] && cat rerunreport.txt || echo "No rerun report found"

--- a/test/e2e/crds/istio.yaml
+++ b/test/e2e/crds/istio.yaml
@@ -14,86 +14,129 @@ spec:
   group: extensions.istio.io
   names:
     categories:
-    - istio-io
-    - extensions-istio-io
+      - istio-io
+      - extensions-istio-io
     kind: WasmPlugin
     listKind: WasmPluginList
     plural: wasmplugins
     singular: wasmplugin
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: 'CreationTimestamp is a timestamp representing the server time
+    - additionalPrinterColumns:
+        - description: 'CreationTimestamp is a timestamp representing the server time
         when this object was created. It is not guaranteed to be set in happens-before
         order across separate operations. Clients may not set this value. It is represented
         in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
         lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Extend the functionality provided by the Istio proxy through
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Extend the functionality provided by the Istio proxy through
               WebAssembly filters. See more details at: https://istio.io/docs/reference/config/proxy_extensions/wasm-plugin.html'
-            properties:
-              imagePullPolicy:
-                description: The pull behaviour to be applied when fetching an OCI
-                  image.
-                enum:
-                - UNSPECIFIED_POLICY
-                - IfNotPresent
-                - Always
-                type: string
-              imagePullSecret:
-                description: Credentials to use for OCI image pulling.
-                type: string
-              phase:
-                description: Determines where in the filter chain this `WasmPlugin`
-                  is to be injected.
-                enum:
-                - UNSPECIFIED_PHASE
-                - AUTHN
-                - AUTHZ
-                - STATS
-                type: string
-              pluginConfig:
-                description: The configuration that will be passed on to the plugin.
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-              pluginName:
-                type: string
-              priority:
-                description: Determines ordering of `WasmPlugins` in the same `phase`.
-                nullable: true
-                type: integer
-              selector:
-                properties:
-                  matchLabels:
-                    additionalProperties:
-                      type: string
+              properties:
+                imagePullPolicy:
+                  enum:
+                    - UNSPECIFIED_POLICY
+                    - IfNotPresent
+                    - Always
+                  type: string
+                imagePullSecret:
+                  description: Credentials to use for OCI image pulling.
+                  type: string
+                match:
+                  description: Specifies the criteria to determine which traffic is
+                    passed to WasmPlugin.
+                  items:
+                    properties:
+                      mode:
+                        description: Criteria for selecting traffic by their direction.
+                        enum:
+                          - UNDEFINED
+                          - CLIENT
+                          - SERVER
+                          - CLIENT_AND_SERVER
+                        type: string
+                      ports:
+                        description: Criteria for selecting traffic by their destination
+                          port.
+                        items:
+                          properties:
+                            number:
+                              type: integer
+                          type: object
+                        type: array
                     type: object
-                type: object
-              sha256:
-                description: SHA256 checksum that will be used to verify Wasm module
-                  or OCI container.
-                type: string
-              url:
-                description: URL of a Wasm module or OCI container.
-                type: string
-              verificationKey:
-                type: string
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  type: array
+                phase:
+                  description: Determines where in the filter chain this `WasmPlugin`
+                    is to be injected.
+                  enum:
+                    - UNSPECIFIED_PHASE
+                    - AUTHN
+                    - AUTHZ
+                    - STATS
+                  type: string
+                pluginConfig:
+                  description: The configuration that will be passed on to the plugin.
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                pluginName:
+                  type: string
+                priority:
+                  description: Determines ordering of `WasmPlugins` in the same `phase`.
+                  nullable: true
+                  type: integer
+                selector:
+                  properties:
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                sha256:
+                  description: SHA256 checksum that will be used to verify Wasm module
+                    or OCI container.
+                  type: string
+                url:
+                  description: URL of a Wasm module or OCI container.
+                  type: string
+                verificationKey:
+                  type: string
+                vmConfig:
+                  description: Configuration for a Wasm VM.
+                  properties:
+                    env:
+                      description: Specifies environment variables to be injected to
+                        this VM.
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            description: Value for the environment variable.
+                            type: string
+                          valueFrom:
+                            enum:
+                              - INLINE
+                              - HOST
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -111,2350 +154,2834 @@ spec:
   group: networking.istio.io
   names:
     categories:
-    - istio-io
-    - networking-istio-io
+      - istio-io
+      - networking-istio-io
     kind: DestinationRule
     listKind: DestinationRuleList
     plural: destinationrules
     shortNames:
-    - dr
+      - dr
     singular: destinationrule
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: The name of a service from the service registry
-      jsonPath: .spec.host
-      name: Host
-      type: string
-    - description: 'CreationTimestamp is a timestamp representing the server time
+    - additionalPrinterColumns:
+        - description: The name of a service from the service registry
+          jsonPath: .spec.host
+          name: Host
+          type: string
+        - description: 'CreationTimestamp is a timestamp representing the server time
         when this object was created. It is not guaranteed to be set in happens-before
         order across separate operations. Clients may not set this value. It is represented
         in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
         lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting load balancing, outlier detection,
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha3
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Configuration affecting load balancing, outlier detection,
               etc. See more details at: https://istio.io/docs/reference/config/networking/destination-rule.html'
-            properties:
-              exportTo:
-                description: A list of namespaces to which this destination rule is
-                  exported.
-                items:
+              properties:
+                exportTo:
+                  description: A list of namespaces to which this destination rule is
+                    exported.
+                  items:
+                    type: string
+                  type: array
+                host:
+                  description: The name of a service from the service registry.
                   type: string
-                type: array
-              host:
-                description: The name of a service from the service registry.
-                type: string
-              subsets:
-                items:
-                  properties:
-                    labels:
-                      additionalProperties:
+                subsets:
+                  items:
+                    properties:
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        description: Name of the subset.
                         type: string
-                      type: object
-                    name:
-                      description: Name of the subset.
-                      type: string
-                    trafficPolicy:
-                      description: Traffic policies that apply to this subset.
-                      properties:
-                        connectionPool:
-                          properties:
-                            http:
-                              description: HTTP connection pool settings.
-                              properties:
-                                h2UpgradePolicy:
-                                  description: Specify if http1.1 connection should
-                                    be upgraded to http2 for the associated destination.
-                                  enum:
-                                  - DEFAULT
-                                  - DO_NOT_UPGRADE
-                                  - UPGRADE
-                                  type: string
-                                http1MaxPendingRequests:
-                                  description: Maximum number of pending HTTP requests
-                                    to a destination.
-                                  format: int32
-                                  type: integer
-                                http2MaxRequests:
-                                  description: Maximum number of requests to a backend.
-                                  format: int32
-                                  type: integer
-                                idleTimeout:
-                                  description: The idle timeout for upstream connection
-                                    pool connections.
-                                  type: string
-                                maxRequestsPerConnection:
-                                  description: Maximum number of requests per connection
-                                    to a backend.
-                                  format: int32
-                                  type: integer
-                                maxRetries:
-                                  format: int32
-                                  type: integer
-                                useClientProtocol:
-                                  description: If set to true, client protocol will
-                                    be preserved while initiating connection to backend.
-                                  type: boolean
-                              type: object
-                            tcp:
-                              description: Settings common to both HTTP and TCP upstream
-                                connections.
-                              properties:
-                                connectTimeout:
-                                  description: TCP connection timeout.
-                                  type: string
-                                maxConnections:
-                                  description: Maximum number of HTTP1 /TCP connections
-                                    to a destination host.
-                                  format: int32
-                                  type: integer
-                                tcpKeepalive:
-                                  description: If set then set SO_KEEPALIVE on the
-                                    socket to enable TCP Keepalives.
-                                  properties:
-                                    interval:
-                                      description: The time duration between keep-alive
-                                        probes.
-                                      type: string
-                                    probes:
-                                      type: integer
-                                    time:
-                                      type: string
-                                  type: object
-                              type: object
-                          type: object
-                        loadBalancer:
-                          description: Settings controlling the load balancer algorithms.
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - simple
-                              - properties:
-                                  consistentHash:
-                                    oneOf:
-                                    - not:
-                                        anyOf:
-                                        - required:
-                                          - httpHeaderName
-                                        - required:
-                                          - httpCookie
-                                        - required:
-                                          - useSourceIp
-                                        - required:
-                                          - httpQueryParameterName
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                required:
-                                - consistentHash
-                          - required:
-                            - simple
-                          - properties:
-                              consistentHash:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                            required:
-                            - consistentHash
-                          properties:
-                            consistentHash:
-                              properties:
-                                httpCookie:
-                                  description: Hash based on HTTP cookie.
-                                  properties:
-                                    name:
-                                      description: Name of the cookie.
-                                      type: string
-                                    path:
-                                      description: Path to set for the cookie.
-                                      type: string
-                                    ttl:
-                                      description: Lifetime of the cookie.
-                                      type: string
-                                  type: object
-                                httpHeaderName:
-                                  description: Hash based on a specific HTTP header.
-                                  type: string
-                                httpQueryParameterName:
-                                  description: Hash based on a specific HTTP query
-                                    parameter.
-                                  type: string
-                                minimumRingSize:
-                                  type: integer
-                                useSourceIp:
-                                  description: Hash based on the source IP address.
-                                  type: boolean
-                              type: object
-                            localityLbSetting:
-                              properties:
-                                distribute:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating locality, '/' separated,
-                                          e.g.
-                                        type: string
-                                      to:
-                                        additionalProperties:
-                                          type: integer
-                                        description: Map of upstream localities to
-                                          traffic distribution weights.
-                                        type: object
-                                    type: object
-                                  type: array
-                                enabled:
-                                  description: enable locality load balancing, this
-                                    is DestinationRule-level and will override mesh
-                                    wide settings in entirety.
-                                  nullable: true
-                                  type: boolean
-                                failover:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating region.
-                                        type: string
-                                      to:
-                                        type: string
-                                    type: object
-                                  type: array
-                                failoverPriority:
-                                  description: failoverPriority is an ordered list
-                                    of labels used to sort endpoints to do priority
-                                    based load balancing.
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            simple:
-                              enum:
-                              - ROUND_ROBIN
-                              - LEAST_CONN
-                              - RANDOM
-                              - PASSTHROUGH
-                              type: string
-                          type: object
-                        outlierDetection:
-                          properties:
-                            baseEjectionTime:
-                              description: Minimum ejection duration.
-                              type: string
-                            consecutive5xxErrors:
-                              description: Number of 5xx errors before a host is ejected
-                                from the connection pool.
-                              nullable: true
-                              type: integer
-                            consecutiveErrors:
-                              format: int32
-                              type: integer
-                            consecutiveGatewayErrors:
-                              description: Number of gateway errors before a host
-                                is ejected from the connection pool.
-                              nullable: true
-                              type: integer
-                            consecutiveLocalOriginFailures:
-                              nullable: true
-                              type: integer
-                            interval:
-                              description: Time interval between ejection sweep analysis.
-                              type: string
-                            maxEjectionPercent:
-                              format: int32
-                              type: integer
-                            minHealthPercent:
-                              format: int32
-                              type: integer
-                            splitExternalLocalOriginErrors:
-                              description: Determines whether to distinguish local
-                                origin failures from external errors.
-                              type: boolean
-                          type: object
-                        portLevelSettings:
-                          description: Traffic policies specific to individual ports.
-                          items:
+                      trafficPolicy:
+                        description: Traffic policies that apply to this subset.
+                        properties:
+                          connectionPool:
                             properties:
-                              connectionPool:
+                              http:
+                                description: HTTP connection pool settings.
                                 properties:
-                                  http:
-                                    description: HTTP connection pool settings.
+                                  h2UpgradePolicy:
+                                    description: Specify if http1.1 connection should
+                                      be upgraded to http2 for the associated destination.
+                                    enum:
+                                      - DEFAULT
+                                      - DO_NOT_UPGRADE
+                                      - UPGRADE
+                                    type: string
+                                  http1MaxPendingRequests:
+                                    format: int32
+                                    type: integer
+                                  http2MaxRequests:
+                                    description: Maximum number of active requests to
+                                      a destination.
+                                    format: int32
+                                    type: integer
+                                  idleTimeout:
+                                    description: The idle timeout for upstream connection
+                                      pool connections.
+                                    type: string
+                                  maxRequestsPerConnection:
+                                    description: Maximum number of requests per connection
+                                      to a backend.
+                                    format: int32
+                                    type: integer
+                                  maxRetries:
+                                    format: int32
+                                    type: integer
+                                  useClientProtocol:
+                                    description: If set to true, client protocol will
+                                      be preserved while initiating connection to backend.
+                                    type: boolean
+                                type: object
+                              tcp:
+                                description: Settings common to both HTTP and TCP upstream
+                                  connections.
+                                properties:
+                                  connectTimeout:
+                                    description: TCP connection timeout.
+                                    type: string
+                                  maxConnectionDuration:
+                                    description: The maximum duration of a connection.
+                                    type: string
+                                  maxConnections:
+                                    description: Maximum number of HTTP1 /TCP connections
+                                      to a destination host.
+                                    format: int32
+                                    type: integer
+                                  tcpKeepalive:
+                                    description: If set then set SO_KEEPALIVE on the
+                                      socket to enable TCP Keepalives.
                                     properties:
-                                      h2UpgradePolicy:
-                                        description: Specify if http1.1 connection
-                                          should be upgraded to http2 for the associated
-                                          destination.
-                                        enum:
-                                        - DEFAULT
-                                        - DO_NOT_UPGRADE
-                                        - UPGRADE
+                                      interval:
+                                        description: The time duration between keep-alive
+                                          probes.
                                         type: string
-                                      http1MaxPendingRequests:
-                                        description: Maximum number of pending HTTP
-                                          requests to a destination.
-                                        format: int32
+                                      probes:
                                         type: integer
-                                      http2MaxRequests:
-                                        description: Maximum number of requests to
-                                          a backend.
-                                        format: int32
-                                        type: integer
-                                      idleTimeout:
-                                        description: The idle timeout for upstream
-                                          connection pool connections.
+                                      time:
                                         type: string
-                                      maxRequestsPerConnection:
-                                        description: Maximum number of requests per
-                                          connection to a backend.
-                                        format: int32
-                                        type: integer
-                                      maxRetries:
-                                        format: int32
-                                        type: integer
-                                      useClientProtocol:
-                                        description: If set to true, client protocol
-                                          will be preserved while initiating connection
-                                          to backend.
-                                        type: boolean
-                                    type: object
-                                  tcp:
-                                    description: Settings common to both HTTP and
-                                      TCP upstream connections.
-                                    properties:
-                                      connectTimeout:
-                                        description: TCP connection timeout.
-                                        type: string
-                                      maxConnections:
-                                        description: Maximum number of HTTP1 /TCP
-                                          connections to a destination host.
-                                        format: int32
-                                        type: integer
-                                      tcpKeepalive:
-                                        description: If set then set SO_KEEPALIVE
-                                          on the socket to enable TCP Keepalives.
-                                        properties:
-                                          interval:
-                                            description: The time duration between
-                                              keep-alive probes.
-                                            type: string
-                                          probes:
-                                            type: integer
-                                          time:
-                                            type: string
-                                        type: object
                                     type: object
                                 type: object
-                              loadBalancer:
-                                description: Settings controlling the load balancer
-                                  algorithms.
-                                oneOf:
-                                - not:
-                                    anyOf:
+                            type: object
+                          loadBalancer:
+                            description: Settings controlling the load balancer algorithms.
+                            oneOf:
+                              - not:
+                                  anyOf:
                                     - required:
-                                      - simple
+                                        - simple
                                     - properties:
                                         consistentHash:
-                                          oneOf:
+                                          allOf:
+                                            - oneOf:
+                                                - not:
+                                                    anyOf:
+                                                      - required:
+                                                          - httpHeaderName
+                                                      - required:
+                                                          - httpCookie
+                                                      - required:
+                                                          - useSourceIp
+                                                      - required:
+                                                          - httpQueryParameterName
+                                                - required:
+                                                    - httpHeaderName
+                                                - required:
+                                                    - httpCookie
+                                                - required:
+                                                    - useSourceIp
+                                                - required:
+                                                    - httpQueryParameterName
+                                            - oneOf:
+                                                - not:
+                                                    anyOf:
+                                                      - required:
+                                                          - ringHash
+                                                      - required:
+                                                          - maglev
+                                                - required:
+                                                    - ringHash
+                                                - required:
+                                                    - maglev
+                                          properties:
+                                            minimumRingSize: {}
+                                      required:
+                                        - consistentHash
+                              - required:
+                                  - simple
+                              - properties:
+                                  consistentHash:
+                                    allOf:
+                                      - oneOf:
                                           - not:
                                               anyOf:
-                                              - required:
-                                                - httpHeaderName
-                                              - required:
-                                                - httpCookie
-                                              - required:
-                                                - useSourceIp
-                                              - required:
-                                                - httpQueryParameterName
+                                                - required:
+                                                    - httpHeaderName
+                                                - required:
+                                                    - httpCookie
+                                                - required:
+                                                    - useSourceIp
+                                                - required:
+                                                    - httpQueryParameterName
                                           - required:
-                                            - httpHeaderName
+                                              - httpHeaderName
                                           - required:
-                                            - httpCookie
+                                              - httpCookie
                                           - required:
-                                            - useSourceIp
+                                              - useSourceIp
                                           - required:
-                                            - httpQueryParameterName
-                                      required:
-                                      - consistentHash
-                                - required:
-                                  - simple
-                                - properties:
-                                    consistentHash:
-                                      oneOf:
-                                      - not:
-                                          anyOf:
+                                              - httpQueryParameterName
+                                      - oneOf:
+                                          - not:
+                                              anyOf:
+                                                - required:
+                                                    - ringHash
+                                                - required:
+                                                    - maglev
                                           - required:
-                                            - httpHeaderName
+                                              - ringHash
                                           - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                  required:
-                                  - consistentHash
-                                properties:
-                                  consistentHash:
+                                              - maglev
                                     properties:
-                                      httpCookie:
-                                        description: Hash based on HTTP cookie.
-                                        properties:
-                                          name:
-                                            description: Name of the cookie.
-                                            type: string
-                                          path:
-                                            description: Path to set for the cookie.
-                                            type: string
-                                          ttl:
-                                            description: Lifetime of the cookie.
-                                            type: string
-                                        type: object
-                                      httpHeaderName:
-                                        description: Hash based on a specific HTTP
-                                          header.
+                                      minimumRingSize: {}
+                                required:
+                                  - consistentHash
+                            properties:
+                              consistentHash:
+                                properties:
+                                  httpCookie:
+                                    description: Hash based on HTTP cookie.
+                                    properties:
+                                      name:
+                                        description: Name of the cookie.
                                         type: string
-                                      httpQueryParameterName:
-                                        description: Hash based on a specific HTTP
-                                          query parameter.
+                                      path:
+                                        description: Path to set for the cookie.
                                         type: string
+                                      ttl:
+                                        description: Lifetime of the cookie.
+                                        type: string
+                                    type: object
+                                  httpHeaderName:
+                                    description: Hash based on a specific HTTP header.
+                                    type: string
+                                  httpQueryParameterName:
+                                    description: Hash based on a specific HTTP query
+                                      parameter.
+                                    type: string
+                                  maglev:
+                                    description: The Maglev load balancer implements
+                                      consistent hashing to backend hosts.
+                                    properties:
+                                      tableSize:
+                                        description: The table size for Maglev hashing.
+                                        type: integer
+                                    type: object
+                                  minimumRingSize:
+                                    description: Deprecated.
+                                    type: integer
+                                  ringHash:
+                                    description: The ring/modulo hash load balancer
+                                      implements consistent hashing to backend hosts.
+                                    properties:
                                       minimumRingSize:
                                         type: integer
-                                      useSourceIp:
-                                        description: Hash based on the source IP address.
-                                        type: boolean
                                     type: object
-                                  localityLbSetting:
-                                    properties:
-                                      distribute:
-                                        description: 'Optional: only one of distribute,
-                                          failover or failoverPriority can be set.'
-                                        items:
-                                          properties:
-                                            from:
-                                              description: Originating locality, '/'
-                                                separated, e.g.
-                                              type: string
-                                            to:
-                                              additionalProperties:
-                                                type: integer
-                                              description: Map of upstream localities
-                                                to traffic distribution weights.
-                                              type: object
-                                          type: object
-                                        type: array
-                                      enabled:
-                                        description: enable locality load balancing,
-                                          this is DestinationRule-level and will override
-                                          mesh wide settings in entirety.
-                                        nullable: true
-                                        type: boolean
-                                      failover:
-                                        description: 'Optional: only one of distribute,
-                                          failover or failoverPriority can be set.'
-                                        items:
-                                          properties:
-                                            from:
-                                              description: Originating region.
-                                              type: string
-                                            to:
-                                              type: string
-                                          type: object
-                                        type: array
-                                      failoverPriority:
-                                        description: failoverPriority is an ordered
-                                          list of labels used to sort endpoints to
-                                          do priority based load balancing.
-                                        items:
+                                  useSourceIp:
+                                    description: Hash based on the source IP address.
+                                    type: boolean
+                                type: object
+                              localityLbSetting:
+                                properties:
+                                  distribute:
+                                    description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                    items:
+                                      properties:
+                                        from:
+                                          description: Originating locality, '/' separated,
+                                            e.g.
                                           type: string
-                                        type: array
-                                    type: object
-                                  simple:
-                                    enum:
-                                    - ROUND_ROBIN
-                                    - LEAST_CONN
-                                    - RANDOM
-                                    - PASSTHROUGH
-                                    type: string
-                                type: object
-                              outlierDetection:
-                                properties:
-                                  baseEjectionTime:
-                                    description: Minimum ejection duration.
-                                    type: string
-                                  consecutive5xxErrors:
-                                    description: Number of 5xx errors before a host
-                                      is ejected from the connection pool.
-                                    nullable: true
-                                    type: integer
-                                  consecutiveErrors:
-                                    format: int32
-                                    type: integer
-                                  consecutiveGatewayErrors:
-                                    description: Number of gateway errors before a
-                                      host is ejected from the connection pool.
-                                    nullable: true
-                                    type: integer
-                                  consecutiveLocalOriginFailures:
-                                    nullable: true
-                                    type: integer
-                                  interval:
-                                    description: Time interval between ejection sweep
-                                      analysis.
-                                    type: string
-                                  maxEjectionPercent:
-                                    format: int32
-                                    type: integer
-                                  minHealthPercent:
-                                    format: int32
-                                    type: integer
-                                  splitExternalLocalOriginErrors:
-                                    description: Determines whether to distinguish
-                                      local origin failures from external errors.
-                                    type: boolean
-                                type: object
-                              port:
-                                properties:
-                                  number:
-                                    type: integer
-                                type: object
-                              tls:
-                                description: TLS related settings for connections
-                                  to the upstream service.
-                                properties:
-                                  caCertificates:
-                                    type: string
-                                  clientCertificate:
-                                    description: REQUIRED if mode is `MUTUAL`.
-                                    type: string
-                                  credentialName:
-                                    type: string
-                                  insecureSkipVerify:
+                                        to:
+                                          additionalProperties:
+                                            type: integer
+                                          description: Map of upstream localities to
+                                            traffic distribution weights.
+                                          type: object
+                                      type: object
+                                    type: array
+                                  enabled:
+                                    description: enable locality load balancing, this
+                                      is DestinationRule-level and will override mesh
+                                      wide settings in entirety.
                                     nullable: true
                                     type: boolean
-                                  mode:
-                                    enum:
-                                    - DISABLE
-                                    - SIMPLE
-                                    - MUTUAL
-                                    - ISTIO_MUTUAL
-                                    type: string
-                                  privateKey:
-                                    description: REQUIRED if mode is `MUTUAL`.
-                                    type: string
-                                  sni:
-                                    description: SNI string to present to the server
-                                      during TLS handshake.
-                                    type: string
-                                  subjectAltNames:
+                                  failover:
+                                    description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                    items:
+                                      properties:
+                                        from:
+                                          description: Originating region.
+                                          type: string
+                                        to:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  failoverPriority:
+                                    description: failoverPriority is an ordered list
+                                      of labels used to sort endpoints to do priority
+                                      based load balancing.
                                     items:
                                       type: string
                                     type: array
                                 type: object
+                              simple:
+                                enum:
+                                  - UNSPECIFIED
+                                  - LEAST_CONN
+                                  - RANDOM
+                                  - PASSTHROUGH
+                                  - ROUND_ROBIN
+                                  - LEAST_REQUEST
+                                type: string
+                              warmupDurationSecs:
+                                description: Represents the warmup duration of Service.
+                                type: string
                             type: object
-                          type: array
-                        tls:
-                          description: TLS related settings for connections to the
-                            upstream service.
-                          properties:
-                            caCertificates:
-                              type: string
-                            clientCertificate:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            credentialName:
-                              type: string
-                            insecureSkipVerify:
-                              nullable: true
-                              type: boolean
-                            mode:
-                              enum:
-                              - DISABLE
-                              - SIMPLE
-                              - MUTUAL
-                              - ISTIO_MUTUAL
-                              type: string
-                            privateKey:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            sni:
-                              description: SNI string to present to the server during
-                                TLS handshake.
-                              type: string
-                            subjectAltNames:
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                      type: object
-                  type: object
-                type: array
-              trafficPolicy:
-                properties:
-                  connectionPool:
-                    properties:
-                      http:
-                        description: HTTP connection pool settings.
-                        properties:
-                          h2UpgradePolicy:
-                            description: Specify if http1.1 connection should be upgraded
-                              to http2 for the associated destination.
-                            enum:
-                            - DEFAULT
-                            - DO_NOT_UPGRADE
-                            - UPGRADE
-                            type: string
-                          http1MaxPendingRequests:
-                            description: Maximum number of pending HTTP requests to
-                              a destination.
-                            format: int32
-                            type: integer
-                          http2MaxRequests:
-                            description: Maximum number of requests to a backend.
-                            format: int32
-                            type: integer
-                          idleTimeout:
-                            description: The idle timeout for upstream connection
-                              pool connections.
-                            type: string
-                          maxRequestsPerConnection:
-                            description: Maximum number of requests per connection
-                              to a backend.
-                            format: int32
-                            type: integer
-                          maxRetries:
-                            format: int32
-                            type: integer
-                          useClientProtocol:
-                            description: If set to true, client protocol will be preserved
-                              while initiating connection to backend.
-                            type: boolean
-                        type: object
-                      tcp:
-                        description: Settings common to both HTTP and TCP upstream
-                          connections.
-                        properties:
-                          connectTimeout:
-                            description: TCP connection timeout.
-                            type: string
-                          maxConnections:
-                            description: Maximum number of HTTP1 /TCP connections
-                              to a destination host.
-                            format: int32
-                            type: integer
-                          tcpKeepalive:
-                            description: If set then set SO_KEEPALIVE on the socket
-                              to enable TCP Keepalives.
+                          outlierDetection:
                             properties:
-                              interval:
-                                description: The time duration between keep-alive
-                                  probes.
+                              baseEjectionTime:
+                                description: Minimum ejection duration.
                                 type: string
-                              probes:
+                              consecutive5xxErrors:
+                                description: Number of 5xx errors before a host is ejected
+                                  from the connection pool.
+                                nullable: true
                                 type: integer
-                              time:
+                              consecutiveErrors:
+                                format: int32
+                                type: integer
+                              consecutiveGatewayErrors:
+                                description: Number of gateway errors before a host
+                                  is ejected from the connection pool.
+                                nullable: true
+                                type: integer
+                              consecutiveLocalOriginFailures:
+                                nullable: true
+                                type: integer
+                              interval:
+                                description: Time interval between ejection sweep analysis.
                                 type: string
+                              maxEjectionPercent:
+                                format: int32
+                                type: integer
+                              minHealthPercent:
+                                format: int32
+                                type: integer
+                              splitExternalLocalOriginErrors:
+                                description: Determines whether to distinguish local
+                                  origin failures from external errors.
+                                type: boolean
                             type: object
-                        type: object
-                    type: object
-                  loadBalancer:
-                    description: Settings controlling the load balancer algorithms.
-                    oneOf:
-                    - not:
-                        anyOf:
-                        - required:
-                          - simple
-                        - properties:
-                            consistentHash:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                              - required:
-                                - httpHeaderName
-                              - required:
-                                - httpCookie
-                              - required:
-                                - useSourceIp
-                              - required:
-                                - httpQueryParameterName
-                          required:
-                          - consistentHash
-                    - required:
-                      - simple
-                    - properties:
-                        consistentHash:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - httpHeaderName
-                              - required:
-                                - httpCookie
-                              - required:
-                                - useSourceIp
-                              - required:
-                                - httpQueryParameterName
-                          - required:
-                            - httpHeaderName
-                          - required:
-                            - httpCookie
-                          - required:
-                            - useSourceIp
-                          - required:
-                            - httpQueryParameterName
-                      required:
-                      - consistentHash
-                    properties:
-                      consistentHash:
-                        properties:
-                          httpCookie:
-                            description: Hash based on HTTP cookie.
-                            properties:
-                              name:
-                                description: Name of the cookie.
-                                type: string
-                              path:
-                                description: Path to set for the cookie.
-                                type: string
-                              ttl:
-                                description: Lifetime of the cookie.
-                                type: string
-                            type: object
-                          httpHeaderName:
-                            description: Hash based on a specific HTTP header.
-                            type: string
-                          httpQueryParameterName:
-                            description: Hash based on a specific HTTP query parameter.
-                            type: string
-                          minimumRingSize:
-                            type: integer
-                          useSourceIp:
-                            description: Hash based on the source IP address.
-                            type: boolean
-                        type: object
-                      localityLbSetting:
-                        properties:
-                          distribute:
-                            description: 'Optional: only one of distribute, failover
-                              or failoverPriority can be set.'
+                          portLevelSettings:
+                            description: Traffic policies specific to individual ports.
                             items:
                               properties:
-                                from:
-                                  description: Originating locality, '/' separated,
-                                    e.g.
-                                  type: string
-                                to:
-                                  additionalProperties:
-                                    type: integer
-                                  description: Map of upstream localities to traffic
-                                    distribution weights.
-                                  type: object
-                              type: object
-                            type: array
-                          enabled:
-                            description: enable locality load balancing, this is DestinationRule-level
-                              and will override mesh wide settings in entirety.
-                            nullable: true
-                            type: boolean
-                          failover:
-                            description: 'Optional: only one of distribute, failover
-                              or failoverPriority can be set.'
-                            items:
-                              properties:
-                                from:
-                                  description: Originating region.
-                                  type: string
-                                to:
-                                  type: string
-                              type: object
-                            type: array
-                          failoverPriority:
-                            description: failoverPriority is an ordered list of labels
-                              used to sort endpoints to do priority based load balancing.
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      simple:
-                        enum:
-                        - ROUND_ROBIN
-                        - LEAST_CONN
-                        - RANDOM
-                        - PASSTHROUGH
-                        type: string
-                    type: object
-                  outlierDetection:
-                    properties:
-                      baseEjectionTime:
-                        description: Minimum ejection duration.
-                        type: string
-                      consecutive5xxErrors:
-                        description: Number of 5xx errors before a host is ejected
-                          from the connection pool.
-                        nullable: true
-                        type: integer
-                      consecutiveErrors:
-                        format: int32
-                        type: integer
-                      consecutiveGatewayErrors:
-                        description: Number of gateway errors before a host is ejected
-                          from the connection pool.
-                        nullable: true
-                        type: integer
-                      consecutiveLocalOriginFailures:
-                        nullable: true
-                        type: integer
-                      interval:
-                        description: Time interval between ejection sweep analysis.
-                        type: string
-                      maxEjectionPercent:
-                        format: int32
-                        type: integer
-                      minHealthPercent:
-                        format: int32
-                        type: integer
-                      splitExternalLocalOriginErrors:
-                        description: Determines whether to distinguish local origin
-                          failures from external errors.
-                        type: boolean
-                    type: object
-                  portLevelSettings:
-                    description: Traffic policies specific to individual ports.
-                    items:
-                      properties:
-                        connectionPool:
-                          properties:
-                            http:
-                              description: HTTP connection pool settings.
-                              properties:
-                                h2UpgradePolicy:
-                                  description: Specify if http1.1 connection should
-                                    be upgraded to http2 for the associated destination.
-                                  enum:
-                                  - DEFAULT
-                                  - DO_NOT_UPGRADE
-                                  - UPGRADE
-                                  type: string
-                                http1MaxPendingRequests:
-                                  description: Maximum number of pending HTTP requests
-                                    to a destination.
-                                  format: int32
-                                  type: integer
-                                http2MaxRequests:
-                                  description: Maximum number of requests to a backend.
-                                  format: int32
-                                  type: integer
-                                idleTimeout:
-                                  description: The idle timeout for upstream connection
-                                    pool connections.
-                                  type: string
-                                maxRequestsPerConnection:
-                                  description: Maximum number of requests per connection
-                                    to a backend.
-                                  format: int32
-                                  type: integer
-                                maxRetries:
-                                  format: int32
-                                  type: integer
-                                useClientProtocol:
-                                  description: If set to true, client protocol will
-                                    be preserved while initiating connection to backend.
-                                  type: boolean
-                              type: object
-                            tcp:
-                              description: Settings common to both HTTP and TCP upstream
-                                connections.
-                              properties:
-                                connectTimeout:
-                                  description: TCP connection timeout.
-                                  type: string
-                                maxConnections:
-                                  description: Maximum number of HTTP1 /TCP connections
-                                    to a destination host.
-                                  format: int32
-                                  type: integer
-                                tcpKeepalive:
-                                  description: If set then set SO_KEEPALIVE on the
-                                    socket to enable TCP Keepalives.
+                                connectionPool:
                                   properties:
-                                    interval:
-                                      description: The time duration between keep-alive
-                                        probes.
-                                      type: string
-                                    probes:
-                                      type: integer
-                                    time:
-                                      type: string
+                                    http:
+                                      description: HTTP connection pool settings.
+                                      properties:
+                                        h2UpgradePolicy:
+                                          description: Specify if http1.1 connection
+                                            should be upgraded to http2 for the associated
+                                            destination.
+                                          enum:
+                                            - DEFAULT
+                                            - DO_NOT_UPGRADE
+                                            - UPGRADE
+                                          type: string
+                                        http1MaxPendingRequests:
+                                          format: int32
+                                          type: integer
+                                        http2MaxRequests:
+                                          description: Maximum number of active requests
+                                            to a destination.
+                                          format: int32
+                                          type: integer
+                                        idleTimeout:
+                                          description: The idle timeout for upstream
+                                            connection pool connections.
+                                          type: string
+                                        maxRequestsPerConnection:
+                                          description: Maximum number of requests per
+                                            connection to a backend.
+                                          format: int32
+                                          type: integer
+                                        maxRetries:
+                                          format: int32
+                                          type: integer
+                                        useClientProtocol:
+                                          description: If set to true, client protocol
+                                            will be preserved while initiating connection
+                                            to backend.
+                                          type: boolean
+                                      type: object
+                                    tcp:
+                                      description: Settings common to both HTTP and
+                                        TCP upstream connections.
+                                      properties:
+                                        connectTimeout:
+                                          description: TCP connection timeout.
+                                          type: string
+                                        maxConnectionDuration:
+                                          description: The maximum duration of a connection.
+                                          type: string
+                                        maxConnections:
+                                          description: Maximum number of HTTP1 /TCP
+                                            connections to a destination host.
+                                          format: int32
+                                          type: integer
+                                        tcpKeepalive:
+                                          description: If set then set SO_KEEPALIVE
+                                            on the socket to enable TCP Keepalives.
+                                          properties:
+                                            interval:
+                                              description: The time duration between
+                                                keep-alive probes.
+                                              type: string
+                                            probes:
+                                              type: integer
+                                            time:
+                                              type: string
+                                          type: object
+                                      type: object
                                   type: object
-                              type: object
-                          type: object
-                        loadBalancer:
-                          description: Settings controlling the load balancer algorithms.
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - simple
-                              - properties:
-                                  consistentHash:
-                                    oneOf:
+                                loadBalancer:
+                                  description: Settings controlling the load balancer
+                                    algorithms.
+                                  oneOf:
                                     - not:
                                         anyOf:
-                                        - required:
-                                          - httpHeaderName
-                                        - required:
-                                          - httpCookie
-                                        - required:
-                                          - useSourceIp
-                                        - required:
-                                          - httpQueryParameterName
+                                          - required:
+                                              - simple
+                                          - properties:
+                                              consistentHash:
+                                                allOf:
+                                                  - oneOf:
+                                                      - not:
+                                                          anyOf:
+                                                            - required:
+                                                                - httpHeaderName
+                                                            - required:
+                                                                - httpCookie
+                                                            - required:
+                                                                - useSourceIp
+                                                            - required:
+                                                                - httpQueryParameterName
+                                                      - required:
+                                                          - httpHeaderName
+                                                      - required:
+                                                          - httpCookie
+                                                      - required:
+                                                          - useSourceIp
+                                                      - required:
+                                                          - httpQueryParameterName
+                                                  - oneOf:
+                                                      - not:
+                                                          anyOf:
+                                                            - required:
+                                                                - ringHash
+                                                            - required:
+                                                                - maglev
+                                                      - required:
+                                                          - ringHash
+                                                      - required:
+                                                          - maglev
+                                                properties:
+                                                  minimumRingSize: {}
+                                            required:
+                                              - consistentHash
                                     - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                required:
-                                - consistentHash
-                          - required:
-                            - simple
-                          - properties:
-                              consistentHash:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                            required:
-                            - consistentHash
-                          properties:
-                            consistentHash:
-                              properties:
-                                httpCookie:
-                                  description: Hash based on HTTP cookie.
+                                        - simple
+                                    - properties:
+                                        consistentHash:
+                                          allOf:
+                                            - oneOf:
+                                                - not:
+                                                    anyOf:
+                                                      - required:
+                                                          - httpHeaderName
+                                                      - required:
+                                                          - httpCookie
+                                                      - required:
+                                                          - useSourceIp
+                                                      - required:
+                                                          - httpQueryParameterName
+                                                - required:
+                                                    - httpHeaderName
+                                                - required:
+                                                    - httpCookie
+                                                - required:
+                                                    - useSourceIp
+                                                - required:
+                                                    - httpQueryParameterName
+                                            - oneOf:
+                                                - not:
+                                                    anyOf:
+                                                      - required:
+                                                          - ringHash
+                                                      - required:
+                                                          - maglev
+                                                - required:
+                                                    - ringHash
+                                                - required:
+                                                    - maglev
+                                          properties:
+                                            minimumRingSize: {}
+                                      required:
+                                        - consistentHash
                                   properties:
-                                    name:
-                                      description: Name of the cookie.
+                                    consistentHash:
+                                      properties:
+                                        httpCookie:
+                                          description: Hash based on HTTP cookie.
+                                          properties:
+                                            name:
+                                              description: Name of the cookie.
+                                              type: string
+                                            path:
+                                              description: Path to set for the cookie.
+                                              type: string
+                                            ttl:
+                                              description: Lifetime of the cookie.
+                                              type: string
+                                          type: object
+                                        httpHeaderName:
+                                          description: Hash based on a specific HTTP
+                                            header.
+                                          type: string
+                                        httpQueryParameterName:
+                                          description: Hash based on a specific HTTP
+                                            query parameter.
+                                          type: string
+                                        maglev:
+                                          description: The Maglev load balancer implements
+                                            consistent hashing to backend hosts.
+                                          properties:
+                                            tableSize:
+                                              description: The table size for Maglev
+                                                hashing.
+                                              type: integer
+                                          type: object
+                                        minimumRingSize:
+                                          description: Deprecated.
+                                          type: integer
+                                        ringHash:
+                                          description: The ring/modulo hash load balancer
+                                            implements consistent hashing to backend
+                                            hosts.
+                                          properties:
+                                            minimumRingSize:
+                                              type: integer
+                                          type: object
+                                        useSourceIp:
+                                          description: Hash based on the source IP address.
+                                          type: boolean
+                                      type: object
+                                    localityLbSetting:
+                                      properties:
+                                        distribute:
+                                          description: 'Optional: only one of distribute,
+                                          failover or failoverPriority can be set.'
+                                          items:
+                                            properties:
+                                              from:
+                                                description: Originating locality, '/'
+                                                  separated, e.g.
+                                                type: string
+                                              to:
+                                                additionalProperties:
+                                                  type: integer
+                                                description: Map of upstream localities
+                                                  to traffic distribution weights.
+                                                type: object
+                                            type: object
+                                          type: array
+                                        enabled:
+                                          description: enable locality load balancing,
+                                            this is DestinationRule-level and will override
+                                            mesh wide settings in entirety.
+                                          nullable: true
+                                          type: boolean
+                                        failover:
+                                          description: 'Optional: only one of distribute,
+                                          failover or failoverPriority can be set.'
+                                          items:
+                                            properties:
+                                              from:
+                                                description: Originating region.
+                                                type: string
+                                              to:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        failoverPriority:
+                                          description: failoverPriority is an ordered
+                                            list of labels used to sort endpoints to
+                                            do priority based load balancing.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    simple:
+                                      enum:
+                                        - UNSPECIFIED
+                                        - LEAST_CONN
+                                        - RANDOM
+                                        - PASSTHROUGH
+                                        - ROUND_ROBIN
+                                        - LEAST_REQUEST
                                       type: string
-                                    path:
-                                      description: Path to set for the cookie.
-                                      type: string
-                                    ttl:
-                                      description: Lifetime of the cookie.
+                                    warmupDurationSecs:
+                                      description: Represents the warmup duration of
+                                        Service.
                                       type: string
                                   type: object
-                                httpHeaderName:
-                                  description: Hash based on a specific HTTP header.
+                                outlierDetection:
+                                  properties:
+                                    baseEjectionTime:
+                                      description: Minimum ejection duration.
+                                      type: string
+                                    consecutive5xxErrors:
+                                      description: Number of 5xx errors before a host
+                                        is ejected from the connection pool.
+                                      nullable: true
+                                      type: integer
+                                    consecutiveErrors:
+                                      format: int32
+                                      type: integer
+                                    consecutiveGatewayErrors:
+                                      description: Number of gateway errors before a
+                                        host is ejected from the connection pool.
+                                      nullable: true
+                                      type: integer
+                                    consecutiveLocalOriginFailures:
+                                      nullable: true
+                                      type: integer
+                                    interval:
+                                      description: Time interval between ejection sweep
+                                        analysis.
+                                      type: string
+                                    maxEjectionPercent:
+                                      format: int32
+                                      type: integer
+                                    minHealthPercent:
+                                      format: int32
+                                      type: integer
+                                    splitExternalLocalOriginErrors:
+                                      description: Determines whether to distinguish
+                                        local origin failures from external errors.
+                                      type: boolean
+                                  type: object
+                                port:
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                tls:
+                                  description: TLS related settings for connections
+                                    to the upstream service.
+                                  properties:
+                                    caCertificates:
+                                      type: string
+                                    clientCertificate:
+                                      description: REQUIRED if mode is `MUTUAL`.
+                                      type: string
+                                    credentialName:
+                                      type: string
+                                    insecureSkipVerify:
+                                      nullable: true
+                                      type: boolean
+                                    mode:
+                                      enum:
+                                        - DISABLE
+                                        - SIMPLE
+                                        - MUTUAL
+                                        - ISTIO_MUTUAL
+                                      type: string
+                                    privateKey:
+                                      description: REQUIRED if mode is `MUTUAL`.
+                                      type: string
+                                    sni:
+                                      description: SNI string to present to the server
+                                        during TLS handshake.
+                                      type: string
+                                    subjectAltNames:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                              type: object
+                            type: array
+                          tls:
+                            description: TLS related settings for connections to the
+                              upstream service.
+                            properties:
+                              caCertificates:
+                                type: string
+                              clientCertificate:
+                                description: REQUIRED if mode is `MUTUAL`.
+                                type: string
+                              credentialName:
+                                type: string
+                              insecureSkipVerify:
+                                nullable: true
+                                type: boolean
+                              mode:
+                                enum:
+                                  - DISABLE
+                                  - SIMPLE
+                                  - MUTUAL
+                                  - ISTIO_MUTUAL
+                                type: string
+                              privateKey:
+                                description: REQUIRED if mode is `MUTUAL`.
+                                type: string
+                              sni:
+                                description: SNI string to present to the server during
+                                  TLS handshake.
+                                type: string
+                              subjectAltNames:
+                                items:
                                   type: string
-                                httpQueryParameterName:
-                                  description: Hash based on a specific HTTP query
-                                    parameter.
+                                type: array
+                            type: object
+                          tunnel:
+                            properties:
+                              protocol:
+                                description: Specifies which protocol to use for tunneling
+                                  the downstream connection.
+                                type: string
+                              targetHost:
+                                description: Specifies a host to which the downstream
+                                  connection is tunneled.
+                                type: string
+                              targetPort:
+                                description: Specifies a port to which the downstream
+                                  connection is tunneled.
+                                type: integer
+                            type: object
+                        type: object
+                    type: object
+                  type: array
+                trafficPolicy:
+                  properties:
+                    connectionPool:
+                      properties:
+                        http:
+                          description: HTTP connection pool settings.
+                          properties:
+                            h2UpgradePolicy:
+                              description: Specify if http1.1 connection should be upgraded
+                                to http2 for the associated destination.
+                              enum:
+                                - DEFAULT
+                                - DO_NOT_UPGRADE
+                                - UPGRADE
+                              type: string
+                            http1MaxPendingRequests:
+                              format: int32
+                              type: integer
+                            http2MaxRequests:
+                              description: Maximum number of active requests to a destination.
+                              format: int32
+                              type: integer
+                            idleTimeout:
+                              description: The idle timeout for upstream connection
+                                pool connections.
+                              type: string
+                            maxRequestsPerConnection:
+                              description: Maximum number of requests per connection
+                                to a backend.
+                              format: int32
+                              type: integer
+                            maxRetries:
+                              format: int32
+                              type: integer
+                            useClientProtocol:
+                              description: If set to true, client protocol will be preserved
+                                while initiating connection to backend.
+                              type: boolean
+                          type: object
+                        tcp:
+                          description: Settings common to both HTTP and TCP upstream
+                            connections.
+                          properties:
+                            connectTimeout:
+                              description: TCP connection timeout.
+                              type: string
+                            maxConnectionDuration:
+                              description: The maximum duration of a connection.
+                              type: string
+                            maxConnections:
+                              description: Maximum number of HTTP1 /TCP connections
+                                to a destination host.
+                              format: int32
+                              type: integer
+                            tcpKeepalive:
+                              description: If set then set SO_KEEPALIVE on the socket
+                                to enable TCP Keepalives.
+                              properties:
+                                interval:
+                                  description: The time duration between keep-alive
+                                    probes.
                                   type: string
+                                probes:
+                                  type: integer
+                                time:
+                                  type: string
+                              type: object
+                          type: object
+                      type: object
+                    loadBalancer:
+                      description: Settings controlling the load balancer algorithms.
+                      oneOf:
+                        - not:
+                            anyOf:
+                              - required:
+                                  - simple
+                              - properties:
+                                  consistentHash:
+                                    allOf:
+                                      - oneOf:
+                                          - not:
+                                              anyOf:
+                                                - required:
+                                                    - httpHeaderName
+                                                - required:
+                                                    - httpCookie
+                                                - required:
+                                                    - useSourceIp
+                                                - required:
+                                                    - httpQueryParameterName
+                                          - required:
+                                              - httpHeaderName
+                                          - required:
+                                              - httpCookie
+                                          - required:
+                                              - useSourceIp
+                                          - required:
+                                              - httpQueryParameterName
+                                      - oneOf:
+                                          - not:
+                                              anyOf:
+                                                - required:
+                                                    - ringHash
+                                                - required:
+                                                    - maglev
+                                          - required:
+                                              - ringHash
+                                          - required:
+                                              - maglev
+                                    properties:
+                                      minimumRingSize: {}
+                                required:
+                                  - consistentHash
+                        - required:
+                            - simple
+                        - properties:
+                            consistentHash:
+                              allOf:
+                                - oneOf:
+                                    - not:
+                                        anyOf:
+                                          - required:
+                                              - httpHeaderName
+                                          - required:
+                                              - httpCookie
+                                          - required:
+                                              - useSourceIp
+                                          - required:
+                                              - httpQueryParameterName
+                                    - required:
+                                        - httpHeaderName
+                                    - required:
+                                        - httpCookie
+                                    - required:
+                                        - useSourceIp
+                                    - required:
+                                        - httpQueryParameterName
+                                - oneOf:
+                                    - not:
+                                        anyOf:
+                                          - required:
+                                              - ringHash
+                                          - required:
+                                              - maglev
+                                    - required:
+                                        - ringHash
+                                    - required:
+                                        - maglev
+                              properties:
+                                minimumRingSize: {}
+                          required:
+                            - consistentHash
+                      properties:
+                        consistentHash:
+                          properties:
+                            httpCookie:
+                              description: Hash based on HTTP cookie.
+                              properties:
+                                name:
+                                  description: Name of the cookie.
+                                  type: string
+                                path:
+                                  description: Path to set for the cookie.
+                                  type: string
+                                ttl:
+                                  description: Lifetime of the cookie.
+                                  type: string
+                              type: object
+                            httpHeaderName:
+                              description: Hash based on a specific HTTP header.
+                              type: string
+                            httpQueryParameterName:
+                              description: Hash based on a specific HTTP query parameter.
+                              type: string
+                            maglev:
+                              description: The Maglev load balancer implements consistent
+                                hashing to backend hosts.
+                              properties:
+                                tableSize:
+                                  description: The table size for Maglev hashing.
+                                  type: integer
+                              type: object
+                            minimumRingSize:
+                              description: Deprecated.
+                              type: integer
+                            ringHash:
+                              description: The ring/modulo hash load balancer implements
+                                consistent hashing to backend hosts.
+                              properties:
                                 minimumRingSize:
                                   type: integer
-                                useSourceIp:
-                                  description: Hash based on the source IP address.
-                                  type: boolean
                               type: object
-                            localityLbSetting:
-                              properties:
-                                distribute:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating locality, '/' separated,
-                                          e.g.
-                                        type: string
-                                      to:
-                                        additionalProperties:
-                                          type: integer
-                                        description: Map of upstream localities to
-                                          traffic distribution weights.
-                                        type: object
-                                    type: object
-                                  type: array
-                                enabled:
-                                  description: enable locality load balancing, this
-                                    is DestinationRule-level and will override mesh
-                                    wide settings in entirety.
-                                  nullable: true
-                                  type: boolean
-                                failover:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating region.
-                                        type: string
-                                      to:
-                                        type: string
-                                    type: object
-                                  type: array
-                                failoverPriority:
-                                  description: failoverPriority is an ordered list
-                                    of labels used to sort endpoints to do priority
-                                    based load balancing.
-                                  items:
+                            useSourceIp:
+                              description: Hash based on the source IP address.
+                              type: boolean
+                          type: object
+                        localityLbSetting:
+                          properties:
+                            distribute:
+                              description: 'Optional: only one of distribute, failover
+                              or failoverPriority can be set.'
+                              items:
+                                properties:
+                                  from:
+                                    description: Originating locality, '/' separated,
+                                      e.g.
                                     type: string
-                                  type: array
-                              type: object
-                            simple:
-                              enum:
-                              - ROUND_ROBIN
-                              - LEAST_CONN
-                              - RANDOM
-                              - PASSTHROUGH
-                              type: string
-                          type: object
-                        outlierDetection:
-                          properties:
-                            baseEjectionTime:
-                              description: Minimum ejection duration.
-                              type: string
-                            consecutive5xxErrors:
-                              description: Number of 5xx errors before a host is ejected
-                                from the connection pool.
-                              nullable: true
-                              type: integer
-                            consecutiveErrors:
-                              format: int32
-                              type: integer
-                            consecutiveGatewayErrors:
-                              description: Number of gateway errors before a host
-                                is ejected from the connection pool.
-                              nullable: true
-                              type: integer
-                            consecutiveLocalOriginFailures:
-                              nullable: true
-                              type: integer
-                            interval:
-                              description: Time interval between ejection sweep analysis.
-                              type: string
-                            maxEjectionPercent:
-                              format: int32
-                              type: integer
-                            minHealthPercent:
-                              format: int32
-                              type: integer
-                            splitExternalLocalOriginErrors:
-                              description: Determines whether to distinguish local
-                                origin failures from external errors.
-                              type: boolean
-                          type: object
-                        port:
-                          properties:
-                            number:
-                              type: integer
-                          type: object
-                        tls:
-                          description: TLS related settings for connections to the
-                            upstream service.
-                          properties:
-                            caCertificates:
-                              type: string
-                            clientCertificate:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            credentialName:
-                              type: string
-                            insecureSkipVerify:
+                                  to:
+                                    additionalProperties:
+                                      type: integer
+                                    description: Map of upstream localities to traffic
+                                      distribution weights.
+                                    type: object
+                                type: object
+                              type: array
+                            enabled:
+                              description: enable locality load balancing, this is DestinationRule-level
+                                and will override mesh wide settings in entirety.
                               nullable: true
                               type: boolean
-                            mode:
-                              enum:
-                              - DISABLE
-                              - SIMPLE
-                              - MUTUAL
-                              - ISTIO_MUTUAL
-                              type: string
-                            privateKey:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            sni:
-                              description: SNI string to present to the server during
-                                TLS handshake.
-                              type: string
-                            subjectAltNames:
+                            failover:
+                              description: 'Optional: only one of distribute, failover
+                              or failoverPriority can be set.'
+                              items:
+                                properties:
+                                  from:
+                                    description: Originating region.
+                                    type: string
+                                  to:
+                                    type: string
+                                type: object
+                              type: array
+                            failoverPriority:
+                              description: failoverPriority is an ordered list of labels
+                                used to sort endpoints to do priority based load balancing.
                               items:
                                 type: string
                               type: array
                           type: object
-                      type: object
-                    type: array
-                  tls:
-                    description: TLS related settings for connections to the upstream
-                      service.
-                    properties:
-                      caCertificates:
-                        type: string
-                      clientCertificate:
-                        description: REQUIRED if mode is `MUTUAL`.
-                        type: string
-                      credentialName:
-                        type: string
-                      insecureSkipVerify:
-                        nullable: true
-                        type: boolean
-                      mode:
-                        enum:
-                        - DISABLE
-                        - SIMPLE
-                        - MUTUAL
-                        - ISTIO_MUTUAL
-                        type: string
-                      privateKey:
-                        description: REQUIRED if mode is `MUTUAL`.
-                        type: string
-                      sni:
-                        description: SNI string to present to the server during TLS
-                          handshake.
-                        type: string
-                      subjectAltNames:
-                        items:
+                        simple:
+                          enum:
+                            - UNSPECIFIED
+                            - LEAST_CONN
+                            - RANDOM
+                            - PASSTHROUGH
+                            - ROUND_ROBIN
+                            - LEAST_REQUEST
                           type: string
-                        type: array
-                    type: object
-                type: object
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - description: The name of a service from the service registry
-      jsonPath: .spec.host
-      name: Host
-      type: string
-    - description: 'CreationTimestamp is a timestamp representing the server time
+                        warmupDurationSecs:
+                          description: Represents the warmup duration of Service.
+                          type: string
+                      type: object
+                    outlierDetection:
+                      properties:
+                        baseEjectionTime:
+                          description: Minimum ejection duration.
+                          type: string
+                        consecutive5xxErrors:
+                          description: Number of 5xx errors before a host is ejected
+                            from the connection pool.
+                          nullable: true
+                          type: integer
+                        consecutiveErrors:
+                          format: int32
+                          type: integer
+                        consecutiveGatewayErrors:
+                          description: Number of gateway errors before a host is ejected
+                            from the connection pool.
+                          nullable: true
+                          type: integer
+                        consecutiveLocalOriginFailures:
+                          nullable: true
+                          type: integer
+                        interval:
+                          description: Time interval between ejection sweep analysis.
+                          type: string
+                        maxEjectionPercent:
+                          format: int32
+                          type: integer
+                        minHealthPercent:
+                          format: int32
+                          type: integer
+                        splitExternalLocalOriginErrors:
+                          description: Determines whether to distinguish local origin
+                            failures from external errors.
+                          type: boolean
+                      type: object
+                    portLevelSettings:
+                      description: Traffic policies specific to individual ports.
+                      items:
+                        properties:
+                          connectionPool:
+                            properties:
+                              http:
+                                description: HTTP connection pool settings.
+                                properties:
+                                  h2UpgradePolicy:
+                                    description: Specify if http1.1 connection should
+                                      be upgraded to http2 for the associated destination.
+                                    enum:
+                                      - DEFAULT
+                                      - DO_NOT_UPGRADE
+                                      - UPGRADE
+                                    type: string
+                                  http1MaxPendingRequests:
+                                    format: int32
+                                    type: integer
+                                  http2MaxRequests:
+                                    description: Maximum number of active requests to
+                                      a destination.
+                                    format: int32
+                                    type: integer
+                                  idleTimeout:
+                                    description: The idle timeout for upstream connection
+                                      pool connections.
+                                    type: string
+                                  maxRequestsPerConnection:
+                                    description: Maximum number of requests per connection
+                                      to a backend.
+                                    format: int32
+                                    type: integer
+                                  maxRetries:
+                                    format: int32
+                                    type: integer
+                                  useClientProtocol:
+                                    description: If set to true, client protocol will
+                                      be preserved while initiating connection to backend.
+                                    type: boolean
+                                type: object
+                              tcp:
+                                description: Settings common to both HTTP and TCP upstream
+                                  connections.
+                                properties:
+                                  connectTimeout:
+                                    description: TCP connection timeout.
+                                    type: string
+                                  maxConnectionDuration:
+                                    description: The maximum duration of a connection.
+                                    type: string
+                                  maxConnections:
+                                    description: Maximum number of HTTP1 /TCP connections
+                                      to a destination host.
+                                    format: int32
+                                    type: integer
+                                  tcpKeepalive:
+                                    description: If set then set SO_KEEPALIVE on the
+                                      socket to enable TCP Keepalives.
+                                    properties:
+                                      interval:
+                                        description: The time duration between keep-alive
+                                          probes.
+                                        type: string
+                                      probes:
+                                        type: integer
+                                      time:
+                                        type: string
+                                    type: object
+                                type: object
+                            type: object
+                          loadBalancer:
+                            description: Settings controlling the load balancer algorithms.
+                            oneOf:
+                              - not:
+                                  anyOf:
+                                    - required:
+                                        - simple
+                                    - properties:
+                                        consistentHash:
+                                          allOf:
+                                            - oneOf:
+                                                - not:
+                                                    anyOf:
+                                                      - required:
+                                                          - httpHeaderName
+                                                      - required:
+                                                          - httpCookie
+                                                      - required:
+                                                          - useSourceIp
+                                                      - required:
+                                                          - httpQueryParameterName
+                                                - required:
+                                                    - httpHeaderName
+                                                - required:
+                                                    - httpCookie
+                                                - required:
+                                                    - useSourceIp
+                                                - required:
+                                                    - httpQueryParameterName
+                                            - oneOf:
+                                                - not:
+                                                    anyOf:
+                                                      - required:
+                                                          - ringHash
+                                                      - required:
+                                                          - maglev
+                                                - required:
+                                                    - ringHash
+                                                - required:
+                                                    - maglev
+                                          properties:
+                                            minimumRingSize: {}
+                                      required:
+                                        - consistentHash
+                              - required:
+                                  - simple
+                              - properties:
+                                  consistentHash:
+                                    allOf:
+                                      - oneOf:
+                                          - not:
+                                              anyOf:
+                                                - required:
+                                                    - httpHeaderName
+                                                - required:
+                                                    - httpCookie
+                                                - required:
+                                                    - useSourceIp
+                                                - required:
+                                                    - httpQueryParameterName
+                                          - required:
+                                              - httpHeaderName
+                                          - required:
+                                              - httpCookie
+                                          - required:
+                                              - useSourceIp
+                                          - required:
+                                              - httpQueryParameterName
+                                      - oneOf:
+                                          - not:
+                                              anyOf:
+                                                - required:
+                                                    - ringHash
+                                                - required:
+                                                    - maglev
+                                          - required:
+                                              - ringHash
+                                          - required:
+                                              - maglev
+                                    properties:
+                                      minimumRingSize: {}
+                                required:
+                                  - consistentHash
+                            properties:
+                              consistentHash:
+                                properties:
+                                  httpCookie:
+                                    description: Hash based on HTTP cookie.
+                                    properties:
+                                      name:
+                                        description: Name of the cookie.
+                                        type: string
+                                      path:
+                                        description: Path to set for the cookie.
+                                        type: string
+                                      ttl:
+                                        description: Lifetime of the cookie.
+                                        type: string
+                                    type: object
+                                  httpHeaderName:
+                                    description: Hash based on a specific HTTP header.
+                                    type: string
+                                  httpQueryParameterName:
+                                    description: Hash based on a specific HTTP query
+                                      parameter.
+                                    type: string
+                                  maglev:
+                                    description: The Maglev load balancer implements
+                                      consistent hashing to backend hosts.
+                                    properties:
+                                      tableSize:
+                                        description: The table size for Maglev hashing.
+                                        type: integer
+                                    type: object
+                                  minimumRingSize:
+                                    description: Deprecated.
+                                    type: integer
+                                  ringHash:
+                                    description: The ring/modulo hash load balancer
+                                      implements consistent hashing to backend hosts.
+                                    properties:
+                                      minimumRingSize:
+                                        type: integer
+                                    type: object
+                                  useSourceIp:
+                                    description: Hash based on the source IP address.
+                                    type: boolean
+                                type: object
+                              localityLbSetting:
+                                properties:
+                                  distribute:
+                                    description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                    items:
+                                      properties:
+                                        from:
+                                          description: Originating locality, '/' separated,
+                                            e.g.
+                                          type: string
+                                        to:
+                                          additionalProperties:
+                                            type: integer
+                                          description: Map of upstream localities to
+                                            traffic distribution weights.
+                                          type: object
+                                      type: object
+                                    type: array
+                                  enabled:
+                                    description: enable locality load balancing, this
+                                      is DestinationRule-level and will override mesh
+                                      wide settings in entirety.
+                                    nullable: true
+                                    type: boolean
+                                  failover:
+                                    description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                    items:
+                                      properties:
+                                        from:
+                                          description: Originating region.
+                                          type: string
+                                        to:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  failoverPriority:
+                                    description: failoverPriority is an ordered list
+                                      of labels used to sort endpoints to do priority
+                                      based load balancing.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              simple:
+                                enum:
+                                  - UNSPECIFIED
+                                  - LEAST_CONN
+                                  - RANDOM
+                                  - PASSTHROUGH
+                                  - ROUND_ROBIN
+                                  - LEAST_REQUEST
+                                type: string
+                              warmupDurationSecs:
+                                description: Represents the warmup duration of Service.
+                                type: string
+                            type: object
+                          outlierDetection:
+                            properties:
+                              baseEjectionTime:
+                                description: Minimum ejection duration.
+                                type: string
+                              consecutive5xxErrors:
+                                description: Number of 5xx errors before a host is ejected
+                                  from the connection pool.
+                                nullable: true
+                                type: integer
+                              consecutiveErrors:
+                                format: int32
+                                type: integer
+                              consecutiveGatewayErrors:
+                                description: Number of gateway errors before a host
+                                  is ejected from the connection pool.
+                                nullable: true
+                                type: integer
+                              consecutiveLocalOriginFailures:
+                                nullable: true
+                                type: integer
+                              interval:
+                                description: Time interval between ejection sweep analysis.
+                                type: string
+                              maxEjectionPercent:
+                                format: int32
+                                type: integer
+                              minHealthPercent:
+                                format: int32
+                                type: integer
+                              splitExternalLocalOriginErrors:
+                                description: Determines whether to distinguish local
+                                  origin failures from external errors.
+                                type: boolean
+                            type: object
+                          port:
+                            properties:
+                              number:
+                                type: integer
+                            type: object
+                          tls:
+                            description: TLS related settings for connections to the
+                              upstream service.
+                            properties:
+                              caCertificates:
+                                type: string
+                              clientCertificate:
+                                description: REQUIRED if mode is `MUTUAL`.
+                                type: string
+                              credentialName:
+                                type: string
+                              insecureSkipVerify:
+                                nullable: true
+                                type: boolean
+                              mode:
+                                enum:
+                                  - DISABLE
+                                  - SIMPLE
+                                  - MUTUAL
+                                  - ISTIO_MUTUAL
+                                type: string
+                              privateKey:
+                                description: REQUIRED if mode is `MUTUAL`.
+                                type: string
+                              sni:
+                                description: SNI string to present to the server during
+                                  TLS handshake.
+                                type: string
+                              subjectAltNames:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      type: array
+                    tls:
+                      description: TLS related settings for connections to the upstream
+                        service.
+                      properties:
+                        caCertificates:
+                          type: string
+                        clientCertificate:
+                          description: REQUIRED if mode is `MUTUAL`.
+                          type: string
+                        credentialName:
+                          type: string
+                        insecureSkipVerify:
+                          nullable: true
+                          type: boolean
+                        mode:
+                          enum:
+                            - DISABLE
+                            - SIMPLE
+                            - MUTUAL
+                            - ISTIO_MUTUAL
+                          type: string
+                        privateKey:
+                          description: REQUIRED if mode is `MUTUAL`.
+                          type: string
+                        sni:
+                          description: SNI string to present to the server during TLS
+                            handshake.
+                          type: string
+                        subjectAltNames:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    tunnel:
+                      properties:
+                        protocol:
+                          description: Specifies which protocol to use for tunneling
+                            the downstream connection.
+                          type: string
+                        targetHost:
+                          description: Specifies a host to which the downstream connection
+                            is tunneled.
+                          type: string
+                        targetPort:
+                          description: Specifies a port to which the downstream connection
+                            is tunneled.
+                          type: integer
+                      type: object
+                  type: object
+                workloadSelector:
+                  properties:
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: The name of a service from the service registry
+          jsonPath: .spec.host
+          name: Host
+          type: string
+        - description: 'CreationTimestamp is a timestamp representing the server time
         when this object was created. It is not guaranteed to be set in happens-before
         order across separate operations. Clients may not set this value. It is represented
         in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
         lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting load balancing, outlier detection,
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Configuration affecting load balancing, outlier detection,
               etc. See more details at: https://istio.io/docs/reference/config/networking/destination-rule.html'
-            properties:
-              exportTo:
-                description: A list of namespaces to which this destination rule is
-                  exported.
-                items:
+              properties:
+                exportTo:
+                  description: A list of namespaces to which this destination rule is
+                    exported.
+                  items:
+                    type: string
+                  type: array
+                host:
+                  description: The name of a service from the service registry.
                   type: string
-                type: array
-              host:
-                description: The name of a service from the service registry.
-                type: string
-              subsets:
-                items:
-                  properties:
-                    labels:
-                      additionalProperties:
+                subsets:
+                  items:
+                    properties:
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        description: Name of the subset.
                         type: string
-                      type: object
-                    name:
-                      description: Name of the subset.
-                      type: string
-                    trafficPolicy:
-                      description: Traffic policies that apply to this subset.
-                      properties:
-                        connectionPool:
-                          properties:
-                            http:
-                              description: HTTP connection pool settings.
-                              properties:
-                                h2UpgradePolicy:
-                                  description: Specify if http1.1 connection should
-                                    be upgraded to http2 for the associated destination.
-                                  enum:
-                                  - DEFAULT
-                                  - DO_NOT_UPGRADE
-                                  - UPGRADE
-                                  type: string
-                                http1MaxPendingRequests:
-                                  description: Maximum number of pending HTTP requests
-                                    to a destination.
-                                  format: int32
-                                  type: integer
-                                http2MaxRequests:
-                                  description: Maximum number of requests to a backend.
-                                  format: int32
-                                  type: integer
-                                idleTimeout:
-                                  description: The idle timeout for upstream connection
-                                    pool connections.
-                                  type: string
-                                maxRequestsPerConnection:
-                                  description: Maximum number of requests per connection
-                                    to a backend.
-                                  format: int32
-                                  type: integer
-                                maxRetries:
-                                  format: int32
-                                  type: integer
-                                useClientProtocol:
-                                  description: If set to true, client protocol will
-                                    be preserved while initiating connection to backend.
-                                  type: boolean
-                              type: object
-                            tcp:
-                              description: Settings common to both HTTP and TCP upstream
-                                connections.
-                              properties:
-                                connectTimeout:
-                                  description: TCP connection timeout.
-                                  type: string
-                                maxConnections:
-                                  description: Maximum number of HTTP1 /TCP connections
-                                    to a destination host.
-                                  format: int32
-                                  type: integer
-                                tcpKeepalive:
-                                  description: If set then set SO_KEEPALIVE on the
-                                    socket to enable TCP Keepalives.
-                                  properties:
-                                    interval:
-                                      description: The time duration between keep-alive
-                                        probes.
-                                      type: string
-                                    probes:
-                                      type: integer
-                                    time:
-                                      type: string
-                                  type: object
-                              type: object
-                          type: object
-                        loadBalancer:
-                          description: Settings controlling the load balancer algorithms.
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - simple
-                              - properties:
-                                  consistentHash:
-                                    oneOf:
-                                    - not:
-                                        anyOf:
-                                        - required:
-                                          - httpHeaderName
-                                        - required:
-                                          - httpCookie
-                                        - required:
-                                          - useSourceIp
-                                        - required:
-                                          - httpQueryParameterName
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                required:
-                                - consistentHash
-                          - required:
-                            - simple
-                          - properties:
-                              consistentHash:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                            required:
-                            - consistentHash
-                          properties:
-                            consistentHash:
-                              properties:
-                                httpCookie:
-                                  description: Hash based on HTTP cookie.
-                                  properties:
-                                    name:
-                                      description: Name of the cookie.
-                                      type: string
-                                    path:
-                                      description: Path to set for the cookie.
-                                      type: string
-                                    ttl:
-                                      description: Lifetime of the cookie.
-                                      type: string
-                                  type: object
-                                httpHeaderName:
-                                  description: Hash based on a specific HTTP header.
-                                  type: string
-                                httpQueryParameterName:
-                                  description: Hash based on a specific HTTP query
-                                    parameter.
-                                  type: string
-                                minimumRingSize:
-                                  type: integer
-                                useSourceIp:
-                                  description: Hash based on the source IP address.
-                                  type: boolean
-                              type: object
-                            localityLbSetting:
-                              properties:
-                                distribute:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating locality, '/' separated,
-                                          e.g.
-                                        type: string
-                                      to:
-                                        additionalProperties:
-                                          type: integer
-                                        description: Map of upstream localities to
-                                          traffic distribution weights.
-                                        type: object
-                                    type: object
-                                  type: array
-                                enabled:
-                                  description: enable locality load balancing, this
-                                    is DestinationRule-level and will override mesh
-                                    wide settings in entirety.
-                                  nullable: true
-                                  type: boolean
-                                failover:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating region.
-                                        type: string
-                                      to:
-                                        type: string
-                                    type: object
-                                  type: array
-                                failoverPriority:
-                                  description: failoverPriority is an ordered list
-                                    of labels used to sort endpoints to do priority
-                                    based load balancing.
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            simple:
-                              enum:
-                              - ROUND_ROBIN
-                              - LEAST_CONN
-                              - RANDOM
-                              - PASSTHROUGH
-                              type: string
-                          type: object
-                        outlierDetection:
-                          properties:
-                            baseEjectionTime:
-                              description: Minimum ejection duration.
-                              type: string
-                            consecutive5xxErrors:
-                              description: Number of 5xx errors before a host is ejected
-                                from the connection pool.
-                              nullable: true
-                              type: integer
-                            consecutiveErrors:
-                              format: int32
-                              type: integer
-                            consecutiveGatewayErrors:
-                              description: Number of gateway errors before a host
-                                is ejected from the connection pool.
-                              nullable: true
-                              type: integer
-                            consecutiveLocalOriginFailures:
-                              nullable: true
-                              type: integer
-                            interval:
-                              description: Time interval between ejection sweep analysis.
-                              type: string
-                            maxEjectionPercent:
-                              format: int32
-                              type: integer
-                            minHealthPercent:
-                              format: int32
-                              type: integer
-                            splitExternalLocalOriginErrors:
-                              description: Determines whether to distinguish local
-                                origin failures from external errors.
-                              type: boolean
-                          type: object
-                        portLevelSettings:
-                          description: Traffic policies specific to individual ports.
-                          items:
+                      trafficPolicy:
+                        description: Traffic policies that apply to this subset.
+                        properties:
+                          connectionPool:
                             properties:
-                              connectionPool:
+                              http:
+                                description: HTTP connection pool settings.
                                 properties:
-                                  http:
-                                    description: HTTP connection pool settings.
+                                  h2UpgradePolicy:
+                                    description: Specify if http1.1 connection should
+                                      be upgraded to http2 for the associated destination.
+                                    enum:
+                                      - DEFAULT
+                                      - DO_NOT_UPGRADE
+                                      - UPGRADE
+                                    type: string
+                                  http1MaxPendingRequests:
+                                    format: int32
+                                    type: integer
+                                  http2MaxRequests:
+                                    description: Maximum number of active requests to
+                                      a destination.
+                                    format: int32
+                                    type: integer
+                                  idleTimeout:
+                                    description: The idle timeout for upstream connection
+                                      pool connections.
+                                    type: string
+                                  maxRequestsPerConnection:
+                                    description: Maximum number of requests per connection
+                                      to a backend.
+                                    format: int32
+                                    type: integer
+                                  maxRetries:
+                                    format: int32
+                                    type: integer
+                                  useClientProtocol:
+                                    description: If set to true, client protocol will
+                                      be preserved while initiating connection to backend.
+                                    type: boolean
+                                type: object
+                              tcp:
+                                description: Settings common to both HTTP and TCP upstream
+                                  connections.
+                                properties:
+                                  connectTimeout:
+                                    description: TCP connection timeout.
+                                    type: string
+                                  maxConnectionDuration:
+                                    description: The maximum duration of a connection.
+                                    type: string
+                                  maxConnections:
+                                    description: Maximum number of HTTP1 /TCP connections
+                                      to a destination host.
+                                    format: int32
+                                    type: integer
+                                  tcpKeepalive:
+                                    description: If set then set SO_KEEPALIVE on the
+                                      socket to enable TCP Keepalives.
                                     properties:
-                                      h2UpgradePolicy:
-                                        description: Specify if http1.1 connection
-                                          should be upgraded to http2 for the associated
-                                          destination.
-                                        enum:
-                                        - DEFAULT
-                                        - DO_NOT_UPGRADE
-                                        - UPGRADE
+                                      interval:
+                                        description: The time duration between keep-alive
+                                          probes.
                                         type: string
-                                      http1MaxPendingRequests:
-                                        description: Maximum number of pending HTTP
-                                          requests to a destination.
-                                        format: int32
+                                      probes:
                                         type: integer
-                                      http2MaxRequests:
-                                        description: Maximum number of requests to
-                                          a backend.
-                                        format: int32
-                                        type: integer
-                                      idleTimeout:
-                                        description: The idle timeout for upstream
-                                          connection pool connections.
+                                      time:
                                         type: string
-                                      maxRequestsPerConnection:
-                                        description: Maximum number of requests per
-                                          connection to a backend.
-                                        format: int32
-                                        type: integer
-                                      maxRetries:
-                                        format: int32
-                                        type: integer
-                                      useClientProtocol:
-                                        description: If set to true, client protocol
-                                          will be preserved while initiating connection
-                                          to backend.
-                                        type: boolean
-                                    type: object
-                                  tcp:
-                                    description: Settings common to both HTTP and
-                                      TCP upstream connections.
-                                    properties:
-                                      connectTimeout:
-                                        description: TCP connection timeout.
-                                        type: string
-                                      maxConnections:
-                                        description: Maximum number of HTTP1 /TCP
-                                          connections to a destination host.
-                                        format: int32
-                                        type: integer
-                                      tcpKeepalive:
-                                        description: If set then set SO_KEEPALIVE
-                                          on the socket to enable TCP Keepalives.
-                                        properties:
-                                          interval:
-                                            description: The time duration between
-                                              keep-alive probes.
-                                            type: string
-                                          probes:
-                                            type: integer
-                                          time:
-                                            type: string
-                                        type: object
                                     type: object
                                 type: object
-                              loadBalancer:
-                                description: Settings controlling the load balancer
-                                  algorithms.
-                                oneOf:
-                                - not:
-                                    anyOf:
+                            type: object
+                          loadBalancer:
+                            description: Settings controlling the load balancer algorithms.
+                            oneOf:
+                              - not:
+                                  anyOf:
                                     - required:
-                                      - simple
+                                        - simple
                                     - properties:
                                         consistentHash:
-                                          oneOf:
+                                          allOf:
+                                            - oneOf:
+                                                - not:
+                                                    anyOf:
+                                                      - required:
+                                                          - httpHeaderName
+                                                      - required:
+                                                          - httpCookie
+                                                      - required:
+                                                          - useSourceIp
+                                                      - required:
+                                                          - httpQueryParameterName
+                                                - required:
+                                                    - httpHeaderName
+                                                - required:
+                                                    - httpCookie
+                                                - required:
+                                                    - useSourceIp
+                                                - required:
+                                                    - httpQueryParameterName
+                                            - oneOf:
+                                                - not:
+                                                    anyOf:
+                                                      - required:
+                                                          - ringHash
+                                                      - required:
+                                                          - maglev
+                                                - required:
+                                                    - ringHash
+                                                - required:
+                                                    - maglev
+                                          properties:
+                                            minimumRingSize: {}
+                                      required:
+                                        - consistentHash
+                              - required:
+                                  - simple
+                              - properties:
+                                  consistentHash:
+                                    allOf:
+                                      - oneOf:
                                           - not:
                                               anyOf:
-                                              - required:
-                                                - httpHeaderName
-                                              - required:
-                                                - httpCookie
-                                              - required:
-                                                - useSourceIp
-                                              - required:
-                                                - httpQueryParameterName
+                                                - required:
+                                                    - httpHeaderName
+                                                - required:
+                                                    - httpCookie
+                                                - required:
+                                                    - useSourceIp
+                                                - required:
+                                                    - httpQueryParameterName
                                           - required:
-                                            - httpHeaderName
+                                              - httpHeaderName
                                           - required:
-                                            - httpCookie
+                                              - httpCookie
                                           - required:
-                                            - useSourceIp
+                                              - useSourceIp
                                           - required:
-                                            - httpQueryParameterName
-                                      required:
-                                      - consistentHash
-                                - required:
-                                  - simple
-                                - properties:
-                                    consistentHash:
-                                      oneOf:
-                                      - not:
-                                          anyOf:
+                                              - httpQueryParameterName
+                                      - oneOf:
+                                          - not:
+                                              anyOf:
+                                                - required:
+                                                    - ringHash
+                                                - required:
+                                                    - maglev
                                           - required:
-                                            - httpHeaderName
+                                              - ringHash
                                           - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                  required:
-                                  - consistentHash
-                                properties:
-                                  consistentHash:
+                                              - maglev
                                     properties:
-                                      httpCookie:
-                                        description: Hash based on HTTP cookie.
-                                        properties:
-                                          name:
-                                            description: Name of the cookie.
-                                            type: string
-                                          path:
-                                            description: Path to set for the cookie.
-                                            type: string
-                                          ttl:
-                                            description: Lifetime of the cookie.
-                                            type: string
-                                        type: object
-                                      httpHeaderName:
-                                        description: Hash based on a specific HTTP
-                                          header.
+                                      minimumRingSize: {}
+                                required:
+                                  - consistentHash
+                            properties:
+                              consistentHash:
+                                properties:
+                                  httpCookie:
+                                    description: Hash based on HTTP cookie.
+                                    properties:
+                                      name:
+                                        description: Name of the cookie.
                                         type: string
-                                      httpQueryParameterName:
-                                        description: Hash based on a specific HTTP
-                                          query parameter.
+                                      path:
+                                        description: Path to set for the cookie.
                                         type: string
+                                      ttl:
+                                        description: Lifetime of the cookie.
+                                        type: string
+                                    type: object
+                                  httpHeaderName:
+                                    description: Hash based on a specific HTTP header.
+                                    type: string
+                                  httpQueryParameterName:
+                                    description: Hash based on a specific HTTP query
+                                      parameter.
+                                    type: string
+                                  maglev:
+                                    description: The Maglev load balancer implements
+                                      consistent hashing to backend hosts.
+                                    properties:
+                                      tableSize:
+                                        description: The table size for Maglev hashing.
+                                        type: integer
+                                    type: object
+                                  minimumRingSize:
+                                    description: Deprecated.
+                                    type: integer
+                                  ringHash:
+                                    description: The ring/modulo hash load balancer
+                                      implements consistent hashing to backend hosts.
+                                    properties:
                                       minimumRingSize:
                                         type: integer
-                                      useSourceIp:
-                                        description: Hash based on the source IP address.
-                                        type: boolean
                                     type: object
-                                  localityLbSetting:
-                                    properties:
-                                      distribute:
-                                        description: 'Optional: only one of distribute,
-                                          failover or failoverPriority can be set.'
-                                        items:
-                                          properties:
-                                            from:
-                                              description: Originating locality, '/'
-                                                separated, e.g.
-                                              type: string
-                                            to:
-                                              additionalProperties:
-                                                type: integer
-                                              description: Map of upstream localities
-                                                to traffic distribution weights.
-                                              type: object
-                                          type: object
-                                        type: array
-                                      enabled:
-                                        description: enable locality load balancing,
-                                          this is DestinationRule-level and will override
-                                          mesh wide settings in entirety.
-                                        nullable: true
-                                        type: boolean
-                                      failover:
-                                        description: 'Optional: only one of distribute,
-                                          failover or failoverPriority can be set.'
-                                        items:
-                                          properties:
-                                            from:
-                                              description: Originating region.
-                                              type: string
-                                            to:
-                                              type: string
-                                          type: object
-                                        type: array
-                                      failoverPriority:
-                                        description: failoverPriority is an ordered
-                                          list of labels used to sort endpoints to
-                                          do priority based load balancing.
-                                        items:
+                                  useSourceIp:
+                                    description: Hash based on the source IP address.
+                                    type: boolean
+                                type: object
+                              localityLbSetting:
+                                properties:
+                                  distribute:
+                                    description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                    items:
+                                      properties:
+                                        from:
+                                          description: Originating locality, '/' separated,
+                                            e.g.
                                           type: string
-                                        type: array
-                                    type: object
-                                  simple:
-                                    enum:
-                                    - ROUND_ROBIN
-                                    - LEAST_CONN
-                                    - RANDOM
-                                    - PASSTHROUGH
-                                    type: string
-                                type: object
-                              outlierDetection:
-                                properties:
-                                  baseEjectionTime:
-                                    description: Minimum ejection duration.
-                                    type: string
-                                  consecutive5xxErrors:
-                                    description: Number of 5xx errors before a host
-                                      is ejected from the connection pool.
-                                    nullable: true
-                                    type: integer
-                                  consecutiveErrors:
-                                    format: int32
-                                    type: integer
-                                  consecutiveGatewayErrors:
-                                    description: Number of gateway errors before a
-                                      host is ejected from the connection pool.
-                                    nullable: true
-                                    type: integer
-                                  consecutiveLocalOriginFailures:
-                                    nullable: true
-                                    type: integer
-                                  interval:
-                                    description: Time interval between ejection sweep
-                                      analysis.
-                                    type: string
-                                  maxEjectionPercent:
-                                    format: int32
-                                    type: integer
-                                  minHealthPercent:
-                                    format: int32
-                                    type: integer
-                                  splitExternalLocalOriginErrors:
-                                    description: Determines whether to distinguish
-                                      local origin failures from external errors.
-                                    type: boolean
-                                type: object
-                              port:
-                                properties:
-                                  number:
-                                    type: integer
-                                type: object
-                              tls:
-                                description: TLS related settings for connections
-                                  to the upstream service.
-                                properties:
-                                  caCertificates:
-                                    type: string
-                                  clientCertificate:
-                                    description: REQUIRED if mode is `MUTUAL`.
-                                    type: string
-                                  credentialName:
-                                    type: string
-                                  insecureSkipVerify:
+                                        to:
+                                          additionalProperties:
+                                            type: integer
+                                          description: Map of upstream localities to
+                                            traffic distribution weights.
+                                          type: object
+                                      type: object
+                                    type: array
+                                  enabled:
+                                    description: enable locality load balancing, this
+                                      is DestinationRule-level and will override mesh
+                                      wide settings in entirety.
                                     nullable: true
                                     type: boolean
-                                  mode:
-                                    enum:
-                                    - DISABLE
-                                    - SIMPLE
-                                    - MUTUAL
-                                    - ISTIO_MUTUAL
-                                    type: string
-                                  privateKey:
-                                    description: REQUIRED if mode is `MUTUAL`.
-                                    type: string
-                                  sni:
-                                    description: SNI string to present to the server
-                                      during TLS handshake.
-                                    type: string
-                                  subjectAltNames:
+                                  failover:
+                                    description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                    items:
+                                      properties:
+                                        from:
+                                          description: Originating region.
+                                          type: string
+                                        to:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  failoverPriority:
+                                    description: failoverPriority is an ordered list
+                                      of labels used to sort endpoints to do priority
+                                      based load balancing.
                                     items:
                                       type: string
                                     type: array
                                 type: object
+                              simple:
+                                enum:
+                                  - UNSPECIFIED
+                                  - LEAST_CONN
+                                  - RANDOM
+                                  - PASSTHROUGH
+                                  - ROUND_ROBIN
+                                  - LEAST_REQUEST
+                                type: string
+                              warmupDurationSecs:
+                                description: Represents the warmup duration of Service.
+                                type: string
                             type: object
-                          type: array
-                        tls:
-                          description: TLS related settings for connections to the
-                            upstream service.
-                          properties:
-                            caCertificates:
-                              type: string
-                            clientCertificate:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            credentialName:
-                              type: string
-                            insecureSkipVerify:
-                              nullable: true
-                              type: boolean
-                            mode:
-                              enum:
-                              - DISABLE
-                              - SIMPLE
-                              - MUTUAL
-                              - ISTIO_MUTUAL
-                              type: string
-                            privateKey:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            sni:
-                              description: SNI string to present to the server during
-                                TLS handshake.
-                              type: string
-                            subjectAltNames:
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                      type: object
-                  type: object
-                type: array
-              trafficPolicy:
-                properties:
-                  connectionPool:
-                    properties:
-                      http:
-                        description: HTTP connection pool settings.
-                        properties:
-                          h2UpgradePolicy:
-                            description: Specify if http1.1 connection should be upgraded
-                              to http2 for the associated destination.
-                            enum:
-                            - DEFAULT
-                            - DO_NOT_UPGRADE
-                            - UPGRADE
-                            type: string
-                          http1MaxPendingRequests:
-                            description: Maximum number of pending HTTP requests to
-                              a destination.
-                            format: int32
-                            type: integer
-                          http2MaxRequests:
-                            description: Maximum number of requests to a backend.
-                            format: int32
-                            type: integer
-                          idleTimeout:
-                            description: The idle timeout for upstream connection
-                              pool connections.
-                            type: string
-                          maxRequestsPerConnection:
-                            description: Maximum number of requests per connection
-                              to a backend.
-                            format: int32
-                            type: integer
-                          maxRetries:
-                            format: int32
-                            type: integer
-                          useClientProtocol:
-                            description: If set to true, client protocol will be preserved
-                              while initiating connection to backend.
-                            type: boolean
-                        type: object
-                      tcp:
-                        description: Settings common to both HTTP and TCP upstream
-                          connections.
-                        properties:
-                          connectTimeout:
-                            description: TCP connection timeout.
-                            type: string
-                          maxConnections:
-                            description: Maximum number of HTTP1 /TCP connections
-                              to a destination host.
-                            format: int32
-                            type: integer
-                          tcpKeepalive:
-                            description: If set then set SO_KEEPALIVE on the socket
-                              to enable TCP Keepalives.
+                          outlierDetection:
                             properties:
-                              interval:
-                                description: The time duration between keep-alive
-                                  probes.
+                              baseEjectionTime:
+                                description: Minimum ejection duration.
                                 type: string
-                              probes:
+                              consecutive5xxErrors:
+                                description: Number of 5xx errors before a host is ejected
+                                  from the connection pool.
+                                nullable: true
                                 type: integer
-                              time:
+                              consecutiveErrors:
+                                format: int32
+                                type: integer
+                              consecutiveGatewayErrors:
+                                description: Number of gateway errors before a host
+                                  is ejected from the connection pool.
+                                nullable: true
+                                type: integer
+                              consecutiveLocalOriginFailures:
+                                nullable: true
+                                type: integer
+                              interval:
+                                description: Time interval between ejection sweep analysis.
                                 type: string
+                              maxEjectionPercent:
+                                format: int32
+                                type: integer
+                              minHealthPercent:
+                                format: int32
+                                type: integer
+                              splitExternalLocalOriginErrors:
+                                description: Determines whether to distinguish local
+                                  origin failures from external errors.
+                                type: boolean
                             type: object
-                        type: object
-                    type: object
-                  loadBalancer:
-                    description: Settings controlling the load balancer algorithms.
-                    oneOf:
-                    - not:
-                        anyOf:
-                        - required:
-                          - simple
-                        - properties:
-                            consistentHash:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                              - required:
-                                - httpHeaderName
-                              - required:
-                                - httpCookie
-                              - required:
-                                - useSourceIp
-                              - required:
-                                - httpQueryParameterName
-                          required:
-                          - consistentHash
-                    - required:
-                      - simple
-                    - properties:
-                        consistentHash:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - httpHeaderName
-                              - required:
-                                - httpCookie
-                              - required:
-                                - useSourceIp
-                              - required:
-                                - httpQueryParameterName
-                          - required:
-                            - httpHeaderName
-                          - required:
-                            - httpCookie
-                          - required:
-                            - useSourceIp
-                          - required:
-                            - httpQueryParameterName
-                      required:
-                      - consistentHash
-                    properties:
-                      consistentHash:
-                        properties:
-                          httpCookie:
-                            description: Hash based on HTTP cookie.
-                            properties:
-                              name:
-                                description: Name of the cookie.
-                                type: string
-                              path:
-                                description: Path to set for the cookie.
-                                type: string
-                              ttl:
-                                description: Lifetime of the cookie.
-                                type: string
-                            type: object
-                          httpHeaderName:
-                            description: Hash based on a specific HTTP header.
-                            type: string
-                          httpQueryParameterName:
-                            description: Hash based on a specific HTTP query parameter.
-                            type: string
-                          minimumRingSize:
-                            type: integer
-                          useSourceIp:
-                            description: Hash based on the source IP address.
-                            type: boolean
-                        type: object
-                      localityLbSetting:
-                        properties:
-                          distribute:
-                            description: 'Optional: only one of distribute, failover
-                              or failoverPriority can be set.'
+                          portLevelSettings:
+                            description: Traffic policies specific to individual ports.
                             items:
                               properties:
-                                from:
-                                  description: Originating locality, '/' separated,
-                                    e.g.
-                                  type: string
-                                to:
-                                  additionalProperties:
-                                    type: integer
-                                  description: Map of upstream localities to traffic
-                                    distribution weights.
-                                  type: object
-                              type: object
-                            type: array
-                          enabled:
-                            description: enable locality load balancing, this is DestinationRule-level
-                              and will override mesh wide settings in entirety.
-                            nullable: true
-                            type: boolean
-                          failover:
-                            description: 'Optional: only one of distribute, failover
-                              or failoverPriority can be set.'
-                            items:
-                              properties:
-                                from:
-                                  description: Originating region.
-                                  type: string
-                                to:
-                                  type: string
-                              type: object
-                            type: array
-                          failoverPriority:
-                            description: failoverPriority is an ordered list of labels
-                              used to sort endpoints to do priority based load balancing.
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      simple:
-                        enum:
-                        - ROUND_ROBIN
-                        - LEAST_CONN
-                        - RANDOM
-                        - PASSTHROUGH
-                        type: string
-                    type: object
-                  outlierDetection:
-                    properties:
-                      baseEjectionTime:
-                        description: Minimum ejection duration.
-                        type: string
-                      consecutive5xxErrors:
-                        description: Number of 5xx errors before a host is ejected
-                          from the connection pool.
-                        nullable: true
-                        type: integer
-                      consecutiveErrors:
-                        format: int32
-                        type: integer
-                      consecutiveGatewayErrors:
-                        description: Number of gateway errors before a host is ejected
-                          from the connection pool.
-                        nullable: true
-                        type: integer
-                      consecutiveLocalOriginFailures:
-                        nullable: true
-                        type: integer
-                      interval:
-                        description: Time interval between ejection sweep analysis.
-                        type: string
-                      maxEjectionPercent:
-                        format: int32
-                        type: integer
-                      minHealthPercent:
-                        format: int32
-                        type: integer
-                      splitExternalLocalOriginErrors:
-                        description: Determines whether to distinguish local origin
-                          failures from external errors.
-                        type: boolean
-                    type: object
-                  portLevelSettings:
-                    description: Traffic policies specific to individual ports.
-                    items:
-                      properties:
-                        connectionPool:
-                          properties:
-                            http:
-                              description: HTTP connection pool settings.
-                              properties:
-                                h2UpgradePolicy:
-                                  description: Specify if http1.1 connection should
-                                    be upgraded to http2 for the associated destination.
-                                  enum:
-                                  - DEFAULT
-                                  - DO_NOT_UPGRADE
-                                  - UPGRADE
-                                  type: string
-                                http1MaxPendingRequests:
-                                  description: Maximum number of pending HTTP requests
-                                    to a destination.
-                                  format: int32
-                                  type: integer
-                                http2MaxRequests:
-                                  description: Maximum number of requests to a backend.
-                                  format: int32
-                                  type: integer
-                                idleTimeout:
-                                  description: The idle timeout for upstream connection
-                                    pool connections.
-                                  type: string
-                                maxRequestsPerConnection:
-                                  description: Maximum number of requests per connection
-                                    to a backend.
-                                  format: int32
-                                  type: integer
-                                maxRetries:
-                                  format: int32
-                                  type: integer
-                                useClientProtocol:
-                                  description: If set to true, client protocol will
-                                    be preserved while initiating connection to backend.
-                                  type: boolean
-                              type: object
-                            tcp:
-                              description: Settings common to both HTTP and TCP upstream
-                                connections.
-                              properties:
-                                connectTimeout:
-                                  description: TCP connection timeout.
-                                  type: string
-                                maxConnections:
-                                  description: Maximum number of HTTP1 /TCP connections
-                                    to a destination host.
-                                  format: int32
-                                  type: integer
-                                tcpKeepalive:
-                                  description: If set then set SO_KEEPALIVE on the
-                                    socket to enable TCP Keepalives.
+                                connectionPool:
                                   properties:
-                                    interval:
-                                      description: The time duration between keep-alive
-                                        probes.
-                                      type: string
-                                    probes:
-                                      type: integer
-                                    time:
-                                      type: string
+                                    http:
+                                      description: HTTP connection pool settings.
+                                      properties:
+                                        h2UpgradePolicy:
+                                          description: Specify if http1.1 connection
+                                            should be upgraded to http2 for the associated
+                                            destination.
+                                          enum:
+                                            - DEFAULT
+                                            - DO_NOT_UPGRADE
+                                            - UPGRADE
+                                          type: string
+                                        http1MaxPendingRequests:
+                                          format: int32
+                                          type: integer
+                                        http2MaxRequests:
+                                          description: Maximum number of active requests
+                                            to a destination.
+                                          format: int32
+                                          type: integer
+                                        idleTimeout:
+                                          description: The idle timeout for upstream
+                                            connection pool connections.
+                                          type: string
+                                        maxRequestsPerConnection:
+                                          description: Maximum number of requests per
+                                            connection to a backend.
+                                          format: int32
+                                          type: integer
+                                        maxRetries:
+                                          format: int32
+                                          type: integer
+                                        useClientProtocol:
+                                          description: If set to true, client protocol
+                                            will be preserved while initiating connection
+                                            to backend.
+                                          type: boolean
+                                      type: object
+                                    tcp:
+                                      description: Settings common to both HTTP and
+                                        TCP upstream connections.
+                                      properties:
+                                        connectTimeout:
+                                          description: TCP connection timeout.
+                                          type: string
+                                        maxConnectionDuration:
+                                          description: The maximum duration of a connection.
+                                          type: string
+                                        maxConnections:
+                                          description: Maximum number of HTTP1 /TCP
+                                            connections to a destination host.
+                                          format: int32
+                                          type: integer
+                                        tcpKeepalive:
+                                          description: If set then set SO_KEEPALIVE
+                                            on the socket to enable TCP Keepalives.
+                                          properties:
+                                            interval:
+                                              description: The time duration between
+                                                keep-alive probes.
+                                              type: string
+                                            probes:
+                                              type: integer
+                                            time:
+                                              type: string
+                                          type: object
+                                      type: object
                                   type: object
-                              type: object
-                          type: object
-                        loadBalancer:
-                          description: Settings controlling the load balancer algorithms.
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - simple
-                              - properties:
-                                  consistentHash:
-                                    oneOf:
+                                loadBalancer:
+                                  description: Settings controlling the load balancer
+                                    algorithms.
+                                  oneOf:
                                     - not:
                                         anyOf:
-                                        - required:
-                                          - httpHeaderName
-                                        - required:
-                                          - httpCookie
-                                        - required:
-                                          - useSourceIp
-                                        - required:
-                                          - httpQueryParameterName
+                                          - required:
+                                              - simple
+                                          - properties:
+                                              consistentHash:
+                                                allOf:
+                                                  - oneOf:
+                                                      - not:
+                                                          anyOf:
+                                                            - required:
+                                                                - httpHeaderName
+                                                            - required:
+                                                                - httpCookie
+                                                            - required:
+                                                                - useSourceIp
+                                                            - required:
+                                                                - httpQueryParameterName
+                                                      - required:
+                                                          - httpHeaderName
+                                                      - required:
+                                                          - httpCookie
+                                                      - required:
+                                                          - useSourceIp
+                                                      - required:
+                                                          - httpQueryParameterName
+                                                  - oneOf:
+                                                      - not:
+                                                          anyOf:
+                                                            - required:
+                                                                - ringHash
+                                                            - required:
+                                                                - maglev
+                                                      - required:
+                                                          - ringHash
+                                                      - required:
+                                                          - maglev
+                                                properties:
+                                                  minimumRingSize: {}
+                                            required:
+                                              - consistentHash
                                     - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                required:
-                                - consistentHash
-                          - required:
-                            - simple
-                          - properties:
-                              consistentHash:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                            required:
-                            - consistentHash
-                          properties:
-                            consistentHash:
-                              properties:
-                                httpCookie:
-                                  description: Hash based on HTTP cookie.
+                                        - simple
+                                    - properties:
+                                        consistentHash:
+                                          allOf:
+                                            - oneOf:
+                                                - not:
+                                                    anyOf:
+                                                      - required:
+                                                          - httpHeaderName
+                                                      - required:
+                                                          - httpCookie
+                                                      - required:
+                                                          - useSourceIp
+                                                      - required:
+                                                          - httpQueryParameterName
+                                                - required:
+                                                    - httpHeaderName
+                                                - required:
+                                                    - httpCookie
+                                                - required:
+                                                    - useSourceIp
+                                                - required:
+                                                    - httpQueryParameterName
+                                            - oneOf:
+                                                - not:
+                                                    anyOf:
+                                                      - required:
+                                                          - ringHash
+                                                      - required:
+                                                          - maglev
+                                                - required:
+                                                    - ringHash
+                                                - required:
+                                                    - maglev
+                                          properties:
+                                            minimumRingSize: {}
+                                      required:
+                                        - consistentHash
                                   properties:
-                                    name:
-                                      description: Name of the cookie.
+                                    consistentHash:
+                                      properties:
+                                        httpCookie:
+                                          description: Hash based on HTTP cookie.
+                                          properties:
+                                            name:
+                                              description: Name of the cookie.
+                                              type: string
+                                            path:
+                                              description: Path to set for the cookie.
+                                              type: string
+                                            ttl:
+                                              description: Lifetime of the cookie.
+                                              type: string
+                                          type: object
+                                        httpHeaderName:
+                                          description: Hash based on a specific HTTP
+                                            header.
+                                          type: string
+                                        httpQueryParameterName:
+                                          description: Hash based on a specific HTTP
+                                            query parameter.
+                                          type: string
+                                        maglev:
+                                          description: The Maglev load balancer implements
+                                            consistent hashing to backend hosts.
+                                          properties:
+                                            tableSize:
+                                              description: The table size for Maglev
+                                                hashing.
+                                              type: integer
+                                          type: object
+                                        minimumRingSize:
+                                          description: Deprecated.
+                                          type: integer
+                                        ringHash:
+                                          description: The ring/modulo hash load balancer
+                                            implements consistent hashing to backend
+                                            hosts.
+                                          properties:
+                                            minimumRingSize:
+                                              type: integer
+                                          type: object
+                                        useSourceIp:
+                                          description: Hash based on the source IP address.
+                                          type: boolean
+                                      type: object
+                                    localityLbSetting:
+                                      properties:
+                                        distribute:
+                                          description: 'Optional: only one of distribute,
+                                          failover or failoverPriority can be set.'
+                                          items:
+                                            properties:
+                                              from:
+                                                description: Originating locality, '/'
+                                                  separated, e.g.
+                                                type: string
+                                              to:
+                                                additionalProperties:
+                                                  type: integer
+                                                description: Map of upstream localities
+                                                  to traffic distribution weights.
+                                                type: object
+                                            type: object
+                                          type: array
+                                        enabled:
+                                          description: enable locality load balancing,
+                                            this is DestinationRule-level and will override
+                                            mesh wide settings in entirety.
+                                          nullable: true
+                                          type: boolean
+                                        failover:
+                                          description: 'Optional: only one of distribute,
+                                          failover or failoverPriority can be set.'
+                                          items:
+                                            properties:
+                                              from:
+                                                description: Originating region.
+                                                type: string
+                                              to:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        failoverPriority:
+                                          description: failoverPriority is an ordered
+                                            list of labels used to sort endpoints to
+                                            do priority based load balancing.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    simple:
+                                      enum:
+                                        - UNSPECIFIED
+                                        - LEAST_CONN
+                                        - RANDOM
+                                        - PASSTHROUGH
+                                        - ROUND_ROBIN
+                                        - LEAST_REQUEST
                                       type: string
-                                    path:
-                                      description: Path to set for the cookie.
-                                      type: string
-                                    ttl:
-                                      description: Lifetime of the cookie.
+                                    warmupDurationSecs:
+                                      description: Represents the warmup duration of
+                                        Service.
                                       type: string
                                   type: object
-                                httpHeaderName:
-                                  description: Hash based on a specific HTTP header.
+                                outlierDetection:
+                                  properties:
+                                    baseEjectionTime:
+                                      description: Minimum ejection duration.
+                                      type: string
+                                    consecutive5xxErrors:
+                                      description: Number of 5xx errors before a host
+                                        is ejected from the connection pool.
+                                      nullable: true
+                                      type: integer
+                                    consecutiveErrors:
+                                      format: int32
+                                      type: integer
+                                    consecutiveGatewayErrors:
+                                      description: Number of gateway errors before a
+                                        host is ejected from the connection pool.
+                                      nullable: true
+                                      type: integer
+                                    consecutiveLocalOriginFailures:
+                                      nullable: true
+                                      type: integer
+                                    interval:
+                                      description: Time interval between ejection sweep
+                                        analysis.
+                                      type: string
+                                    maxEjectionPercent:
+                                      format: int32
+                                      type: integer
+                                    minHealthPercent:
+                                      format: int32
+                                      type: integer
+                                    splitExternalLocalOriginErrors:
+                                      description: Determines whether to distinguish
+                                        local origin failures from external errors.
+                                      type: boolean
+                                  type: object
+                                port:
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                tls:
+                                  description: TLS related settings for connections
+                                    to the upstream service.
+                                  properties:
+                                    caCertificates:
+                                      type: string
+                                    clientCertificate:
+                                      description: REQUIRED if mode is `MUTUAL`.
+                                      type: string
+                                    credentialName:
+                                      type: string
+                                    insecureSkipVerify:
+                                      nullable: true
+                                      type: boolean
+                                    mode:
+                                      enum:
+                                        - DISABLE
+                                        - SIMPLE
+                                        - MUTUAL
+                                        - ISTIO_MUTUAL
+                                      type: string
+                                    privateKey:
+                                      description: REQUIRED if mode is `MUTUAL`.
+                                      type: string
+                                    sni:
+                                      description: SNI string to present to the server
+                                        during TLS handshake.
+                                      type: string
+                                    subjectAltNames:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                              type: object
+                            type: array
+                          tls:
+                            description: TLS related settings for connections to the
+                              upstream service.
+                            properties:
+                              caCertificates:
+                                type: string
+                              clientCertificate:
+                                description: REQUIRED if mode is `MUTUAL`.
+                                type: string
+                              credentialName:
+                                type: string
+                              insecureSkipVerify:
+                                nullable: true
+                                type: boolean
+                              mode:
+                                enum:
+                                  - DISABLE
+                                  - SIMPLE
+                                  - MUTUAL
+                                  - ISTIO_MUTUAL
+                                type: string
+                              privateKey:
+                                description: REQUIRED if mode is `MUTUAL`.
+                                type: string
+                              sni:
+                                description: SNI string to present to the server during
+                                  TLS handshake.
+                                type: string
+                              subjectAltNames:
+                                items:
                                   type: string
-                                httpQueryParameterName:
-                                  description: Hash based on a specific HTTP query
-                                    parameter.
+                                type: array
+                            type: object
+                          tunnel:
+                            properties:
+                              protocol:
+                                description: Specifies which protocol to use for tunneling
+                                  the downstream connection.
+                                type: string
+                              targetHost:
+                                description: Specifies a host to which the downstream
+                                  connection is tunneled.
+                                type: string
+                              targetPort:
+                                description: Specifies a port to which the downstream
+                                  connection is tunneled.
+                                type: integer
+                            type: object
+                        type: object
+                    type: object
+                  type: array
+                trafficPolicy:
+                  properties:
+                    connectionPool:
+                      properties:
+                        http:
+                          description: HTTP connection pool settings.
+                          properties:
+                            h2UpgradePolicy:
+                              description: Specify if http1.1 connection should be upgraded
+                                to http2 for the associated destination.
+                              enum:
+                                - DEFAULT
+                                - DO_NOT_UPGRADE
+                                - UPGRADE
+                              type: string
+                            http1MaxPendingRequests:
+                              format: int32
+                              type: integer
+                            http2MaxRequests:
+                              description: Maximum number of active requests to a destination.
+                              format: int32
+                              type: integer
+                            idleTimeout:
+                              description: The idle timeout for upstream connection
+                                pool connections.
+                              type: string
+                            maxRequestsPerConnection:
+                              description: Maximum number of requests per connection
+                                to a backend.
+                              format: int32
+                              type: integer
+                            maxRetries:
+                              format: int32
+                              type: integer
+                            useClientProtocol:
+                              description: If set to true, client protocol will be preserved
+                                while initiating connection to backend.
+                              type: boolean
+                          type: object
+                        tcp:
+                          description: Settings common to both HTTP and TCP upstream
+                            connections.
+                          properties:
+                            connectTimeout:
+                              description: TCP connection timeout.
+                              type: string
+                            maxConnectionDuration:
+                              description: The maximum duration of a connection.
+                              type: string
+                            maxConnections:
+                              description: Maximum number of HTTP1 /TCP connections
+                                to a destination host.
+                              format: int32
+                              type: integer
+                            tcpKeepalive:
+                              description: If set then set SO_KEEPALIVE on the socket
+                                to enable TCP Keepalives.
+                              properties:
+                                interval:
+                                  description: The time duration between keep-alive
+                                    probes.
                                   type: string
+                                probes:
+                                  type: integer
+                                time:
+                                  type: string
+                              type: object
+                          type: object
+                      type: object
+                    loadBalancer:
+                      description: Settings controlling the load balancer algorithms.
+                      oneOf:
+                        - not:
+                            anyOf:
+                              - required:
+                                  - simple
+                              - properties:
+                                  consistentHash:
+                                    allOf:
+                                      - oneOf:
+                                          - not:
+                                              anyOf:
+                                                - required:
+                                                    - httpHeaderName
+                                                - required:
+                                                    - httpCookie
+                                                - required:
+                                                    - useSourceIp
+                                                - required:
+                                                    - httpQueryParameterName
+                                          - required:
+                                              - httpHeaderName
+                                          - required:
+                                              - httpCookie
+                                          - required:
+                                              - useSourceIp
+                                          - required:
+                                              - httpQueryParameterName
+                                      - oneOf:
+                                          - not:
+                                              anyOf:
+                                                - required:
+                                                    - ringHash
+                                                - required:
+                                                    - maglev
+                                          - required:
+                                              - ringHash
+                                          - required:
+                                              - maglev
+                                    properties:
+                                      minimumRingSize: {}
+                                required:
+                                  - consistentHash
+                        - required:
+                            - simple
+                        - properties:
+                            consistentHash:
+                              allOf:
+                                - oneOf:
+                                    - not:
+                                        anyOf:
+                                          - required:
+                                              - httpHeaderName
+                                          - required:
+                                              - httpCookie
+                                          - required:
+                                              - useSourceIp
+                                          - required:
+                                              - httpQueryParameterName
+                                    - required:
+                                        - httpHeaderName
+                                    - required:
+                                        - httpCookie
+                                    - required:
+                                        - useSourceIp
+                                    - required:
+                                        - httpQueryParameterName
+                                - oneOf:
+                                    - not:
+                                        anyOf:
+                                          - required:
+                                              - ringHash
+                                          - required:
+                                              - maglev
+                                    - required:
+                                        - ringHash
+                                    - required:
+                                        - maglev
+                              properties:
+                                minimumRingSize: {}
+                          required:
+                            - consistentHash
+                      properties:
+                        consistentHash:
+                          properties:
+                            httpCookie:
+                              description: Hash based on HTTP cookie.
+                              properties:
+                                name:
+                                  description: Name of the cookie.
+                                  type: string
+                                path:
+                                  description: Path to set for the cookie.
+                                  type: string
+                                ttl:
+                                  description: Lifetime of the cookie.
+                                  type: string
+                              type: object
+                            httpHeaderName:
+                              description: Hash based on a specific HTTP header.
+                              type: string
+                            httpQueryParameterName:
+                              description: Hash based on a specific HTTP query parameter.
+                              type: string
+                            maglev:
+                              description: The Maglev load balancer implements consistent
+                                hashing to backend hosts.
+                              properties:
+                                tableSize:
+                                  description: The table size for Maglev hashing.
+                                  type: integer
+                              type: object
+                            minimumRingSize:
+                              description: Deprecated.
+                              type: integer
+                            ringHash:
+                              description: The ring/modulo hash load balancer implements
+                                consistent hashing to backend hosts.
+                              properties:
                                 minimumRingSize:
                                   type: integer
-                                useSourceIp:
-                                  description: Hash based on the source IP address.
-                                  type: boolean
                               type: object
-                            localityLbSetting:
-                              properties:
-                                distribute:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating locality, '/' separated,
-                                          e.g.
-                                        type: string
-                                      to:
-                                        additionalProperties:
-                                          type: integer
-                                        description: Map of upstream localities to
-                                          traffic distribution weights.
-                                        type: object
-                                    type: object
-                                  type: array
-                                enabled:
-                                  description: enable locality load balancing, this
-                                    is DestinationRule-level and will override mesh
-                                    wide settings in entirety.
-                                  nullable: true
-                                  type: boolean
-                                failover:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating region.
-                                        type: string
-                                      to:
-                                        type: string
-                                    type: object
-                                  type: array
-                                failoverPriority:
-                                  description: failoverPriority is an ordered list
-                                    of labels used to sort endpoints to do priority
-                                    based load balancing.
-                                  items:
+                            useSourceIp:
+                              description: Hash based on the source IP address.
+                              type: boolean
+                          type: object
+                        localityLbSetting:
+                          properties:
+                            distribute:
+                              description: 'Optional: only one of distribute, failover
+                              or failoverPriority can be set.'
+                              items:
+                                properties:
+                                  from:
+                                    description: Originating locality, '/' separated,
+                                      e.g.
                                     type: string
-                                  type: array
-                              type: object
-                            simple:
-                              enum:
-                              - ROUND_ROBIN
-                              - LEAST_CONN
-                              - RANDOM
-                              - PASSTHROUGH
-                              type: string
-                          type: object
-                        outlierDetection:
-                          properties:
-                            baseEjectionTime:
-                              description: Minimum ejection duration.
-                              type: string
-                            consecutive5xxErrors:
-                              description: Number of 5xx errors before a host is ejected
-                                from the connection pool.
-                              nullable: true
-                              type: integer
-                            consecutiveErrors:
-                              format: int32
-                              type: integer
-                            consecutiveGatewayErrors:
-                              description: Number of gateway errors before a host
-                                is ejected from the connection pool.
-                              nullable: true
-                              type: integer
-                            consecutiveLocalOriginFailures:
-                              nullable: true
-                              type: integer
-                            interval:
-                              description: Time interval between ejection sweep analysis.
-                              type: string
-                            maxEjectionPercent:
-                              format: int32
-                              type: integer
-                            minHealthPercent:
-                              format: int32
-                              type: integer
-                            splitExternalLocalOriginErrors:
-                              description: Determines whether to distinguish local
-                                origin failures from external errors.
-                              type: boolean
-                          type: object
-                        port:
-                          properties:
-                            number:
-                              type: integer
-                          type: object
-                        tls:
-                          description: TLS related settings for connections to the
-                            upstream service.
-                          properties:
-                            caCertificates:
-                              type: string
-                            clientCertificate:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            credentialName:
-                              type: string
-                            insecureSkipVerify:
+                                  to:
+                                    additionalProperties:
+                                      type: integer
+                                    description: Map of upstream localities to traffic
+                                      distribution weights.
+                                    type: object
+                                type: object
+                              type: array
+                            enabled:
+                              description: enable locality load balancing, this is DestinationRule-level
+                                and will override mesh wide settings in entirety.
                               nullable: true
                               type: boolean
-                            mode:
-                              enum:
-                              - DISABLE
-                              - SIMPLE
-                              - MUTUAL
-                              - ISTIO_MUTUAL
-                              type: string
-                            privateKey:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            sni:
-                              description: SNI string to present to the server during
-                                TLS handshake.
-                              type: string
-                            subjectAltNames:
+                            failover:
+                              description: 'Optional: only one of distribute, failover
+                              or failoverPriority can be set.'
+                              items:
+                                properties:
+                                  from:
+                                    description: Originating region.
+                                    type: string
+                                  to:
+                                    type: string
+                                type: object
+                              type: array
+                            failoverPriority:
+                              description: failoverPriority is an ordered list of labels
+                                used to sort endpoints to do priority based load balancing.
                               items:
                                 type: string
                               type: array
                           type: object
-                      type: object
-                    type: array
-                  tls:
-                    description: TLS related settings for connections to the upstream
-                      service.
-                    properties:
-                      caCertificates:
-                        type: string
-                      clientCertificate:
-                        description: REQUIRED if mode is `MUTUAL`.
-                        type: string
-                      credentialName:
-                        type: string
-                      insecureSkipVerify:
-                        nullable: true
-                        type: boolean
-                      mode:
-                        enum:
-                        - DISABLE
-                        - SIMPLE
-                        - MUTUAL
-                        - ISTIO_MUTUAL
-                        type: string
-                      privateKey:
-                        description: REQUIRED if mode is `MUTUAL`.
-                        type: string
-                      sni:
-                        description: SNI string to present to the server during TLS
-                          handshake.
-                        type: string
-                      subjectAltNames:
-                        items:
+                        simple:
+                          enum:
+                            - UNSPECIFIED
+                            - LEAST_CONN
+                            - RANDOM
+                            - PASSTHROUGH
+                            - ROUND_ROBIN
+                            - LEAST_REQUEST
                           type: string
-                        type: array
-                    type: object
-                type: object
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
+                        warmupDurationSecs:
+                          description: Represents the warmup duration of Service.
+                          type: string
+                      type: object
+                    outlierDetection:
+                      properties:
+                        baseEjectionTime:
+                          description: Minimum ejection duration.
+                          type: string
+                        consecutive5xxErrors:
+                          description: Number of 5xx errors before a host is ejected
+                            from the connection pool.
+                          nullable: true
+                          type: integer
+                        consecutiveErrors:
+                          format: int32
+                          type: integer
+                        consecutiveGatewayErrors:
+                          description: Number of gateway errors before a host is ejected
+                            from the connection pool.
+                          nullable: true
+                          type: integer
+                        consecutiveLocalOriginFailures:
+                          nullable: true
+                          type: integer
+                        interval:
+                          description: Time interval between ejection sweep analysis.
+                          type: string
+                        maxEjectionPercent:
+                          format: int32
+                          type: integer
+                        minHealthPercent:
+                          format: int32
+                          type: integer
+                        splitExternalLocalOriginErrors:
+                          description: Determines whether to distinguish local origin
+                            failures from external errors.
+                          type: boolean
+                      type: object
+                    portLevelSettings:
+                      description: Traffic policies specific to individual ports.
+                      items:
+                        properties:
+                          connectionPool:
+                            properties:
+                              http:
+                                description: HTTP connection pool settings.
+                                properties:
+                                  h2UpgradePolicy:
+                                    description: Specify if http1.1 connection should
+                                      be upgraded to http2 for the associated destination.
+                                    enum:
+                                      - DEFAULT
+                                      - DO_NOT_UPGRADE
+                                      - UPGRADE
+                                    type: string
+                                  http1MaxPendingRequests:
+                                    format: int32
+                                    type: integer
+                                  http2MaxRequests:
+                                    description: Maximum number of active requests to
+                                      a destination.
+                                    format: int32
+                                    type: integer
+                                  idleTimeout:
+                                    description: The idle timeout for upstream connection
+                                      pool connections.
+                                    type: string
+                                  maxRequestsPerConnection:
+                                    description: Maximum number of requests per connection
+                                      to a backend.
+                                    format: int32
+                                    type: integer
+                                  maxRetries:
+                                    format: int32
+                                    type: integer
+                                  useClientProtocol:
+                                    description: If set to true, client protocol will
+                                      be preserved while initiating connection to backend.
+                                    type: boolean
+                                type: object
+                              tcp:
+                                description: Settings common to both HTTP and TCP upstream
+                                  connections.
+                                properties:
+                                  connectTimeout:
+                                    description: TCP connection timeout.
+                                    type: string
+                                  maxConnectionDuration:
+                                    description: The maximum duration of a connection.
+                                    type: string
+                                  maxConnections:
+                                    description: Maximum number of HTTP1 /TCP connections
+                                      to a destination host.
+                                    format: int32
+                                    type: integer
+                                  tcpKeepalive:
+                                    description: If set then set SO_KEEPALIVE on the
+                                      socket to enable TCP Keepalives.
+                                    properties:
+                                      interval:
+                                        description: The time duration between keep-alive
+                                          probes.
+                                        type: string
+                                      probes:
+                                        type: integer
+                                      time:
+                                        type: string
+                                    type: object
+                                type: object
+                            type: object
+                          loadBalancer:
+                            description: Settings controlling the load balancer algorithms.
+                            oneOf:
+                              - not:
+                                  anyOf:
+                                    - required:
+                                        - simple
+                                    - properties:
+                                        consistentHash:
+                                          allOf:
+                                            - oneOf:
+                                                - not:
+                                                    anyOf:
+                                                      - required:
+                                                          - httpHeaderName
+                                                      - required:
+                                                          - httpCookie
+                                                      - required:
+                                                          - useSourceIp
+                                                      - required:
+                                                          - httpQueryParameterName
+                                                - required:
+                                                    - httpHeaderName
+                                                - required:
+                                                    - httpCookie
+                                                - required:
+                                                    - useSourceIp
+                                                - required:
+                                                    - httpQueryParameterName
+                                            - oneOf:
+                                                - not:
+                                                    anyOf:
+                                                      - required:
+                                                          - ringHash
+                                                      - required:
+                                                          - maglev
+                                                - required:
+                                                    - ringHash
+                                                - required:
+                                                    - maglev
+                                          properties:
+                                            minimumRingSize: {}
+                                      required:
+                                        - consistentHash
+                              - required:
+                                  - simple
+                              - properties:
+                                  consistentHash:
+                                    allOf:
+                                      - oneOf:
+                                          - not:
+                                              anyOf:
+                                                - required:
+                                                    - httpHeaderName
+                                                - required:
+                                                    - httpCookie
+                                                - required:
+                                                    - useSourceIp
+                                                - required:
+                                                    - httpQueryParameterName
+                                          - required:
+                                              - httpHeaderName
+                                          - required:
+                                              - httpCookie
+                                          - required:
+                                              - useSourceIp
+                                          - required:
+                                              - httpQueryParameterName
+                                      - oneOf:
+                                          - not:
+                                              anyOf:
+                                                - required:
+                                                    - ringHash
+                                                - required:
+                                                    - maglev
+                                          - required:
+                                              - ringHash
+                                          - required:
+                                              - maglev
+                                    properties:
+                                      minimumRingSize: {}
+                                required:
+                                  - consistentHash
+                            properties:
+                              consistentHash:
+                                properties:
+                                  httpCookie:
+                                    description: Hash based on HTTP cookie.
+                                    properties:
+                                      name:
+                                        description: Name of the cookie.
+                                        type: string
+                                      path:
+                                        description: Path to set for the cookie.
+                                        type: string
+                                      ttl:
+                                        description: Lifetime of the cookie.
+                                        type: string
+                                    type: object
+                                  httpHeaderName:
+                                    description: Hash based on a specific HTTP header.
+                                    type: string
+                                  httpQueryParameterName:
+                                    description: Hash based on a specific HTTP query
+                                      parameter.
+                                    type: string
+                                  maglev:
+                                    description: The Maglev load balancer implements
+                                      consistent hashing to backend hosts.
+                                    properties:
+                                      tableSize:
+                                        description: The table size for Maglev hashing.
+                                        type: integer
+                                    type: object
+                                  minimumRingSize:
+                                    description: Deprecated.
+                                    type: integer
+                                  ringHash:
+                                    description: The ring/modulo hash load balancer
+                                      implements consistent hashing to backend hosts.
+                                    properties:
+                                      minimumRingSize:
+                                        type: integer
+                                    type: object
+                                  useSourceIp:
+                                    description: Hash based on the source IP address.
+                                    type: boolean
+                                type: object
+                              localityLbSetting:
+                                properties:
+                                  distribute:
+                                    description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                    items:
+                                      properties:
+                                        from:
+                                          description: Originating locality, '/' separated,
+                                            e.g.
+                                          type: string
+                                        to:
+                                          additionalProperties:
+                                            type: integer
+                                          description: Map of upstream localities to
+                                            traffic distribution weights.
+                                          type: object
+                                      type: object
+                                    type: array
+                                  enabled:
+                                    description: enable locality load balancing, this
+                                      is DestinationRule-level and will override mesh
+                                      wide settings in entirety.
+                                    nullable: true
+                                    type: boolean
+                                  failover:
+                                    description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                    items:
+                                      properties:
+                                        from:
+                                          description: Originating region.
+                                          type: string
+                                        to:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  failoverPriority:
+                                    description: failoverPriority is an ordered list
+                                      of labels used to sort endpoints to do priority
+                                      based load balancing.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              simple:
+                                enum:
+                                  - UNSPECIFIED
+                                  - LEAST_CONN
+                                  - RANDOM
+                                  - PASSTHROUGH
+                                  - ROUND_ROBIN
+                                  - LEAST_REQUEST
+                                type: string
+                              warmupDurationSecs:
+                                description: Represents the warmup duration of Service.
+                                type: string
+                            type: object
+                          outlierDetection:
+                            properties:
+                              baseEjectionTime:
+                                description: Minimum ejection duration.
+                                type: string
+                              consecutive5xxErrors:
+                                description: Number of 5xx errors before a host is ejected
+                                  from the connection pool.
+                                nullable: true
+                                type: integer
+                              consecutiveErrors:
+                                format: int32
+                                type: integer
+                              consecutiveGatewayErrors:
+                                description: Number of gateway errors before a host
+                                  is ejected from the connection pool.
+                                nullable: true
+                                type: integer
+                              consecutiveLocalOriginFailures:
+                                nullable: true
+                                type: integer
+                              interval:
+                                description: Time interval between ejection sweep analysis.
+                                type: string
+                              maxEjectionPercent:
+                                format: int32
+                                type: integer
+                              minHealthPercent:
+                                format: int32
+                                type: integer
+                              splitExternalLocalOriginErrors:
+                                description: Determines whether to distinguish local
+                                  origin failures from external errors.
+                                type: boolean
+                            type: object
+                          port:
+                            properties:
+                              number:
+                                type: integer
+                            type: object
+                          tls:
+                            description: TLS related settings for connections to the
+                              upstream service.
+                            properties:
+                              caCertificates:
+                                type: string
+                              clientCertificate:
+                                description: REQUIRED if mode is `MUTUAL`.
+                                type: string
+                              credentialName:
+                                type: string
+                              insecureSkipVerify:
+                                nullable: true
+                                type: boolean
+                              mode:
+                                enum:
+                                  - DISABLE
+                                  - SIMPLE
+                                  - MUTUAL
+                                  - ISTIO_MUTUAL
+                                type: string
+                              privateKey:
+                                description: REQUIRED if mode is `MUTUAL`.
+                                type: string
+                              sni:
+                                description: SNI string to present to the server during
+                                  TLS handshake.
+                                type: string
+                              subjectAltNames:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      type: array
+                    tls:
+                      description: TLS related settings for connections to the upstream
+                        service.
+                      properties:
+                        caCertificates:
+                          type: string
+                        clientCertificate:
+                          description: REQUIRED if mode is `MUTUAL`.
+                          type: string
+                        credentialName:
+                          type: string
+                        insecureSkipVerify:
+                          nullable: true
+                          type: boolean
+                        mode:
+                          enum:
+                            - DISABLE
+                            - SIMPLE
+                            - MUTUAL
+                            - ISTIO_MUTUAL
+                          type: string
+                        privateKey:
+                          description: REQUIRED if mode is `MUTUAL`.
+                          type: string
+                        sni:
+                          description: SNI string to present to the server during TLS
+                            handshake.
+                          type: string
+                        subjectAltNames:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    tunnel:
+                      properties:
+                        protocol:
+                          description: Specifies which protocol to use for tunneling
+                            the downstream connection.
+                          type: string
+                        targetHost:
+                          description: Specifies a host to which the downstream connection
+                            is tunneled.
+                          type: string
+                        targetPort:
+                          description: Specifies a port to which the downstream connection
+                            is tunneled.
+                          type: integer
+                      type: object
+                  type: object
+                workloadSelector:
+                  properties:
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -2472,228 +2999,232 @@ spec:
   group: networking.istio.io
   names:
     categories:
-    - istio-io
-    - networking-istio-io
+      - istio-io
+      - networking-istio-io
     kind: EnvoyFilter
     listKind: EnvoyFilterList
     plural: envoyfilters
     singular: envoyfilter
   scope: Namespaced
   versions:
-  - name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Customizing Envoy configuration generated by Istio. See
+    - name: v1alpha3
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Customizing Envoy configuration generated by Istio. See
               more details at: https://istio.io/docs/reference/config/networking/envoy-filter.html'
-            properties:
-              configPatches:
-                description: One or more patches with match conditions.
-                items:
-                  properties:
-                    applyTo:
-                      enum:
-                      - INVALID
-                      - LISTENER
-                      - FILTER_CHAIN
-                      - NETWORK_FILTER
-                      - HTTP_FILTER
-                      - ROUTE_CONFIGURATION
-                      - VIRTUAL_HOST
-                      - HTTP_ROUTE
-                      - CLUSTER
-                      - EXTENSION_CONFIG
-                      - BOOTSTRAP
-                      type: string
-                    match:
-                      description: Match on listener/route configuration/cluster.
-                      oneOf:
-                      - not:
-                          anyOf:
-                          - required:
-                            - listener
-                          - required:
-                            - routeConfiguration
-                          - required:
-                            - cluster
-                      - required:
-                        - listener
-                      - required:
-                        - routeConfiguration
-                      - required:
-                        - cluster
-                      properties:
-                        cluster:
-                          description: Match on envoy cluster attributes.
-                          properties:
-                            name:
-                              description: The exact name of the cluster to match.
-                              type: string
-                            portNumber:
-                              description: The service port for which this cluster
-                                was generated.
-                              type: integer
-                            service:
-                              description: The fully qualified service name for this
-                                cluster.
-                              type: string
-                            subset:
-                              description: The subset associated with the service.
-                              type: string
-                          type: object
-                        context:
-                          description: The specific config generation context to match
-                            on.
-                          enum:
-                          - ANY
-                          - SIDECAR_INBOUND
-                          - SIDECAR_OUTBOUND
-                          - GATEWAY
-                          type: string
-                        listener:
-                          description: Match on envoy listener attributes.
-                          properties:
-                            filterChain:
-                              description: Match a specific filter chain in a listener.
-                              properties:
-                                applicationProtocols:
-                                  description: Applies only to sidecars.
-                                  type: string
-                                destinationPort:
-                                  description: The destination_port value used by
-                                    a filter chain's match condition.
-                                  type: integer
-                                filter:
-                                  description: The name of a specific filter to apply
-                                    the patch to.
-                                  properties:
-                                    name:
-                                      description: The filter name to match on.
-                                      type: string
-                                    subFilter:
-                                      properties:
-                                        name:
-                                          description: The filter name to match on.
-                                          type: string
-                                      type: object
-                                  type: object
-                                name:
-                                  description: The name assigned to the filter chain.
-                                  type: string
-                                sni:
-                                  description: The SNI value used by a filter chain's
-                                    match condition.
-                                  type: string
-                                transportProtocol:
-                                  description: Applies only to `SIDECAR_INBOUND` context.
-                                  type: string
-                              type: object
-                            name:
-                              description: Match a specific listener by its name.
-                              type: string
-                            portName:
-                              type: string
-                            portNumber:
-                              type: integer
-                          type: object
-                        proxy:
-                          description: Match on properties associated with a proxy.
-                          properties:
-                            metadata:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            proxyVersion:
-                              type: string
-                          type: object
-                        routeConfiguration:
-                          description: Match on envoy HTTP route configuration attributes.
-                          properties:
-                            gateway:
-                              type: string
-                            name:
-                              description: Route configuration name to match on.
-                              type: string
-                            portName:
-                              description: Applicable only for GATEWAY context.
-                              type: string
-                            portNumber:
-                              type: integer
-                            vhost:
-                              properties:
-                                name:
-                                  type: string
-                                route:
-                                  description: Match a specific route within the virtual
-                                    host.
-                                  properties:
-                                    action:
-                                      description: Match a route with specific action
-                                        type.
-                                      enum:
-                                      - ANY
-                                      - ROUTE
-                                      - REDIRECT
-                                      - DIRECT_RESPONSE
-                                      type: string
-                                    name:
-                                      type: string
-                                  type: object
-                              type: object
-                          type: object
-                      type: object
-                    patch:
-                      description: The patch to apply along with the operation.
-                      properties:
-                        filterClass:
-                          description: Determines the filter insertion order.
-                          enum:
-                          - UNSPECIFIED
-                          - AUTHN
-                          - AUTHZ
-                          - STATS
-                          type: string
-                        operation:
-                          description: Determines how the patch should be applied.
-                          enum:
+              properties:
+                configPatches:
+                  description: One or more patches with match conditions.
+                  items:
+                    properties:
+                      applyTo:
+                        enum:
                           - INVALID
-                          - MERGE
-                          - ADD
-                          - REMOVE
-                          - INSERT_BEFORE
-                          - INSERT_AFTER
-                          - INSERT_FIRST
-                          - REPLACE
-                          type: string
-                        value:
-                          description: The JSON config of the object being patched.
-                          type: object
-                          x-kubernetes-preserve-unknown-fields: true
+                          - LISTENER
+                          - FILTER_CHAIN
+                          - NETWORK_FILTER
+                          - HTTP_FILTER
+                          - ROUTE_CONFIGURATION
+                          - VIRTUAL_HOST
+                          - HTTP_ROUTE
+                          - CLUSTER
+                          - EXTENSION_CONFIG
+                          - BOOTSTRAP
+                          - LISTENER_FILTER
+                        type: string
+                      match:
+                        description: Match on listener/route configuration/cluster.
+                        oneOf:
+                          - not:
+                              anyOf:
+                                - required:
+                                    - listener
+                                - required:
+                                    - routeConfiguration
+                                - required:
+                                    - cluster
+                          - required:
+                              - listener
+                          - required:
+                              - routeConfiguration
+                          - required:
+                              - cluster
+                        properties:
+                          cluster:
+                            description: Match on envoy cluster attributes.
+                            properties:
+                              name:
+                                description: The exact name of the cluster to match.
+                                type: string
+                              portNumber:
+                                description: The service port for which this cluster
+                                  was generated.
+                                type: integer
+                              service:
+                                description: The fully qualified service name for this
+                                  cluster.
+                                type: string
+                              subset:
+                                description: The subset associated with the service.
+                                type: string
+                            type: object
+                          context:
+                            description: The specific config generation context to match
+                              on.
+                            enum:
+                              - ANY
+                              - SIDECAR_INBOUND
+                              - SIDECAR_OUTBOUND
+                              - GATEWAY
+                            type: string
+                          listener:
+                            description: Match on envoy listener attributes.
+                            properties:
+                              filterChain:
+                                description: Match a specific filter chain in a listener.
+                                properties:
+                                  applicationProtocols:
+                                    description: Applies only to sidecars.
+                                    type: string
+                                  destinationPort:
+                                    description: The destination_port value used by
+                                      a filter chain's match condition.
+                                    type: integer
+                                  filter:
+                                    description: The name of a specific filter to apply
+                                      the patch to.
+                                    properties:
+                                      name:
+                                        description: The filter name to match on.
+                                        type: string
+                                      subFilter:
+                                        properties:
+                                          name:
+                                            description: The filter name to match on.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  name:
+                                    description: The name assigned to the filter chain.
+                                    type: string
+                                  sni:
+                                    description: The SNI value used by a filter chain's
+                                      match condition.
+                                    type: string
+                                  transportProtocol:
+                                    description: Applies only to `SIDECAR_INBOUND` context.
+                                    type: string
+                                type: object
+                              listenerFilter:
+                                description: Match a specific listener filter.
+                                type: string
+                              name:
+                                description: Match a specific listener by its name.
+                                type: string
+                              portName:
+                                type: string
+                              portNumber:
+                                type: integer
+                            type: object
+                          proxy:
+                            description: Match on properties associated with a proxy.
+                            properties:
+                              metadata:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              proxyVersion:
+                                type: string
+                            type: object
+                          routeConfiguration:
+                            description: Match on envoy HTTP route configuration attributes.
+                            properties:
+                              gateway:
+                                type: string
+                              name:
+                                description: Route configuration name to match on.
+                                type: string
+                              portName:
+                                description: Applicable only for GATEWAY context.
+                                type: string
+                              portNumber:
+                                type: integer
+                              vhost:
+                                properties:
+                                  name:
+                                    type: string
+                                  route:
+                                    description: Match a specific route within the virtual
+                                      host.
+                                    properties:
+                                      action:
+                                        description: Match a route with specific action
+                                          type.
+                                        enum:
+                                          - ANY
+                                          - ROUTE
+                                          - REDIRECT
+                                          - DIRECT_RESPONSE
+                                        type: string
+                                      name:
+                                        type: string
+                                    type: object
+                                type: object
+                            type: object
+                        type: object
+                      patch:
+                        description: The patch to apply along with the operation.
+                        properties:
+                          filterClass:
+                            description: Determines the filter insertion order.
+                            enum:
+                              - UNSPECIFIED
+                              - AUTHN
+                              - AUTHZ
+                              - STATS
+                            type: string
+                          operation:
+                            description: Determines how the patch should be applied.
+                            enum:
+                              - INVALID
+                              - MERGE
+                              - ADD
+                              - REMOVE
+                              - INSERT_BEFORE
+                              - INSERT_AFTER
+                              - INSERT_FIRST
+                              - REPLACE
+                            type: string
+                          value:
+                            description: The JSON config of the object being patched.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                    type: object
+                  type: array
+                priority:
+                  description: Priority defines the order in which patch sets are applied
+                    within a context.
+                  format: int32
+                  type: integer
+                workloadSelector:
+                  properties:
+                    labels:
+                      additionalProperties:
+                        type: string
                       type: object
                   type: object
-                type: array
-              priority:
-                description: Priority defines the order in which patch sets are applied
-                  within a context.
-                format: int32
-                type: integer
-              workloadSelector:
-                properties:
-                  labels:
-                    additionalProperties:
-                      type: string
-                    type: object
-                type: object
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -2711,248 +3242,314 @@ spec:
   group: networking.istio.io
   names:
     categories:
-    - istio-io
-    - networking-istio-io
+      - istio-io
+      - networking-istio-io
     kind: Gateway
     listKind: GatewayList
     plural: gateways
     shortNames:
-    - gw
+      - gw
     singular: gateway
   scope: Namespaced
   versions:
-  - name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting edge load balancer. See more details
+    - name: v1alpha3
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Configuration affecting edge load balancer. See more details
               at: https://istio.io/docs/reference/config/networking/gateway.html'
-            properties:
-              selector:
-                additionalProperties:
-                  type: string
-                type: object
-              servers:
-                description: A list of server specifications.
-                items:
-                  properties:
-                    bind:
-                      type: string
-                    defaultEndpoint:
-                      type: string
-                    hosts:
-                      description: One or more hosts exposed by this gateway.
-                      items:
+              properties:
+                selector:
+                  additionalProperties:
+                    type: string
+                  type: object
+                servers:
+                  description: A list of server specifications.
+                  items:
+                    properties:
+                      bind:
                         type: string
-                      type: array
-                    name:
-                      description: An optional name of the server, when set must be
-                        unique across all servers.
-                      type: string
-                    port:
-                      properties:
-                        name:
-                          description: Label assigned to the port.
+                      defaultEndpoint:
+                        type: string
+                      hosts:
+                        description: One or more hosts exposed by this gateway.
+                        items:
                           type: string
-                        number:
-                          description: A valid non-negative integer port number.
-                          type: integer
-                        protocol:
-                          description: The protocol exposed on the port.
-                          type: string
-                        targetPort:
-                          type: integer
-                      type: object
-                    tls:
-                      description: Set of TLS related options that govern the server's
-                        behavior.
-                      properties:
-                        caCertificates:
-                          description: REQUIRED if mode is `MUTUAL`.
-                          type: string
-                        cipherSuites:
-                          description: 'Optional: If specified, only support the specified
+                        type: array
+                      name:
+                        description: An optional name of the server, when set must be
+                          unique across all servers.
+                        type: string
+                      port:
+                        properties:
+                          name:
+                            description: Label assigned to the port.
+                            type: string
+                          number:
+                            description: A valid non-negative integer port number.
+                            type: integer
+                          protocol:
+                            description: The protocol exposed on the port.
+                            type: string
+                          targetPort:
+                            type: integer
+                        type: object
+                      tls:
+                        description: Set of TLS related options that govern the server's
+                          behavior.
+                        properties:
+                          caCertificates:
+                            description: REQUIRED if mode is `MUTUAL`.
+                            type: string
+                          cipherSuites:
+                            description: 'Optional: If specified, only support the specified
                             cipher list.'
-                          items:
+                            items:
+                              type: string
+                            type: array
+                          credentialName:
                             type: string
-                          type: array
-                        credentialName:
-                          type: string
-                        httpsRedirect:
-                          type: boolean
-                        maxProtocolVersion:
-                          description: 'Optional: Maximum TLS protocol version.'
-                          enum:
-                          - TLS_AUTO
-                          - TLSV1_0
-                          - TLSV1_1
-                          - TLSV1_2
-                          - TLSV1_3
-                          type: string
-                        minProtocolVersion:
-                          description: 'Optional: Minimum TLS protocol version.'
-                          enum:
-                          - TLS_AUTO
-                          - TLSV1_0
-                          - TLSV1_1
-                          - TLSV1_2
-                          - TLSV1_3
-                          type: string
-                        mode:
-                          enum:
-                          - PASSTHROUGH
-                          - SIMPLE
-                          - MUTUAL
-                          - AUTO_PASSTHROUGH
-                          - ISTIO_MUTUAL
-                          type: string
-                        privateKey:
-                          description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
-                          type: string
-                        serverCertificate:
-                          description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
-                          type: string
-                        subjectAltNames:
-                          items:
+                          httpsRedirect:
+                            type: boolean
+                          maxProtocolVersion:
+                            description: 'Optional: Maximum TLS protocol version.'
+                            enum:
+                              - TLS_AUTO
+                              - TLSV1_0
+                              - TLSV1_1
+                              - TLSV1_2
+                              - TLSV1_3
                             type: string
-                          type: array
-                        verifyCertificateHash:
-                          items:
+                          minProtocolVersion:
+                            description: 'Optional: Minimum TLS protocol version.'
+                            enum:
+                              - TLS_AUTO
+                              - TLSV1_0
+                              - TLSV1_1
+                              - TLSV1_2
+                              - TLSV1_3
                             type: string
-                          type: array
-                        verifyCertificateSpki:
-                          items:
+                          mode:
+                            enum:
+                              - PASSTHROUGH
+                              - SIMPLE
+                              - MUTUAL
+                              - AUTO_PASSTHROUGH
+                              - ISTIO_MUTUAL
                             type: string
-                          type: array
+                          privateKey:
+                            description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                            type: string
+                          serverCertificate:
+                            description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                            type: string
+                          subjectAltNames:
+                            items:
+                              type: string
+                            type: array
+                          verifyCertificateHash:
+                            items:
+                              type: string
+                            type: array
+                          verifyCertificateSpki:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                  type: array
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Configuration affecting edge load balancer. See more details
+              at: https://istio.io/docs/reference/config/networking/gateway.html'
+              properties:
+                selector:
+                  additionalProperties:
+                    type: string
+                  type: object
+                servers:
+                  description: A list of server specifications.
+                  items:
+                    properties:
+                      bind:
+                        type: string
+                      defaultEndpoint:
+                        type: string
+                      hosts:
+                        description: One or more hosts exposed by this gateway.
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: An optional name of the server, when set must be
+                          unique across all servers.
+                        type: string
+                      port:
+                        properties:
+                          name:
+                            description: Label assigned to the port.
+                            type: string
+                          number:
+                            description: A valid non-negative integer port number.
+                            type: integer
+                          protocol:
+                            description: The protocol exposed on the port.
+                            type: string
+                          targetPort:
+                            type: integer
+                        type: object
+                      tls:
+                        description: Set of TLS related options that govern the server's
+                          behavior.
+                        properties:
+                          caCertificates:
+                            description: REQUIRED if mode is `MUTUAL`.
+                            type: string
+                          cipherSuites:
+                            description: 'Optional: If specified, only support the specified
+                            cipher list.'
+                            items:
+                              type: string
+                            type: array
+                          credentialName:
+                            type: string
+                          httpsRedirect:
+                            type: boolean
+                          maxProtocolVersion:
+                            description: 'Optional: Maximum TLS protocol version.'
+                            enum:
+                              - TLS_AUTO
+                              - TLSV1_0
+                              - TLSV1_1
+                              - TLSV1_2
+                              - TLSV1_3
+                            type: string
+                          minProtocolVersion:
+                            description: 'Optional: Minimum TLS protocol version.'
+                            enum:
+                              - TLS_AUTO
+                              - TLSV1_0
+                              - TLSV1_1
+                              - TLSV1_2
+                              - TLSV1_3
+                            type: string
+                          mode:
+                            enum:
+                              - PASSTHROUGH
+                              - SIMPLE
+                              - MUTUAL
+                              - AUTO_PASSTHROUGH
+                              - ISTIO_MUTUAL
+                            type: string
+                          privateKey:
+                            description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                            type: string
+                          serverCertificate:
+                            description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                            type: string
+                          subjectAltNames:
+                            items:
+                              type: string
+                            type: array
+                          verifyCertificateHash:
+                            items:
+                              type: string
+                            type: array
+                          verifyCertificateSpki:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                  type: array
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/resource-policy": keep
+  labels:
+    app: istio-pilot
+    chart: istio
+    heritage: Tiller
+    release: istio
+  name: proxyconfigs.networking.istio.io
+spec:
+  group: networking.istio.io
+  names:
+    categories:
+      - istio-io
+      - networking-istio-io
+    kind: ProxyConfig
+    listKind: ProxyConfigList
+    plural: proxyconfigs
+    singular: proxyconfig
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Provides configuration for individual workloads. See more
+              details at: https://istio.io/docs/reference/config/networking/proxy-config.html'
+              properties:
+                concurrency:
+                  description: The number of worker threads to run.
+                  nullable: true
+                  type: integer
+                environmentVariables:
+                  additionalProperties:
+                    type: string
+                  description: Additional environment variables for the proxy.
+                  type: object
+                image:
+                  description: Specifies the details of the proxy image.
+                  properties:
+                    imageType:
+                      description: The image type of the image.
+                      type: string
+                  type: object
+                selector:
+                  description: Optional.
+                  properties:
+                    matchLabels:
+                      additionalProperties:
+                        type: string
                       type: object
                   type: object
-                type: array
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-  - name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting edge load balancer. See more details
-              at: https://istio.io/docs/reference/config/networking/gateway.html'
-            properties:
-              selector:
-                additionalProperties:
-                  type: string
-                type: object
-              servers:
-                description: A list of server specifications.
-                items:
-                  properties:
-                    bind:
-                      type: string
-                    defaultEndpoint:
-                      type: string
-                    hosts:
-                      description: One or more hosts exposed by this gateway.
-                      items:
-                        type: string
-                      type: array
-                    name:
-                      description: An optional name of the server, when set must be
-                        unique across all servers.
-                      type: string
-                    port:
-                      properties:
-                        name:
-                          description: Label assigned to the port.
-                          type: string
-                        number:
-                          description: A valid non-negative integer port number.
-                          type: integer
-                        protocol:
-                          description: The protocol exposed on the port.
-                          type: string
-                        targetPort:
-                          type: integer
-                      type: object
-                    tls:
-                      description: Set of TLS related options that govern the server's
-                        behavior.
-                      properties:
-                        caCertificates:
-                          description: REQUIRED if mode is `MUTUAL`.
-                          type: string
-                        cipherSuites:
-                          description: 'Optional: If specified, only support the specified
-                            cipher list.'
-                          items:
-                            type: string
-                          type: array
-                        credentialName:
-                          type: string
-                        httpsRedirect:
-                          type: boolean
-                        maxProtocolVersion:
-                          description: 'Optional: Maximum TLS protocol version.'
-                          enum:
-                          - TLS_AUTO
-                          - TLSV1_0
-                          - TLSV1_1
-                          - TLSV1_2
-                          - TLSV1_3
-                          type: string
-                        minProtocolVersion:
-                          description: 'Optional: Minimum TLS protocol version.'
-                          enum:
-                          - TLS_AUTO
-                          - TLSV1_0
-                          - TLSV1_1
-                          - TLSV1_2
-                          - TLSV1_3
-                          type: string
-                        mode:
-                          enum:
-                          - PASSTHROUGH
-                          - SIMPLE
-                          - MUTUAL
-                          - AUTO_PASSTHROUGH
-                          - ISTIO_MUTUAL
-                          type: string
-                        privateKey:
-                          description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
-                          type: string
-                        serverCertificate:
-                          description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
-                          type: string
-                        subjectAltNames:
-                          items:
-                            type: string
-                          type: array
-                        verifyCertificateHash:
-                          items:
-                            type: string
-                          type: array
-                        verifyCertificateSpki:
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                  type: object
-                type: array
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -2970,264 +3567,264 @@ spec:
   group: networking.istio.io
   names:
     categories:
-    - istio-io
-    - networking-istio-io
+      - istio-io
+      - networking-istio-io
     kind: ServiceEntry
     listKind: ServiceEntryList
     plural: serviceentries
     shortNames:
-    - se
+      - se
     singular: serviceentry
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: The hosts associated with the ServiceEntry
-      jsonPath: .spec.hosts
-      name: Hosts
-      type: string
-    - description: Whether the service is external to the mesh or part of the mesh
-        (MESH_EXTERNAL or MESH_INTERNAL)
-      jsonPath: .spec.location
-      name: Location
-      type: string
-    - description: Service discovery mode for the hosts (NONE, STATIC, or DNS)
-      jsonPath: .spec.resolution
-      name: Resolution
-      type: string
-    - description: 'CreationTimestamp is a timestamp representing the server time
+    - additionalPrinterColumns:
+        - description: The hosts associated with the ServiceEntry
+          jsonPath: .spec.hosts
+          name: Hosts
+          type: string
+        - description: Whether the service is external to the mesh or part of the mesh
+            (MESH_EXTERNAL or MESH_INTERNAL)
+          jsonPath: .spec.location
+          name: Location
+          type: string
+        - description: Service resolution mode for the hosts (NONE, STATIC, or DNS)
+          jsonPath: .spec.resolution
+          name: Resolution
+          type: string
+        - description: 'CreationTimestamp is a timestamp representing the server time
         when this object was created. It is not guaranteed to be set in happens-before
         order across separate operations. Clients may not set this value. It is represented
         in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
         lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting service registry. See more details
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha3
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Configuration affecting service registry. See more details
               at: https://istio.io/docs/reference/config/networking/service-entry.html'
-            properties:
-              addresses:
-                description: The virtual IP addresses associated with the service.
-                items:
+              properties:
+                addresses:
+                  description: The virtual IP addresses associated with the service.
+                  items:
+                    type: string
+                  type: array
+                endpoints:
+                  description: One or more endpoints associated with the service.
+                  items:
+                    properties:
+                      address:
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: One or more labels associated with the endpoint.
+                        type: object
+                      locality:
+                        description: The locality associated with the endpoint.
+                        type: string
+                      network:
+                        type: string
+                      ports:
+                        additionalProperties:
+                          type: integer
+                        description: Set of ports associated with the endpoint.
+                        type: object
+                      serviceAccount:
+                        type: string
+                      weight:
+                        description: The load balancing weight associated with the endpoint.
+                        type: integer
+                    type: object
+                  type: array
+                exportTo:
+                  description: A list of namespaces to which this service is exported.
+                  items:
+                    type: string
+                  type: array
+                hosts:
+                  description: The hosts associated with the ServiceEntry.
+                  items:
+                    type: string
+                  type: array
+                location:
+                  enum:
+                    - MESH_EXTERNAL
+                    - MESH_INTERNAL
                   type: string
-                type: array
-              endpoints:
-                description: One or more endpoints associated with the service.
-                items:
+                ports:
+                  description: The ports associated with the external service.
+                  items:
+                    properties:
+                      name:
+                        description: Label assigned to the port.
+                        type: string
+                      number:
+                        description: A valid non-negative integer port number.
+                        type: integer
+                      protocol:
+                        description: The protocol exposed on the port.
+                        type: string
+                      targetPort:
+                        type: integer
+                    type: object
+                  type: array
+                resolution:
+                  description: Service resolution mode for the hosts.
+                  enum:
+                    - NONE
+                    - STATIC
+                    - DNS
+                    - DNS_ROUND_ROBIN
+                  type: string
+                subjectAltNames:
+                  items:
+                    type: string
+                  type: array
+                workloadSelector:
+                  description: Applicable only for MESH_INTERNAL services.
                   properties:
-                    address:
-                      type: string
                     labels:
                       additionalProperties:
                         type: string
-                      description: One or more labels associated with the endpoint.
                       type: object
-                    locality:
-                      description: The locality associated with the endpoint.
-                      type: string
-                    network:
-                      type: string
-                    ports:
-                      additionalProperties:
-                        type: integer
-                      description: Set of ports associated with the endpoint.
-                      type: object
-                    serviceAccount:
-                      type: string
-                    weight:
-                      description: The load balancing weight associated with the endpoint.
-                      type: integer
                   type: object
-                type: array
-              exportTo:
-                description: A list of namespaces to which this service is exported.
-                items:
-                  type: string
-                type: array
-              hosts:
-                description: The hosts associated with the ServiceEntry.
-                items:
-                  type: string
-                type: array
-              location:
-                enum:
-                - MESH_EXTERNAL
-                - MESH_INTERNAL
-                type: string
-              ports:
-                description: The ports associated with the external service.
-                items:
-                  properties:
-                    name:
-                      description: Label assigned to the port.
-                      type: string
-                    number:
-                      description: A valid non-negative integer port number.
-                      type: integer
-                    protocol:
-                      description: The protocol exposed on the port.
-                      type: string
-                    targetPort:
-                      type: integer
-                  type: object
-                type: array
-              resolution:
-                description: Service discovery mode for the hosts.
-                enum:
-                - NONE
-                - STATIC
-                - DNS
-                - DNS_ROUND_ROBIN
-                type: string
-              subjectAltNames:
-                items:
-                  type: string
-                type: array
-              workloadSelector:
-                description: Applicable only for MESH_INTERNAL services.
-                properties:
-                  labels:
-                    additionalProperties:
-                      type: string
-                    type: object
-                type: object
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - description: The hosts associated with the ServiceEntry
-      jsonPath: .spec.hosts
-      name: Hosts
-      type: string
-    - description: Whether the service is external to the mesh or part of the mesh
-        (MESH_EXTERNAL or MESH_INTERNAL)
-      jsonPath: .spec.location
-      name: Location
-      type: string
-    - description: Service discovery mode for the hosts (NONE, STATIC, or DNS)
-      jsonPath: .spec.resolution
-      name: Resolution
-      type: string
-    - description: 'CreationTimestamp is a timestamp representing the server time
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: The hosts associated with the ServiceEntry
+          jsonPath: .spec.hosts
+          name: Hosts
+          type: string
+        - description: Whether the service is external to the mesh or part of the mesh
+            (MESH_EXTERNAL or MESH_INTERNAL)
+          jsonPath: .spec.location
+          name: Location
+          type: string
+        - description: Service resolution mode for the hosts (NONE, STATIC, or DNS)
+          jsonPath: .spec.resolution
+          name: Resolution
+          type: string
+        - description: 'CreationTimestamp is a timestamp representing the server time
         when this object was created. It is not guaranteed to be set in happens-before
         order across separate operations. Clients may not set this value. It is represented
         in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
         lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting service registry. See more details
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Configuration affecting service registry. See more details
               at: https://istio.io/docs/reference/config/networking/service-entry.html'
-            properties:
-              addresses:
-                description: The virtual IP addresses associated with the service.
-                items:
+              properties:
+                addresses:
+                  description: The virtual IP addresses associated with the service.
+                  items:
+                    type: string
+                  type: array
+                endpoints:
+                  description: One or more endpoints associated with the service.
+                  items:
+                    properties:
+                      address:
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: One or more labels associated with the endpoint.
+                        type: object
+                      locality:
+                        description: The locality associated with the endpoint.
+                        type: string
+                      network:
+                        type: string
+                      ports:
+                        additionalProperties:
+                          type: integer
+                        description: Set of ports associated with the endpoint.
+                        type: object
+                      serviceAccount:
+                        type: string
+                      weight:
+                        description: The load balancing weight associated with the endpoint.
+                        type: integer
+                    type: object
+                  type: array
+                exportTo:
+                  description: A list of namespaces to which this service is exported.
+                  items:
+                    type: string
+                  type: array
+                hosts:
+                  description: The hosts associated with the ServiceEntry.
+                  items:
+                    type: string
+                  type: array
+                location:
+                  enum:
+                    - MESH_EXTERNAL
+                    - MESH_INTERNAL
                   type: string
-                type: array
-              endpoints:
-                description: One or more endpoints associated with the service.
-                items:
+                ports:
+                  description: The ports associated with the external service.
+                  items:
+                    properties:
+                      name:
+                        description: Label assigned to the port.
+                        type: string
+                      number:
+                        description: A valid non-negative integer port number.
+                        type: integer
+                      protocol:
+                        description: The protocol exposed on the port.
+                        type: string
+                      targetPort:
+                        type: integer
+                    type: object
+                  type: array
+                resolution:
+                  description: Service resolution mode for the hosts.
+                  enum:
+                    - NONE
+                    - STATIC
+                    - DNS
+                    - DNS_ROUND_ROBIN
+                  type: string
+                subjectAltNames:
+                  items:
+                    type: string
+                  type: array
+                workloadSelector:
+                  description: Applicable only for MESH_INTERNAL services.
                   properties:
-                    address:
-                      type: string
                     labels:
                       additionalProperties:
                         type: string
-                      description: One or more labels associated with the endpoint.
                       type: object
-                    locality:
-                      description: The locality associated with the endpoint.
-                      type: string
-                    network:
-                      type: string
-                    ports:
-                      additionalProperties:
-                        type: integer
-                      description: Set of ports associated with the endpoint.
-                      type: object
-                    serviceAccount:
-                      type: string
-                    weight:
-                      description: The load balancing weight associated with the endpoint.
-                      type: integer
                   type: object
-                type: array
-              exportTo:
-                description: A list of namespaces to which this service is exported.
-                items:
-                  type: string
-                type: array
-              hosts:
-                description: The hosts associated with the ServiceEntry.
-                items:
-                  type: string
-                type: array
-              location:
-                enum:
-                - MESH_EXTERNAL
-                - MESH_INTERNAL
-                type: string
-              ports:
-                description: The ports associated with the external service.
-                items:
-                  properties:
-                    name:
-                      description: Label assigned to the port.
-                      type: string
-                    number:
-                      description: A valid non-negative integer port number.
-                      type: integer
-                    protocol:
-                      description: The protocol exposed on the port.
-                      type: string
-                    targetPort:
-                      type: integer
-                  type: object
-                type: array
-              resolution:
-                description: Service discovery mode for the hosts.
-                enum:
-                - NONE
-                - STATIC
-                - DNS
-                - DNS_ROUND_ROBIN
-                type: string
-              subjectAltNames:
-                items:
-                  type: string
-                type: array
-              workloadSelector:
-                description: Applicable only for MESH_INTERNAL services.
-                properties:
-                  labels:
-                    additionalProperties:
-                      type: string
-                    type: object
-                type: object
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -3245,238 +3842,360 @@ spec:
   group: networking.istio.io
   names:
     categories:
-    - istio-io
-    - networking-istio-io
+      - istio-io
+      - networking-istio-io
     kind: Sidecar
     listKind: SidecarList
     plural: sidecars
     singular: sidecar
   scope: Namespaced
   versions:
-  - name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting network reachability of a sidecar.
+    - name: v1alpha3
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Configuration affecting network reachability of a sidecar.
               See more details at: https://istio.io/docs/reference/config/networking/sidecar.html'
-            properties:
-              egress:
-                items:
-                  properties:
-                    bind:
-                      type: string
-                    captureMode:
-                      enum:
-                      - DEFAULT
-                      - IPTABLES
-                      - NONE
-                      type: string
-                    hosts:
-                      items:
-                        type: string
-                      type: array
-                    port:
-                      description: The port associated with the listener.
-                      properties:
-                        name:
-                          description: Label assigned to the port.
-                          type: string
-                        number:
-                          description: A valid non-negative integer port number.
-                          type: integer
-                        protocol:
-                          description: The protocol exposed on the port.
-                          type: string
-                        targetPort:
-                          type: integer
-                      type: object
-                  type: object
-                type: array
-              ingress:
-                items:
-                  properties:
-                    bind:
-                      description: The IP to which the listener should be bound.
-                      type: string
-                    captureMode:
-                      enum:
-                      - DEFAULT
-                      - IPTABLES
-                      - NONE
-                      type: string
-                    defaultEndpoint:
-                      type: string
-                    port:
-                      description: The port associated with the listener.
-                      properties:
-                        name:
-                          description: Label assigned to the port.
-                          type: string
-                        number:
-                          description: A valid non-negative integer port number.
-                          type: integer
-                        protocol:
-                          description: The protocol exposed on the port.
-                          type: string
-                        targetPort:
-                          type: integer
-                      type: object
-                  type: object
-                type: array
-              outboundTrafficPolicy:
-                description: Configuration for the outbound traffic policy.
-                properties:
-                  egressProxy:
+              properties:
+                egress:
+                  items:
                     properties:
-                      host:
-                        description: The name of a service from the service registry.
+                      bind:
                         type: string
+                      captureMode:
+                        enum:
+                          - DEFAULT
+                          - IPTABLES
+                          - NONE
+                        type: string
+                      hosts:
+                        items:
+                          type: string
+                        type: array
                       port:
-                        description: Specifies the port on the host that is being
-                          addressed.
+                        description: The port associated with the listener.
                         properties:
+                          name:
+                            description: Label assigned to the port.
+                            type: string
                           number:
+                            description: A valid non-negative integer port number.
+                            type: integer
+                          protocol:
+                            description: The protocol exposed on the port.
+                            type: string
+                          targetPort:
                             type: integer
                         type: object
-                      subset:
-                        description: The name of a subset within the service.
-                        type: string
                     type: object
-                  mode:
-                    enum:
-                    - REGISTRY_ONLY
-                    - ALLOW_ANY
-                    type: string
-                type: object
-              workloadSelector:
-                properties:
-                  labels:
-                    additionalProperties:
-                      type: string
-                    type: object
-                type: object
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-  - name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting network reachability of a sidecar.
-              See more details at: https://istio.io/docs/reference/config/networking/sidecar.html'
-            properties:
-              egress:
-                items:
-                  properties:
-                    bind:
-                      type: string
-                    captureMode:
-                      enum:
-                      - DEFAULT
-                      - IPTABLES
-                      - NONE
-                      type: string
-                    hosts:
-                      items:
-                        type: string
-                      type: array
-                    port:
-                      description: The port associated with the listener.
-                      properties:
-                        name:
-                          description: Label assigned to the port.
-                          type: string
-                        number:
-                          description: A valid non-negative integer port number.
-                          type: integer
-                        protocol:
-                          description: The protocol exposed on the port.
-                          type: string
-                        targetPort:
-                          type: integer
-                      type: object
-                  type: object
-                type: array
-              ingress:
-                items:
-                  properties:
-                    bind:
-                      description: The IP to which the listener should be bound.
-                      type: string
-                    captureMode:
-                      enum:
-                      - DEFAULT
-                      - IPTABLES
-                      - NONE
-                      type: string
-                    defaultEndpoint:
-                      type: string
-                    port:
-                      description: The port associated with the listener.
-                      properties:
-                        name:
-                          description: Label assigned to the port.
-                          type: string
-                        number:
-                          description: A valid non-negative integer port number.
-                          type: integer
-                        protocol:
-                          description: The protocol exposed on the port.
-                          type: string
-                        targetPort:
-                          type: integer
-                      type: object
-                  type: object
-                type: array
-              outboundTrafficPolicy:
-                description: Configuration for the outbound traffic policy.
-                properties:
-                  egressProxy:
+                  type: array
+                ingress:
+                  items:
                     properties:
-                      host:
-                        description: The name of a service from the service registry.
+                      bind:
+                        description: The IP(IPv4 or IPv6) to which the listener should
+                          be bound.
+                        type: string
+                      captureMode:
+                        enum:
+                          - DEFAULT
+                          - IPTABLES
+                          - NONE
+                        type: string
+                      defaultEndpoint:
                         type: string
                       port:
-                        description: Specifies the port on the host that is being
-                          addressed.
+                        description: The port associated with the listener.
                         properties:
+                          name:
+                            description: Label assigned to the port.
+                            type: string
                           number:
+                            description: A valid non-negative integer port number.
+                            type: integer
+                          protocol:
+                            description: The protocol exposed on the port.
+                            type: string
+                          targetPort:
                             type: integer
                         type: object
-                      subset:
-                        description: The name of a subset within the service.
-                        type: string
+                      tls:
+                        properties:
+                          caCertificates:
+                            description: REQUIRED if mode is `MUTUAL`.
+                            type: string
+                          cipherSuites:
+                            description: 'Optional: If specified, only support the specified
+                            cipher list.'
+                            items:
+                              type: string
+                            type: array
+                          credentialName:
+                            type: string
+                          httpsRedirect:
+                            type: boolean
+                          maxProtocolVersion:
+                            description: 'Optional: Maximum TLS protocol version.'
+                            enum:
+                              - TLS_AUTO
+                              - TLSV1_0
+                              - TLSV1_1
+                              - TLSV1_2
+                              - TLSV1_3
+                            type: string
+                          minProtocolVersion:
+                            description: 'Optional: Minimum TLS protocol version.'
+                            enum:
+                              - TLS_AUTO
+                              - TLSV1_0
+                              - TLSV1_1
+                              - TLSV1_2
+                              - TLSV1_3
+                            type: string
+                          mode:
+                            enum:
+                              - PASSTHROUGH
+                              - SIMPLE
+                              - MUTUAL
+                              - AUTO_PASSTHROUGH
+                              - ISTIO_MUTUAL
+                            type: string
+                          privateKey:
+                            description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                            type: string
+                          serverCertificate:
+                            description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                            type: string
+                          subjectAltNames:
+                            items:
+                              type: string
+                            type: array
+                          verifyCertificateHash:
+                            items:
+                              type: string
+                            type: array
+                          verifyCertificateSpki:
+                            items:
+                              type: string
+                            type: array
+                        type: object
                     type: object
-                  mode:
-                    enum:
-                    - REGISTRY_ONLY
-                    - ALLOW_ANY
-                    type: string
-                type: object
-              workloadSelector:
-                properties:
-                  labels:
-                    additionalProperties:
+                  type: array
+                outboundTrafficPolicy:
+                  description: Configuration for the outbound traffic policy.
+                  properties:
+                    egressProxy:
+                      properties:
+                        host:
+                          description: The name of a service from the service registry.
+                          type: string
+                        port:
+                          description: Specifies the port on the host that is being
+                            addressed.
+                          properties:
+                            number:
+                              type: integer
+                          type: object
+                        subset:
+                          description: The name of a subset within the service.
+                          type: string
+                      type: object
+                    mode:
+                      enum:
+                        - REGISTRY_ONLY
+                        - ALLOW_ANY
                       type: string
+                  type: object
+                workloadSelector:
+                  properties:
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Configuration affecting network reachability of a sidecar.
+              See more details at: https://istio.io/docs/reference/config/networking/sidecar.html'
+              properties:
+                egress:
+                  items:
+                    properties:
+                      bind:
+                        type: string
+                      captureMode:
+                        enum:
+                          - DEFAULT
+                          - IPTABLES
+                          - NONE
+                        type: string
+                      hosts:
+                        items:
+                          type: string
+                        type: array
+                      port:
+                        description: The port associated with the listener.
+                        properties:
+                          name:
+                            description: Label assigned to the port.
+                            type: string
+                          number:
+                            description: A valid non-negative integer port number.
+                            type: integer
+                          protocol:
+                            description: The protocol exposed on the port.
+                            type: string
+                          targetPort:
+                            type: integer
+                        type: object
                     type: object
-                type: object
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
+                  type: array
+                ingress:
+                  items:
+                    properties:
+                      bind:
+                        description: The IP(IPv4 or IPv6) to which the listener should
+                          be bound.
+                        type: string
+                      captureMode:
+                        enum:
+                          - DEFAULT
+                          - IPTABLES
+                          - NONE
+                        type: string
+                      defaultEndpoint:
+                        type: string
+                      port:
+                        description: The port associated with the listener.
+                        properties:
+                          name:
+                            description: Label assigned to the port.
+                            type: string
+                          number:
+                            description: A valid non-negative integer port number.
+                            type: integer
+                          protocol:
+                            description: The protocol exposed on the port.
+                            type: string
+                          targetPort:
+                            type: integer
+                        type: object
+                      tls:
+                        properties:
+                          caCertificates:
+                            description: REQUIRED if mode is `MUTUAL`.
+                            type: string
+                          cipherSuites:
+                            description: 'Optional: If specified, only support the specified
+                            cipher list.'
+                            items:
+                              type: string
+                            type: array
+                          credentialName:
+                            type: string
+                          httpsRedirect:
+                            type: boolean
+                          maxProtocolVersion:
+                            description: 'Optional: Maximum TLS protocol version.'
+                            enum:
+                              - TLS_AUTO
+                              - TLSV1_0
+                              - TLSV1_1
+                              - TLSV1_2
+                              - TLSV1_3
+                            type: string
+                          minProtocolVersion:
+                            description: 'Optional: Minimum TLS protocol version.'
+                            enum:
+                              - TLS_AUTO
+                              - TLSV1_0
+                              - TLSV1_1
+                              - TLSV1_2
+                              - TLSV1_3
+                            type: string
+                          mode:
+                            enum:
+                              - PASSTHROUGH
+                              - SIMPLE
+                              - MUTUAL
+                              - AUTO_PASSTHROUGH
+                              - ISTIO_MUTUAL
+                            type: string
+                          privateKey:
+                            description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                            type: string
+                          serverCertificate:
+                            description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                            type: string
+                          subjectAltNames:
+                            items:
+                              type: string
+                            type: array
+                          verifyCertificateHash:
+                            items:
+                              type: string
+                            type: array
+                          verifyCertificateSpki:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                  type: array
+                outboundTrafficPolicy:
+                  description: Configuration for the outbound traffic policy.
+                  properties:
+                    egressProxy:
+                      properties:
+                        host:
+                          description: The name of a service from the service registry.
+                          type: string
+                        port:
+                          description: Specifies the port on the host that is being
+                            addressed.
+                          properties:
+                            number:
+                              type: integer
+                          type: object
+                        subset:
+                          description: The name of a subset within the service.
+                          type: string
+                      type: object
+                    mode:
+                      enum:
+                        - REGISTRY_ONLY
+                        - ALLOW_ANY
+                      type: string
+                  type: object
+                workloadSelector:
+                  properties:
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -3494,1502 +4213,1582 @@ spec:
   group: networking.istio.io
   names:
     categories:
-    - istio-io
-    - networking-istio-io
+      - istio-io
+      - networking-istio-io
     kind: VirtualService
     listKind: VirtualServiceList
     plural: virtualservices
     shortNames:
-    - vs
+      - vs
     singular: virtualservice
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: The names of gateways and sidecars that should apply these routes
-      jsonPath: .spec.gateways
-      name: Gateways
-      type: string
-    - description: The destination hosts to which traffic is being sent
-      jsonPath: .spec.hosts
-      name: Hosts
-      type: string
-    - description: 'CreationTimestamp is a timestamp representing the server time
+    - additionalPrinterColumns:
+        - description: The names of gateways and sidecars that should apply these routes
+          jsonPath: .spec.gateways
+          name: Gateways
+          type: string
+        - description: The destination hosts to which traffic is being sent
+          jsonPath: .spec.hosts
+          name: Hosts
+          type: string
+        - description: 'CreationTimestamp is a timestamp representing the server time
         when this object was created. It is not guaranteed to be set in happens-before
         order across separate operations. Clients may not set this value. It is represented
         in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
         lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting label/content routing, sni routing,
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha3
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Configuration affecting label/content routing, sni routing,
               etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
-            properties:
-              exportTo:
-                description: A list of namespaces to which this virtual service is
-                  exported.
-                items:
-                  type: string
-                type: array
-              gateways:
-                description: The names of gateways and sidecars that should apply
-                  these routes.
-                items:
-                  type: string
-                type: array
-              hosts:
-                description: The destination hosts to which traffic is being sent.
-                items:
-                  type: string
-                type: array
-              http:
-                description: An ordered list of route rules for HTTP traffic.
-                items:
-                  properties:
-                    corsPolicy:
-                      description: Cross-Origin Resource Sharing policy (CORS).
-                      properties:
-                        allowCredentials:
-                          nullable: true
-                          type: boolean
-                        allowHeaders:
-                          items:
+              properties:
+                exportTo:
+                  description: A list of namespaces to which this virtual service is
+                    exported.
+                  items:
+                    type: string
+                  type: array
+                gateways:
+                  description: The names of gateways and sidecars that should apply
+                    these routes.
+                  items:
+                    type: string
+                  type: array
+                hosts:
+                  description: The destination hosts to which traffic is being sent.
+                  items:
+                    type: string
+                  type: array
+                http:
+                  description: An ordered list of route rules for HTTP traffic.
+                  items:
+                    properties:
+                      corsPolicy:
+                        description: Cross-Origin Resource Sharing policy (CORS).
+                        properties:
+                          allowCredentials:
+                            nullable: true
+                            type: boolean
+                          allowHeaders:
+                            items:
+                              type: string
+                            type: array
+                          allowMethods:
+                            description: List of HTTP methods allowed to access the
+                              resource.
+                            items:
+                              type: string
+                            type: array
+                          allowOrigin:
+                            description: The list of origins that are allowed to perform
+                              CORS requests.
+                            items:
+                              type: string
+                            type: array
+                          allowOrigins:
+                            description: String patterns that match allowed origins.
+                            items:
+                              oneOf:
+                                - not:
+                                    anyOf:
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                - required:
+                                    - exact
+                                - required:
+                                    - prefix
+                                - required:
+                                    - regex
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  type: string
+                              type: object
+                            type: array
+                          exposeHeaders:
+                            items:
+                              type: string
+                            type: array
+                          maxAge:
                             type: string
-                          type: array
-                        allowMethods:
-                          description: List of HTTP methods allowed to access the
-                            resource.
-                          items:
+                        type: object
+                      delegate:
+                        properties:
+                          name:
+                            description: Name specifies the name of the delegate VirtualService.
                             type: string
-                          type: array
-                        allowOrigin:
-                          description: The list of origins that are allowed to perform
-                            CORS requests.
-                          items:
+                          namespace:
+                            description: Namespace specifies the namespace where the
+                              delegate VirtualService resides.
                             type: string
-                          type: array
-                        allowOrigins:
-                          description: String patterns that match allowed origins.
-                          items:
+                        type: object
+                      directResponse:
+                        description: A HTTP rule can either return a direct_response,
+                          redirect or forward (default) traffic.
+                        properties:
+                          body:
+                            description: Specifies the content of the response body.
                             oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
+                              - not:
+                                  anyOf:
+                                    - required:
+                                        - string
+                                    - required:
+                                        - bytes
+                              - required:
+                                  - string
+                              - required:
+                                  - bytes
                             properties:
-                              exact:
+                              bytes:
+                                description: response body as base64 encoded bytes.
+                                format: binary
                                 type: string
-                              prefix:
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                              string:
                                 type: string
                             type: object
-                          type: array
-                        exposeHeaders:
-                          items:
+                          status:
+                            description: Specifies the HTTP response status to be returned.
+                            type: integer
+                        type: object
+                      fault:
+                        description: Fault injection policy to apply on HTTP traffic
+                          at the client side.
+                        properties:
+                          abort:
+                            oneOf:
+                              - not:
+                                  anyOf:
+                                    - required:
+                                        - httpStatus
+                                    - required:
+                                        - grpcStatus
+                                    - required:
+                                        - http2Error
+                              - required:
+                                  - httpStatus
+                              - required:
+                                  - grpcStatus
+                              - required:
+                                  - http2Error
+                            properties:
+                              grpcStatus:
+                                description: GRPC status code to use to abort the request.
+                                type: string
+                              http2Error:
+                                type: string
+                              httpStatus:
+                                description: HTTP status code to use to abort the Http
+                                  request.
+                                format: int32
+                                type: integer
+                              percentage:
+                                description: Percentage of requests to be aborted with
+                                  the error code provided.
+                                properties:
+                                  value:
+                                    format: double
+                                    type: number
+                                type: object
+                            type: object
+                          delay:
+                            oneOf:
+                              - not:
+                                  anyOf:
+                                    - required:
+                                        - fixedDelay
+                                    - required:
+                                        - exponentialDelay
+                              - required:
+                                  - fixedDelay
+                              - required:
+                                  - exponentialDelay
+                            properties:
+                              exponentialDelay:
+                                type: string
+                              fixedDelay:
+                                description: Add a fixed delay before forwarding the
+                                  request.
+                                type: string
+                              percent:
+                                description: Percentage of requests on which the delay
+                                  will be injected (0-100).
+                                format: int32
+                                type: integer
+                              percentage:
+                                description: Percentage of requests on which the delay
+                                  will be injected.
+                                properties:
+                                  value:
+                                    format: double
+                                    type: number
+                                type: object
+                            type: object
+                        type: object
+                      headers:
+                        properties:
+                          request:
+                            properties:
+                              add:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              remove:
+                                items:
+                                  type: string
+                                type: array
+                              set:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          response:
+                            properties:
+                              add:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              remove:
+                                items:
+                                  type: string
+                                type: array
+                              set:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                        type: object
+                      match:
+                        items:
+                          properties:
+                            authority:
+                              oneOf:
+                                - not:
+                                    anyOf:
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                - required:
+                                    - exact
+                                - required:
+                                    - prefix
+                                - required:
+                                    - regex
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  type: string
+                              type: object
+                            gateways:
+                              description: Names of gateways where the rule should be
+                                applied.
+                              items:
+                                type: string
+                              type: array
+                            headers:
+                              additionalProperties:
+                                oneOf:
+                                  - not:
+                                      anyOf:
+                                        - required:
+                                            - exact
+                                        - required:
+                                            - prefix
+                                        - required:
+                                            - regex
+                                  - required:
+                                      - exact
+                                  - required:
+                                      - prefix
+                                  - required:
+                                      - regex
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                  regex:
+                                    description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                    type: string
+                                type: object
+                              type: object
+                            ignoreUriCase:
+                              description: Flag to specify whether the URI matching
+                                should be case-insensitive.
+                              type: boolean
+                            method:
+                              oneOf:
+                                - not:
+                                    anyOf:
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                - required:
+                                    - exact
+                                - required:
+                                    - prefix
+                                - required:
+                                    - regex
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  type: string
+                              type: object
+                            name:
+                              description: The name assigned to a match.
+                              type: string
+                            port:
+                              description: Specifies the ports on the host that is being
+                                addressed.
+                              type: integer
+                            queryParams:
+                              additionalProperties:
+                                oneOf:
+                                  - not:
+                                      anyOf:
+                                        - required:
+                                            - exact
+                                        - required:
+                                            - prefix
+                                        - required:
+                                            - regex
+                                  - required:
+                                      - exact
+                                  - required:
+                                      - prefix
+                                  - required:
+                                      - regex
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                  regex:
+                                    description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                    type: string
+                                type: object
+                              description: Query parameters for matching.
+                              type: object
+                            scheme:
+                              oneOf:
+                                - not:
+                                    anyOf:
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                - required:
+                                    - exact
+                                - required:
+                                    - prefix
+                                - required:
+                                    - regex
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  type: string
+                              type: object
+                            sourceLabels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            sourceNamespace:
+                              description: Source namespace constraining the applicability
+                                of a rule to workloads in that namespace.
+                              type: string
+                            statPrefix:
+                              description: The human readable prefix to use when emitting
+                                statistics for this route.
+                              type: string
+                            uri:
+                              oneOf:
+                                - not:
+                                    anyOf:
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                - required:
+                                    - exact
+                                - required:
+                                    - prefix
+                                - required:
+                                    - regex
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  type: string
+                              type: object
+                            withoutHeaders:
+                              additionalProperties:
+                                oneOf:
+                                  - not:
+                                      anyOf:
+                                        - required:
+                                            - exact
+                                        - required:
+                                            - prefix
+                                        - required:
+                                            - regex
+                                  - required:
+                                      - exact
+                                  - required:
+                                      - prefix
+                                  - required:
+                                      - regex
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                  regex:
+                                    description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                    type: string
+                                type: object
+                              description: withoutHeader has the same syntax with the
+                                header, but has opposite meaning.
+                              type: object
+                          type: object
+                        type: array
+                      mirror:
+                        properties:
+                          host:
+                            description: The name of a service from the service registry.
                             type: string
-                          type: array
-                        maxAge:
-                          type: string
-                      type: object
-                    delegate:
-                      properties:
-                        name:
-                          description: Name specifies the name of the delegate VirtualService.
-                          type: string
-                        namespace:
-                          description: Namespace specifies the namespace where the
-                            delegate VirtualService resides.
-                          type: string
-                      type: object
-                    fault:
-                      description: Fault injection policy to apply on HTTP traffic
-                        at the client side.
-                      properties:
-                        abort:
-                          oneOf:
+                          port:
+                            description: Specifies the port on the host that is being
+                              addressed.
+                            properties:
+                              number:
+                                type: integer
+                            type: object
+                          subset:
+                            description: The name of a subset within the service.
+                            type: string
+                        type: object
+                      mirror_percent:
+                        description: Percentage of the traffic to be mirrored by the
+                          `mirror` field.
+                        nullable: true
+                        type: integer
+                      mirrorPercent:
+                        description: Percentage of the traffic to be mirrored by the
+                          `mirror` field.
+                        nullable: true
+                        type: integer
+                      mirrorPercentage:
+                        description: Percentage of the traffic to be mirrored by the
+                          `mirror` field.
+                        properties:
+                          value:
+                            format: double
+                            type: number
+                        type: object
+                      name:
+                        description: The name assigned to the route for debugging purposes.
+                        type: string
+                      redirect:
+                        description: A HTTP rule can either return a direct_response,
+                          redirect or forward (default) traffic.
+                        oneOf:
                           - not:
                               anyOf:
-                              - required:
-                                - httpStatus
-                              - required:
-                                - grpcStatus
-                              - required:
-                                - http2Error
+                                - required:
+                                    - port
+                                - required:
+                                    - derivePort
                           - required:
-                            - httpStatus
+                              - port
                           - required:
-                            - grpcStatus
-                          - required:
-                            - http2Error
-                          properties:
-                            grpcStatus:
-                              type: string
-                            http2Error:
-                              type: string
-                            httpStatus:
-                              description: HTTP status code to use to abort the Http
-                                request.
-                              format: int32
-                              type: integer
-                            percentage:
-                              description: Percentage of requests to be aborted with
-                                the error code provided.
-                              properties:
-                                value:
-                                  format: double
-                                  type: number
-                              type: object
-                          type: object
-                        delay:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - fixedDelay
-                              - required:
-                                - exponentialDelay
-                          - required:
-                            - fixedDelay
-                          - required:
-                            - exponentialDelay
-                          properties:
-                            exponentialDelay:
-                              type: string
-                            fixedDelay:
-                              description: Add a fixed delay before forwarding the
-                                request.
-                              type: string
-                            percent:
-                              description: Percentage of requests on which the delay
-                                will be injected (0-100).
-                              format: int32
-                              type: integer
-                            percentage:
-                              description: Percentage of requests on which the delay
-                                will be injected.
-                              properties:
-                                value:
-                                  format: double
-                                  type: number
-                              type: object
-                          type: object
-                      type: object
-                    headers:
-                      properties:
-                        request:
-                          properties:
-                            add:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            remove:
-                              items:
-                                type: string
-                              type: array
-                            set:
-                              additionalProperties:
-                                type: string
-                              type: object
-                          type: object
-                        response:
-                          properties:
-                            add:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            remove:
-                              items:
-                                type: string
-                              type: array
-                            set:
-                              additionalProperties:
-                                type: string
-                              type: object
-                          type: object
-                      type: object
-                    match:
-                      items:
+                              - derivePort
                         properties:
                           authority:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                type: string
-                              prefix:
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                type: string
-                            type: object
-                          gateways:
-                            description: Names of gateways where the rule should be
-                              applied.
-                            items:
-                              type: string
-                            type: array
-                          headers:
-                            additionalProperties:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - exact
-                                  - required:
-                                    - prefix
-                                  - required:
-                                    - regex
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                              properties:
-                                exact:
-                                  type: string
-                                prefix:
-                                  type: string
-                                regex:
-                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  type: string
-                              type: object
-                            type: object
-                          ignoreUriCase:
-                            description: Flag to specify whether the URI matching
-                              should be case-insensitive.
-                            type: boolean
-                          method:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                type: string
-                              prefix:
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                type: string
-                            type: object
-                          name:
-                            description: The name assigned to a match.
+                            type: string
+                          derivePort:
+                            enum:
+                              - FROM_PROTOCOL_DEFAULT
+                              - FROM_REQUEST_PORT
                             type: string
                           port:
-                            description: Specifies the ports on the host that is being
-                              addressed.
+                            description: On a redirect, overwrite the port portion of
+                              the URL with this value.
                             type: integer
-                          queryParams:
-                            additionalProperties:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - exact
-                                  - required:
-                                    - prefix
-                                  - required:
-                                    - regex
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                              properties:
-                                exact:
-                                  type: string
-                                prefix:
-                                  type: string
-                                regex:
-                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  type: string
-                              type: object
-                            description: Query parameters for matching.
-                            type: object
+                          redirectCode:
+                            type: integer
                           scheme:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                type: string
-                              prefix:
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                type: string
-                            type: object
-                          sourceLabels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          sourceNamespace:
-                            description: Source namespace constraining the applicability
-                              of a rule to workloads in that namespace.
+                            description: On a redirect, overwrite the scheme portion
+                              of the URL with this value.
                             type: string
                           uri:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                type: string
-                              prefix:
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                type: string
-                            type: object
-                          withoutHeaders:
-                            additionalProperties:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - exact
-                                  - required:
-                                    - prefix
-                                  - required:
-                                    - regex
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
+                            type: string
+                        type: object
+                      retries:
+                        description: Retry policy for HTTP requests.
+                        properties:
+                          attempts:
+                            description: Number of retries to be allowed for a given
+                              request.
+                            format: int32
+                            type: integer
+                          perTryTimeout:
+                            description: Timeout per attempt for a given request, including
+                              the initial call and any retries.
+                            type: string
+                          retryOn:
+                            description: Specifies the conditions under which retry
+                              takes place.
+                            type: string
+                          retryRemoteLocalities:
+                            description: Flag to specify whether the retries should
+                              retry to other localities.
+                            nullable: true
+                            type: boolean
+                        type: object
+                      rewrite:
+                        description: Rewrite HTTP URIs and Authority headers.
+                        properties:
+                          authority:
+                            description: rewrite the Authority/Host header with this
+                              value.
+                            type: string
+                          uri:
+                            type: string
+                        type: object
+                      route:
+                        description: A HTTP rule can either return a direct_response,
+                          redirect or forward (default) traffic.
+                        items:
+                          properties:
+                            destination:
                               properties:
-                                exact:
+                                host:
+                                  description: The name of a service from the service
+                                    registry.
                                   type: string
-                                prefix:
-                                  type: string
-                                regex:
-                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                port:
+                                  description: Specifies the port on the host that is
+                                    being addressed.
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                subset:
+                                  description: The name of a subset within the service.
                                   type: string
                               type: object
-                            description: withoutHeader has the same syntax with the
-                              header, but has opposite meaning.
-                            type: object
-                        type: object
-                      type: array
-                    mirror:
-                      properties:
-                        host:
-                          description: The name of a service from the service registry.
-                          type: string
-                        port:
-                          description: Specifies the port on the host that is being
-                            addressed.
-                          properties:
-                            number:
+                            headers:
+                              properties:
+                                request:
+                                  properties:
+                                    add:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    remove:
+                                      items:
+                                        type: string
+                                      type: array
+                                    set:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                response:
+                                  properties:
+                                    add:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    remove:
+                                      items:
+                                        type: string
+                                      type: array
+                                    set:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                              type: object
+                            weight:
+                              description: Weight specifies the relative proportion
+                                of traffic to be forwarded to the destination.
+                              format: int32
                               type: integer
                           type: object
-                        subset:
-                          description: The name of a subset within the service.
-                          type: string
-                      type: object
-                    mirror_percent:
-                      description: Percentage of the traffic to be mirrored by the
-                        `mirror` field.
-                      nullable: true
-                      type: integer
-                    mirrorPercent:
-                      description: Percentage of the traffic to be mirrored by the
-                        `mirror` field.
-                      nullable: true
-                      type: integer
-                    mirrorPercentage:
-                      description: Percentage of the traffic to be mirrored by the
-                        `mirror` field.
-                      properties:
-                        value:
-                          format: double
-                          type: number
-                      type: object
-                    name:
-                      description: The name assigned to the route for debugging purposes.
-                      type: string
-                    redirect:
-                      description: A HTTP rule can either redirect or forward (default)
-                        traffic.
-                      oneOf:
-                      - not:
-                          anyOf:
-                          - required:
-                            - port
-                          - required:
-                            - derivePort
-                      - required:
-                        - port
-                      - required:
-                        - derivePort
-                      properties:
-                        authority:
-                          type: string
-                        derivePort:
-                          enum:
-                          - FROM_PROTOCOL_DEFAULT
-                          - FROM_REQUEST_PORT
-                          type: string
-                        port:
-                          description: On a redirect, overwrite the port portion of
-                            the URL with this value.
-                          type: integer
-                        redirectCode:
-                          type: integer
-                        scheme:
-                          description: On a redirect, overwrite the scheme portion
-                            of the URL with this value.
-                          type: string
-                        uri:
-                          type: string
-                      type: object
-                    retries:
-                      description: Retry policy for HTTP requests.
-                      properties:
-                        attempts:
-                          description: Number of retries to be allowed for a given
-                            request.
-                          format: int32
-                          type: integer
-                        perTryTimeout:
-                          description: Timeout per attempt for a given request, including
-                            the initial call and any retries.
-                          type: string
-                        retryOn:
-                          description: Specifies the conditions under which retry
-                            takes place.
-                          type: string
-                        retryRemoteLocalities:
-                          description: Flag to specify whether the retries should
-                            retry to other localities.
-                          nullable: true
-                          type: boolean
-                      type: object
-                    rewrite:
-                      description: Rewrite HTTP URIs and Authority headers.
-                      properties:
-                        authority:
-                          description: rewrite the Authority/Host header with this
-                            value.
-                          type: string
-                        uri:
-                          type: string
-                      type: object
-                    route:
-                      description: A HTTP rule can either redirect or forward (default)
-                        traffic.
-                      items:
-                        properties:
-                          destination:
-                            properties:
-                              host:
-                                description: The name of a service from the service
-                                  registry.
+                        type: array
+                      timeout:
+                        description: Timeout for HTTP requests, default is disabled.
+                        type: string
+                    type: object
+                  type: array
+                tcp:
+                  description: An ordered list of route rules for opaque TCP traffic.
+                  items:
+                    properties:
+                      match:
+                        items:
+                          properties:
+                            destinationSubnets:
+                              description: IPv4 or IPv6 ip addresses of destination
+                                with optional subnet.
+                              items:
                                 type: string
-                              port:
-                                description: Specifies the port on the host that is
-                                  being addressed.
-                                properties:
-                                  number:
-                                    type: integer
-                                type: object
-                              subset:
-                                description: The name of a subset within the service.
+                              type: array
+                            gateways:
+                              description: Names of gateways where the rule should be
+                                applied.
+                              items:
                                 type: string
-                            type: object
-                          headers:
-                            properties:
-                              request:
-                                properties:
-                                  add:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                  remove:
-                                    items:
-                                      type: string
-                                    type: array
-                                  set:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              response:
-                                properties:
-                                  add:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                  remove:
-                                    items:
-                                      type: string
-                                    type: array
-                                  set:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                            type: object
-                          weight:
-                            format: int32
-                            type: integer
-                        type: object
-                      type: array
-                    timeout:
-                      description: Timeout for HTTP requests, default is disabled.
-                      type: string
-                  type: object
-                type: array
-              tcp:
-                description: An ordered list of route rules for opaque TCP traffic.
-                items:
-                  properties:
-                    match:
-                      items:
-                        properties:
-                          destinationSubnets:
-                            description: IPv4 or IPv6 ip addresses of destination
-                              with optional subnet.
-                            items:
-                              type: string
-                            type: array
-                          gateways:
-                            description: Names of gateways where the rule should be
-                              applied.
-                            items:
-                              type: string
-                            type: array
-                          port:
-                            description: Specifies the port on the host that is being
-                              addressed.
-                            type: integer
-                          sourceLabels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          sourceNamespace:
-                            description: Source namespace constraining the applicability
-                              of a rule to workloads in that namespace.
-                            type: string
-                          sourceSubnet:
-                            description: IPv4 or IPv6 ip address of source with optional
-                              subnet.
-                            type: string
-                        type: object
-                      type: array
-                    route:
-                      description: The destination to which the connection should
-                        be forwarded to.
-                      items:
-                        properties:
-                          destination:
-                            properties:
-                              host:
-                                description: The name of a service from the service
-                                  registry.
+                              type: array
+                            port:
+                              description: Specifies the port on the host that is being
+                                addressed.
+                              type: integer
+                            sourceLabels:
+                              additionalProperties:
                                 type: string
-                              port:
-                                description: Specifies the port on the host that is
-                                  being addressed.
-                                properties:
-                                  number:
-                                    type: integer
-                                type: object
-                              subset:
-                                description: The name of a subset within the service.
+                              type: object
+                            sourceNamespace:
+                              description: Source namespace constraining the applicability
+                                of a rule to workloads in that namespace.
+                              type: string
+                            sourceSubnet:
+                              description: IPv4 or IPv6 ip address of source with optional
+                                subnet.
+                              type: string
+                          type: object
+                        type: array
+                      route:
+                        description: The destination to which the connection should
+                          be forwarded to.
+                        items:
+                          properties:
+                            destination:
+                              properties:
+                                host:
+                                  description: The name of a service from the service
+                                    registry.
+                                  type: string
+                                port:
+                                  description: Specifies the port on the host that is
+                                    being addressed.
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                subset:
+                                  description: The name of a subset within the service.
+                                  type: string
+                              type: object
+                            weight:
+                              description: Weight specifies the relative proportion
+                                of traffic to be forwarded to the destination.
+                              format: int32
+                              type: integer
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+                tls:
+                  items:
+                    properties:
+                      match:
+                        items:
+                          properties:
+                            destinationSubnets:
+                              description: IPv4 or IPv6 ip addresses of destination
+                                with optional subnet.
+                              items:
                                 type: string
-                            type: object
-                          weight:
-                            format: int32
-                            type: integer
-                        type: object
-                      type: array
-                  type: object
-                type: array
-              tls:
-                items:
-                  properties:
-                    match:
-                      items:
-                        properties:
-                          destinationSubnets:
-                            description: IPv4 or IPv6 ip addresses of destination
-                              with optional subnet.
-                            items:
-                              type: string
-                            type: array
-                          gateways:
-                            description: Names of gateways where the rule should be
-                              applied.
-                            items:
-                              type: string
-                            type: array
-                          port:
-                            description: Specifies the port on the host that is being
-                              addressed.
-                            type: integer
-                          sniHosts:
-                            description: SNI (server name indicator) to match on.
-                            items:
-                              type: string
-                            type: array
-                          sourceLabels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          sourceNamespace:
-                            description: Source namespace constraining the applicability
-                              of a rule to workloads in that namespace.
-                            type: string
-                        type: object
-                      type: array
-                    route:
-                      description: The destination to which the connection should
-                        be forwarded to.
-                      items:
-                        properties:
-                          destination:
-                            properties:
-                              host:
-                                description: The name of a service from the service
-                                  registry.
+                              type: array
+                            gateways:
+                              description: Names of gateways where the rule should be
+                                applied.
+                              items:
                                 type: string
-                              port:
-                                description: Specifies the port on the host that is
-                                  being addressed.
-                                properties:
-                                  number:
-                                    type: integer
-                                type: object
-                              subset:
-                                description: The name of a subset within the service.
+                              type: array
+                            port:
+                              description: Specifies the port on the host that is being
+                                addressed.
+                              type: integer
+                            sniHosts:
+                              description: SNI (server name indicator) to match on.
+                              items:
                                 type: string
-                            type: object
-                          weight:
-                            format: int32
-                            type: integer
-                        type: object
-                      type: array
-                  type: object
-                type: array
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - description: The names of gateways and sidecars that should apply these routes
-      jsonPath: .spec.gateways
-      name: Gateways
-      type: string
-    - description: The destination hosts to which traffic is being sent
-      jsonPath: .spec.hosts
-      name: Hosts
-      type: string
-    - description: 'CreationTimestamp is a timestamp representing the server time
+                              type: array
+                            sourceLabels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            sourceNamespace:
+                              description: Source namespace constraining the applicability
+                                of a rule to workloads in that namespace.
+                              type: string
+                          type: object
+                        type: array
+                      route:
+                        description: The destination to which the connection should
+                          be forwarded to.
+                        items:
+                          properties:
+                            destination:
+                              properties:
+                                host:
+                                  description: The name of a service from the service
+                                    registry.
+                                  type: string
+                                port:
+                                  description: Specifies the port on the host that is
+                                    being addressed.
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                subset:
+                                  description: The name of a subset within the service.
+                                  type: string
+                              type: object
+                            weight:
+                              description: Weight specifies the relative proportion
+                                of traffic to be forwarded to the destination.
+                              format: int32
+                              type: integer
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: The names of gateways and sidecars that should apply these routes
+          jsonPath: .spec.gateways
+          name: Gateways
+          type: string
+        - description: The destination hosts to which traffic is being sent
+          jsonPath: .spec.hosts
+          name: Hosts
+          type: string
+        - description: 'CreationTimestamp is a timestamp representing the server time
         when this object was created. It is not guaranteed to be set in happens-before
         order across separate operations. Clients may not set this value. It is represented
         in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
         lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting label/content routing, sni routing,
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Configuration affecting label/content routing, sni routing,
               etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
-            properties:
-              exportTo:
-                description: A list of namespaces to which this virtual service is
-                  exported.
-                items:
-                  type: string
-                type: array
-              gateways:
-                description: The names of gateways and sidecars that should apply
-                  these routes.
-                items:
-                  type: string
-                type: array
-              hosts:
-                description: The destination hosts to which traffic is being sent.
-                items:
-                  type: string
-                type: array
-              http:
-                description: An ordered list of route rules for HTTP traffic.
-                items:
-                  properties:
-                    corsPolicy:
-                      description: Cross-Origin Resource Sharing policy (CORS).
-                      properties:
-                        allowCredentials:
-                          nullable: true
-                          type: boolean
-                        allowHeaders:
-                          items:
+              properties:
+                exportTo:
+                  description: A list of namespaces to which this virtual service is
+                    exported.
+                  items:
+                    type: string
+                  type: array
+                gateways:
+                  description: The names of gateways and sidecars that should apply
+                    these routes.
+                  items:
+                    type: string
+                  type: array
+                hosts:
+                  description: The destination hosts to which traffic is being sent.
+                  items:
+                    type: string
+                  type: array
+                http:
+                  description: An ordered list of route rules for HTTP traffic.
+                  items:
+                    properties:
+                      corsPolicy:
+                        description: Cross-Origin Resource Sharing policy (CORS).
+                        properties:
+                          allowCredentials:
+                            nullable: true
+                            type: boolean
+                          allowHeaders:
+                            items:
+                              type: string
+                            type: array
+                          allowMethods:
+                            description: List of HTTP methods allowed to access the
+                              resource.
+                            items:
+                              type: string
+                            type: array
+                          allowOrigin:
+                            description: The list of origins that are allowed to perform
+                              CORS requests.
+                            items:
+                              type: string
+                            type: array
+                          allowOrigins:
+                            description: String patterns that match allowed origins.
+                            items:
+                              oneOf:
+                                - not:
+                                    anyOf:
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                - required:
+                                    - exact
+                                - required:
+                                    - prefix
+                                - required:
+                                    - regex
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  type: string
+                              type: object
+                            type: array
+                          exposeHeaders:
+                            items:
+                              type: string
+                            type: array
+                          maxAge:
                             type: string
-                          type: array
-                        allowMethods:
-                          description: List of HTTP methods allowed to access the
-                            resource.
-                          items:
+                        type: object
+                      delegate:
+                        properties:
+                          name:
+                            description: Name specifies the name of the delegate VirtualService.
                             type: string
-                          type: array
-                        allowOrigin:
-                          description: The list of origins that are allowed to perform
-                            CORS requests.
-                          items:
+                          namespace:
+                            description: Namespace specifies the namespace where the
+                              delegate VirtualService resides.
                             type: string
-                          type: array
-                        allowOrigins:
-                          description: String patterns that match allowed origins.
-                          items:
+                        type: object
+                      directResponse:
+                        description: A HTTP rule can either return a direct_response,
+                          redirect or forward (default) traffic.
+                        properties:
+                          body:
+                            description: Specifies the content of the response body.
                             oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
+                              - not:
+                                  anyOf:
+                                    - required:
+                                        - string
+                                    - required:
+                                        - bytes
+                              - required:
+                                  - string
+                              - required:
+                                  - bytes
                             properties:
-                              exact:
+                              bytes:
+                                description: response body as base64 encoded bytes.
+                                format: binary
                                 type: string
-                              prefix:
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                              string:
                                 type: string
                             type: object
-                          type: array
-                        exposeHeaders:
-                          items:
+                          status:
+                            description: Specifies the HTTP response status to be returned.
+                            type: integer
+                        type: object
+                      fault:
+                        description: Fault injection policy to apply on HTTP traffic
+                          at the client side.
+                        properties:
+                          abort:
+                            oneOf:
+                              - not:
+                                  anyOf:
+                                    - required:
+                                        - httpStatus
+                                    - required:
+                                        - grpcStatus
+                                    - required:
+                                        - http2Error
+                              - required:
+                                  - httpStatus
+                              - required:
+                                  - grpcStatus
+                              - required:
+                                  - http2Error
+                            properties:
+                              grpcStatus:
+                                description: GRPC status code to use to abort the request.
+                                type: string
+                              http2Error:
+                                type: string
+                              httpStatus:
+                                description: HTTP status code to use to abort the Http
+                                  request.
+                                format: int32
+                                type: integer
+                              percentage:
+                                description: Percentage of requests to be aborted with
+                                  the error code provided.
+                                properties:
+                                  value:
+                                    format: double
+                                    type: number
+                                type: object
+                            type: object
+                          delay:
+                            oneOf:
+                              - not:
+                                  anyOf:
+                                    - required:
+                                        - fixedDelay
+                                    - required:
+                                        - exponentialDelay
+                              - required:
+                                  - fixedDelay
+                              - required:
+                                  - exponentialDelay
+                            properties:
+                              exponentialDelay:
+                                type: string
+                              fixedDelay:
+                                description: Add a fixed delay before forwarding the
+                                  request.
+                                type: string
+                              percent:
+                                description: Percentage of requests on which the delay
+                                  will be injected (0-100).
+                                format: int32
+                                type: integer
+                              percentage:
+                                description: Percentage of requests on which the delay
+                                  will be injected.
+                                properties:
+                                  value:
+                                    format: double
+                                    type: number
+                                type: object
+                            type: object
+                        type: object
+                      headers:
+                        properties:
+                          request:
+                            properties:
+                              add:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              remove:
+                                items:
+                                  type: string
+                                type: array
+                              set:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          response:
+                            properties:
+                              add:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              remove:
+                                items:
+                                  type: string
+                                type: array
+                              set:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                        type: object
+                      match:
+                        items:
+                          properties:
+                            authority:
+                              oneOf:
+                                - not:
+                                    anyOf:
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                - required:
+                                    - exact
+                                - required:
+                                    - prefix
+                                - required:
+                                    - regex
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  type: string
+                              type: object
+                            gateways:
+                              description: Names of gateways where the rule should be
+                                applied.
+                              items:
+                                type: string
+                              type: array
+                            headers:
+                              additionalProperties:
+                                oneOf:
+                                  - not:
+                                      anyOf:
+                                        - required:
+                                            - exact
+                                        - required:
+                                            - prefix
+                                        - required:
+                                            - regex
+                                  - required:
+                                      - exact
+                                  - required:
+                                      - prefix
+                                  - required:
+                                      - regex
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                  regex:
+                                    description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                    type: string
+                                type: object
+                              type: object
+                            ignoreUriCase:
+                              description: Flag to specify whether the URI matching
+                                should be case-insensitive.
+                              type: boolean
+                            method:
+                              oneOf:
+                                - not:
+                                    anyOf:
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                - required:
+                                    - exact
+                                - required:
+                                    - prefix
+                                - required:
+                                    - regex
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  type: string
+                              type: object
+                            name:
+                              description: The name assigned to a match.
+                              type: string
+                            port:
+                              description: Specifies the ports on the host that is being
+                                addressed.
+                              type: integer
+                            queryParams:
+                              additionalProperties:
+                                oneOf:
+                                  - not:
+                                      anyOf:
+                                        - required:
+                                            - exact
+                                        - required:
+                                            - prefix
+                                        - required:
+                                            - regex
+                                  - required:
+                                      - exact
+                                  - required:
+                                      - prefix
+                                  - required:
+                                      - regex
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                  regex:
+                                    description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                    type: string
+                                type: object
+                              description: Query parameters for matching.
+                              type: object
+                            scheme:
+                              oneOf:
+                                - not:
+                                    anyOf:
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                - required:
+                                    - exact
+                                - required:
+                                    - prefix
+                                - required:
+                                    - regex
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  type: string
+                              type: object
+                            sourceLabels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            sourceNamespace:
+                              description: Source namespace constraining the applicability
+                                of a rule to workloads in that namespace.
+                              type: string
+                            statPrefix:
+                              description: The human readable prefix to use when emitting
+                                statistics for this route.
+                              type: string
+                            uri:
+                              oneOf:
+                                - not:
+                                    anyOf:
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                - required:
+                                    - exact
+                                - required:
+                                    - prefix
+                                - required:
+                                    - regex
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  type: string
+                              type: object
+                            withoutHeaders:
+                              additionalProperties:
+                                oneOf:
+                                  - not:
+                                      anyOf:
+                                        - required:
+                                            - exact
+                                        - required:
+                                            - prefix
+                                        - required:
+                                            - regex
+                                  - required:
+                                      - exact
+                                  - required:
+                                      - prefix
+                                  - required:
+                                      - regex
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                  regex:
+                                    description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                    type: string
+                                type: object
+                              description: withoutHeader has the same syntax with the
+                                header, but has opposite meaning.
+                              type: object
+                          type: object
+                        type: array
+                      mirror:
+                        properties:
+                          host:
+                            description: The name of a service from the service registry.
                             type: string
-                          type: array
-                        maxAge:
-                          type: string
-                      type: object
-                    delegate:
-                      properties:
-                        name:
-                          description: Name specifies the name of the delegate VirtualService.
-                          type: string
-                        namespace:
-                          description: Namespace specifies the namespace where the
-                            delegate VirtualService resides.
-                          type: string
-                      type: object
-                    fault:
-                      description: Fault injection policy to apply on HTTP traffic
-                        at the client side.
-                      properties:
-                        abort:
-                          oneOf:
+                          port:
+                            description: Specifies the port on the host that is being
+                              addressed.
+                            properties:
+                              number:
+                                type: integer
+                            type: object
+                          subset:
+                            description: The name of a subset within the service.
+                            type: string
+                        type: object
+                      mirror_percent:
+                        description: Percentage of the traffic to be mirrored by the
+                          `mirror` field.
+                        nullable: true
+                        type: integer
+                      mirrorPercent:
+                        description: Percentage of the traffic to be mirrored by the
+                          `mirror` field.
+                        nullable: true
+                        type: integer
+                      mirrorPercentage:
+                        description: Percentage of the traffic to be mirrored by the
+                          `mirror` field.
+                        properties:
+                          value:
+                            format: double
+                            type: number
+                        type: object
+                      name:
+                        description: The name assigned to the route for debugging purposes.
+                        type: string
+                      redirect:
+                        description: A HTTP rule can either return a direct_response,
+                          redirect or forward (default) traffic.
+                        oneOf:
                           - not:
                               anyOf:
-                              - required:
-                                - httpStatus
-                              - required:
-                                - grpcStatus
-                              - required:
-                                - http2Error
+                                - required:
+                                    - port
+                                - required:
+                                    - derivePort
                           - required:
-                            - httpStatus
+                              - port
                           - required:
-                            - grpcStatus
-                          - required:
-                            - http2Error
-                          properties:
-                            grpcStatus:
-                              type: string
-                            http2Error:
-                              type: string
-                            httpStatus:
-                              description: HTTP status code to use to abort the Http
-                                request.
-                              format: int32
-                              type: integer
-                            percentage:
-                              description: Percentage of requests to be aborted with
-                                the error code provided.
-                              properties:
-                                value:
-                                  format: double
-                                  type: number
-                              type: object
-                          type: object
-                        delay:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - fixedDelay
-                              - required:
-                                - exponentialDelay
-                          - required:
-                            - fixedDelay
-                          - required:
-                            - exponentialDelay
-                          properties:
-                            exponentialDelay:
-                              type: string
-                            fixedDelay:
-                              description: Add a fixed delay before forwarding the
-                                request.
-                              type: string
-                            percent:
-                              description: Percentage of requests on which the delay
-                                will be injected (0-100).
-                              format: int32
-                              type: integer
-                            percentage:
-                              description: Percentage of requests on which the delay
-                                will be injected.
-                              properties:
-                                value:
-                                  format: double
-                                  type: number
-                              type: object
-                          type: object
-                      type: object
-                    headers:
-                      properties:
-                        request:
-                          properties:
-                            add:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            remove:
-                              items:
-                                type: string
-                              type: array
-                            set:
-                              additionalProperties:
-                                type: string
-                              type: object
-                          type: object
-                        response:
-                          properties:
-                            add:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            remove:
-                              items:
-                                type: string
-                              type: array
-                            set:
-                              additionalProperties:
-                                type: string
-                              type: object
-                          type: object
-                      type: object
-                    match:
-                      items:
+                              - derivePort
                         properties:
                           authority:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                type: string
-                              prefix:
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                type: string
-                            type: object
-                          gateways:
-                            description: Names of gateways where the rule should be
-                              applied.
-                            items:
-                              type: string
-                            type: array
-                          headers:
-                            additionalProperties:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - exact
-                                  - required:
-                                    - prefix
-                                  - required:
-                                    - regex
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                              properties:
-                                exact:
-                                  type: string
-                                prefix:
-                                  type: string
-                                regex:
-                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  type: string
-                              type: object
-                            type: object
-                          ignoreUriCase:
-                            description: Flag to specify whether the URI matching
-                              should be case-insensitive.
-                            type: boolean
-                          method:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                type: string
-                              prefix:
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                type: string
-                            type: object
-                          name:
-                            description: The name assigned to a match.
+                            type: string
+                          derivePort:
+                            enum:
+                              - FROM_PROTOCOL_DEFAULT
+                              - FROM_REQUEST_PORT
                             type: string
                           port:
-                            description: Specifies the ports on the host that is being
-                              addressed.
+                            description: On a redirect, overwrite the port portion of
+                              the URL with this value.
                             type: integer
-                          queryParams:
-                            additionalProperties:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - exact
-                                  - required:
-                                    - prefix
-                                  - required:
-                                    - regex
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                              properties:
-                                exact:
-                                  type: string
-                                prefix:
-                                  type: string
-                                regex:
-                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  type: string
-                              type: object
-                            description: Query parameters for matching.
-                            type: object
+                          redirectCode:
+                            type: integer
                           scheme:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                type: string
-                              prefix:
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                type: string
-                            type: object
-                          sourceLabels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          sourceNamespace:
-                            description: Source namespace constraining the applicability
-                              of a rule to workloads in that namespace.
+                            description: On a redirect, overwrite the scheme portion
+                              of the URL with this value.
                             type: string
                           uri:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                type: string
-                              prefix:
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                type: string
-                            type: object
-                          withoutHeaders:
-                            additionalProperties:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - exact
-                                  - required:
-                                    - prefix
-                                  - required:
-                                    - regex
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
+                            type: string
+                        type: object
+                      retries:
+                        description: Retry policy for HTTP requests.
+                        properties:
+                          attempts:
+                            description: Number of retries to be allowed for a given
+                              request.
+                            format: int32
+                            type: integer
+                          perTryTimeout:
+                            description: Timeout per attempt for a given request, including
+                              the initial call and any retries.
+                            type: string
+                          retryOn:
+                            description: Specifies the conditions under which retry
+                              takes place.
+                            type: string
+                          retryRemoteLocalities:
+                            description: Flag to specify whether the retries should
+                              retry to other localities.
+                            nullable: true
+                            type: boolean
+                        type: object
+                      rewrite:
+                        description: Rewrite HTTP URIs and Authority headers.
+                        properties:
+                          authority:
+                            description: rewrite the Authority/Host header with this
+                              value.
+                            type: string
+                          uri:
+                            type: string
+                        type: object
+                      route:
+                        description: A HTTP rule can either return a direct_response,
+                          redirect or forward (default) traffic.
+                        items:
+                          properties:
+                            destination:
                               properties:
-                                exact:
+                                host:
+                                  description: The name of a service from the service
+                                    registry.
                                   type: string
-                                prefix:
-                                  type: string
-                                regex:
-                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                port:
+                                  description: Specifies the port on the host that is
+                                    being addressed.
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                subset:
+                                  description: The name of a subset within the service.
                                   type: string
                               type: object
-                            description: withoutHeader has the same syntax with the
-                              header, but has opposite meaning.
-                            type: object
-                        type: object
-                      type: array
-                    mirror:
-                      properties:
-                        host:
-                          description: The name of a service from the service registry.
-                          type: string
-                        port:
-                          description: Specifies the port on the host that is being
-                            addressed.
-                          properties:
-                            number:
+                            headers:
+                              properties:
+                                request:
+                                  properties:
+                                    add:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    remove:
+                                      items:
+                                        type: string
+                                      type: array
+                                    set:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                response:
+                                  properties:
+                                    add:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    remove:
+                                      items:
+                                        type: string
+                                      type: array
+                                    set:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                              type: object
+                            weight:
+                              description: Weight specifies the relative proportion
+                                of traffic to be forwarded to the destination.
+                              format: int32
                               type: integer
                           type: object
-                        subset:
-                          description: The name of a subset within the service.
-                          type: string
-                      type: object
-                    mirror_percent:
-                      description: Percentage of the traffic to be mirrored by the
-                        `mirror` field.
-                      nullable: true
-                      type: integer
-                    mirrorPercent:
-                      description: Percentage of the traffic to be mirrored by the
-                        `mirror` field.
-                      nullable: true
-                      type: integer
-                    mirrorPercentage:
-                      description: Percentage of the traffic to be mirrored by the
-                        `mirror` field.
-                      properties:
-                        value:
-                          format: double
-                          type: number
-                      type: object
-                    name:
-                      description: The name assigned to the route for debugging purposes.
-                      type: string
-                    redirect:
-                      description: A HTTP rule can either redirect or forward (default)
-                        traffic.
-                      oneOf:
-                      - not:
-                          anyOf:
-                          - required:
-                            - port
-                          - required:
-                            - derivePort
-                      - required:
-                        - port
-                      - required:
-                        - derivePort
-                      properties:
-                        authority:
-                          type: string
-                        derivePort:
-                          enum:
-                          - FROM_PROTOCOL_DEFAULT
-                          - FROM_REQUEST_PORT
-                          type: string
-                        port:
-                          description: On a redirect, overwrite the port portion of
-                            the URL with this value.
-                          type: integer
-                        redirectCode:
-                          type: integer
-                        scheme:
-                          description: On a redirect, overwrite the scheme portion
-                            of the URL with this value.
-                          type: string
-                        uri:
-                          type: string
-                      type: object
-                    retries:
-                      description: Retry policy for HTTP requests.
-                      properties:
-                        attempts:
-                          description: Number of retries to be allowed for a given
-                            request.
-                          format: int32
-                          type: integer
-                        perTryTimeout:
-                          description: Timeout per attempt for a given request, including
-                            the initial call and any retries.
-                          type: string
-                        retryOn:
-                          description: Specifies the conditions under which retry
-                            takes place.
-                          type: string
-                        retryRemoteLocalities:
-                          description: Flag to specify whether the retries should
-                            retry to other localities.
-                          nullable: true
-                          type: boolean
-                      type: object
-                    rewrite:
-                      description: Rewrite HTTP URIs and Authority headers.
-                      properties:
-                        authority:
-                          description: rewrite the Authority/Host header with this
-                            value.
-                          type: string
-                        uri:
-                          type: string
-                      type: object
-                    route:
-                      description: A HTTP rule can either redirect or forward (default)
-                        traffic.
-                      items:
-                        properties:
-                          destination:
-                            properties:
-                              host:
-                                description: The name of a service from the service
-                                  registry.
+                        type: array
+                      timeout:
+                        description: Timeout for HTTP requests, default is disabled.
+                        type: string
+                    type: object
+                  type: array
+                tcp:
+                  description: An ordered list of route rules for opaque TCP traffic.
+                  items:
+                    properties:
+                      match:
+                        items:
+                          properties:
+                            destinationSubnets:
+                              description: IPv4 or IPv6 ip addresses of destination
+                                with optional subnet.
+                              items:
                                 type: string
-                              port:
-                                description: Specifies the port on the host that is
-                                  being addressed.
-                                properties:
-                                  number:
-                                    type: integer
-                                type: object
-                              subset:
-                                description: The name of a subset within the service.
+                              type: array
+                            gateways:
+                              description: Names of gateways where the rule should be
+                                applied.
+                              items:
                                 type: string
-                            type: object
-                          headers:
-                            properties:
-                              request:
-                                properties:
-                                  add:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                  remove:
-                                    items:
-                                      type: string
-                                    type: array
-                                  set:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              response:
-                                properties:
-                                  add:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                  remove:
-                                    items:
-                                      type: string
-                                    type: array
-                                  set:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                            type: object
-                          weight:
-                            format: int32
-                            type: integer
-                        type: object
-                      type: array
-                    timeout:
-                      description: Timeout for HTTP requests, default is disabled.
-                      type: string
-                  type: object
-                type: array
-              tcp:
-                description: An ordered list of route rules for opaque TCP traffic.
-                items:
-                  properties:
-                    match:
-                      items:
-                        properties:
-                          destinationSubnets:
-                            description: IPv4 or IPv6 ip addresses of destination
-                              with optional subnet.
-                            items:
-                              type: string
-                            type: array
-                          gateways:
-                            description: Names of gateways where the rule should be
-                              applied.
-                            items:
-                              type: string
-                            type: array
-                          port:
-                            description: Specifies the port on the host that is being
-                              addressed.
-                            type: integer
-                          sourceLabels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          sourceNamespace:
-                            description: Source namespace constraining the applicability
-                              of a rule to workloads in that namespace.
-                            type: string
-                          sourceSubnet:
-                            description: IPv4 or IPv6 ip address of source with optional
-                              subnet.
-                            type: string
-                        type: object
-                      type: array
-                    route:
-                      description: The destination to which the connection should
-                        be forwarded to.
-                      items:
-                        properties:
-                          destination:
-                            properties:
-                              host:
-                                description: The name of a service from the service
-                                  registry.
+                              type: array
+                            port:
+                              description: Specifies the port on the host that is being
+                                addressed.
+                              type: integer
+                            sourceLabels:
+                              additionalProperties:
                                 type: string
-                              port:
-                                description: Specifies the port on the host that is
-                                  being addressed.
-                                properties:
-                                  number:
-                                    type: integer
-                                type: object
-                              subset:
-                                description: The name of a subset within the service.
+                              type: object
+                            sourceNamespace:
+                              description: Source namespace constraining the applicability
+                                of a rule to workloads in that namespace.
+                              type: string
+                            sourceSubnet:
+                              description: IPv4 or IPv6 ip address of source with optional
+                                subnet.
+                              type: string
+                          type: object
+                        type: array
+                      route:
+                        description: The destination to which the connection should
+                          be forwarded to.
+                        items:
+                          properties:
+                            destination:
+                              properties:
+                                host:
+                                  description: The name of a service from the service
+                                    registry.
+                                  type: string
+                                port:
+                                  description: Specifies the port on the host that is
+                                    being addressed.
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                subset:
+                                  description: The name of a subset within the service.
+                                  type: string
+                              type: object
+                            weight:
+                              description: Weight specifies the relative proportion
+                                of traffic to be forwarded to the destination.
+                              format: int32
+                              type: integer
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+                tls:
+                  items:
+                    properties:
+                      match:
+                        items:
+                          properties:
+                            destinationSubnets:
+                              description: IPv4 or IPv6 ip addresses of destination
+                                with optional subnet.
+                              items:
                                 type: string
-                            type: object
-                          weight:
-                            format: int32
-                            type: integer
-                        type: object
-                      type: array
-                  type: object
-                type: array
-              tls:
-                items:
-                  properties:
-                    match:
-                      items:
-                        properties:
-                          destinationSubnets:
-                            description: IPv4 or IPv6 ip addresses of destination
-                              with optional subnet.
-                            items:
-                              type: string
-                            type: array
-                          gateways:
-                            description: Names of gateways where the rule should be
-                              applied.
-                            items:
-                              type: string
-                            type: array
-                          port:
-                            description: Specifies the port on the host that is being
-                              addressed.
-                            type: integer
-                          sniHosts:
-                            description: SNI (server name indicator) to match on.
-                            items:
-                              type: string
-                            type: array
-                          sourceLabels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          sourceNamespace:
-                            description: Source namespace constraining the applicability
-                              of a rule to workloads in that namespace.
-                            type: string
-                        type: object
-                      type: array
-                    route:
-                      description: The destination to which the connection should
-                        be forwarded to.
-                      items:
-                        properties:
-                          destination:
-                            properties:
-                              host:
-                                description: The name of a service from the service
-                                  registry.
+                              type: array
+                            gateways:
+                              description: Names of gateways where the rule should be
+                                applied.
+                              items:
                                 type: string
-                              port:
-                                description: Specifies the port on the host that is
-                                  being addressed.
-                                properties:
-                                  number:
-                                    type: integer
-                                type: object
-                              subset:
-                                description: The name of a subset within the service.
+                              type: array
+                            port:
+                              description: Specifies the port on the host that is being
+                                addressed.
+                              type: integer
+                            sniHosts:
+                              description: SNI (server name indicator) to match on.
+                              items:
                                 type: string
-                            type: object
-                          weight:
-                            format: int32
-                            type: integer
-                        type: object
-                      type: array
-                  type: object
-                type: array
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
+                              type: array
+                            sourceLabels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            sourceNamespace:
+                              description: Source namespace constraining the applicability
+                                of a rule to workloads in that namespace.
+                              type: string
+                          type: object
+                        type: array
+                      route:
+                        description: The destination to which the connection should
+                          be forwarded to.
+                        items:
+                          properties:
+                            destination:
+                              properties:
+                                host:
+                                  description: The name of a service from the service
+                                    registry.
+                                  type: string
+                                port:
+                                  description: Specifies the port on the host that is
+                                    being addressed.
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                subset:
+                                  description: The name of a subset within the service.
+                                  type: string
+                              type: object
+                            weight:
+                              description: Weight specifies the relative proportion
+                                of traffic to be forwarded to the destination.
+                              format: int32
+                              type: integer
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -5007,120 +5806,120 @@ spec:
   group: networking.istio.io
   names:
     categories:
-    - istio-io
-    - networking-istio-io
+      - istio-io
+      - networking-istio-io
     kind: WorkloadEntry
     listKind: WorkloadEntryList
     plural: workloadentries
     shortNames:
-    - we
+      - we
     singular: workloadentry
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: 'CreationTimestamp is a timestamp representing the server time
+    - additionalPrinterColumns:
+        - description: 'CreationTimestamp is a timestamp representing the server time
         when this object was created. It is not guaranteed to be set in happens-before
         order across separate operations. Clients may not set this value. It is represented
         in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
         lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - description: Address associated with the network endpoint.
-      jsonPath: .spec.address
-      name: Address
-      type: string
-    name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting VMs onboarded into the mesh. See
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: Address associated with the network endpoint.
+          jsonPath: .spec.address
+          name: Address
+          type: string
+      name: v1alpha3
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Configuration affecting VMs onboarded into the mesh. See
               more details at: https://istio.io/docs/reference/config/networking/workload-entry.html'
-            properties:
-              address:
-                type: string
-              labels:
-                additionalProperties:
+              properties:
+                address:
                   type: string
-                description: One or more labels associated with the endpoint.
-                type: object
-              locality:
-                description: The locality associated with the endpoint.
-                type: string
-              network:
-                type: string
-              ports:
-                additionalProperties:
+                labels:
+                  additionalProperties:
+                    type: string
+                  description: One or more labels associated with the endpoint.
+                  type: object
+                locality:
+                  description: The locality associated with the endpoint.
+                  type: string
+                network:
+                  type: string
+                ports:
+                  additionalProperties:
+                    type: integer
+                  description: Set of ports associated with the endpoint.
+                  type: object
+                serviceAccount:
+                  type: string
+                weight:
+                  description: The load balancing weight associated with the endpoint.
                   type: integer
-                description: Set of ports associated with the endpoint.
-                type: object
-              serviceAccount:
-                type: string
-              weight:
-                description: The load balancing weight associated with the endpoint.
-                type: integer
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - description: 'CreationTimestamp is a timestamp representing the server time
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: 'CreationTimestamp is a timestamp representing the server time
         when this object was created. It is not guaranteed to be set in happens-before
         order across separate operations. Clients may not set this value. It is represented
         in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
         lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - description: Address associated with the network endpoint.
-      jsonPath: .spec.address
-      name: Address
-      type: string
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting VMs onboarded into the mesh. See
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: Address associated with the network endpoint.
+          jsonPath: .spec.address
+          name: Address
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Configuration affecting VMs onboarded into the mesh. See
               more details at: https://istio.io/docs/reference/config/networking/workload-entry.html'
-            properties:
-              address:
-                type: string
-              labels:
-                additionalProperties:
+              properties:
+                address:
                   type: string
-                description: One or more labels associated with the endpoint.
-                type: object
-              locality:
-                description: The locality associated with the endpoint.
-                type: string
-              network:
-                type: string
-              ports:
-                additionalProperties:
+                labels:
+                  additionalProperties:
+                    type: string
+                  description: One or more labels associated with the endpoint.
+                  type: object
+                locality:
+                  description: The locality associated with the endpoint.
+                  type: string
+                network:
+                  type: string
+                ports:
+                  additionalProperties:
+                    type: integer
+                  description: Set of ports associated with the endpoint.
+                  type: object
+                serviceAccount:
+                  type: string
+                weight:
+                  description: The load balancing weight associated with the endpoint.
                   type: integer
-                description: Set of ports associated with the endpoint.
-                type: object
-              serviceAccount:
-                type: string
-              weight:
-                description: The load balancing weight associated with the endpoint.
-                type: integer
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -5136,167 +5935,316 @@ spec:
   group: networking.istio.io
   names:
     categories:
-    - istio-io
-    - networking-istio-io
+      - istio-io
+      - networking-istio-io
     kind: WorkloadGroup
     listKind: WorkloadGroupList
     plural: workloadgroups
     shortNames:
-    - wg
+      - wg
     singular: workloadgroup
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: 'CreationTimestamp is a timestamp representing the server time
+    - additionalPrinterColumns:
+        - description: 'CreationTimestamp is a timestamp representing the server time
         when this object was created. It is not guaranteed to be set in happens-before
         order across separate operations. Clients may not set this value. It is represented
         in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
         lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Describes a collection of workload instances. See more details
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha3
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Describes a collection of workload instances. See more details
               at: https://istio.io/docs/reference/config/networking/workload-group.html'
-            properties:
-              metadata:
-                description: Metadata that will be used for all corresponding `WorkloadEntries`.
-                properties:
-                  annotations:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  labels:
-                    additionalProperties:
-                      type: string
-                    type: object
-                type: object
-              probe:
-                description: '`ReadinessProbe` describes the configuration the user
+              properties:
+                metadata:
+                  description: Metadata that will be used for all corresponding `WorkloadEntries`.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                probe:
+                  description: '`ReadinessProbe` describes the configuration the user
                   must provide for healthchecking on their workload.'
-                oneOf:
-                - not:
-                    anyOf:
+                  oneOf:
+                    - not:
+                        anyOf:
+                          - required:
+                              - httpGet
+                          - required:
+                              - tcpSocket
+                          - required:
+                              - exec
                     - required:
-                      - httpGet
+                        - httpGet
                     - required:
-                      - tcpSocket
+                        - tcpSocket
                     - required:
-                      - exec
-                - required:
-                  - httpGet
-                - required:
-                  - tcpSocket
-                - required:
-                  - exec
-                properties:
-                  exec:
-                    description: Health is determined by how the command that is executed
-                      exited.
-                    properties:
-                      command:
-                        description: Command to run.
-                        items:
-                          type: string
-                        type: array
-                    type: object
-                  failureThreshold:
-                    description: Minimum consecutive failures for the probe to be
-                      considered failed after having succeeded.
-                    format: int32
-                    type: integer
-                  httpGet:
-                    properties:
-                      host:
-                        description: Host name to connect to, defaults to the pod
-                          IP.
-                        type: string
-                      httpHeaders:
-                        description: Headers the proxy will pass on to make the request.
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            value:
-                              type: string
-                          type: object
-                        type: array
-                      path:
-                        description: Path to access on the HTTP server.
-                        type: string
-                      port:
-                        description: Port on which the endpoint lives.
-                        type: integer
-                      scheme:
-                        type: string
-                    type: object
-                  initialDelaySeconds:
-                    description: Number of seconds after the container has started
-                      before readiness probes are initiated.
-                    format: int32
-                    type: integer
-                  periodSeconds:
-                    description: How often (in seconds) to perform the probe.
-                    format: int32
-                    type: integer
-                  successThreshold:
-                    description: Minimum consecutive successes for the probe to be
-                      considered successful after having failed.
-                    format: int32
-                    type: integer
-                  tcpSocket:
-                    description: Health is determined by if the proxy is able to connect.
-                    properties:
-                      host:
-                        type: string
-                      port:
-                        type: integer
-                    type: object
-                  timeoutSeconds:
-                    description: Number of seconds after which the probe times out.
-                    format: int32
-                    type: integer
-                type: object
-              template:
-                description: Template to be used for the generation of `WorkloadEntry`
-                  resources that belong to this `WorkloadGroup`.
-                properties:
-                  address:
-                    type: string
-                  labels:
-                    additionalProperties:
-                      type: string
-                    description: One or more labels associated with the endpoint.
-                    type: object
-                  locality:
-                    description: The locality associated with the endpoint.
-                    type: string
-                  network:
-                    type: string
-                  ports:
-                    additionalProperties:
+                        - exec
+                  properties:
+                    exec:
+                      description: Health is determined by how the command that is executed
+                        exited.
+                      properties:
+                        command:
+                          description: Command to run.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded.
+                      format: int32
                       type: integer
-                    description: Set of ports associated with the endpoint.
-                    type: object
-                  serviceAccount:
-                    type: string
-                  weight:
-                    description: The load balancing weight associated with the endpoint.
-                    type: integer
-                type: object
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                    httpGet:
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP.
+                          type: string
+                        httpHeaders:
+                          description: Headers the proxy will pass on to make the request.
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          description: Port on which the endpoint lives.
+                          type: integer
+                        scheme:
+                          type: string
+                      type: object
+                    initialDelaySeconds:
+                      description: Number of seconds after the container has started
+                        before readiness probes are initiated.
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to be
+                        considered successful after having failed.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: Health is determined by if the proxy is able to connect.
+                      properties:
+                        host:
+                          type: string
+                        port:
+                          type: integer
+                      type: object
+                    timeoutSeconds:
+                      description: Number of seconds after which the probe times out.
+                      format: int32
+                      type: integer
+                  type: object
+                template:
+                  description: Template to be used for the generation of `WorkloadEntry`
+                    resources that belong to this `WorkloadGroup`.
+                  properties:
+                    address:
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: One or more labels associated with the endpoint.
+                      type: object
+                    locality:
+                      description: The locality associated with the endpoint.
+                      type: string
+                    network:
+                      type: string
+                    ports:
+                      additionalProperties:
+                        type: integer
+                      description: Set of ports associated with the endpoint.
+                      type: object
+                    serviceAccount:
+                      type: string
+                    weight:
+                      description: The load balancing weight associated with the endpoint.
+                      type: integer
+                  type: object
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: 'CreationTimestamp is a timestamp representing the server time
+        when this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              properties:
+                metadata:
+                  description: Metadata that will be used for all corresponding `WorkloadEntries`.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                probe:
+                  description: '`ReadinessProbe` describes the configuration the user
+                  must provide for healthchecking on their workload.'
+                  oneOf:
+                    - not:
+                        anyOf:
+                          - required:
+                              - httpGet
+                          - required:
+                              - tcpSocket
+                          - required:
+                              - exec
+                    - required:
+                        - httpGet
+                    - required:
+                        - tcpSocket
+                    - required:
+                        - exec
+                  properties:
+                    exec:
+                      description: Health is determined by how the command that is executed
+                        exited.
+                      properties:
+                        command:
+                          description: Command to run.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded.
+                      format: int32
+                      type: integer
+                    httpGet:
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP.
+                          type: string
+                        httpHeaders:
+                          description: Headers the proxy will pass on to make the request.
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          description: Port on which the endpoint lives.
+                          type: integer
+                        scheme:
+                          type: string
+                      type: object
+                    initialDelaySeconds:
+                      description: Number of seconds after the container has started
+                        before readiness probes are initiated.
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to be
+                        considered successful after having failed.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: Health is determined by if the proxy is able to connect.
+                      properties:
+                        host:
+                          type: string
+                        port:
+                          type: integer
+                      type: object
+                    timeoutSeconds:
+                      description: Number of seconds after which the probe times out.
+                      format: int32
+                      type: integer
+                  type: object
+                template:
+                  description: Template to be used for the generation of `WorkloadEntry`
+                    resources that belong to this `WorkloadGroup`.
+                  properties:
+                    address:
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: One or more labels associated with the endpoint.
+                      type: object
+                    locality:
+                      description: The locality associated with the endpoint.
+                      type: string
+                    network:
+                      type: string
+                    ports:
+                      additionalProperties:
+                        type: integer
+                      description: Set of ports associated with the endpoint.
+                      type: object
+                    serviceAccount:
+                      type: string
+                    weight:
+                      description: The load balancing weight associated with the endpoint.
+                      type: integer
+                  type: object
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -5315,196 +6263,378 @@ spec:
   group: security.istio.io
   names:
     categories:
-    - istio-io
-    - security-istio-io
+      - istio-io
+      - security-istio-io
     kind: AuthorizationPolicy
     listKind: AuthorizationPolicyList
     plural: authorizationpolicies
     singular: authorizationpolicy
   scope: Namespaced
   versions:
-  - name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration for access control on workloads. See more
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Configuration for access control on workloads. See more
               details at: https://istio.io/docs/reference/config/security/authorization-policy.html'
-            oneOf:
-            - not:
-                anyOf:
+              oneOf:
+                - not:
+                    anyOf:
+                      - required:
+                          - provider
                 - required:
-                  - provider
-            - required:
-              - provider
-            properties:
-              action:
-                description: Optional.
-                enum:
-                - ALLOW
-                - DENY
-                - AUDIT
-                - CUSTOM
-                type: string
-              provider:
-                description: Specifies detailed configuration of the CUSTOM action.
-                properties:
-                  name:
-                    description: Specifies the name of the extension provider.
-                    type: string
-                type: object
-              rules:
-                description: Optional.
-                items:
+                    - provider
+              properties:
+                action:
+                  description: Optional.
+                  enum:
+                    - ALLOW
+                    - DENY
+                    - AUDIT
+                    - CUSTOM
+                  type: string
+                provider:
+                  description: Specifies detailed configuration of the CUSTOM action.
                   properties:
-                    from:
-                      description: Optional.
-                      items:
-                        properties:
-                          source:
-                            description: Source specifies the source of a request.
-                            properties:
-                              ipBlocks:
-                                description: Optional.
-                                items:
-                                  type: string
-                                type: array
-                              namespaces:
-                                description: Optional.
-                                items:
-                                  type: string
-                                type: array
-                              notIpBlocks:
-                                description: Optional.
-                                items:
-                                  type: string
-                                type: array
-                              notNamespaces:
-                                description: Optional.
-                                items:
-                                  type: string
-                                type: array
-                              notPrincipals:
-                                description: Optional.
-                                items:
-                                  type: string
-                                type: array
-                              notRemoteIpBlocks:
-                                description: Optional.
-                                items:
-                                  type: string
-                                type: array
-                              notRequestPrincipals:
-                                description: Optional.
-                                items:
-                                  type: string
-                                type: array
-                              principals:
-                                description: Optional.
-                                items:
-                                  type: string
-                                type: array
-                              remoteIpBlocks:
-                                description: Optional.
-                                items:
-                                  type: string
-                                type: array
-                              requestPrincipals:
-                                description: Optional.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                        type: object
-                      type: array
-                    to:
-                      description: Optional.
-                      items:
-                        properties:
-                          operation:
-                            description: Operation specifies the operation of a request.
-                            properties:
-                              hosts:
-                                description: Optional.
-                                items:
-                                  type: string
-                                type: array
-                              methods:
-                                description: Optional.
-                                items:
-                                  type: string
-                                type: array
-                              notHosts:
-                                description: Optional.
-                                items:
-                                  type: string
-                                type: array
-                              notMethods:
-                                description: Optional.
-                                items:
-                                  type: string
-                                type: array
-                              notPaths:
-                                description: Optional.
-                                items:
-                                  type: string
-                                type: array
-                              notPorts:
-                                description: Optional.
-                                items:
-                                  type: string
-                                type: array
-                              paths:
-                                description: Optional.
-                                items:
-                                  type: string
-                                type: array
-                              ports:
-                                description: Optional.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                        type: object
-                      type: array
-                    when:
-                      description: Optional.
-                      items:
-                        properties:
-                          key:
-                            description: The name of an Istio attribute.
-                            type: string
-                          notValues:
-                            description: Optional.
-                            items:
-                              type: string
-                            type: array
-                          values:
-                            description: Optional.
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      type: array
-                  type: object
-                type: array
-              selector:
-                description: Optional.
-                properties:
-                  matchLabels:
-                    additionalProperties:
+                    name:
+                      description: Specifies the name of the extension provider.
                       type: string
+                  type: object
+                rules:
+                  description: Optional.
+                  items:
+                    properties:
+                      from:
+                        description: Optional.
+                        items:
+                          properties:
+                            source:
+                              description: Source specifies the source of a request.
+                              properties:
+                                ipBlocks:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                namespaces:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notIpBlocks:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notNamespaces:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notPrincipals:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notRemoteIpBlocks:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notRequestPrincipals:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                principals:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                remoteIpBlocks:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                requestPrincipals:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                      to:
+                        description: Optional.
+                        items:
+                          properties:
+                            operation:
+                              description: Operation specifies the operation of a request.
+                              properties:
+                                hosts:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                methods:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notHosts:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notMethods:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notPaths:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notPorts:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                paths:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                ports:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                      when:
+                        description: Optional.
+                        items:
+                          properties:
+                            key:
+                              description: The name of an Istio attribute.
+                              type: string
+                            notValues:
+                              description: Optional.
+                              items:
+                                type: string
+                              type: array
+                            values:
+                              description: Optional.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
                     type: object
-                type: object
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  type: array
+                selector:
+                  description: Optional.
+                  properties:
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Configuration for access control on workloads. See more
+              details at: https://istio.io/docs/reference/config/security/authorization-policy.html'
+              oneOf:
+                - not:
+                    anyOf:
+                      - required:
+                          - provider
+                - required:
+                    - provider
+              properties:
+                action:
+                  description: Optional.
+                  enum:
+                    - ALLOW
+                    - DENY
+                    - AUDIT
+                    - CUSTOM
+                  type: string
+                provider:
+                  description: Specifies detailed configuration of the CUSTOM action.
+                  properties:
+                    name:
+                      description: Specifies the name of the extension provider.
+                      type: string
+                  type: object
+                rules:
+                  description: Optional.
+                  items:
+                    properties:
+                      from:
+                        description: Optional.
+                        items:
+                          properties:
+                            source:
+                              description: Source specifies the source of a request.
+                              properties:
+                                ipBlocks:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                namespaces:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notIpBlocks:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notNamespaces:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notPrincipals:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notRemoteIpBlocks:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notRequestPrincipals:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                principals:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                remoteIpBlocks:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                requestPrincipals:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                      to:
+                        description: Optional.
+                        items:
+                          properties:
+                            operation:
+                              description: Operation specifies the operation of a request.
+                              properties:
+                                hosts:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                methods:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notHosts:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notMethods:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notPaths:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notPorts:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                paths:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                ports:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                      when:
+                        description: Optional.
+                        items:
+                          properties:
+                            key:
+                              description: The name of an Istio attribute.
+                              type: string
+                            notValues:
+                              description: Optional.
+                              items:
+                                type: string
+                              type: array
+                            values:
+                              description: Optional.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+                selector:
+                  description: Optional.
+                  properties:
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -5523,81 +6653,81 @@ spec:
   group: security.istio.io
   names:
     categories:
-    - istio-io
-    - security-istio-io
+      - istio-io
+      - security-istio-io
     kind: PeerAuthentication
     listKind: PeerAuthenticationList
     plural: peerauthentications
     shortNames:
-    - pa
+      - pa
     singular: peerauthentication
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Defines the mTLS mode used for peer authentication.
-      jsonPath: .spec.mtls.mode
-      name: Mode
-      type: string
-    - description: 'CreationTimestamp is a timestamp representing the server time
+    - additionalPrinterColumns:
+        - description: Defines the mTLS mode used for peer authentication.
+          jsonPath: .spec.mtls.mode
+          name: Mode
+          type: string
+        - description: 'CreationTimestamp is a timestamp representing the server time
         when this object was created. It is not guaranteed to be set in happens-before
         order across separate operations. Clients may not set this value. It is represented
         in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
         lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: PeerAuthentication defines how traffic will be tunneled (or
-              not) to the sidecar.
-            properties:
-              mtls:
-                description: Mutual TLS settings for workload.
-                properties:
-                  mode:
-                    description: Defines the mTLS mode used for peer authentication.
-                    enum:
-                    - UNSET
-                    - DISABLE
-                    - PERMISSIVE
-                    - STRICT
-                    type: string
-                type: object
-              portLevelMtls:
-                additionalProperties:
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: PeerAuthentication defines how traffic will be tunneled (or
+                not) to the sidecar.
+              properties:
+                mtls:
+                  description: Mutual TLS settings for workload.
                   properties:
                     mode:
                       description: Defines the mTLS mode used for peer authentication.
                       enum:
-                      - UNSET
-                      - DISABLE
-                      - PERMISSIVE
-                      - STRICT
+                        - UNSET
+                        - DISABLE
+                        - PERMISSIVE
+                        - STRICT
                       type: string
                   type: object
-                description: Port specific mutual TLS settings.
-                type: object
-              selector:
-                description: The selector determines the workloads to apply the ChannelAuthentication
-                  on.
-                properties:
-                  matchLabels:
-                    additionalProperties:
-                      type: string
+                portLevelMtls:
+                  additionalProperties:
+                    properties:
+                      mode:
+                        description: Defines the mTLS mode used for peer authentication.
+                        enum:
+                          - UNSET
+                          - DISABLE
+                          - PERMISSIVE
+                          - STRICT
+                        type: string
                     type: object
-                type: object
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  description: Port specific mutual TLS settings.
+                  type: object
+                selector:
+                  description: The selector determines the workloads to apply the ChannelAuthentication
+                    on.
+                  properties:
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -5616,87 +6746,184 @@ spec:
   group: security.istio.io
   names:
     categories:
-    - istio-io
-    - security-istio-io
+      - istio-io
+      - security-istio-io
     kind: RequestAuthentication
     listKind: RequestAuthenticationList
     plural: requestauthentications
     shortNames:
-    - ra
+      - ra
     singular: requestauthentication
   scope: Namespaced
   versions:
-  - name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: RequestAuthentication defines what request authentication
-              methods are supported by a workload.
-            properties:
-              jwtRules:
-                description: Define the list of JWTs that can be validated at the
-                  selected workloads' proxy.
-                items:
-                  properties:
-                    audiences:
-                      items:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: RequestAuthentication defines what request authentication
+                methods are supported by a workload.
+              properties:
+                jwtRules:
+                  description: Define the list of JWTs that can be validated at the
+                    selected workloads' proxy.
+                  items:
+                    properties:
+                      audiences:
+                        items:
+                          type: string
+                        type: array
+                      forwardOriginalToken:
+                        description: If set to true, the original token will be kept
+                          for the upstream request.
+                        type: boolean
+                      fromHeaders:
+                        description: List of header locations from which JWT is expected.
+                        items:
+                          properties:
+                            name:
+                              description: The HTTP header name.
+                              type: string
+                            prefix:
+                              description: The prefix that should be stripped before
+                                decoding the token.
+                              type: string
+                          type: object
+                        type: array
+                      fromParams:
+                        description: List of query parameters from which JWT is expected.
+                        items:
+                          type: string
+                        type: array
+                      issuer:
+                        description: Identifies the issuer that issued the JWT.
                         type: string
-                      type: array
-                    forwardOriginalToken:
-                      description: If set to true, the original token will be kept
-                        for the upstream request.
-                      type: boolean
-                    fromHeaders:
-                      description: List of header locations from which JWT is expected.
-                      items:
-                        properties:
-                          name:
-                            description: The HTTP header name.
-                            type: string
-                          prefix:
-                            description: The prefix that should be stripped before
-                              decoding the token.
-                            type: string
-                        type: object
-                      type: array
-                    fromParams:
-                      description: List of query parameters from which JWT is expected.
-                      items:
+                      jwks:
+                        description: JSON Web Key Set of public keys to validate signature
+                          of the JWT.
                         type: string
-                      type: array
-                    issuer:
-                      description: Identifies the issuer that issued the JWT.
-                      type: string
-                    jwks:
-                      description: JSON Web Key Set of public keys to validate signature
-                        of the JWT.
-                      type: string
-                    jwks_uri:
-                      type: string
-                    jwksUri:
-                      type: string
-                    outputPayloadToHeader:
-                      type: string
-                  type: object
-                type: array
-              selector:
-                description: Optional.
-                properties:
-                  matchLabels:
-                    additionalProperties:
-                      type: string
+                      jwks_uri:
+                        type: string
+                      jwksUri:
+                        type: string
+                      outputClaimToHeaders:
+                        description: This field specifies a list of operations to copy
+                          the claim to HTTP headers on a successfully verified token.
+                        items:
+                          properties:
+                            claim:
+                              description: The name of the claim to be copied from.
+                              type: string
+                            header:
+                              description: The name of the header to be created.
+                              type: string
+                          type: object
+                        type: array
+                      outputPayloadToHeader:
+                        type: string
                     type: object
-                type: object
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  type: array
+                selector:
+                  description: Optional.
+                  properties:
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: RequestAuthentication defines what request authentication
+                methods are supported by a workload.
+              properties:
+                jwtRules:
+                  description: Define the list of JWTs that can be validated at the
+                    selected workloads' proxy.
+                  items:
+                    properties:
+                      audiences:
+                        items:
+                          type: string
+                        type: array
+                      forwardOriginalToken:
+                        description: If set to true, the original token will be kept
+                          for the upstream request.
+                        type: boolean
+                      fromHeaders:
+                        description: List of header locations from which JWT is expected.
+                        items:
+                          properties:
+                            name:
+                              description: The HTTP header name.
+                              type: string
+                            prefix:
+                              description: The prefix that should be stripped before
+                                decoding the token.
+                              type: string
+                          type: object
+                        type: array
+                      fromParams:
+                        description: List of query parameters from which JWT is expected.
+                        items:
+                          type: string
+                        type: array
+                      issuer:
+                        description: Identifies the issuer that issued the JWT.
+                        type: string
+                      jwks:
+                        description: JSON Web Key Set of public keys to validate signature
+                          of the JWT.
+                        type: string
+                      jwks_uri:
+                        type: string
+                      jwksUri:
+                        type: string
+                      outputClaimToHeaders:
+                        description: This field specifies a list of operations to copy
+                          the claim to HTTP headers on a successfully verified token.
+                        items:
+                          properties:
+                            claim:
+                              description: The name of the claim to be copied from.
+                              type: string
+                            header:
+                              description: The name of the header to be created.
+                              type: string
+                          type: object
+                        type: array
+                      outputPayloadToHeader:
+                        type: string
+                    type: object
+                  type: array
+                selector:
+                  description: Optional.
+                  properties:
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -5715,227 +6942,258 @@ spec:
   group: telemetry.istio.io
   names:
     categories:
-    - istio-io
-    - telemetry-istio-io
+      - istio-io
+      - telemetry-istio-io
     kind: Telemetry
     listKind: TelemetryList
     plural: telemetries
     shortNames:
-    - telemetry
+      - telemetry
     singular: telemetry
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: 'CreationTimestamp is a timestamp representing the server time
+    - additionalPrinterColumns:
+        - description: 'CreationTimestamp is a timestamp representing the server time
         when this object was created. It is not guaranteed to be set in happens-before
         order across separate operations. Clients may not set this value. It is represented
         in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
         lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Telemetry configuration for workloads. See more details
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Telemetry configuration for workloads. See more details
               at: https://istio.io/docs/reference/config/telemetry.html'
-            properties:
-              accessLogging:
-                description: Optional.
-                items:
-                  properties:
-                    disabled:
-                      description: Controls logging.
-                      nullable: true
-                      type: boolean
-                    providers:
-                      description: Optional.
-                      items:
+              properties:
+                accessLogging:
+                  description: Optional.
+                  items:
+                    properties:
+                      disabled:
+                        description: Controls logging.
+                        nullable: true
+                        type: boolean
+                      filter:
+                        description: Optional.
                         properties:
-                          name:
-                            description: Required.
+                          expression:
+                            description: CEL expression for selecting when requests/connections
+                              should be logged.
                             type: string
                         type: object
-                      type: array
-                  type: object
-                type: array
-              metrics:
-                description: Optional.
-                items:
-                  properties:
-                    overrides:
-                      description: Optional.
-                      items:
+                      match:
+                        description: Allows tailoring of logging behavior to specific
+                          conditions.
                         properties:
-                          disabled:
-                            description: Optional.
-                            nullable: true
-                            type: boolean
-                          match:
-                            description: Match allows provides the scope of the override.
-                            oneOf:
-                            - not:
-                                anyOf:
+                          mode:
+                            enum:
+                              - CLIENT_AND_SERVER
+                              - CLIENT
+                              - SERVER
+                            type: string
+                        type: object
+                      providers:
+                        description: Optional.
+                        items:
+                          properties:
+                            name:
+                              description: Required.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+                metrics:
+                  description: Optional.
+                  items:
+                    properties:
+                      overrides:
+                        description: Optional.
+                        items:
+                          properties:
+                            disabled:
+                              description: Optional.
+                              nullable: true
+                              type: boolean
+                            match:
+                              description: Match allows provides the scope of the override.
+                              oneOf:
+                                - not:
+                                    anyOf:
+                                      - required:
+                                          - metric
+                                      - required:
+                                          - customMetric
                                 - required:
-                                  - metric
+                                    - metric
                                 - required:
-                                  - customMetric
-                            - required:
-                              - metric
-                            - required:
-                              - customMetric
-                            properties:
-                              customMetric:
-                                description: Allows free-form specification of a metric.
-                                type: string
-                              metric:
-                                description: One of the well-known Istio Standard
-                                  Metrics.
-                                enum:
-                                - ALL_METRICS
-                                - REQUEST_COUNT
-                                - REQUEST_DURATION
-                                - REQUEST_SIZE
-                                - RESPONSE_SIZE
-                                - TCP_OPENED_CONNECTIONS
-                                - TCP_CLOSED_CONNECTIONS
-                                - TCP_SENT_BYTES
-                                - TCP_RECEIVED_BYTES
-                                - GRPC_REQUEST_MESSAGES
-                                - GRPC_RESPONSE_MESSAGES
-                                type: string
-                              mode:
-                                description: 'Controls which mode of metrics generation
-                                  is selected: CLIENT and/or SERVER.'
-                                enum:
-                                - CLIENT_AND_SERVER
-                                - CLIENT
-                                - SERVER
-                                type: string
-                            type: object
-                          tagOverrides:
-                            additionalProperties:
+                                    - customMetric
                               properties:
-                                operation:
-                                  description: Operation controls whether or not to
-                                    update/add a tag, or to remove it.
-                                  enum:
-                                  - UPSERT
-                                  - REMOVE
+                                customMetric:
+                                  description: Allows free-form specification of a metric.
                                   type: string
-                                value:
-                                  description: Value is only considered if the operation
-                                    is `UPSERT`.
+                                metric:
+                                  description: One of the well-known Istio Standard
+                                    Metrics.
+                                  enum:
+                                    - ALL_METRICS
+                                    - REQUEST_COUNT
+                                    - REQUEST_DURATION
+                                    - REQUEST_SIZE
+                                    - RESPONSE_SIZE
+                                    - TCP_OPENED_CONNECTIONS
+                                    - TCP_CLOSED_CONNECTIONS
+                                    - TCP_SENT_BYTES
+                                    - TCP_RECEIVED_BYTES
+                                    - GRPC_REQUEST_MESSAGES
+                                    - GRPC_RESPONSE_MESSAGES
+                                  type: string
+                                mode:
+                                  enum:
+                                    - CLIENT_AND_SERVER
+                                    - CLIENT
+                                    - SERVER
                                   type: string
                               type: object
-                            description: Optional.
-                            type: object
-                        type: object
-                      type: array
-                    providers:
-                      description: Optional.
-                      items:
-                        properties:
-                          name:
-                            description: Required.
-                            type: string
-                        type: object
-                      type: array
-                  type: object
-                type: array
-              selector:
-                description: Optional.
-                properties:
-                  matchLabels:
-                    additionalProperties:
-                      type: string
+                            tagOverrides:
+                              additionalProperties:
+                                properties:
+                                  operation:
+                                    description: Operation controls whether or not to
+                                      update/add a tag, or to remove it.
+                                    enum:
+                                      - UPSERT
+                                      - REMOVE
+                                    type: string
+                                  value:
+                                    description: Value is only considered if the operation
+                                      is `UPSERT`.
+                                    type: string
+                                type: object
+                              description: Optional.
+                              type: object
+                          type: object
+                        type: array
+                      providers:
+                        description: Optional.
+                        items:
+                          properties:
+                            name:
+                              description: Required.
+                              type: string
+                          type: object
+                        type: array
+                      reportingInterval:
+                        description: Optional.
+                        type: string
                     type: object
-                type: object
-              tracing:
-                description: Optional.
-                items:
+                  type: array
+                selector:
+                  description: Optional.
                   properties:
-                    customTags:
+                    matchLabels:
                       additionalProperties:
-                        oneOf:
-                        - not:
-                            anyOf:
-                            - required:
-                              - literal
-                            - required:
-                              - environment
-                            - required:
-                              - header
-                        - required:
-                          - literal
-                        - required:
-                          - environment
-                        - required:
-                          - header
-                        properties:
-                          environment:
-                            description: Environment adds the value of an environment
-                              variable to each span.
-                            properties:
-                              defaultValue:
-                                description: Optional.
-                                type: string
-                              name:
-                                description: Name of the environment variable from
-                                  which to extract the tag value.
-                                type: string
-                            type: object
-                          header:
-                            description: RequestHeader adds the value of an header
-                              from the request to each span.
-                            properties:
-                              defaultValue:
-                                description: Optional.
-                                type: string
-                              name:
-                                description: Name of the header from which to extract
-                                  the tag value.
-                                type: string
-                            type: object
-                          literal:
-                            description: Literal adds the same, hard-coded value to
-                              each span.
-                            properties:
-                              value:
-                                description: The tag value to use.
-                                type: string
-                            type: object
-                        type: object
-                      description: Optional.
+                        type: string
                       type: object
-                    disableSpanReporting:
-                      description: Controls span reporting.
-                      nullable: true
-                      type: boolean
-                    providers:
-                      description: Optional.
-                      items:
+                  type: object
+                tracing:
+                  description: Optional.
+                  items:
+                    properties:
+                      customTags:
+                        additionalProperties:
+                          oneOf:
+                            - not:
+                                anyOf:
+                                  - required:
+                                      - literal
+                                  - required:
+                                      - environment
+                                  - required:
+                                      - header
+                            - required:
+                                - literal
+                            - required:
+                                - environment
+                            - required:
+                                - header
+                          properties:
+                            environment:
+                              description: Environment adds the value of an environment
+                                variable to each span.
+                              properties:
+                                defaultValue:
+                                  description: Optional.
+                                  type: string
+                                name:
+                                  description: Name of the environment variable from
+                                    which to extract the tag value.
+                                  type: string
+                              type: object
+                            header:
+                              properties:
+                                defaultValue:
+                                  description: Optional.
+                                  type: string
+                                name:
+                                  description: Name of the header from which to extract
+                                    the tag value.
+                                  type: string
+                              type: object
+                            literal:
+                              description: Literal adds the same, hard-coded value to
+                                each span.
+                              properties:
+                                value:
+                                  description: The tag value to use.
+                                  type: string
+                              type: object
+                          type: object
+                        description: Optional.
+                        type: object
+                      disableSpanReporting:
+                        description: Controls span reporting.
+                        nullable: true
+                        type: boolean
+                      match:
+                        description: Allows tailoring of behavior to specific conditions.
                         properties:
-                          name:
-                            description: Required.
+                          mode:
+                            enum:
+                              - CLIENT_AND_SERVER
+                              - CLIENT
+                              - SERVER
                             type: string
                         type: object
-                      type: array
-                    randomSamplingPercentage:
-                      nullable: true
-                      type: number
-                  type: object
-                type: array
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                      providers:
+                        description: Optional.
+                        items:
+                          properties:
+                            name:
+                              description: Required.
+                              type: string
+                          type: object
+                        type: array
+                      randomSamplingPercentage:
+                        nullable: true
+                        type: number
+                      useRequestIdForTraceSampling:
+                        nullable: true
+                        type: boolean
+                    type: object
+                  type: array
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 
 ---

--- a/test/e2e/crds/split.yaml
+++ b/test/e2e/crds/split.yaml
@@ -1,265 +1,147 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: trafficsplits.split.smi-spec.io
 spec:
   group: split.smi-spec.io
+  scope: Namespaced
   names:
     kind: TrafficSplit
     listKind: TrafficSplitList
-    plural: trafficsplits
     shortNames:
-    - ts
+      - ts
+    plural: trafficsplits
     singular: trafficsplit
-  scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: TrafficSplit is the Schema for the trafficsplits API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: TrafficSplitSpec defines the desired state of TrafficSplit
-            properties:
-              backends:
-                items:
-                  description: TrafficSplitBackend defines a backend
-                  properties:
-                    service:
-                      type: string
-                    weight:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                  type: object
-                type: array
-              service:
-                type: string
-            type: object
-          status:
-            description: TrafficSplitStatus defines the observed state of TrafficSplit
-            type: object
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
-  - name: v1alpha2
-    schema:
-      openAPIV3Schema:
-        description: TrafficSplit is the Schema for the trafficsplits API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: TrafficSplitSpec defines the desired state of TrafficSplit
-            properties:
-              backends:
-                items:
-                  description: TrafficSplitBackend defines a backend
-                  properties:
-                    service:
-                      type: string
-                    weight:
-                      type: integer
-                  required:
-                  - service
-                  - weight
-                  type: object
-                type: array
-              service:
-                type: string
-            type: object
-          status:
-            description: TrafficSplitStatus defines the observed state of TrafficSplit
-            type: object
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
-  - name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        description: TrafficSplit is the Schema for the trafficsplits API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: TrafficSplitSpec defines the desired state of TrafficSplit
-            properties:
-              backends:
-                description: Backends defines a list of Kubernetes services used as
-                  the traffic split destination
-                items:
-                  description: TrafficSplitBackend defines a backend
-                  properties:
-                    service:
-                      description: Service is the name of a Kubernetes service
-                      type: string
-                    weight:
-                      description: Weight defines the traffic split percentage
-                      type: integer
-                  required:
-                  - service
-                  - weight
-                  type: object
-                type: array
-              matches:
-                description: Matches allows defining a list of HTTP route groups that
-                  this traffic split object should match
-                items:
-                  description: TypedLocalObjectReference contains enough information
-                    to let you locate the typed referenced object inside the same
-                    namespace.
-                  properties:
-                    apiGroup:
-                      description: APIGroup is the group for the resource being referenced.
-                        If APIGroup is not specified, the specified Kind must be in
-                        the core API group. For any other third-party types, APIGroup
-                        is required.
-                      type: string
-                    kind:
-                      description: Kind is the type of resource being referenced
-                      type: string
-                    name:
-                      description: Name is the name of resource being referenced
-                      type: string
-                  required:
-                  - kind
-                  - name
-                  type: object
-                type: array
-              service:
-                description: Service represents the apex service
-                type: string
-            required:
-            - backends
-            - service
-            type: object
-          status:
-            description: TrafficSplitStatus defines the observed state of TrafficSplit
-            type: object
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
-  - name: v1alpha4
-    schema:
-      openAPIV3Schema:
-        description: TrafficSplit is the Schema for the trafficsplits API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: TrafficSplitSpec defines the desired state of TrafficSplit
-            properties:
-              backends:
-                description: Backends defines a list of Kubernetes services used as
-                  the traffic split destination
-                items:
-                  description: TrafficSplitBackend defines a backend
-                  properties:
-                    service:
-                      description: Service is the name of a Kubernetes service
-                      type: string
-                    weight:
-                      description: Weight defines the traffic split percentage
-                      type: integer
-                  required:
-                  - service
-                  - weight
-                  type: object
-                type: array
-              matches:
-                description: Matches allows defining a list of HTTP route groups that
-                  this traffic split object should match
-                items:
-                  description: TypedLocalObjectReference contains enough information
-                    to let you locate the typed referenced object inside the same
-                    namespace.
-                  properties:
-                    apiGroup:
-                      description: APIGroup is the group for the resource being referenced.
-                        If APIGroup is not specified, the specified Kind must be in
-                        the core API group. For any other third-party types, APIGroup
-                        is required.
-                      type: string
-                    kind:
-                      description: Kind is the type of resource being referenced
-                      type: string
-                    name:
-                      description: Name is the name of resource being referenced
-                      type: string
-                  required:
-                  - kind
-                  - name
-                  type: object
-                type: array
-              service:
-                description: Service represents the apex service
-                type: string
-            required:
-            - backends
-            - service
-            type: object
-          status:
-            description: TrafficSplitStatus defines the observed state of TrafficSplit
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+    - name: v1alpha4
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Service
+          type: string
+          description: The apex service of this split.
+          jsonPath: .spec.service
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - service
+                - backends
+              properties:
+                service:
+                  description: The apex service of this split.
+                  type: string
+                matches:
+                  description: The HTTP route groups that this traffic split should match.
+                  type: array
+                  items:
+                    type: object
+                    required: ['kind', 'name']
+                    properties:
+                      kind:
+                        description: Kind of the matching group.
+                        type: string
+                        enum:
+                          - HTTPRouteGroup
+                      name:
+                        description: Name of the matching group.
+                        type: string
+                backends:
+                  description: The backend services of this split.
+                  type: array
+                  items:
+                    type: object
+                    required: ['service', 'weight']
+                    properties:
+                      service:
+                        description: Name of the Kubernetes service.
+                        type: string
+                      weight:
+                        description: Traffic weight value of this backend.
+                        type: number
+    - name: v1alpha3
+      served: false
+      storage: false
+      additionalPrinterColumns:
+        - name: Service
+          type: string
+          description: The apex service of this split.
+          jsonPath: .spec.service
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - service
+                - backends
+              properties:
+                service:
+                  description: The apex service of this split.
+                  type: string
+                matches:
+                  description: The HTTP route groups that this traffic split should match.
+                  type: array
+                  items:
+                    type: object
+                    required: ['kind', 'name']
+                    properties:
+                      kind:
+                        description: Kind of the matching group.
+                        type: string
+                        enum:
+                          - HTTPRouteGroup
+                      name:
+                        description: Name of the matching group.
+                        type: string
+                backends:
+                  description: The backend services of this split.
+                  type: array
+                  items:
+                    type: object
+                    required: ['service', 'weight']
+                    properties:
+                      service:
+                        description: Name of the Kubernetes service.
+                        type: string
+                      weight:
+                        description: Traffic weight value of this backend.
+                        type: number
+    - name: v1alpha2
+      served: false
+      storage: false
+      additionalPrinterColumns:
+        - name: Service
+          type: string
+          description: The apex service of this split.
+          jsonPath: .spec.service
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - service
+                - backends
+              properties:
+                service:
+                  description: The apex service of this split.
+                  type: string
+                backends:
+                  description: The backend services of this split.
+                  type: array
+                  items:
+                    type: object
+                    required: ['service', 'weight']
+                    properties:
+                      service:
+                        description: Name of the Kubernetes service.
+                        type: string
+                      weight:
+                        description: Traffic weight value of this backend.
+                        type: number


### PR DESCRIPTION
run e2e tests on more current k8s versions, going forward 4 will be the most we support and will start dropping older versions. 

I also updated the crd's from their upstreams for e2e tests.

I also fixed a bug with the tmate logic on manual runs, an empty string passes as true on actions and so we would always fall into debug mode.