### PR TITLE
fix: log rs name when update fails

### DIFF
--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -380,7 +380,7 @@ func (c *rolloutContext) scaleReplicaSet(rs *appsv1.ReplicaSet, newScale int32, 
 
 		rs, err = c.kubeclientset.AppsV1().ReplicaSets(rsCopy.Namespace).Update(ctx, rsCopy, metav1.UpdateOptions{})
 		if err != nil {
-			return scaled, rs, fmt.Errorf("error updating replicaset %s: %w", rs.Name, err)
+			return scaled, rs, fmt.Errorf("error updating replicaset %s: %w", rsCopy.Name, err)
 		}
 		err = c.replicaSetInformer.GetIndexer().Update(rs)
 		if err != nil {


### PR DESCRIPTION
don't log an empty rs.Name because when we error out we end up getting a defaulted replicaset.