### PR TITLE
fix: inopportune scaling events would lose some status fields

### DIFF
--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -274,10 +274,11 @@ func (c *rolloutContext) syncReplicasOnly() error {
 	if err != nil {
 		return err
 	}
+	newStatus := c.rollout.Status.DeepCopy()
 
 	// NOTE: it is possible for newRS to be nil (e.g. when template and replicas changed at same time)
 	if c.rollout.Spec.Strategy.BlueGreen != nil {
-		previewSvc, activeSvc, err := c.getPreviewAndActiveServices()
+		_, activeSvc, err := c.getPreviewAndActiveServices()
 		if err != nil {
 			return nil
 		}
@@ -286,7 +287,15 @@ func (c *rolloutContext) syncReplicasOnly() error {
 			// so we can abort this resync
 			return err
 		}
-		return c.syncRolloutStatusBlueGreen(previewSvc, activeSvc)
+		activeRS, _ := replicasetutil.GetReplicaSetByTemplateHash(c.allRSs, newStatus.BlueGreen.ActiveSelector)
+		if activeRS != nil {
+			newStatus.HPAReplicas = activeRS.Status.Replicas
+			newStatus.AvailableReplicas = activeRS.Status.AvailableReplicas
+		} else {
+			// when we do not have an active replicaset, accounting is done on the default rollout selector
+			newStatus.HPAReplicas = replicasetutil.GetActualReplicaCountForReplicaSets(c.allRSs)
+			newStatus.AvailableReplicas = replicasetutil.GetAvailableReplicaCountForReplicaSets(c.allRSs)
+		}
 	}
 	// The controller wants to use the rolloutCanary method to reconcile the rollout if the rollout is not paused.
 	// If there are no scaling events, the rollout should only sync its status
@@ -296,9 +305,10 @@ func (c *rolloutContext) syncReplicasOnly() error {
 			// so we can abort this resync
 			return err
 		}
-		return c.syncRolloutStatusCanary()
+		newStatus.AvailableReplicas = replicasetutil.GetAvailableReplicaCountForReplicaSets(c.allRSs)
+		newStatus.HPAReplicas = replicasetutil.GetActualReplicaCountForReplicaSets(c.allRSs)
 	}
-	return fmt.Errorf("no rollout strategy provided")
+	return c.persistRolloutStatus(newStatus)
 }
 
 // isScalingEvent checks whether the provided rollout has been updated with a scaling event


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/2931

During a scaling event, we will now only perform scaling against our ReplicaSets, and only reconcile:
* `status.availableReplicas`
* `status.HPAReplicas`

This fixes a bug where we would lose some information in status (because we did not perform the normal full logic of reconciliation).

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).