### PR TITLE
docs: Include PagerDuty in service type listing

### DIFF
--- a/docs/generated/notification-services/overview.md
+++ b/docs/generated/notification-services/overview.md
@@ -51,3 +51,4 @@ metadata:
 * [Rocket.Chat](./rocketchat.md)
 * [Pushover](./pushover.md)
 * [Alertmanager](./alertmanager.md)
+* [PagerDuty](./pagerduty.md)


### PR DESCRIPTION
Exists as an option in the sidebar, but not included in the list of "Service Types".

Apologies, I'm not exactly sure where these "generated" docs come from and if I should be modifying elsewhere.
