### PR TITLE
fix: docs require build.os to be defined

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,3 +5,4 @@ mkdocs:
 python:
   install:
     - requirements: docs/requirements.txt
+build.os: ubuntu

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,4 +5,7 @@ mkdocs:
 python:
   install:
     - requirements: docs/requirements.txt
-build.os: ubuntu
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.7"


### PR DESCRIPTION
https://github.com/readthedocs/readthedocs.org/issues/8861#issuecomment-1025568797