### PR TITLE
fix(analysis): Graphite query - remove whitespaces

### DIFF
--- a/metricproviders/graphite/api.go
+++ b/metricproviders/graphite/api.go
@@ -77,7 +77,7 @@ func (api APIClient) Query(quer string) ([]dataPoint, error) {
 
 func (api APIClient) trimQuery(q string) string {
 	space := regexp.MustCompile(`\s+`)
-	return space.ReplaceAllString(q, " ")
+	return space.ReplaceAllString(q, "")
 }
 
 type dataPoint struct {

--- a/metricproviders/graphite/api.go
+++ b/metricproviders/graphite/api.go
@@ -27,9 +27,11 @@ type APIClient struct {
 	logCTX log.Entry
 }
 
+var spaceRegex = regexp.MustCompile(`\s+`)
+
 // Query performs a Graphite API query with the query it's passed
 func (api APIClient) Query(quer string) ([]dataPoint, error) {
-	query := api.trimQuery(quer)
+	query := api.sanitizeQuery(quer)
 	u, err := url.Parse(fmt.Sprintf("./render?%s", query))
 	if err != nil {
 		return []dataPoint{}, err
@@ -75,9 +77,8 @@ func (api APIClient) Query(quer string) ([]dataPoint, error) {
 	return result[0].DataPoints, nil
 }
 
-func (api APIClient) trimQuery(q string) string {
-	space := regexp.MustCompile(`\s+`)
-	return space.ReplaceAllString(q, "")
+func (api APIClient) sanitizeQuery(q string) string {
+	return spaceRegex.ReplaceAllLiteralString(q, "")
 }
 
 type dataPoint struct {

--- a/metricproviders/graphite/api_test.go
+++ b/metricproviders/graphite/api_test.go
@@ -92,6 +92,29 @@ func TestQuery(t *testing.T) {
 		`[]`,
 		200,
 	}, {
+		"query with surrounding whitespace",
+		fmt.Sprintf("\n  %s \t  \n", query),
+		targetQuery,
+		fromQuery,
+		goodResult,
+		nil,
+		fmt.Sprintf(`[
+			{
+				"datapoints": [
+					[
+						%f,
+						%d
+					]
+				],
+				"target": " sumSeries(app.http.*.*.count)",
+				"tags": {
+					"aggregatedBy": "sum",
+					"name": "sumSeries(app.http.*.*.count)"
+				}
+			}
+		]`, value, timestamp),
+		200,
+	}, {
 		"graphite response body with invalid JSON",
 		query,
 		targetQuery,

--- a/metricproviders/graphite/api_test.go
+++ b/metricproviders/graphite/api_test.go
@@ -106,7 +106,7 @@ func TestQuery(t *testing.T) {
 						%d
 					]
 				],
-				"target": " sumSeries(app.http.*.*.count)",
+				"target": "sumSeries(app.http.*.*.count)",
 				"tags": {
 					"aggregatedBy": "sum",
 					"name": "sumSeries(app.http.*.*.count)"


### PR DESCRIPTION
If metric query contains surrounding whitespace, then it's not trimmed and Graphite host returns `400 Bad Request`

Simplest example of analysis template:
```yaml
apiVersion: argoproj.io/v1alpha1
kind: ClusterAnalysisTemplate
metadata:
  name: error-rate
  namespace: argo-rollouts
spec:
  metrics:
    - name: error-rate
      failureLimit: 1
      # Note that the Argo Rollouts Graphite metrics provider returns result as an array of float64s with 6 decimal places.
      successCondition: 'len(result) > 0 and result[len(result)-1] < asFloat(10)'
      provider:
        graphite:
          address: https://some-graphite-host.com
          query: |
            from=-2&target=sumSeries(app.http.*.*.count)

```

When this is parsed from YAML, this query contains a newline in the end, so when it's "trimmed", it still contains a trailing space, so when put into the query, it becomes:

```
format=json&from=-2min&target=sumSeries%28app.http.%2A.%2A.count%29+
```

This leads to `400 Bad Request` response from Graphite, example cURL command:

```shell
$ curl 'https://some-graphite-host.com/render?format=json&from=-2min&target=sumSeries%28app.http.%2A.%2A.count%29+'
Bad Request: Bad Request

Target              : sumSeries(app.http.*.*.count) 
Parsed so far       : sumSeries(app.http.*.*.count)
Could not parse     :  
```

Proposed solution: **replace all whitespace in the query with an empty string**.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).