### PR TITLE
docs: replace `patchesStrategicMerge` with `patches` in tests/docs

### DIFF
--- a/docs/features/kustomize.md
+++ b/docs/features/kustomize.md
@@ -4,7 +4,7 @@ Kustomize can be extended to understand CRD objects through the use of
 [transformer configs](https://github.com/kubernetes-sigs/kustomize/tree/master/examples/transformerconfigs).
 Using transformer configs, kustomize can be "taught" about the structure of a Rollout object and
 leverage kustomize features such as ConfigMap/Secret generators, variable references, and common
-labels & annotations. To use Rollouts with kustomize: 
+labels & annotations. To use Rollouts with kustomize:
 
 1. Download [`rollout-transform.yaml`](kustomize/rollout-transform.yaml) into your kustomize directory.
 
@@ -65,18 +65,18 @@ resources:
 openapi:
   path: https://raw.githubusercontent.com/argoproj/argo-schema-generator/main/schema/argo_all_k8s_kustomize_schema.json
 
-patchesStrategicMerge:
-- |-
-  apiVersion: argoproj.io/v1alpha1
-  kind: Rollout
-  metadata:
-    name: rollout-canary
-  spec:
-    template:
-      spec:
-        containers:
-        - name: rollouts-demo
-          image: nginx
+patches:
+- patch: |-
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
+    metadata:
+      name: rollout-canary
+    spec:
+      template:
+        spec:
+          containers:
+          - name: rollouts-demo
+            image: nginx
 ```
 
 The OpenAPI data is auto-generated and defined in this [file](https://github.com/argoproj/argo-schema-generator/blob/main/schema/argo_all_k8s_kustomize_schema.json).

--- a/examples/notifications/kustomization.yaml
+++ b/examples/notifications/kustomization.yaml
@@ -4,5 +4,5 @@ kind: Kustomization
 resources:
 - ../../manifests/notifications
 
-patchesStrategicMerge:
-- configmap.yaml
+patches:
+- path: configmap.yaml

--- a/manifests/namespace-install/kustomization.yaml
+++ b/manifests/namespace-install/kustomization.yaml
@@ -8,8 +8,8 @@ bases:
 resources:
 - argo-rollouts-rolebinding.yaml
 
-patchesStrategicMerge:
-- add-namespaced-flag.yaml
+patches:
+- path: add-namespaced-flag.yaml
 
 patchesJson6902:
 - path: clusterrole-to-role.yaml

--- a/manifests/notifications/kustomization.yaml
+++ b/manifests/notifications/kustomization.yaml
@@ -4,13 +4,13 @@ kind: Kustomization
 resources:
 - argo-rollouts-notification-configmap.yaml
 
-patchesStrategicMerge:
-  - on-rollout-completed.yaml
-  - on-scaling-replica-set.yaml
-  - on-rollout-step-completed.yaml
-  - on-rollout-updated.yaml
-  - on-rollout-aborted.yaml
-  - on-rollout-paused.yaml
-  - on-analysis-run-running.yaml
-  - on-analysis-run-error.yaml
-  - on-analysis-run-failed.yaml
+patches:
+  - path: on-rollout-completed.yaml
+  - path: on-scaling-replica-set.yaml
+  - path: on-rollout-step-completed.yaml
+  - path: on-rollout-updated.yaml
+  - path: on-rollout-aborted.yaml
+  - path: on-rollout-paused.yaml
+  - path: on-analysis-run-running.yaml
+  - path: on-analysis-run-error.yaml
+  - path: on-analysis-run-failed.yaml

--- a/test/kustomize/rollout/kustomization.yaml
+++ b/test/kustomize/rollout/kustomization.yaml
@@ -45,15 +45,15 @@ images:
 openapi:
   path: https://raw.githubusercontent.com/argoproj/argo-schema-generator/main/schema/argo_all_k8s_kustomize_schema.json
 
-patchesStrategicMerge:
-- |-
-  apiVersion: argoproj.io/v1alpha1
-  kind: Rollout
-  metadata:
-    name: guestbook
-  spec:
-    template:
-      spec:
-        containers:
-        - name: guestbook
-          image: guestbook-patched:v1
+patches:
+- patch: |-
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
+    metadata:
+      name: guestbook
+    spec:
+      template:
+        spec:
+          containers:
+          - name: guestbook
+            image: guestbook-patched:v1


### PR DESCRIPTION
This update ensures documentation and test examples reflect the use
of the newer `patches` method, transitioning away from the deprecated
`patchesStrategicMerge`. This aligns with current best practices and
recommendations from the kustomize project.

Signed-off-by: Daniel Wright <danielwright@bitgo.com>

Closes #3009

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).