### PR TITLE
docs: Update shell autocompletion instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -81,7 +81,21 @@ kubectl argo rollouts version
 
 ## Shell auto completion
 
-The CLI can export shell completion code for several shells.
+To enable auto completion for the plugin when used with `kubectl` (version 1.26 or newer), you need to create a shell script on your PATH called `kubectl_complete-argo-rollouts` which will provide the completions.
+
+```shell
+cat <<EOF >kubectl_complete-argo-rollouts
+#!/usr/bin/env sh
+
+# Call the __complete command passing it all arguments
+kubectl argo rollouts __complete "\$@"
+EOF
+
+chmod +x kubectl_complete-argo-rollouts
+sudo mv ./kubectl_complete-argo-rollouts /usr/local/bin/
+```
+
+To enable auto completion for the CLI run as a standalone binary, the CLI can export shell completion code for several shells.
 
 For bash, ensure you have bash completions installed and enabled. To access completions in your current shell, run $ `source <(kubectl-argo-rollouts completion bash)`. Alternatively, write it to a file and source in `.bash_profile`.
 
@@ -120,4 +134,3 @@ To upgrade Argo Rollouts:
 If deployments are happening while you upgrade the controller, then you shouldn't
 have any downtime. Current Rollouts will be paused and as soon as the new controller becomes
 active it will resume all in-flight deployments.
-


### PR DESCRIPTION
The docs currently describe how to enable shell auto completion for the rollouts CLI when run as a standalone binary, but the don't describe how to get auto completion to work when used from `kubectl`.

This PR updates the docs with instructions on how this can be done, based on the information here: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/2379-kubectl-plugins#shell-completion-support

This works with `kubectl` version 1.26 and newer.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).