### PR TITLE
fix: get new httpRoutesI after removeRoute() to avoid duplicates. Fixes #2769

### DIFF
--- a/rollout/trafficrouting/istio/istio.go
+++ b/rollout/trafficrouting/istio/istio.go
@@ -712,11 +712,6 @@ func (r *Reconciler) getVirtualService(namespace string, vsvcName string, client
 }
 
 func (r *Reconciler) reconcileVirtualServiceHeaderRoutes(virtualService v1alpha1.IstioVirtualService, obj *unstructured.Unstructured, headerRouting *v1alpha1.SetHeaderRoute) error {
-	// HTTP Routes
-	httpRoutesI, err := GetHttpRoutesI(obj)
-	if err != nil {
-		return err
-	}
 	destRuleHost, err := r.getDestinationRuleHost()
 	if err != nil {
 		return err
@@ -744,6 +739,12 @@ func (r *Reconciler) reconcileVirtualServiceHeaderRoutes(virtualService v1alpha1
 	err = removeRoute(obj, headerRouting.Name)
 	if err != nil {
 		return fmt.Errorf("[reconcileVirtualServiceHeaderRoutes] failed to remove http route from virtual service: %w", err)
+	}
+
+	// HTTP Routes
+	httpRoutesI, err := GetHttpRoutesI(obj)
+	if err != nil {
+		return err
 	}
 
 	httpRoutesI = append(httpRoutesI, createHeaderRoute(virtualService, obj, headerRouting, canarySvc, canarySubset))


### PR DESCRIPTION
 Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).