### PR TITLE
fix: stuck rollout when 2nd deployment happens before 1st finishes

### DIFF
--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -184,7 +184,7 @@ func (c *rolloutContext) scaleDownOldReplicaSetsForCanary(oldRSs []*appsv1.Repli
 
 	annotationedRSs := int32(0)
 	for _, targetRS := range oldRSs {
-		if c.isReplicaSetReferenced(targetRS) {
+		if c.rollout.Spec.Strategy.Canary.TrafficRouting != nil && c.isReplicaSetReferenced(targetRS) {
 			// We might get here if user interrupted an an update in order to move back to stable.
 			c.log.Infof("Skip scale down of older RS '%s': still referenced", targetRS.Name)
 			continue

--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -565,6 +565,23 @@ func (s *CanarySuite) TestCanaryScaleDownOnAbortNoTrafficRouting() {
 		ExpectRevisionPodCount("2", 0)
 }
 
+func (s *CanarySuite) TestCanaryWithPausedRollout() {
+	(s.Given().
+		HealthyRollout(`@functional/rollout-canary-with-pause.yaml`).
+		When().
+		ApplyManifests().
+		MarkPodsReady("1", 3). // mark all 3 pods ready
+		WaitForRolloutStatus("Healthy").
+		UpdateSpec(). // update to revision 2
+		WaitForRolloutStatus("Paused").
+		UpdateSpec(). // update to revision 3
+		WaitForRolloutStatus("Paused").
+		Then().
+		ExpectRevisionPodCount("1", 3).
+		ExpectRevisionPodCount("2", 0).
+		ExpectRevisionPodCount("3", 1))
+}
+
 func (s *CanarySuite) TestCanaryUnScaleDownOnAbort() {
 	s.Given().
 		HealthyRollout(`@functional/canary-unscaledownonabort.yaml`).

--- a/test/e2e/functional/rollout-canary-with-pause.yaml
+++ b/test/e2e/functional/rollout-canary-with-pause.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rollout-canary-with-pause-root
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: rollout-canary-with-pause
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rollout-canary-with-pause-canary
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: rollout-canary-with-pause
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rollout-canary-with-pause-stable
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: rollout-canary-with-pause
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: rollout-canary-with-pause
+spec:
+  replicas: 3
+  revisionHistoryLimit: 3
+  progressDeadlineSeconds: 5
+  selector:
+    matchLabels:
+      app: rollout-canary-with-pause
+  template:
+    metadata:
+      labels:
+        app: rollout-canary-with-pause
+    spec:
+      containers:
+        - name: rollouts-demo
+          image: nginx:1.19-alpine
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            initialDelaySeconds: 10
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 30
+  strategy:
+    canary:
+      canaryService: rollout-canary-with-pause-canary
+      stableService: rollout-canary-with-pause-stable
+      steps:
+        - setWeight: 20
+        - pause: {}
+        


### PR DESCRIPTION
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).