### PR TITLE
fix: properly wrap Datadog API v2 request body (#2771)

### DIFF
--- a/metricproviders/datadog/datadog.go
+++ b/metricproviders/datadog/datadog.go
@@ -56,6 +56,10 @@ type datadogQuery struct {
 	QueryType  string                 `json:"type"`
 }
 
+type datadogRequest struct {
+	Data datadogQuery `json:"data"`
+}
+
 type datadogResponseV1 struct {
 	Series []struct {
 		Pointlist [][]float64 `json:"pointlist"`
@@ -182,17 +186,18 @@ func (p *Provider) createRequest(query string, apiVersion string, now int64, int
 
 		return &http.Request{Method: "GET"}, nil
 	} else if apiVersion == "v2" {
-		queryBody, err := json.Marshal(datadogQuery{
-			QueryType: "timeseries_request",
-			Attributes: datadogQueryAttributes{
-				From: now - interval,
-				To:   now,
-				Queries: []map[string]string{{
-					"data_source": "metrics",
-					"query":       query,
-				}},
-			},
-		})
+		queryBody, err := json.Marshal(datadogRequest{
+			Data: datadogQuery{
+				QueryType: "timeseries_request",
+				Attributes: datadogQueryAttributes{
+					From: now - interval,
+					To:   now,
+					Queries: []map[string]string{{
+						"data_source": "metrics",
+						"query":       query,
+					}},
+				},
+			}})
 		if err != nil {
 			return nil, fmt.Errorf("Could not parse your JSON request: %v", err)
 		}

--- a/metricproviders/datadog/datadog.go
+++ b/metricproviders/datadog/datadog.go
@@ -190,8 +190,8 @@ func (p *Provider) createRequest(query string, apiVersion string, now int64, int
 			Data: datadogQuery{
 				QueryType: "timeseries_request",
 				Attributes: datadogQueryAttributes{
-					From: now - interval,
-					To:   now,
+					From: (now - interval) * 1000,
+					To:   now * 1000,
 					Queries: []map[string]string{{
 						"data_source": "metrics",
 						"query":       query,

--- a/metricproviders/datadog/datadogV2_test.go
+++ b/metricproviders/datadog/datadogV2_test.go
@@ -245,15 +245,15 @@ func TestRunSuiteV2(t *testing.T) {
 					t.Errorf("\nreceived no bytes in request: %v", err)
 				}
 
-				var reqBody datadogQuery
+				var reqBody datadogRequest
 				err = json.Unmarshal(bodyBytes, &reqBody)
 				if err != nil {
 					t.Errorf("\nCould not parse JSON request body: %v", err)
 				}
 
-				actualQuery := reqBody.Attributes.Queries[0]["query"]
-				actualFrom := reqBody.Attributes.From
-				actualTo := reqBody.Attributes.To
+				actualQuery := reqBody.Data.Attributes.Queries[0]["query"]
+				actualFrom := reqBody.Data.Attributes.From
+				actualTo := reqBody.Data.Attributes.To
 
 				if actualQuery != "avg:kubernetes.cpu.user.total{*}" {
 					t.Errorf("\nquery expected avg:kubernetes.cpu.user.total{*} but got %s", actualQuery)

--- a/metricproviders/datadog/datadogV2_test.go
+++ b/metricproviders/datadog/datadogV2_test.go
@@ -259,14 +259,14 @@ func TestRunSuiteV2(t *testing.T) {
 					t.Errorf("\nquery expected avg:kubernetes.cpu.user.total{*} but got %s", actualQuery)
 				}
 
-				if actualFrom != unixNow()-test.expectedIntervalSeconds {
-					t.Errorf("\nfrom %d expected be equal to %d", actualFrom, unixNow()-test.expectedIntervalSeconds)
+				if actualFrom != (unixNow()-test.expectedIntervalSeconds)*1000 {
+					t.Errorf("\nfrom %d expected be equal to %d", actualFrom, (unixNow()-test.expectedIntervalSeconds)*1000)
 				} else if err != nil {
 					t.Errorf("\nfailed to parse from: %v", err)
 				}
 
-				if actualTo != unixNow() {
-					t.Errorf("\nto %d was expected be equal to %d", actualTo, unixNow())
+				if actualTo != unixNow()*1000 {
+					t.Errorf("\nto %d was expected be equal to %d", actualTo, unixNow()*1000)
 				} else if err != nil {
 					t.Errorf("\nfailed to parse to: %v", err)
 				}


### PR DESCRIPTION
this is more inline with the docs at: https://docs.datadoghq.com/api/latest/metrics/?code-lang=curl#query-timeseries-data-across-multiple-products

fixes: #2771 

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).