### PR TITLE
chore: updating getCanaryConfigId to be more efficient with better error handling

### DIFF
--- a/metricproviders/kayenta/kayenta.go
+++ b/metricproviders/kayenta/kayenta.go
@@ -67,26 +67,20 @@ func (p *Provider) GetMetadata(metric v1alpha1.Metric) map[string]string {
 }
 
 func getCanaryConfigId(metric v1alpha1.Metric, p *Provider) (string, error) {
-
 	configIdLookupURL := fmt.Sprintf(configIdLookupURLFormat, metric.Provider.Kayenta.Address, metric.Provider.Kayenta.Application, metric.Provider.Kayenta.StorageAccountName)
 
 	response, err := p.client.Get(configIdLookupURL)
-	if err != nil || response.Body == nil || response.StatusCode != 200 {
-		if err == nil {
-			err = errors.New("Invalid Response")
-		}
-		return "", err
-	}
-
-	data, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != 200 {
+		return "", fmt.Errorf("Invalid Response: HTTP %d", response.StatusCode)
 	}
 
 	var cc []canaryConfig
-
-	err = json.Unmarshal(data, &cc)
-	if err != nil {
+	if err := json.NewDecoder(response.Body).Decode(&cc); err != nil {
 		return "", err
 	}
 
@@ -96,7 +90,7 @@ func getCanaryConfigId(metric v1alpha1.Metric, p *Provider) (string, error) {
 		}
 	}
 
-	return "", err
+	return "", errors.New("Canary config not found")
 }
 
 // Run queries kayentd for the metric


### PR DESCRIPTION
Updating `getCanaryConfigId` func:

`Error Handling:` It now handles errors more cleanly.

`Resource Management:` It closes the HTTP response body to prevent resource leaks.

Last but not least it simplifies things by reducing nesting and using the defer statement for cleanup.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).