### PR TITLE
ci: use keyless signing for main and release branches

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,66 +9,42 @@ on:
   # Run tests for any PRs.
   pull_request:
 
-permissions:
-  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
-  docker:
+  set-vars:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
+    outputs:
+      controller-meta-tags: ${{ steps.controller-meta.outputs.tags }}
+      plugin-meta-tags: ${{ steps.plugin-meta.outputs.tags }}
+      platforms: ${{ steps.platform-matrix.outputs.platform-matrix }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3.1.0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          config-inline: |
-            [worker.oci]
-            gc = false
-
       - name: Docker meta (controller)
         id: controller-meta
         uses: docker/metadata-action@v4
         with:
           images: |
-            quay.io/argoproj/argo-rollouts
-          # ghcr.io/argoproj/argo-rollouts
+            quay.io/34fathombelow/argo-rollouts
           tags: |
-            type=ref,event=branch
-          flavor: |
-            latest=${{ github.ref == 'refs/heads/master' }}
+            type=ref,event=branch,enable=${{ github.ref != 'refs/heads/master'}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
 
       - name: Docker meta (plugin)
         id: plugin-meta
         uses: docker/metadata-action@v4
         with:
           images: |
-            quay.io/argoproj/kubectl-argo-rollouts
-          # ghcr.io/argoproj/kubectl-argo-rollouts
+            quay.io/34fathombelow/kubectl-argo-rollouts
           tags: |
-            type=ref,event=branch
-          flavor: |
-            latest=${{ github.ref == 'refs/heads/master' }}
-
-      # - name: Login to GitHub Container Registry
-      #   if: github.event_name != 'pull_request'
-      #   uses: docker/login-action@v2 
-      #   with:
-      #     registry: ghcr.io
-      #     username: ${{ github.repository_owner }}
-      #     password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to Quay.io
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+            type=ref,event=branch,enable=${{ github.ref != 'refs/heads/master'}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
 
       # avoid building linux/arm64 for PRs since it takes so long
       - name: Set Platform Matrix
@@ -79,73 +55,39 @@ jobs:
           then
             PLATFORM_MATRIX=$PLATFORM_MATRIX,linux/arm64
           fi
-          echo "::set-output name=platform-matrix::$PLATFORM_MATRIX"
+          echo "platform-matrix=$PLATFORM_MATRIX" >> $GITHUB_OUTPUT
 
-      - name: Build and push (controller-image)
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4.0.0
-        with:
-          platforms: ${{ steps.platform-matrix.outputs.platform-matrix }}
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.controller-meta.outputs.tags }}
-          provenance: false
-          sbom: false
+  build-and-push-controller-image:
+    needs: [set-vars]
+    permissions:
+      contents: read
+      packages: write  # for pushing packages to GHCR, which is used by cd.apps.argoproj.io to avoid polluting Quay with tags
+      id-token: write # for creating OIDC tokens for signing.
+    uses: ./.github/workflows/image-reuse.yaml
+    with:
+      quay_image_name: ${{ needs.set-vars.outputs.controller-meta-tags }}
+      # Note: cannot use env variables to set go-version (https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations)
+      go-version: 1.19
+      platforms: ${{ needs.set-vars.outputs.platforms }}
+      push: ${{ github.event_name != 'pull_request' }}
+    secrets:
+      quay_username: ${{ secrets.QUAY_USERNAME }}
+      quay_password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      - name: Build and push (plugin-image)
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4.0.0
-        with:
-          target: kubectl-argo-rollouts
-          platforms: ${{ steps.platform-matrix.outputs.platform-matrix }}
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.plugin-meta.outputs.tags }}
-          provenance: false
-          sbom: false
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@main
-        with:
-          cosign-release: 'v1.13.1'
-
-      - name: Install crane to get digest of image
-        uses: imjasonh/setup-crane@v0.3
-
-      - name: Get digest of controller-image
-        run: |
-          if [[ "${{ github.ref == 'refs/heads/master' }}" ]]
-          then
-            echo "CONTROLLER_DIGEST=$(crane digest quay.io/argoproj/argo-rollouts:latest)" >> $GITHUB_ENV
-          fi
-          if [[ "${{ github.ref != 'refs/heads/master' }}" ]]
-          then
-            echo "CONTROLLER_DIGEST=$(crane digest ${{ steps.controller-meta.outputs.tags }})" >> $GITHUB_ENV
-          fi
-        if: github.event_name != 'pull_request'
-
-      - name: Get digest of plugin-image
-        run: |
-          if [[ "${{ github.ref == 'refs/heads/master' }}" ]]
-          then
-            echo "PLUGIN_DIGEST=$(crane digest quay.io/argoproj/kubectl-argo-rollouts:latest)" >> $GITHUB_ENV
-          fi
-          if [[ "${{ github.ref != 'refs/heads/master' }}" ]]
-          then
-            echo "PLUGIN_DIGEST=$(crane digest ${{ steps.plugin-meta.outputs.tags }})" >> $GITHUB_ENV
-          fi
-        if: github.event_name != 'pull_request'
-
-      - name: Sign Argo Rollouts Images
-        run: |
-          cosign sign --key env://COSIGN_PRIVATE_KEY quay.io/argoproj/argo-rollouts@${{ env.CONTROLLER_DIGEST }}
-          cosign sign --key env://COSIGN_PRIVATE_KEY quay.io/argoproj/kubectl-argo-rollouts@${{ env.PLUGIN_DIGEST }}
-        env:
-          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
-          COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
-        if: ${{ github.event_name == 'push' }}
-
-      - name: Display the public key to share.
-        run: |
-          # Displays the public key to share
-          cosign public-key --key env://COSIGN_PRIVATE_KEY
-        env:
-          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
-          COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
-        if: ${{ github.event_name == 'push' }}
+  build-and-push-plugin-image:
+    needs: [set-vars]
+    permissions:
+      contents: read
+      packages: write  # for pushing packages to GHCR, which is used by cd.apps.argoproj.io to avoid polluting Quay with tags
+      id-token: write # for creating OIDC tokens for signing.
+    uses: ./.github/workflows/image-reuse.yaml
+    with:
+      quay_image_name: ${{ needs.set-vars.outputs.plugin-meta-tags }}
+      # Note: cannot use env variables to set go-version (https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations)
+      go-version: 1.19
+      platforms: ${{ needs.set-vars.outputs.platforms }}
+      push: ${{ github.event_name != 'pull_request' }}
+      target: kubectl-argo-rollouts
+    secrets:
+      quay_username: ${{ secrets.QUAY_USERNAME }}
+      quay_password: ${{ secrets.QUAY_ROBOT_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,7 +31,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            quay.io/34fathombelow/argo-rollouts
+            quay.io/argoproj/argo-rollouts
           tags: |
             type=ref,event=branch,enable=${{ github.ref != 'refs/heads/master'}}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
@@ -41,7 +41,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            quay.io/34fathombelow/kubectl-argo-rollouts
+            quay.io/argoproj/kubectl-argo-rollouts
           tags: |
             type=ref,event=branch,enable=${{ github.ref != 'refs/heads/master'}}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/image-reuse.yaml
+++ b/.github/workflows/image-reuse.yaml
@@ -1,0 +1,153 @@
+name: Publish and Sign Container Image
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        required: true
+        type: string
+      quay_image_name:
+        required: false
+        type: string
+      ghcr_image_name:
+        required: false
+        type: string
+      docker_image_name:
+        required: false
+        type: string
+      platforms:
+        required: true
+        type: string
+        default: linux/amd64
+      push:
+        required: true
+        type: boolean
+        default: false
+      target:
+        required: false
+        type: string
+
+    secrets:
+      quay_username:
+        required: false
+      quay_password:
+        required: false
+      ghcr_username:
+        required: false
+      ghcr_password:
+        required: false
+      docker_username:
+        required: false
+      docker_password:
+        required: false
+
+    outputs:
+      image-digest:
+        description: "sha256 digest of container image"
+        value: ${{ jobs.publish.outputs.image-digest }}
+
+permissions: {}
+
+jobs:
+  publish:
+    permissions:
+      contents: read
+      packages: write # Used to push images to `ghcr.io` if used.
+      id-token: write # Needed to create an OIDC token for keyless signing
+    runs-on: ubuntu-22.04
+    outputs:
+      image-digest: ${{ steps.image.outputs.digest }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.3.0
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.ref_type == 'tag'}}
+
+      - name: Checkout code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.3.0
+        if: ${{ github.ref_type != 'tag'}}
+
+      - name: Setup Golang
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@204a51a57a74d190b284a0ce69b44bc37201f343 # v3.0.3
+        with:
+          cosign-release: 'v2.0.2'
+
+      - uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+      - uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c # v2.5.0
+
+      - name: Setup tags for container image as a CSV type
+        run: |
+          IMAGE_TAGS=$(for str in \
+            ${{ inputs.quay_image_name }} \
+            ${{ inputs.ghcr_image_name }} \
+            ${{ inputs.docker_image_name}}; do
+            echo -n "${str}",;done | sed 's/,$//')
+
+          echo $IMAGE_TAGS
+          echo "TAGS=$IMAGE_TAGS" >> $GITHUB_ENV
+
+      - name: Setup image namespace for signing, strip off the tag
+        run: |
+          TAGS=$(for tag in \
+            ${{ inputs.quay_image_name }} \
+            ${{ inputs.ghcr_image_name }} \
+            ${{ inputs.docker_image_name}}; do
+            echo -n "${tag}" | awk -F ":" '{print $1}' -;done)
+          
+            echo $TAGS
+            echo 'SIGNING_TAGS<<EOF' >> $GITHUB_ENV
+            echo $TAGS >> $GITHUB_ENV
+            echo 'EOF' >> $GITHUB_ENV
+
+      - name: Login to Quay.io
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.quay_username }}
+          password: ${{ secrets.quay_password }}
+        if: ${{ inputs.quay_image_name && inputs.push }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.ghcr_username }}
+          password: ${{ secrets.ghcr_password }}
+        if: ${{ inputs.ghcr_image_name && inputs.push }}
+
+      - name: Login to dockerhub Container Registry
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+        with:
+          username: ${{ secrets.docker_username }}
+          password: ${{ secrets.docker_password }}
+        if: ${{ inputs.docker_image_name && inputs.push }}
+
+      - name: Build and push container image
+        id: image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 #v4.0.0
+        with:
+          context: .
+          platforms: ${{ inputs.platforms }}
+          push: ${{ inputs.push }}
+          tags: ${{ env.TAGS }}
+          target: ${{ inputs.target }}
+          provenance: false
+          sbom: false
+ 
+      - name: Sign container images
+        run: |
+          for signing_tag in $SIGNING_TAGS; do
+            cosign sign \
+            -a "repo=${{ github.repository }}" \
+            -a "workflow=${{ github.workflow }}" \
+            -a "sha=${{ github.sha }}" \
+            --yes \
+            "$signing_tag"@${{ steps.image.outputs.digest }}
+          done
+        if: ${{ inputs.push }}


### PR DESCRIPTION
This PR implements using keyless signing for cosign.  It uses a reusable workflow (image-reuse.yaml) that will also be used in the `release` workflow to generate attestations. 

Changes in `docker-publish` workflow:
1. Concurrency added to reduce the amount of executors used on multiple pushes.
2. Only the `latest` tag will be used, `master` tag has been removed on a push events of the `master` branch.
3. `image-reuse.yaml` is the exact same reusable workflow we are using in Argo CD.

Successful testing of generating attestations for Argo Rollouts has been completed and will come in a separate PR along with all the documentation.
https://github.com/34fathombelow/rollouts-testing/actions/runs/4989497845
https://github.com/34fathombelow/rollouts-testing/releases/tag/v2.0.0-rc3
