### PR TITLE
fix: Add the GOPATH to the go-to-protobuf command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ gen-proto: k8s-proto api-proto ui-proto
 # generates the .proto files affected by changes to types.go
 .PHONY: k8s-proto
 k8s-proto: go-mod-vendor $(TYPES) ## generate kubernetes protobuf files
-	PATH=${DIST_DIR}:$$PATH go-to-protobuf \
+	PATH=${DIST_DIR}:$$PATH GOPATH=${GOPATH} go-to-protobuf \
 		--go-header-file=./hack/custom-boilerplate.go.txt \
 		--packages=github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1 \
 		--apimachinery-packages=${APIMACHINERY_PKGS} \


### PR DESCRIPTION
This came up when trying to run the codegen. Need the GOPATH env var to be set.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).