### PR TITLE
docs: Add gateway API link, fix Contour plugin naming

### DIFF
--- a/docs/features/traffic-management/plugins.md
+++ b/docs/features/traffic-management/plugins.md
@@ -72,5 +72,8 @@ responsibility of the Argo Rollouts administrator to define the plugin installat
 * This is just a sample plugin that can be used as a starting point for creating your own plugin.
   It is not meant to be used in production. It is based on the built-in prometheus provider.
 
-#### [rollouts-plugin-trafficrouter-contour](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-contour)
+#### [Contour](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-contour)
 * This is a plugin for support Contour.
+
+#### [Gateway API](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/)
+* Provide support for Gateway API, which includes Kuma, Traefix, cilium, Contour, GloodMesh, HAProxy, and [many others](https://gateway-api.sigs.k8s.io/implementations/#implementation-status). 


### PR DESCRIPTION
The format for the plugin names shouldn't just be what the git repo name is, it should be the plugin name so I updated that as well.

Checklist:

* [c] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [b] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [y] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [n] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [y] My builds are green. Try syncing with master if they are not. 
* [y] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).