### PR TITLE
docs(analysis): Add note about availability of new datadog v2 functionality

### DIFF
--- a/docs/analysis/datadog.md
+++ b/docs/analysis/datadog.md
@@ -1,8 +1,5 @@
 # Datadog Metrics
 
-!!! important
-    Available since v0.10.0
-
 A [Datadog](https://www.datadoghq.com/) query can be used to obtain measurements for analysis.
 
 ```yaml
@@ -45,6 +42,9 @@ stringData:
 `apiVersion` here is different from the `apiVersion` from the Datadog configuration above.
 
 ### Working with Datadog API v2
+
+!!! important
+    While some basic v2 functionality is working in earlier versions, the new properties of `formula` and `queries` are only available as of v1.7
 
 #### Moving to v2
 


### PR DESCRIPTION
Was pointed out with the docs live from merge https://github.com/argoproj/argo-rollouts/pull/2997, but we're still only at 1.6 this can be confusing for users. 

Added the following: 

<img width="787" alt="image" src="https://github.com/argoproj/argo-rollouts/assets/4623/73872a80-d181-481d-915c-01bd816cecea">

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).