### PR TITLE
chore: bump gotestsum and fix flakey test causing nil channel send

### DIFF
--- a/hack/installers/install-dev-tools.sh
+++ b/hack/installers/install-dev-tools.sh
@@ -7,7 +7,7 @@ PATH="${DIST_PATH}:${PATH}"
 
 mkdir -p ${DIST_PATH}
 
-gotestsum_version=1.8.1
+gotestsum_version=1.10.1
 
 OS=$(go env GOOS)
 ARCH=$(go env GOARCH)

--- a/test/fixtures/when.go
+++ b/test/fixtures/when.go
@@ -335,11 +335,11 @@ func (w *When) WatchRolloutStatus(expectedStatus string, timeouts ...time.Durati
 
 	controller := viewcontroller.NewRolloutViewController(w.namespace, w.rollout.GetName(), w.kubeClient, w.rolloutClient)
 	ctx, cancel := context.WithCancel(w.Context)
-	defer cancel()
+	//defer cancel()
 	controller.Start(ctx)
 
 	rolloutUpdates := make(chan *rollout.RolloutInfo)
-	defer close(rolloutUpdates)
+	//defer close(rolloutUpdates)
 	controller.RegisterCallback(func(roInfo *rollout.RolloutInfo) {
 		rolloutUpdates <- roInfo
 	})
@@ -353,6 +353,8 @@ func (w *When) WatchRolloutStatus(expectedStatus string, timeouts ...time.Durati
 		w.t.Fatalf("unexpected status %s", finalStatus)
 	}
 
+	cancel()
+	close(rolloutUpdates)
 	return w
 }
 

--- a/test/fixtures/when.go
+++ b/test/fixtures/when.go
@@ -345,14 +345,15 @@ func (w *When) WatchRolloutStatus(expectedStatus string, timeouts ...time.Durati
 	go controller.Run(ctx)
 	finalStatus := statusOptions.WatchStatus(ctx.Done(), rolloutUpdates)
 
+	cancel()
+	close(rolloutUpdates)
+
 	if finalStatus == expectedStatus {
 		w.log.Infof("expected status %s", finalStatus)
 	} else {
 		w.t.Fatalf("unexpected status %s", finalStatus)
 	}
 
-	cancel()
-	close(rolloutUpdates)
 	return w
 }
 

--- a/test/fixtures/when.go
+++ b/test/fixtures/when.go
@@ -345,6 +345,8 @@ func (w *When) WatchRolloutStatus(expectedStatus string, timeouts ...time.Durati
 	go controller.Run(ctx)
 	finalStatus := statusOptions.WatchStatus(ctx.Done(), rolloutUpdates)
 
+	controller.DeregisterCallbacks()
+
 	cancel()
 	close(rolloutUpdates)
 

--- a/test/fixtures/when.go
+++ b/test/fixtures/when.go
@@ -335,11 +335,9 @@ func (w *When) WatchRolloutStatus(expectedStatus string, timeouts ...time.Durati
 
 	controller := viewcontroller.NewRolloutViewController(w.namespace, w.rollout.GetName(), w.kubeClient, w.rolloutClient)
 	ctx, cancel := context.WithCancel(w.Context)
-	//defer cancel()
 	controller.Start(ctx)
 
 	rolloutUpdates := make(chan *rollout.RolloutInfo)
-	//defer close(rolloutUpdates)
 	controller.RegisterCallback(func(roInfo *rollout.RolloutInfo) {
 		rolloutUpdates <- roInfo
 	})


### PR DESCRIPTION
gotestsum now fails on nil pointers by default which is why this test issue is being fixed here as well

Change order of defer to prevent using closed channel

So deferes are called in a last-in-first-out order this means,
that we would close the channel before canceling the context which could
lead to a nil pointer usage. Let's just manually control order. We will also deregister the callbacks.