### PR TITLE
docs: add CONTRIBUTING.md at root of repo, directing to docs/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md).


### PR DESCRIPTION
Add a root CONTRIBUTING.md that directs to docs/CONTRIBUTING.md

# Details

- having a `CONTRIBUTING.md` at the root of the repo is a common convention
  - I looked at the root of the repo initially, didn't find it, then checked the website, but potential contributors may think it doesn't exist as a result

Shamelessly copied from https://github.com/argoproj/argo-workflows/pull/10969 (thank you @agilgur5)

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).