### PR TITLE
fix: fix the rollout stuck issue when pod/replicas changed together for canary rollout. 

### DIFF
--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -435,6 +435,13 @@ func (c *rolloutContext) reconcileCanaryReplicaSets() (bool, error) {
 		return true, nil
 	}
 
+	if c.newRS == nil {
+		canaryRS, err := c.getCanaryReplicaSet()
+		if err != nil {
+			return false, err
+		}
+		c.newRS = canaryRS
+	}
 	scaledNewRS, err := c.reconcileNewReplicaSet()
 	if err != nil {
 		return false, err

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -1,6 +1,7 @@
 package rollout
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -2008,4 +2009,46 @@ func TestIsDynamicallyRollingBackToStable(t *testing.T) {
 			assert.Equal(t, tc.expectedResult, rbToStable)
 		})
 	}
+}
+
+func TestCanaryReplicaAndSpecChangedTogether(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	originReplicas := 3
+	r1 := newCanaryRollout("foo", originReplicas, nil, nil, nil, intstr.FromInt(1), intstr.FromInt(0))
+	canarySVCName := "canary"
+	stableSVCName := "stable"
+	r1.Spec.Strategy.Canary.CanaryService = canarySVCName
+	r1.Spec.Strategy.Canary.StableService = stableSVCName
+
+	stableRS := newReplicaSetWithStatus(r1, originReplicas, originReplicas)
+	stableSVC := newService(stableSVCName, 80,
+		map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: stableRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]}, r1)
+
+	r2 := bumpVersion(r1)
+	canaryRS := newReplicaSetWithStatus(r2, originReplicas, originReplicas)
+	canarySVC := newService(canarySVCName, 80,
+		map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: canaryRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]}, r2)
+
+	f.replicaSetLister = append(f.replicaSetLister, canaryRS, stableRS)
+	f.serviceLister = append(f.serviceLister, canarySVC, stableSVC)
+
+	r3 := bumpVersion(r2)
+	r3.Spec.Replicas = pointer.Int32(int32(originReplicas) + 5)
+	r3.Status.StableRS = stableRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+
+	f.rolloutLister = append(f.rolloutLister, r3)
+	f.kubeobjects = append(f.kubeobjects, canaryRS, stableRS, canarySVC, stableSVC)
+	f.objects = append(f.objects, r3)
+
+	ctrl, _, _ := f.newController(noResyncPeriodFunc)
+	roCtx, err := ctrl.newRolloutContext(r3)
+	assert.NoError(t, err)
+	err = roCtx.reconcile()
+	assert.NoError(t, err)
+	updated, err := f.kubeclient.AppsV1().ReplicaSets(r3.Namespace).Get(context.Background(), canaryRS.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	// check the canary one is updated
+	assert.NotEqual(t, originReplicas, int(*updated.Spec.Replicas))
 }

