### PR TITLE
chore: change controller's deploy strategy to RollingUpdate due to leader election

### DIFF
--- a/manifests/base/argo-rollouts-deployment.yaml
+++ b/manifests/base/argo-rollouts-deployment.yaml
@@ -47,4 +47,4 @@ spec:
       securityContext:
         runAsNonRoot: true
   strategy:
-    type: Recreate
+    type: RollingUpdate

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -15971,7 +15971,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: argo-rollouts
   strategy:
-    type: Recreate
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -377,7 +377,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: argo-rollouts
   strategy:
-    type: Recreate
+    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

---

## background
Though there was a constraint to use deployment strategy `Recreate` due to race condition https://github.com/argoproj/argo-rollouts/issues/38, now it seems we don't have to care about deployment strategy as below.

https://cloud-native.slack.com/archives/C01U781DW2E/p1640199673233000
<img width="681" alt="image" src="https://github.com/argoproj/argo-rollouts/assets/30188755/69b45e3e-a5d0-4d5b-b51a-ddb6ef65aa7a">

[argo-helm](https://github.com/argoproj/argo-helm) got [the PR](https://github.com/argoproj/argo-helm/pull/2412) that let controller's deployment strategy configurable, so I wonder we can change the default strategy as `RollingUpdate`. 🙋 
