### PR TITLE
fix: append weight destination only when weight is mentioned

### DIFF
--- a/experiments/experiment_test.go
+++ b/experiments/experiment_test.go
@@ -529,6 +529,7 @@ func TestServiceInheritPortsFromRS(t *testing.T) {
 	assert.NotNil(t, exCtx.templateServices["bar"])
 	assert.Equal(t, exCtx.templateServices["bar"].Name, "foo-bar")
 	assert.Equal(t, exCtx.templateServices["bar"].Spec.Ports[0].Port, int32(80))
+	assert.Equal(t, exCtx.templateServices["bar"].Spec.Ports[0].Name, "testport")
 }
 
 func TestServiceNameSet(t *testing.T) {

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -354,11 +354,13 @@ func (c *rolloutContext) calculateWeightDestinationsFromExperiment() []v1alpha1.
 		}
 		for _, templateStatus := range c.currentEx.Status.TemplateStatuses {
 			templateWeight := getTemplateWeight(templateStatus.Name)
-			weightDestinations = append(weightDestinations, v1alpha1.WeightDestination{
-				ServiceName:     templateStatus.ServiceName,
-				PodTemplateHash: templateStatus.PodTemplateHash,
-				Weight:          *templateWeight,
-			})
+			if templateWeight != nil {
+				weightDestinations = append(weightDestinations, v1alpha1.WeightDestination{
+					ServiceName:     templateStatus.ServiceName,
+					PodTemplateHash: templateStatus.PodTemplateHash,
+					Weight:          *templateWeight,
+				})
+			}
 		}
 	}
 	return weightDestinations


### PR DESCRIPTION
As of now, in canary deployment with weighted experiment, the rollout throws nil pointer exception, when in an experiment step, one template contains weight and the other doesn't. For example: 

<img width="324" alt="Screenshot 2023-04-19 at 5 03 25 PM" src="https://user-images.githubusercontent.com/34120560/233062373-17c1eea5-4e28-424a-a3ee-2aec2a8af6f9.png">


Hence handling a nil pointer check and also a UT verification for port name .


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).