### PR TITLE
chore: Add tests for pause functionality in rollout package

### DIFF
--- a/rollout/pause_test.go
+++ b/rollout/pause_test.go
@@ -1,0 +1,210 @@
+package rollout
+
+import (
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	intstr "k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+)
+
+func TestHasAddPause(t *testing.T) {
+	work := &pauseContext{
+		rollout: &v1alpha1.Rollout{
+			Status: v1alpha1.RolloutStatus{
+				ControllerPause: false,
+				PauseConditions: []v1alpha1.PauseCondition{},
+			},
+		},
+		log: log.WithFields(log.Fields{}),
+
+		addPauseReasons:    []v1alpha1.PauseReason{v1alpha1.PauseReasonCanaryPauseStep},
+		removePauseReasons: []v1alpha1.PauseReason{},
+	}
+
+	result := work.HasAddPause()
+	assert.Equal(t, true, result)
+}
+
+func TestHasAddPauseNoReasons(t *testing.T) {
+	work := &pauseContext{
+		rollout: &v1alpha1.Rollout{
+			Status: v1alpha1.RolloutStatus{
+				ControllerPause: false,
+				PauseConditions: []v1alpha1.PauseCondition{},
+			},
+		},
+		log: log.WithFields(log.Fields{}),
+
+		addPauseReasons:    []v1alpha1.PauseReason{},
+		removePauseReasons: []v1alpha1.PauseReason{},
+	}
+
+	result := work.HasAddPause()
+	assert.Equal(t, false, result)
+}
+
+func TestCalculatePauseStatus(t *testing.T) {
+	work := &pauseContext{
+		rollout: &v1alpha1.Rollout{
+			Status: v1alpha1.RolloutStatus{
+				ControllerPause: false,
+				PauseConditions: []v1alpha1.PauseCondition{},
+			},
+		},
+		log: log.WithFields(log.Fields{}),
+
+		addPauseReasons:    []v1alpha1.PauseReason{v1alpha1.PauseReasonCanaryPauseStep},
+		removePauseReasons: []v1alpha1.PauseReason{},
+	}
+
+	newStatus := &v1alpha1.RolloutStatus{}
+	work.CalculatePauseStatus(newStatus)
+
+	assert.Equal(t, true, newStatus.ControllerPause)
+	assert.Len(t, newStatus.PauseConditions, 1)
+	assert.Equal(t, v1alpha1.PauseReasonCanaryPauseStep, newStatus.PauseConditions[0].Reason)
+}
+
+func TestCalculatePauseStatusRemovePause(t *testing.T) {
+	now := v1.NewTime(time.Now())
+	work := &pauseContext{
+		rollout: &v1alpha1.Rollout{
+			Status: v1alpha1.RolloutStatus{
+				ControllerPause: true,
+				PauseConditions: []v1alpha1.PauseCondition{
+					{
+						Reason:    v1alpha1.PauseReasonCanaryPauseStep,
+						StartTime: v1.NewTime(now.Add(-1 * time.Minute)),
+					},
+				},
+			},
+		},
+		log: log.WithFields(log.Fields{}),
+
+		addPauseReasons:    []v1alpha1.PauseReason{},
+		removePauseReasons: []v1alpha1.PauseReason{v1alpha1.PauseReasonCanaryPauseStep},
+	}
+
+	newStatus := &v1alpha1.RolloutStatus{}
+	work.CalculatePauseStatus(newStatus)
+
+	assert.Equal(t, false, newStatus.ControllerPause)
+	assert.Len(t, newStatus.PauseConditions, 0)
+}
+
+func TestCompletedBlueGreenPause(t *testing.T) {
+	now := v1.NewTime(time.Now())
+	work := &pauseContext{
+		rollout: &v1alpha1.Rollout{
+			Spec: v1alpha1.RolloutSpec{
+				Strategy: v1alpha1.RolloutStrategy{
+					BlueGreen: &v1alpha1.BlueGreenStrategy{},
+				},
+			},
+			Status: v1alpha1.RolloutStatus{
+				ControllerPause: true,
+				PauseConditions: []v1alpha1.PauseCondition{
+					{
+						Reason:    v1alpha1.PauseReasonBlueGreenPause,
+						StartTime: now,
+					},
+				},
+				BlueGreen: v1alpha1.BlueGreenStatus{
+					ScaleUpPreviewCheckPoint: true,
+				},
+			},
+		},
+		log: log.WithFields(log.Fields{}),
+	}
+
+	result := work.CompletedBlueGreenPause()
+	assert.Equal(t, true, result)
+}
+
+func TestCompletedBlueGreenPauseAutoPromotionDisabled(t *testing.T) {
+	autoPromotionEnabled := false
+	now := v1.NewTime(time.Now())
+	work := &pauseContext{
+		rollout: &v1alpha1.Rollout{
+			Spec: v1alpha1.RolloutSpec{
+				Strategy: v1alpha1.RolloutStrategy{
+					BlueGreen: &v1alpha1.BlueGreenStrategy{
+						AutoPromotionEnabled: &autoPromotionEnabled,
+					},
+				},
+			},
+			Status: v1alpha1.RolloutStatus{
+				ControllerPause: true,
+				PauseConditions: []v1alpha1.PauseCondition{
+					{
+						Reason:    v1alpha1.PauseReasonBlueGreenPause,
+						StartTime: now,
+					},
+				},
+				BlueGreen: v1alpha1.BlueGreenStatus{
+					ScaleUpPreviewCheckPoint: false,
+				},
+			},
+		},
+		log: log.WithFields(log.Fields{}),
+	}
+
+	result := work.CompletedBlueGreenPause()
+	assert.Equal(t, false, result)
+}
+
+func TestCompletedCanaryPauseStep(t *testing.T) {
+	now := v1.NewTime(time.Now())
+	work := &pauseContext{
+		rollout: &v1alpha1.Rollout{
+			Status: v1alpha1.RolloutStatus{
+				ControllerPause: true,
+				PauseConditions: []v1alpha1.PauseCondition{
+					{
+						Reason:    v1alpha1.PauseReasonCanaryPauseStep,
+						StartTime: now,
+					},
+				},
+			},
+		},
+		log: log.WithFields(log.Fields{}),
+	}
+
+	pause := v1alpha1.RolloutPause{
+		Duration: &intstr.IntOrString{IntVal: intstr.FromInt(0).IntVal},
+	}
+
+	result := work.CompletedCanaryPauseStep(pause)
+	assert.Equal(t, true, result)
+}
+
+func TestCompletedCanaryPauseStepInProgress(t *testing.T) {
+	now := v1.NewTime(time.Now())
+	work := &pauseContext{
+		rollout: &v1alpha1.Rollout{
+			Status: v1alpha1.RolloutStatus{
+				ControllerPause: true,
+				PauseConditions: []v1alpha1.PauseCondition{
+					{
+						Reason:    v1alpha1.PauseReasonCanaryPauseStep,
+						StartTime: now,
+					},
+				},
+			},
+		},
+		log: log.WithFields(log.Fields{}),
+	}
+
+	pauseDuration := int((2 * time.Hour).Seconds())
+	pause := v1alpha1.RolloutPause{
+		Duration: &intstr.IntOrString{IntVal: intstr.FromInt(pauseDuration).IntVal},
+	}
+
+	result := work.CompletedCanaryPauseStep(pause)
+	assert.Equal(t, false, result)
+}


### PR DESCRIPTION
1. The `TestHasAddPause` checks the behavior of the `HasAddPause()` function in the pauseContext struct. It creates a `pauseContext` instance with an empty v1alpha1.RolloutStatus and an empty list of pause conditions. It sets one `addPauseReason` with the value `v1alpha1.PauseReasonCanaryPauseStep` with an empty list for `removePauseReasons`. The test then calls the function on the `pauseContext` and asserts that the result is true.
2. The test `TestHasAddPauseNoReasons` is basically the unhappy path for the `HasAddPause()` function. It creates a `pauseContext` instance with an empty `v1alpha1.RolloutStatus` and an empty list of pause conditions. It sets both the `addPauseReasons` and `removePauseReasons` lists as empty. The test then calls the function and asserts that the result is false.
3. The test `TestCalculatePauseStatus` checks the behavior of the `CalculatePauseStatus()` function in the `pauseContext` struct. It creates a `pauseContext` instance with an empty `v1alpha1.RolloutStatus` and an empty list of pause conditions. It sets one `addPauseReason` with the value `v1alpha1.PauseReasonCanaryPauseStep` and keeps an empty list for `removePauseReasons`. The test creates an empty `newStatus` variable of type `v1alpha1.RolloutStatus` and calls the CalculatePauseStatus(newStatus) method.
4. The test `TestCalculatePauseStatusRemovePause` is the unhappy path of the `CalculatePauseStatus()` function with assertions.
5. The `TestCompletedBlueGreenPause` test checks the behavior of the `CompletedBlueGreenPause()` function for a Blue-Green deployment strategy. It creates a `pauseContext` instance with a `v1alpha1.Rollout` having a Blue-Green strategy, `ControllerPause` is set to true, with one pause condition `v1alpha1.PauseReasonBlueGreenPause` & `ScaleUpPreviewCheckPoint` is set to true. The test then calls the function and asserts that the result is true.
6. The test `TestCompletedBlueGreenPauseAutoPromotionDisabled` is the unhappy path of the `CompletedBlueGreenPause()` function with assertions.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).