### PR TITLE
docs: Update docs of Rollout spec to add active/previewMetadata

### DIFF
--- a/docs/features/specification.md
+++ b/docs/features/specification.md
@@ -151,6 +151,18 @@ spec:
         requiredDuringSchedulingIgnoredDuringExecution: {}
         preferredDuringSchedulingIgnoredDuringExecution:
           weight: 1 # Between 1 - 100
+          
+      # activeMetadata will be merged and updated in-place into the ReplicaSet's spec.template.metadata
+      # of the active pods. +optional
+      activeMetadata:
+        labels:
+          role: active
+          
+      # Metadata which will be attached to the preview pods only during their preview phase.
+      # +optional
+      previewMetadata:
+        labels:
+          role: preview
 
     # Canary update strategy
     canary:


### PR DESCRIPTION
Add blueGreen activeMetadata / previewMetadata as its part of the spec.

This was added back in https://github.com/argoproj/argo-rollouts/pull/974 , its part of the docs in https://github.com/argoproj/argo-rollouts/blob/master/docs/features/ephemeral-metadata.md but not documented as part of the spec

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore. - chore
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).