### PR TITLE
fix: keep replicaset tracking updated (newRs and informer)

### DIFF
--- a/rollout/bluegreen_test.go
+++ b/rollout/bluegreen_test.go
@@ -1561,6 +1561,8 @@ func TestBlueGreenAddScaleDownDelay(t *testing.T) {
 	f.objects = append(f.objects, r2)
 
 	rs1Patch := f.expectPatchReplicaSetAction(rs1) // set scale-down-deadline annotation
+	f.expectPatchRolloutAction(r2)
+	f.expectPatchServiceAction(activeSvc, rs2PodHash) // update service labels
 	f.run(getKey(r2, t))
 
 	f.verifyPatchedReplicaSet(rs1Patch, 30)

--- a/rollout/replicaset.go
+++ b/rollout/replicaset.go
@@ -34,7 +34,7 @@ func (c *rolloutContext) removeScaleDownDelay(rs *appsv1.ReplicaSet) error {
 		return nil
 	}
 	patch := fmt.Sprintf(removeScaleDownAtAnnotationsPatch, v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey)
-	_, err := c.kubeclientset.AppsV1().ReplicaSets(rs.Namespace).Patch(ctx, rs.Name, patchtypes.JSONPatchType, []byte(patch), metav1.PatchOptions{})
+	rs, err := c.kubeclientset.AppsV1().ReplicaSets(rs.Namespace).Patch(ctx, rs.Name, patchtypes.JSONPatchType, []byte(patch), metav1.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("error removing scale-down-deadline annotation from RS '%s': %w", rs.Name, err)
 	}

--- a/rollout/replicaset.go
+++ b/rollout/replicaset.go
@@ -43,6 +43,7 @@ func (c *rolloutContext) removeScaleDownDelay(rs *appsv1.ReplicaSet) error {
 	if err != nil {
 		return fmt.Errorf("error updating replicaset informer in removeScaleDownDelay: %w", err)
 	}
+	c.newRS = rs.DeepCopy()
 	return err
 }
 
@@ -72,6 +73,7 @@ func (c *rolloutContext) addScaleDownDelay(rs *appsv1.ReplicaSet, scaleDownDelay
 	if err != nil {
 		return fmt.Errorf("error updating replicaset informer in addScaleDownDelay: %w", err)
 	}
+	c.newRS = rs.DeepCopy()
 	return err
 }
 

--- a/rollout/service_test.go
+++ b/rollout/service_test.go
@@ -609,10 +609,12 @@ func TestCanaryAWSVerifyTargetGroupsReady(t *testing.T) {
 
 	f.expectGetEndpointsAction(ep)
 	scaleDownRSIndex := f.expectPatchReplicaSetAction(rs1)
+	f.expectPatchRolloutAction(r2) // update status message
 	f.run(getKey(r2, t))
 	f.verifyPatchedReplicaSet(scaleDownRSIndex, 30)
 	f.assertEvents([]string{
 		conditions.TargetGroupVerifiedReason,
+		conditions.RolloutNotCompletedReason,
 	})
 }
 

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -783,6 +783,7 @@ func TestCanaryWithTrafficRoutingAddScaleDownDelay(t *testing.T) {
 	f.objects = append(f.objects, r2)
 
 	rs1Patch := f.expectPatchReplicaSetAction(rs1) // set scale-down-deadline annotation
+	f.expectPatchRolloutAction(r2)                 // updates the rollout status
 	f.run(getKey(r2, t))
 
 	f.verifyPatchedReplicaSet(rs1Patch, 30)


### PR DESCRIPTION
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).