### PR TITLE
docs: Ensure image not present between incomplete sentence.

### DIFF
--- a/docs/features/anti-affinity/anti-affinity.md
+++ b/docs/features/anti-affinity/anti-affinity.md
@@ -31,6 +31,7 @@ You can learn more about anti-affinity [here](https://kubernetes.io/docs/concept
 
 Repeating the above example with anti-affinity enabled, here is what happens when the `.spec.template` of the Rollout changes. Due to anti-affinity, the new pods cannot be scheduled on nodes which run the old ReplicaSet's pods.
 As a result, the cluster auto-scaler must create 2 nodes to host the new ReplicaSet's pods. In this case, pods won't be started since the scaled-down nodes are guaranteed to not have the new pods.
+
 ![ Original Rollout is running, spread across two nodes](images/solution.png)
 
 ## Enabling Anti-Affinity in Rollouts


### PR DESCRIPTION
**ISSUE DETAILS**
Image is present between the incomplete sentence. To see the issue  go to this link : https://argo-rollouts.readthedocs.io/en/stable/features/anti-affinity/anti-affinity/#enabling-anti-affinity-in-rollouts and check the above image.

<img width="552" alt="image_bet_sentence" src="https://github.com/argoproj/argo-rollouts/assets/102309095/6c2078e8-a1b8-4dee-9ed6-4e5700c972e8">

Commits:
3c83b2d0ef7398c7f9376480e6f8362eb36c74a5
905af66ffbc576f21767619d12219eea0c5ae808

Checklist:


* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).