### PR TITLE
fix(controller): typo fix ("Secrete" -> "Secret") in secret informer

### DIFF
--- a/cmd/rollouts-controller/main.go
+++ b/cmd/rollouts-controller/main.go
@@ -165,7 +165,7 @@ func newCommand() *cobra.Command {
 				resyncDuration,
 				kubeinformers.WithNamespace(notificationConfigNamespace),
 				kubeinformers.WithTweakListOptions(func(options *metav1.ListOptions) {
-					options.Kind = "Secrete"
+					options.Kind = "Secret"
 					options.FieldSelector = fmt.Sprintf("metadata.name=%s", record.NotificationSecret)
 				}),
 			)


### PR DESCRIPTION
When reading the code I found this typo in the resource kind. I'm not sure how huge of an impact this bug has yet, as I'm not very familiar with the codebase and project.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
  * There are no tests I could adjust according to the fix
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
  * I'm doing it personally