--- a/rollout/service.go
+++ b/rollout/service.go
@@ -286,7 +286,7 @@ func (c *rolloutContext) reconcileStableAndCanaryService() error {
 }
 
 func (c *rolloutContext) getCanaryReplicaSet() (*appsv1.ReplicaSet, error) {
-	if c.rollout.Spec.Strategy.Canary == nil {
+	if c.rollout.Spec.Strategy.Canary == nil || c.rollout.Spec.Strategy.Canary.CanaryService == "" {
 		return nil, nil
 	}
 	svc, err := c.servicesLister.Services(c.rollout.Namespace).Get(c.rollout.Spec.Strategy.Canary.CanaryService)

--- a/rollout/service.go
+++ b/rollout/service.go
@@ -17,6 +17,7 @@ import (
 	serviceutil "github.com/argoproj/argo-rollouts/utils/service"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	patchtypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
@@ -282,6 +283,27 @@ func (c *rolloutContext) reconcileStableAndCanaryService() error {
 		return err
 	}
 	return nil
+}
+
+func (c *rolloutContext) getCanaryReplicaSet() (*appsv1.ReplicaSet, error) {
+	if c.rollout.Spec.Strategy.Canary == nil {
+		return nil, nil
+	}
+	svc, err := c.servicesLister.Services(c.rollout.Namespace).Get(c.rollout.Spec.Strategy.Canary.CanaryService)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if svc != nil {
+		for _, rs := range c.allRSs {
+			if serviceutil.GetRolloutSelectorLabel(svc) == rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] {
+				return rs, nil
+			}
+		}
+	}
+	return nil, nil
 }
 
 // ensureSVCTargets updates the service with the given name to point to the given ReplicaSet,

--- a/rollout/service_test.go
+++ b/rollout/service_test.go
@@ -889,8 +889,22 @@ func TestGetCanaryReplicaSet(t *testing.T) {
 		roCtx, err := ctrl.newRolloutContext(ro)
 		assert.NoError(t, err)
 		rs, err := roCtx.getCanaryReplicaSet()
-		assert.Nil(t, rs)
 		assert.NoError(t, err)
+		assert.Nil(t, rs)
+	},
+	)
+
+	t.Run("Empty Canary Service", func(t *testing.T) {
+		f := newFixture(t)
+		defer f.Close()
+		ctrl, _, _ := f.newController(noResyncPeriodFunc)
+		ro := newCanaryRollout("foo", 3, nil, nil, nil, intstr.FromInt(1), intstr.FromInt(1))
+		ro.Spec.Strategy.Canary.CanaryService = ""
+		roCtx, err := ctrl.newRolloutContext(ro)
+		assert.NoError(t, err)
+		rs, err := roCtx.getCanaryReplicaSet()
+		assert.NoError(t, err)
+		assert.Nil(t, rs)
 	},
 	)
 
@@ -899,6 +913,7 @@ func TestGetCanaryReplicaSet(t *testing.T) {
 		defer f.Close()
 		ctrl, _, _ := f.newController(noResyncPeriodFunc)
 		ro := newCanaryRollout("foo", 3, nil, nil, nil, intstr.FromInt(1), intstr.FromInt(1))
+		ro.Spec.Strategy.Canary.CanaryService = "canary"
 		roCtx, err := ctrl.newRolloutContext(ro)
 		assert.NoError(t, err)
 		rs, err := roCtx.getCanaryReplicaSet()
@@ -906,11 +921,13 @@ func TestGetCanaryReplicaSet(t *testing.T) {
 		assert.NoError(t, err)
 	},
 	)
+
 	t.Run("Have Canary SVC", func(t *testing.T) {
 		f := newFixture(t)
 		defer f.Close()
 		ro := newCanaryRollout("foo", 3, nil, nil, nil, intstr.FromInt(1), intstr.FromInt(1))
 		canarySVCName := "canary"
+		ro.Spec.Strategy.Canary.CanaryService = canarySVCName
 		canaryRS := newReplicaSetWithStatus(ro, 3, 3)
 		canarySVC := newService(canarySVCName, 80,
 			map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: canaryRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]}, ro)
@@ -927,11 +944,13 @@ func TestGetCanaryReplicaSet(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, rs)
 	})
+
 	t.Run("No Matched Replicaset", func(t *testing.T) {
 		f := newFixture(t)
 		defer f.Close()
 		ro := newCanaryRollout("foo", 3, nil, nil, nil, intstr.FromInt(1), intstr.FromInt(1))
 		canarySVCName := "canary"
+		ro.Spec.Strategy.Canary.CanaryService = canarySVCName
 		canaryRS := newReplicaSetWithStatus(ro, 3, 0)
 		canarySVC := newService(canarySVCName, 80,
 			map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: "youknowthisisdifferent"}, ro)


### PR DESCRIPTION
when the rollout is in the "Pause" status,
and replica/poc spec changed together, then the rollout will stuck there forever.
this is because the newRS will be nil,
and there's one short circut return in reconcileNewReplicaSet().

issue reported in:
https://github.com/argoproj/argo-rollouts/issues/3256

the change will follow the "BlueGreen" style to handle this.
pick the replica set which the canary svc targeted to. and reconcile it.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).