### PR TITLE
build(deps): always resolve momentjs version 2.29.4

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -71,6 +71,7 @@
         "webpack-merge": "^5.7.3"
     },
     "resolutions": {
-        "@types/react": "16.9.3"
+        "@types/react": "16.9.3",
+        "moment": "2.29.4"
     }
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7973,12 +7973,7 @@ moment-timezone@^0.5.33:
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0", moment@^2.20.1:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
-
-moment@^2.29.4:
+moment@2.29.4, "moment@>= 2.9.0", moment@^2.20.1, moment@^2.29.4:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==


### PR DESCRIPTION
Before this change both version 2.29.1 and version 2.29.4 of momentjs were brougth in. The bump from v2.29.1 -> v2.29.4 remediates two CVEs: CVE-2022-24785 [1] and CVE-2022-31129 [2].

The most notable change comes with the bump from v2.29.1 -> v2.29.2 which introduces a breaking change to remediate CVE-2022-24785: Forward slash and backward slash is no longer allowed in locale names. Locales containing either of those characters will not be loaded from the filesystem any longer [3].

Other than that it looks like there's only patch fixes which can be seen in the full changelog [4].

[1] https://github.com/moment/moment/security/advisories/GHSA-8hfj-j24r-96c4
[2] https://github.com/moment/moment/security/advisories/GHSA-wc69-rhjr-hc9g
[3] https://gist.github.com/ichernev/1904b564f6679d9aac1ae08ce13bc45c
[4] https://github.com/moment/moment/blob/536ad0c348f2f99009755698f491080757a48221/CHANGELOG.md

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`. 
  * **Everything except (c) since this does not have a related issue, I can create one if required.**
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).