### PR TITLE
chore: quote golang version string to not use go 1.2.2

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4.0.1
         with:
-          go-version: 1.20
+          go-version: '1.20'
       - name: build
         run: |
           pip install mkdocs mkdocs_material


### PR DESCRIPTION
Needed because of:

https://github.com/actions/setup-go/issues/326