### PR TITLE
fix: missing notification on error

### DIFF
--- a/utils/record/record.go
+++ b/utils/record/record.go
@@ -217,7 +217,7 @@ func (e *EventRecorderAdapter) defaultEventf(object runtime.Object, warn bool, o
 		for _, api := range apis {
 			err := e.sendNotifications(api, object, opts)
 			if err != nil {
-				logCtx.Errorf("notifications failed to send for eventReason %s with error: %s", opts.EventReason, err)
+				logCtx.Errorf("Notifications failed to send for eventReason %s with error: %s", opts.EventReason, err)
 			}
 		}
 	}
@@ -257,7 +257,7 @@ func (e *EventRecorderAdapter) sendNotifications(notificationsAPI api.API, objec
 	}()
 
 	if notificationsAPI == nil {
-		return []error{fmt.Errorf("notificationsAPI is nil")}
+		return []error{fmt.Errorf("NotificationsAPI is nil")}
 	}
 
 	cfg := notificationsAPI.GetConfig()
@@ -282,12 +282,12 @@ func (e *EventRecorderAdapter) sendNotifications(notificationsAPI api.API, objec
 	for _, destination := range destinations {
 		res, err := notificationsAPI.RunTrigger(trigger, objMap)
 		if err != nil {
-			log.Errorf("failed to run trigger, trigger: %s, destination: %s, namespace config: %s : %v",
+			log.Errorf("Failed to run trigger, trigger: %s, destination: %s, namespace config: %s : %v",
 				trigger, destination, notificationsAPI.GetConfig().Namespace, err)
 			errors = append(errors, err)
 			continue
 		}
-		log.Infof("trigger %s result: %v", trigger, res)
+		log.Infof("Trigger %s result: %v", trigger, res)
 
 		for _, c := range res {
 			log.Infof("result when condition hash: %s, templates: %s", c.Key, c.Templates)
@@ -295,7 +295,7 @@ func (e *EventRecorderAdapter) sendNotifications(notificationsAPI api.API, objec
 			if s != emptyCondition && c.Triggered == true {
 				err = notificationsAPI.Send(objMap, c.Templates, destination)
 				if err != nil {
-					log.Errorf("failed to execute the sending of notification on not empty condition, trigger: %s, destination: %s, namespace config: %s : %v",
+					log.Errorf("Failed to execute the sending of notification on not empty condition, trigger: %s, destination: %s, namespace config: %s : %v",
 						trigger, destination, notificationsAPI.GetConfig().Namespace, err)
 					e.NotificationFailedCounter.WithLabelValues(namespace, name, opts.EventType, opts.EventReason).Inc()
 					errors = append(errors, err)
@@ -305,7 +305,7 @@ func (e *EventRecorderAdapter) sendNotifications(notificationsAPI api.API, objec
 			} else if s == emptyCondition {
 				err = notificationsAPI.Send(objMap, c.Templates, destination)
 				if err != nil {
-					log.Errorf("failed to execute the sending of notification on empty condition, trigger: %s, destination: %s, namespace config: %s : %v",
+					log.Errorf("Failed to execute the sending of notification on empty condition, trigger: %s, destination: %s, namespace config: %s : %v",
 						trigger, destination, notificationsAPI.GetConfig().Namespace, err)
 					e.NotificationFailedCounter.WithLabelValues(namespace, name, opts.EventType, opts.EventReason).Inc()
 					errors = append(errors, err)

--- a/utils/record/record.go
+++ b/utils/record/record.go
@@ -290,7 +290,7 @@ func (e *EventRecorderAdapter) sendNotifications(notificationsAPI api.API, objec
 		log.Infof("Trigger %s result: %v", trigger, res)
 
 		for _, c := range res {
-			log.Infof("result when condition hash: %s, templates: %s", c.Key, c.Templates)
+			log.Infof("Result when condition hash: %s, templates: %s", c.Key, c.Templates)
 			s := strings.Split(c.Key, ".")[1]
 			if s != emptyCondition && c.Triggered == true {
 				err = notificationsAPI.Send(objMap, c.Templates, destination)

--- a/utils/record/record.go
+++ b/utils/record/record.go
@@ -315,8 +315,10 @@ func (e *EventRecorderAdapter) sendNotifications(notificationsAPI api.API, objec
 			}
 		}
 	}
-
-	return nil
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
 }
 
 // This function is copied over from notification engine to make sure we honour emptyCondition

--- a/utils/record/record_test.go
+++ b/utils/record/record_test.go
@@ -340,7 +340,7 @@ func TestSendNotificationsFails(t *testing.T) {
 		rec.EventRecorderAdapter.apiFactory = apiFactory
 
 		err := rec.sendNotifications(mockAPI, &r, EventOptions{EventReason: "FooReason"})
-		assert.Error(t, err)
+		assert.Nil(t, err)
 	})
 
 	t.Run("GetAPIError", func(t *testing.T) {
@@ -380,7 +380,7 @@ func TestSendNotificationsFailsWithRunTriggerError(t *testing.T) {
 		rec.EventRecorderAdapter.apiFactory = apiFactory
 
 		err := rec.sendNotifications(mockAPI, &r, EventOptions{EventReason: "FooReason"})
-		assert.Error(t, err)
+		assert.Nil(t, err)
 	})
 
 	t.Run("GetAPIError", func(t *testing.T) {
@@ -419,7 +419,7 @@ func TestSendNotificationsNoTrigger(t *testing.T) {
 	rec.EventRecorderAdapter.apiFactory = apiFactory
 
 	err := rec.sendNotifications(mockAPI, &r, EventOptions{EventReason: "MissingReason"})
-	assert.Error(t, err)
+	assert.Nil(t, err)
 }
 
 func TestNewAPIFactorySettings(t *testing.T) {

--- a/utils/record/record_test.go
+++ b/utils/record/record_test.go
@@ -340,7 +340,7 @@ func TestSendNotificationsFails(t *testing.T) {
 		rec.EventRecorderAdapter.apiFactory = apiFactory
 
 		err := rec.sendNotifications(mockAPI, &r, EventOptions{EventReason: "FooReason"})
-		assert.Nil(t, err)
+		assert.Len(t, err, 1)
 	})
 
 	t.Run("GetAPIError", func(t *testing.T) {
@@ -380,7 +380,7 @@ func TestSendNotificationsFailsWithRunTriggerError(t *testing.T) {
 		rec.EventRecorderAdapter.apiFactory = apiFactory
 
 		err := rec.sendNotifications(mockAPI, &r, EventOptions{EventReason: "FooReason"})
-		assert.Nil(t, err)
+		assert.Len(t, err, 1)
 	})
 
 	t.Run("GetAPIError", func(t *testing.T) {
@@ -419,7 +419,7 @@ func TestSendNotificationsNoTrigger(t *testing.T) {
 	rec.EventRecorderAdapter.apiFactory = apiFactory
 
 	err := rec.sendNotifications(mockAPI, &r, EventOptions{EventReason: "MissingReason"})
-	assert.Nil(t, err)
+	assert.Len(t, err, 1)
 }
 
 func TestNewAPIFactorySettings(t *testing.T) {

--- a/utils/record/record_test.go
+++ b/utils/record/record_test.go
@@ -113,7 +113,7 @@ func TestSendNotifications(t *testing.T) {
 	rec.EventRecorderAdapter.apiFactory = apiFactory
 	//ch := make(chan prometheus.HistogramVec, 1)
 	err := rec.sendNotifications(mockAPI, &r, EventOptions{EventReason: "FooReason"})
-	assert.NoError(t, err)
+	assert.Nil(t, err)
 }
 
 func TestSendNotificationsWhenCondition(t *testing.T) {
@@ -140,7 +140,7 @@ func TestSendNotificationsWhenCondition(t *testing.T) {
 	rec.EventRecorderAdapter.apiFactory = apiFactory
 	//ch := make(chan prometheus.HistogramVec, 1)
 	err := rec.sendNotifications(mockAPI, &r, EventOptions{EventReason: "FooReason"})
-	assert.NoError(t, err)
+	assert.Nil(t, err)
 }
 
 func TestSendNotificationsWhenConditionTime(t *testing.T) {
@@ -349,7 +349,7 @@ func TestSendNotificationsFails(t *testing.T) {
 		rec.EventRecorderAdapter.apiFactory = apiFactory
 
 		err := rec.sendNotifications(nil, &r, EventOptions{EventReason: "FooReason"})
-		assert.Error(t, err)
+		assert.NotNil(t, err)
 	})
 
 }
@@ -389,7 +389,7 @@ func TestSendNotificationsFailsWithRunTriggerError(t *testing.T) {
 		rec.EventRecorderAdapter.apiFactory = apiFactory
 
 		err := rec.sendNotifications(nil, &r, EventOptions{EventReason: "FooReason"})
-		assert.Error(t, err)
+		assert.NotNil(t, err)
 	})
 
 }


### PR DESCRIPTION
Notifications would stop processing if any error happened on a single notification 'API' configuration, we should continue processing other notifications so that we do not miss sending a notification that is properly configured.

This also fixes an incorrect prometheus stat, we where only incrementing errors and success counts on api creations not at the sending and erroring of the actually execution of the notification.