### PR TITLE
fix: change logic of analysis run to better handle errors

### DIFF
--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -359,9 +359,10 @@ func (c *Controller) runMeasurements(run *v1alpha1.AnalysisRun, tasks []metricTa
 					Phase:  v1alpha1.AnalysisPhaseRunning,
 					DryRun: dryRunMetricsMap[t.metric.Name],
 				}
-			}
-			if provider != nil && providerErr == nil {
-				metricResult.Metadata = provider.GetMetadata(t.metric)
+
+				if provider != nil && providerErr == nil {
+					metricResult.Metadata = provider.GetMetadata(t.metric)
+				}
 			}
 
 			if newMeasurement.Phase.Completed() {

--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -360,7 +360,7 @@ func (c *Controller) runMeasurements(run *v1alpha1.AnalysisRun, tasks []metricTa
 					DryRun: dryRunMetricsMap[t.metric.Name],
 				}
 			}
-			if providerErr != nil {
+			if provider != nil && providerErr == nil {
 				metricResult.Metadata = provider.GetMetadata(t.metric)
 			}
 

--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -347,7 +347,14 @@ func (c *Controller) runMeasurements(run *v1alpha1.AnalysisRun, tasks []metricTa
 				newMeasurement.Message = err.Error()
 			} else {
 
-				metricResult.Metadata = provider.GetMetadata(t.metric)
+				if metricResult == nil {
+					metricResult = &v1alpha1.MetricResult{
+						Name:     t.metric.Name,
+						Phase:    v1alpha1.AnalysisPhaseRunning,
+						DryRun:   dryRunMetricsMap[t.metric.Name],
+						Metadata: provider.GetMetadata(t.metric),
+					}
+				}
 
 				if t.incompleteMeasurement == nil {
 					newMeasurement = provider.Run(run, t.metric)


### PR DESCRIPTION
The logic for error handling of anaysisruns was incorrect, we returned an error from a go routine that did not get used at all. This cause errors to not get bubbled up into the status field of the AR resource. This changes the logic around a bit to make sure we bubble up the error to the AR object as well as log it.

fixes: #2696 