### PR TITLE
fix: make new alb fullName field  optional for backward compatability

### DIFF
--- a/manifests/crds/rollout-crd.yaml
+++ b/manifests/crds/rollout-crd.yaml
@@ -3318,7 +3318,6 @@ spec:
                         type: string
                     required:
                     - arn
-                    - fullName
                     - name
                     type: object
                   loadBalancer:
@@ -3331,7 +3330,6 @@ spec:
                         type: string
                     required:
                     - arn
-                    - fullName
                     - name
                     type: object
                   stableTargetGroup:
@@ -3344,7 +3342,6 @@ spec:
                         type: string
                     required:
                     - arn
-                    - fullName
                     - name
                     type: object
                 type: object

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -14552,7 +14552,6 @@ spec:
                         type: string
                     required:
                     - arn
-                    - fullName
                     - name
                     type: object
                   loadBalancer:
@@ -14565,7 +14564,6 @@ spec:
                         type: string
                     required:
                     - arn
-                    - fullName
                     - name
                     type: object
                   stableTargetGroup:
@@ -14578,7 +14576,6 @@ spec:
                         type: string
                     required:
                     - arn
-                    - fullName
                     - name
                     type: object
                 type: object

--- a/pkg/apiclient/rollout/rollout.swagger.json
+++ b/pkg/apiclient/rollout/rollout.swagger.json
@@ -724,7 +724,8 @@
           "type": "string"
         },
         "fullName": {
-          "type": "string"
+          "type": "string",
+          "title": "FullName is the full name of the resource\n+optional"
         }
       }
     },

--- a/pkg/apis/rollouts/v1alpha1/generated.proto
+++ b/pkg/apis/rollouts/v1alpha1/generated.proto
@@ -302,6 +302,8 @@ message AwsResourceRef {
 
   optional string arn = 2;
 
+  // FullName is the full name of the resource
+  // +optional
   optional string fullName = 3;
 }
 

--- a/pkg/apis/rollouts/v1alpha1/openapi_generated.go
+++ b/pkg/apis/rollouts/v1alpha1/openapi_generated.go
@@ -1099,13 +1099,14 @@ func schema_pkg_apis_rollouts_v1alpha1_AwsResourceRef(ref common.ReferenceCallba
 					},
 					"fullName": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "FullName is the full name of the resource",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
-				Required: []string{"name", "arn", "fullName"},
+				Required: []string{"name", "arn"},
 			},
 		},
 	}

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -1007,8 +1007,10 @@ type ALBStatus struct {
 }
 
 type AwsResourceRef struct {
-	Name     string `json:"name" protobuf:"bytes,1,opt,name=name"`
-	ARN      string `json:"arn" protobuf:"bytes,2,opt,name=arn"`
+	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
+	ARN  string `json:"arn" protobuf:"bytes,2,opt,name=arn"`
+	// FullName is the full name of the resource
+	// +optional
 	FullName string `json:"fullName" protobuf:"bytes,3,opt,name=fullName"`
 }
 


### PR DESCRIPTION
This field was added as non optional, when a rollout exists with the upper level item included in status new apply's of the resource fail because this status field is missing on them, making it optional fixes this.

This field was introduced in https://github.com/argoproj/argo-rollouts/pull/2604