### PR TITLE
fix: resolve args to metric in garbage collection function

### DIFF
--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -713,7 +713,7 @@ func (c *Controller) garbageCollectMeasurements(run *v1alpha1.AnalysisRun, measu
 
 	resolvedArgsMetric, err := getResolvedMetricsWithoutSecrets(run.Spec.Metrics, run.Spec.Args)
 	if err != nil {
-		return fmt.Errorf("failed to resolve metrics during garbage collection: %w", err)
+		return fmt.Errorf("failed to resolve args on metric during garbage collection: %w", err)
 	}
 
 	metricsByName := make(map[string]v1alpha1.Metric)

--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -711,8 +711,13 @@ func calculateNextReconcileTime(run *v1alpha1.AnalysisRun, metrics []v1alpha1.Me
 func (c *Controller) garbageCollectMeasurements(run *v1alpha1.AnalysisRun, measurementRetentionMetricNamesMap map[string]*v1alpha1.MeasurementRetention, limit int) error {
 	var errors []error
 
+	resolvedArgsMetric, err := getResolvedMetricsWithoutSecrets(run.Spec.Metrics, run.Spec.Args)
+	if err != nil {
+		return err
+	}
+
 	metricsByName := make(map[string]v1alpha1.Metric)
-	for _, metric := range run.Spec.Metrics {
+	for _, metric := range resolvedArgsMetric {
 		metricsByName[metric.Name] = metric
 	}
 

--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -713,7 +713,7 @@ func (c *Controller) garbageCollectMeasurements(run *v1alpha1.AnalysisRun, measu
 
 	resolvedArgsMetric, err := getResolvedMetricsWithoutSecrets(run.Spec.Metrics, run.Spec.Args)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to resolve metrics during garbage collection: %w", err)
 	}
 
 	metricsByName := make(map[string]v1alpha1.Metric)

--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -713,7 +713,7 @@ func (c *Controller) garbageCollectMeasurements(run *v1alpha1.AnalysisRun, measu
 
 	resolvedArgsMetric, err := getResolvedMetricsWithoutSecrets(run.Spec.Metrics, run.Spec.Args)
 	if err != nil {
-		return fmt.Errorf("failed to resolve args on metric during garbage collection: %w", err)
+		return fmt.Errorf("failed to resolve args on metrics during garbage collection: %w", err)
 	}
 
 	metricsByName := make(map[string]v1alpha1.Metric)

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -1099,33 +1099,6 @@ func TestTrimMeasurementHistory(t *testing.T) {
 		assert.Equal(t, "2", run.Status.MetricResults[1].Measurements[0].Value)
 		assert.Equal(t, "3", run.Status.MetricResults[1].Measurements[1].Value)
 	}
-	{
-		run := newRun()
-		run.Spec.Args = append(run.Spec.Args, v1alpha1.Argument{
-			Name:  "port",
-			Value: pointer.String("port"),
-		})
-		run.Spec.Metrics = []v1alpha1.Metric{
-			{
-				Name:     "metric-prom1",
-				Interval: "60s",
-				Provider: v1alpha1.MetricProvider{
-					Prometheus: &v1alpha1.PrometheusMetric{
-						Address: "https://prometheus.kubeaddons:{{args.port}}",
-					},
-				},
-			},
-		}
-		var measurementRetentionMetricsMap = map[string]*v1alpha1.MeasurementRetention{}
-		measurementRetentionMetricsMap["metric2"] = &v1alpha1.MeasurementRetention{MetricName: "metric2", Limit: 2}
-		err := c.garbageCollectMeasurements(run, measurementRetentionMetricsMap, 1)
-		assert.Nil(t, err)
-		assert.Len(t, run.Status.MetricResults[0].Measurements, 1)
-		assert.Equal(t, "1", run.Status.MetricResults[0].Measurements[0].Value)
-		assert.Len(t, run.Status.MetricResults[1].Measurements, 2)
-		assert.Equal(t, "2", run.Status.MetricResults[1].Measurements[0].Value)
-		assert.Equal(t, "3", run.Status.MetricResults[1].Measurements[1].Value)
-	}
 }
 
 func TestGarbageCollectArgResolution(t *testing.T) {

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/argoproj/argo-rollouts/metric"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -1097,6 +1099,129 @@ func TestTrimMeasurementHistory(t *testing.T) {
 		assert.Equal(t, "2", run.Status.MetricResults[1].Measurements[0].Value)
 		assert.Equal(t, "3", run.Status.MetricResults[1].Measurements[1].Value)
 	}
+	{
+		run := newRun()
+		run.Spec.Args = append(run.Spec.Args, v1alpha1.Argument{
+			Name:  "port",
+			Value: pointer.String("port"),
+		})
+		run.Spec.Metrics = []v1alpha1.Metric{
+			{
+				Name:     "metric-prom1",
+				Interval: "60s",
+				Provider: v1alpha1.MetricProvider{
+					Prometheus: &v1alpha1.PrometheusMetric{
+						Address: "https://prometheus.kubeaddons:{{args.port}}",
+					},
+				},
+			},
+		}
+		var measurementRetentionMetricsMap = map[string]*v1alpha1.MeasurementRetention{}
+		measurementRetentionMetricsMap["metric2"] = &v1alpha1.MeasurementRetention{MetricName: "metric2", Limit: 2}
+		err := c.garbageCollectMeasurements(run, measurementRetentionMetricsMap, 1)
+		assert.Nil(t, err)
+		assert.Len(t, run.Status.MetricResults[0].Measurements, 1)
+		assert.Equal(t, "1", run.Status.MetricResults[0].Measurements[0].Value)
+		assert.Len(t, run.Status.MetricResults[1].Measurements, 2)
+		assert.Equal(t, "2", run.Status.MetricResults[1].Measurements[0].Value)
+		assert.Equal(t, "3", run.Status.MetricResults[1].Measurements[1].Value)
+	}
+}
+
+func TestGarbageCollectArgResolution(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+	c, _, _ := f.newController(noResyncPeriodFunc)
+
+	c.newProvider = func(logCtx log.Entry, metric v1alpha1.Metric) (metric.Provider, error) {
+		assert.Equal(t, "https://prometheus.kubeaddons:8080", metric.Provider.Prometheus.Address)
+		return f.provider, nil
+	}
+
+	f.provider.On("GarbageCollect", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	run := &v1alpha1.AnalysisRun{
+		Spec: v1alpha1.AnalysisRunSpec{
+			Metrics: []v1alpha1.Metric{
+				{
+					Name:     "metric1",
+					Interval: "60s",
+					Provider: v1alpha1.MetricProvider{
+						Prometheus: &v1alpha1.PrometheusMetric{
+							Address: "https://prometheus.kubeaddons:{{args.port}}",
+						},
+					},
+				},
+				{
+					Name:     "metric2",
+					Interval: "60s",
+					Provider: v1alpha1.MetricProvider{
+						Prometheus: &v1alpha1.PrometheusMetric{
+							Address: "https://prometheus.kubeaddons:{{args.port}}",
+						},
+					},
+				},
+			},
+		},
+		Status: v1alpha1.AnalysisRunStatus{
+			Phase: v1alpha1.AnalysisPhaseRunning,
+			MetricResults: []v1alpha1.MetricResult{
+				{
+					Name:  "metric1",
+					Phase: v1alpha1.AnalysisPhaseRunning,
+					Measurements: []v1alpha1.Measurement{
+						{
+							Value:      "1",
+							Phase:      v1alpha1.AnalysisPhaseSuccessful,
+							StartedAt:  timePtr(metav1.NewTime(time.Now().Add(-60 * time.Second))),
+							FinishedAt: timePtr(metav1.NewTime(time.Now().Add(-60 * time.Second))),
+						},
+						{
+							Value:      "2",
+							Phase:      v1alpha1.AnalysisPhaseSuccessful,
+							StartedAt:  timePtr(metav1.NewTime(time.Now().Add(-60 * time.Second))),
+							FinishedAt: timePtr(metav1.NewTime(time.Now().Add(-60 * time.Second))),
+						},
+					},
+				},
+				{
+					Name: "metric2",
+					Measurements: []v1alpha1.Measurement{
+						{
+							Value:      "2",
+							Phase:      v1alpha1.AnalysisPhaseSuccessful,
+							StartedAt:  timePtr(metav1.NewTime(time.Now().Add(-60 * time.Second))),
+							FinishedAt: timePtr(metav1.NewTime(time.Now().Add(-60 * time.Second))),
+						},
+						{
+							Value:      "3",
+							Phase:      v1alpha1.AnalysisPhaseSuccessful,
+							StartedAt:  timePtr(metav1.NewTime(time.Now().Add(-30 * time.Second))),
+							FinishedAt: timePtr(metav1.NewTime(time.Now().Add(-30 * time.Second))),
+						},
+						{
+							Value:      "4",
+							Phase:      v1alpha1.AnalysisPhaseSuccessful,
+							StartedAt:  timePtr(metav1.NewTime(time.Now().Add(-30 * time.Second))),
+							FinishedAt: timePtr(metav1.NewTime(time.Now().Add(-30 * time.Second))),
+						},
+					},
+				},
+			},
+		},
+	}
+	run.Spec.Args = append(run.Spec.Args, v1alpha1.Argument{
+		Name:  "port",
+		Value: pointer.String("8080"),
+	})
+	var measurementRetentionMetricsMap = map[string]*v1alpha1.MeasurementRetention{}
+	measurementRetentionMetricsMap["metric2"] = &v1alpha1.MeasurementRetention{MetricName: "metric2", Limit: 2}
+	err := c.garbageCollectMeasurements(run, measurementRetentionMetricsMap, 1)
+	assert.Nil(t, err)
+	assert.Len(t, run.Status.MetricResults[0].Measurements, 1)
+	assert.Equal(t, "2", run.Status.MetricResults[0].Measurements[0].Value)
+	assert.Len(t, run.Status.MetricResults[1].Measurements, 2)
+	assert.Equal(t, "3", run.Status.MetricResults[1].Measurements[0].Value)
+	assert.Equal(t, "4", run.Status.MetricResults[1].Measurements[1].Value)
 }
 
 func TestResolveMetricArgsUnableToSubstitute(t *testing.T) {


### PR DESCRIPTION
Make sure we resolve args before creating the provider for garbage collection, this lets providers such as prometheus check that the url is valid if it contains any args.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).