### PR TITLE
docs: Fixed the key for headers in prometheus based argo analysis

### DIFF
--- a/docs/analysis/prometheus.md
+++ b/docs/analysis/prometheus.md
@@ -11,7 +11,7 @@ spec:
   args:
   - name: service-name
   metrics:
-  - name: success-rate 
+  - name: success-rate
     interval: 5m
     # NOTE: prometheus queries return results in the form of a vector.
     # So it is common to access the index 0 of the returned array to obtain the value

--- a/docs/analysis/prometheus.md
+++ b/docs/analysis/prometheus.md
@@ -23,7 +23,7 @@ spec:
         # timeout is expressed in seconds
         timeout: 40
         headers:
-        - name: X-Scope-Org-ID
+        - key: X-Scope-Org-ID
           value: tenant_a
         query: |
           sum(irate(

--- a/docs/analysis/prometheus.md
+++ b/docs/analysis/prometheus.md
@@ -11,7 +11,7 @@ spec:
   args:
   - name: service-name
   metrics:
-  - name: success-rate
+  - name: success-rate 
     interval: 5m
     # NOTE: prometheus queries return results in the form of a vector.
     # So it is common to access the index 0 of the returned array to obtain the value


### PR DESCRIPTION
The existing key "name" results in an error. The expected key is "key" as defined in the struct:
https://github.com/argoproj/argo-rollouts/blob/99ae20c0ffdfd2543856561fd528fcd51b4fb0a5/pkg/apis/rollouts/v1alpha1/analysis_types.go#L567


Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).