### PR TITLE
chore: Update notifications engine to 7a06976

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -1,6 +1,7 @@
 ## Who uses Argo Rollouts?
 Organizations below are **officially** using Argo Rollouts. Please send a PR with your organization name if you are using Argo Rollouts.
 
+1. [Ada](https://www.ada.cx)
 1. [ADP](https://www.adp.com)
 1. [Akuity](https://akuity.io/)
 1. [Alibaba Group](https://www.alibabagroup.com/)
@@ -19,6 +20,7 @@ Organizations below are **officially** using Argo Rollouts. Please send a PR wit
 1. [Flipkart](https://flipkart.com)
 1. [GetYourGuide](https://www.getyourguide.com)
 1. [Gllue](https://gllue.com)
+1. [HashiCorp](https://www.hashicorp.com/)
 1. [Ibotta](https://home.ibotta.com/)
 1. [Intuit](https://www.intuit.com/)
 1. [New Relic](https://newrelic.com/)
@@ -48,4 +50,3 @@ Organizations below are **officially** using Argo Rollouts. Please send a PR wit
 1. [WeLab Bank](https://www.welab.bank/)
 1. [Yotpo](https://www.yotpo.com/)
 1. [VGS](https://www.vgs.io)
-1. [HashiCorp](https://www.hashicorp.com/)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -247,6 +247,23 @@ pushed into the other kubernetes repositories yet. In order to import the kubern
 associated repos have to pinned to the correct version specified by the kubernetes/kubernetes release. The
 `./hack/update-k8s-dependencies.sh` updates all the dependencies to the those correct versions.
 
+## Upgrading Notifications Engine
+Argo Rollouts has a dependency on the [argoproj/notifications-engines](https://github.com/argoproj/notifications-engine) repo 
+for the notifications functionality and related documentation. 
+
+This is updated by upgrading the Go library in `go.mod` by running the commands:
+
+```shell
+go get github.com/argoproj/notifications-engine@LATEST_COMMIT_HASH
+go mod tidy
+```
+
+Next the latest notifications documentation can be imported by running:
+
+```shell
+make docs
+```
+
 ## Documentation Changes
 
 Modify contents in `docs/` directory.

--- a/docs/generated/notification-services/alertmanager.md
+++ b/docs/generated/notification-services/alertmanager.md
@@ -43,7 +43,7 @@ You should turn off "send_resolved" or you will receive unnecessary recovery not
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.alertmanager: |
     targets:
@@ -58,7 +58,7 @@ If your alertmanager has changed the default api, you can customize "apiPath".
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.alertmanager: |
     targets:
@@ -70,7 +70,7 @@ data:
 
 ### Send high availability alertmanager with auth
 
-Store auth token in `argocd-notifications-secret` Secret and use configure in `<config-map-name>` ConfigMap.
+Store auth token in `argo-rollouts-notification-secret` Secret and use configure in `argo-rollouts-notification-configmap` ConfigMap.
 
 ```yaml
 apiVersion: v1
@@ -89,7 +89,7 @@ stringData:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.alertmanager: |
     targets:
@@ -110,7 +110,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.alertmanager: |
     targets:

--- a/docs/generated/notification-services/alertmanager.md
+++ b/docs/generated/notification-services/alertmanager.md
@@ -70,7 +70,7 @@ data:
 
 ### Send high availability alertmanager with auth
 
-Store auth token in `argocd-notifications-secret` Secret and use configure in `argocd-notifications-cm` ConfigMap.
+Store auth token in `argocd-notifications-secret` Secret and use configure in `<config-map-name>` ConfigMap.
 
 ```yaml
 apiVersion: v1

--- a/docs/generated/notification-services/awssqs.md
+++ b/docs/generated/notification-services/awssqs.md
@@ -1,8 +1,8 @@
-# AWS SQS 
+# AWS SQS
 
 ## Parameters
 
-This notification service is capable of sending simple messages to AWS SQS queue. 
+This notification service is capable of sending simple messages to AWS SQS queue.
 
 * `queue` - name of the queue you are intending to send messages to. Can be overridden with target destination annotation.
 * `region` - region of the sqs queue can be provided via env variable AWS_DEFAULT_REGION
@@ -63,7 +63,7 @@ stringData:
 
 ### Minimal configuration using AWS Env variables
 
-Ensure following list of environment variables are injected via OIDC, or other method. And assuming SQS is local to the account.
+Ensure the following list of environment variables are injected via OIDC, or another method. And assuming SQS is local to the account.
 You may skip usage of secret for sensitive data and omit other parameters. (Setting parameters via ConfigMap takes precedent.)
 
 Variables:
@@ -103,4 +103,17 @@ data:
       send: [deployment-ready]
     - oncePer: obj.metadata.annotations["generation"]
 
+```
+
+## FIFO SQS Queues
+
+FIFO queues require a [MessageGroupId](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html#SQS-SendMessage-request-MessageGroupId) to be sent along with every message, every message with a matching MessageGroupId will be processed one by one in order.
+
+To send to a FIFO SQS Queue you must include a `messageGroupId` in the template such as in the example below:
+
+```yaml
+template.deployment-ready: |
+  message: |
+    Deployment {{.obj.metadata.name}} is ready!
+  messageGroupId: {{.obj.metadata.name}}-deployment
 ```

--- a/docs/generated/notification-services/awssqs.md
+++ b/docs/generated/notification-services/awssqs.md
@@ -30,7 +30,7 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.awssqs: |
     region: "us-east-2"
@@ -89,7 +89,7 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.awssqs: |
     queue: "myqueue"

--- a/docs/generated/notification-services/email.md
+++ b/docs/generated/notification-services/email.md
@@ -20,7 +20,7 @@ The following snippet contains sample Gmail service configuration:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.email.gmail: |
     username: $email-username
@@ -36,7 +36,7 @@ Without authentication:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.email.example: |
     host: smtp.example.com
@@ -52,7 +52,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   template.app-sync-succeeded: |
     email:

--- a/docs/generated/notification-services/github.md
+++ b/docs/generated/notification-services/github.md
@@ -17,14 +17,14 @@ The GitHub notification service changes commit status using [GitHub Apps](https:
 3. Generate a private key, and download it automatically
 ![3](https://user-images.githubusercontent.com/18019529/108397926-d4a36300-725b-11eb-83fe-74795c8c3e03.png)
 4. Install app to account
-5. Store privateKey in `argocd-notifications-secret` Secret and configure GitHub integration
-in `<config-map-name>` ConfigMap
+5. Store privateKey in `argo-rollouts-notification-secret` Secret and configure GitHub integration
+in `argo-rollouts-notification-configmap` ConfigMap
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.github: |
     appID: <app-id>

--- a/docs/generated/notification-services/github.md
+++ b/docs/generated/notification-services/github.md
@@ -18,7 +18,7 @@ The GitHub notification service changes commit status using [GitHub Apps](https:
 ![3](https://user-images.githubusercontent.com/18019529/108397926-d4a36300-725b-11eb-83fe-74795c8c3e03.png)
 4. Install app to account
 5. Store privateKey in `argocd-notifications-secret` Secret and configure GitHub integration
-in `argocd-notifications-cm` ConfigMap
+in `<config-map-name>` ConfigMap
 
 ```yaml
 apiVersion: v1
@@ -76,6 +76,7 @@ template.app-deployed: |
       logURL: "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"
       requiredContexts: []
       autoMerge: true
+      transientEnvironment: false
     pullRequestComment:
       content: |
         Application {{.app.metadata.name}} is now running new version of deployments manifests.

--- a/docs/generated/notification-services/googlechat.md
+++ b/docs/generated/notification-services/googlechat.md
@@ -13,7 +13,7 @@ The Google Chat notification service send message notifications to a google chat
 3. Under **Incoming Webhooks**, click **Add Webhook**
 4. Give a name to the webhook, optionally add an image and click **Save**
 5. Copy the URL next to your webhook
-6. Store the URL in `argocd-notification-secret` and declare it in `argocd-notifications-cm`
+6. Store the URL in `argocd-notification-secret` and declare it in `<config-map-name>`
 
 ```yaml
 apiVersion: v1

--- a/docs/generated/notification-services/googlechat.md
+++ b/docs/generated/notification-services/googlechat.md
@@ -13,13 +13,13 @@ The Google Chat notification service send message notifications to a google chat
 3. Under **Incoming Webhooks**, click **Add Webhook**
 4. Give a name to the webhook, optionally add an image and click **Save**
 5. Copy the URL next to your webhook
-6. Store the URL in `argocd-notification-secret` and declare it in `<config-map-name>`
+6. Store the URL in `argocd-notification-secret` and declare it in `argo-rollouts-notification-configmap`
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.googlechat: |
     webhooks:

--- a/docs/generated/notification-services/grafana.md
+++ b/docs/generated/notification-services/grafana.md
@@ -15,7 +15,7 @@ Available parameters :
 3. Click "Add API Key" 
 4. Fill the Key with name `ArgoCD Notification`, role `Editor` and Time to Live `10y` (for example)
 5. Click on Add button
-6. Store apiKey in `argocd-notifications-secret` Secret and Copy your API Key and define it in `argocd-notifications-cm` ConfigMap
+6. Store apiKey in `argocd-notifications-secret` Secret and Copy your API Key and define it in `<config-map-name>` ConfigMap
 
 ```yaml
 apiVersion: v1

--- a/docs/generated/notification-services/grafana.md
+++ b/docs/generated/notification-services/grafana.md
@@ -15,13 +15,13 @@ Available parameters :
 3. Click "Add API Key" 
 4. Fill the Key with name `ArgoCD Notification`, role `Editor` and Time to Live `10y` (for example)
 5. Click on Add button
-6. Store apiKey in `argocd-notifications-secret` Secret and Copy your API Key and define it in `<config-map-name>` ConfigMap
+6. Store apiKey in `argo-rollouts-notification-secret` Secret and Copy your API Key and define it in `argo-rollouts-notification-configmap` ConfigMap
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.grafana: |
     apiUrl: https://grafana.example.com/api

--- a/docs/generated/notification-services/mattermost.md
+++ b/docs/generated/notification-services/mattermost.md
@@ -12,14 +12,14 @@
 ![1](https://user-images.githubusercontent.com/18019529/111499520-62ed0500-8786-11eb-88b0-d0aade61fed4.png)
 2. Invite team
 ![2](https://user-images.githubusercontent.com/18019529/111500197-1229dc00-8787-11eb-98e5-587ee36c94a9.png)
-3. Store token in `argocd-notifications-secret` Secret and configure Mattermost integration
-in `<config-map-name>` ConfigMap
+3. Store token in `argo-rollouts-notification-secret` Secret and configure Mattermost integration
+in `argo-rollouts-notification-configmap` ConfigMap
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.mattermost: |
     apiURL: <api-url>

--- a/docs/generated/notification-services/mattermost.md
+++ b/docs/generated/notification-services/mattermost.md
@@ -13,7 +13,7 @@
 2. Invite team
 ![2](https://user-images.githubusercontent.com/18019529/111500197-1229dc00-8787-11eb-98e5-587ee36c94a9.png)
 3. Store token in `argocd-notifications-secret` Secret and configure Mattermost integration
-in `argocd-notifications-cm` ConfigMap
+in `<config-map-name>` ConfigMap
 
 ```yaml
 apiVersion: v1

--- a/docs/generated/notification-services/newrelic.md
+++ b/docs/generated/notification-services/newrelic.md
@@ -8,7 +8,7 @@
 ## Configuration
 
 1. Create a NewRelic [Api Key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#user-api-key)
-2. Store apiKey in `argocd-notifications-secret` Secret and configure NewRelic integration in `argocd-notifications-cm` ConfigMap
+2. Store apiKey in `argocd-notifications-secret` Secret and configure NewRelic integration in `<config-map-name>` ConfigMap
 
 ```yaml
 apiVersion: v1

--- a/docs/generated/notification-services/newrelic.md
+++ b/docs/generated/notification-services/newrelic.md
@@ -8,13 +8,13 @@
 ## Configuration
 
 1. Create a NewRelic [Api Key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#user-api-key)
-2. Store apiKey in `argocd-notifications-secret` Secret and configure NewRelic integration in `<config-map-name>` ConfigMap
+2. Store apiKey in `argo-rollouts-notification-secret` Secret and configure NewRelic integration in `argo-rollouts-notification-configmap` ConfigMap
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.newrelic: |
     apiURL: <api-url>

--- a/docs/generated/notification-services/opsgenie.md
+++ b/docs/generated/notification-services/opsgenie.md
@@ -7,13 +7,23 @@ To be able to send notifications with argocd-notifications you have to create an
 3. Click "Teams" in the Menu on the left
 4. Select the team that you want to notify
 5. In the teams configuration menu select "Integrations"
-6. click "Add Integration" in the top right corner
+6. Click "Add Integration" in the top right corner
 7. Select "API" integration
 8. Give your integration a name, copy the "API key" and safe it somewhere for later
-9. Make sure the checkboxes for "Create and Update Access" and "enable" are selected, disable the other checkboxes to remove unnecessary permissions
-10. Click "Safe Integration" at the bottom
-11. Check your browser for the correct server apiURL. If it is "app.opsgenie.com" then use the US/international api url `api.opsgenie.com` in the next step, otherwise use `api.eu.opsgenie.com` (European API). 
-12. You are finished with configuring opsgenie. Now you need to configure argocd-notifications. Use the apiUrl, the team name and the apiKey to configure the Opsgenie integration in the `argocd-notifications-secret` secret. 
+9. Click "Edit" in the integration settings
+10. Make sure the checkbox for "Create and Update Access" is selected, disable the other checkboxes to remove unnecessary permissions
+11. Click "Save" at the bottom
+12. Click "Turn on integration" in the top right corner
+13. Check your browser for the correct server apiURL. If it is "app.opsgenie.com" then use the US/international api url `api.opsgenie.com` in the next step, otherwise use `api.eu.opsgenie.com` (European API). 
+14. You are finished with configuring Opsgenie. Now you need to configure argocd-notifications. Use the apiUrl, the team name and the apiKey to configure the Opsgenie integration in the `argocd-notifications-secret` secret.
+15. You can find the example `<config-map-name>` configuration at the below.
+
+| **Option**    | **Required** | **Type** | **Description**                                                                                          | **Example**                      |
+| ------------- | ------------ | -------- | -------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| `description` | True         | `string` | Description field of the alert that is generally used to provide a detailed information about the alert. | `Hello from Argo CD!`            |
+| `priority`    | False        | `string` | Priority level of the alert. Possible values are P1, P2, P3, P4 and P5. Default value is P3.             | `P1`                             |
+| `alias`       | False        | `string` | Client-defined identifier of the alert, that is also the key element of Alert De-Duplication.            | `Life is too short for no alias` |
+| `note`       | False        | `string` | Additional note that will be added while creating the alert.            | `Error from Argo CD!` |
 
 ```yaml
 apiVersion: v1
@@ -25,4 +35,30 @@ data:
     apiUrl: <api-url>
     apiKeys:
       <your-team>: <integration-api-key>
+  template.opsgenie: |
+    message: |
+      [Argo CD] Application {{.app.metadata.name}} has a problem.
+    opsgenie:
+      description: |
+        Application: {{.app.metadata.name}}
+        Health Status: {{.app.status.health.status}}
+        Operation State Phase: {{.app.status.operationState.phase}}
+        Sync Status: {{.app.status.sync.status}}
+      priority: P1
+      alias: {{.app.metadata.name}}
+      note: Error from Argo CD!
+  trigger.on-a-problem: |
+    - description: Application has a problem.
+      send:
+      - opsgenie
+      when: app.status.health.status == 'Degraded' or app.status.operationState.phase in ['Error', 'Failed'] or app.status.sync.status == 'Unknown'
+```
+
+16. Add annotation in application yaml file to enable notifications for specific Argo CD app.
+```yaml
+  apiVersion: argoproj.io/v1alpha1
+  kind: Application
+  metadata:
+    annotations:
+      notifications.argoproj.io/subscribe.on-a-problem.opsgenie: <your-team>
 ```

--- a/docs/generated/notification-services/opsgenie.md
+++ b/docs/generated/notification-services/opsgenie.md
@@ -15,8 +15,8 @@ To be able to send notifications with argocd-notifications you have to create an
 11. Click "Save" at the bottom
 12. Click "Turn on integration" in the top right corner
 13. Check your browser for the correct server apiURL. If it is "app.opsgenie.com" then use the US/international api url `api.opsgenie.com` in the next step, otherwise use `api.eu.opsgenie.com` (European API). 
-14. You are finished with configuring Opsgenie. Now you need to configure argocd-notifications. Use the apiUrl, the team name and the apiKey to configure the Opsgenie integration in the `argocd-notifications-secret` secret.
-15. You can find the example `<config-map-name>` configuration at the below.
+14. You are finished with configuring Opsgenie. Now you need to configure argocd-notifications. Use the apiUrl, the team name and the apiKey to configure the Opsgenie integration in the `argo-rollouts-notification-secret` secret.
+15. You can find the example `argo-rollouts-notification-configmap` configuration at the below.
 
 | **Option**    | **Required** | **Type** | **Description**                                                                                          | **Example**                      |
 | ------------- | ------------ | -------- | -------------------------------------------------------------------------------------------------------- | -------------------------------- |
@@ -29,7 +29,7 @@ To be able to send notifications with argocd-notifications you have to create an
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.opsgenie: |
     apiUrl: <api-url>

--- a/docs/generated/notification-services/overview.md
+++ b/docs/generated/notification-services/overview.md
@@ -1,5 +1,5 @@
-The notification services represent integration with services such as slack, email or custom webhook. Services are configured in `<config-map-name>` ConfigMap
-using `service.<type>.(<custom-name>)` keys and might reference sensitive data from `argocd-notifications-secret` Secret. Following example demonstrates slack
+The notification services represent integration with services such as slack, email or custom webhook. Services are configured in `argo-rollouts-notification-configmap` ConfigMap
+using `service.<type>.(<custom-name>)` keys and might reference sensitive data from `argo-rollouts-notification-secret` Secret. Following example demonstrates slack
 service configuration:
 
 ```yaml

--- a/docs/generated/notification-services/overview.md
+++ b/docs/generated/notification-services/overview.md
@@ -1,4 +1,4 @@
-The notification services represent integration with services such as slack, email or custom webhook. Services are configured in `argocd-notifications-cm` ConfigMap
+The notification services represent integration with services such as slack, email or custom webhook. Services are configured in `<config-map-name>` ConfigMap
 using `service.<type>.(<custom-name>)` keys and might reference sensitive data from `argocd-notifications-secret` Secret. Following example demonstrates slack
 service configuration:
 

--- a/docs/generated/notification-services/pagerduty.md
+++ b/docs/generated/notification-services/pagerduty.md
@@ -26,7 +26,7 @@ stringData:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.pagerduty: |
     token: $pagerdutyToken
@@ -41,7 +41,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   template.rollout-aborted: |
     message: Rollout {{.rollout.metadata.name}} is aborted.

--- a/docs/generated/notification-services/pagerduty_v2.md
+++ b/docs/generated/notification-services/pagerduty_v2.md
@@ -28,7 +28,7 @@ stringData:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.pagerdutyv2: |
     serviceKeys:
@@ -43,7 +43,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   template.rollout-aborted: |
     message: Rollout {{.rollout.metadata.name}} is aborted.

--- a/docs/generated/notification-services/pushover.md
+++ b/docs/generated/notification-services/pushover.md
@@ -1,13 +1,13 @@
 # Pushover
 
 1. Create an app at [pushover.net](https://pushover.net/apps/build).
-2. Store the API key in `<secret-name>` Secret and define the secret name in `<config-map-name>` ConfigMap:
+2. Store the API key in `<secret-name>` Secret and define the secret name in `argo-rollouts-notification-configmap` ConfigMap:
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.pushover: |
     token: $pushover-token

--- a/docs/generated/notification-services/rocketchat.md
+++ b/docs/generated/notification-services/rocketchat.md
@@ -43,7 +43,7 @@ stringData:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.rocketchat: |
     email: $rocketchat-email

--- a/docs/generated/notification-services/slack.md
+++ b/docs/generated/notification-services/slack.md
@@ -15,6 +15,7 @@ The Slack notification service configuration includes following settings:
 | `signingSecret`       | False        | `string`       |                 | `8f742231b10e8888abcd99yyyzzz85a5` |
 | `token`              | **True**     | `string`       | The app's OAuth access token. | `xoxb-1234567890-1234567890123-5n38u5ed63fgzqlvuyxvxcx6` |
 | `username`           | False        | `string`       | The app username. | `argocd` |
+| `disableUnfurl`      | False        | `bool`         | Disable slack unfurling links in messages | `true` |
 
 ## Configuration
 
@@ -42,7 +43,7 @@ The Slack notification service configuration includes following settings:
           slack-token: <Oauth-access-token>
     ```
 
-1. Define service type slack in data section of `argocd-notifications-cm` configmap:
+1. Define service type slack in data section of `<config-map-name>` configmap:
 
     ```yaml
       apiVersion: v1

--- a/docs/generated/notification-services/slack.md
+++ b/docs/generated/notification-services/slack.md
@@ -32,7 +32,7 @@ The Slack notification service configuration includes following settings:
 
 1. Create a public or private channel, for this example `my_channel`
 1. Invite your slack bot to this channel **otherwise slack bot won't be able to deliver notifications to this channel**
-1. Store Oauth access token in `argocd-notifications-secret` secret
+1. Store Oauth access token in `argo-rollouts-notification-secret` secret
 
     ```yaml
       apiVersion: v1
@@ -43,13 +43,13 @@ The Slack notification service configuration includes following settings:
           slack-token: <Oauth-access-token>
     ```
 
-1. Define service type slack in data section of `<config-map-name>` configmap:
+1. Define service type slack in data section of `argo-rollouts-notification-configmap` configmap:
 
     ```yaml
       apiVersion: v1
       kind: ConfigMap
       metadata:
-        name: <config-map-name>
+        name: argo-rollouts-notification-configmap
       data:
         service.slack: |
           token: $slack-token

--- a/docs/generated/notification-services/teams.md
+++ b/docs/generated/notification-services/teams.md
@@ -12,7 +12,7 @@ The Teams notification service send message notifications using Teams bot and re
 2. Find `Incoming Webhook` microsoft app and click on it
 3. Press `Add to a team` -> select team and channel -> press `Set up a connector`
 4. Enter webhook name and upload image (optional)
-5. Press `Create` then copy webhook url and store it in `argocd-notifications-secret` and define it in `argocd-notifications-cm`
+5. Press `Create` then copy webhook url and store it in `argocd-notifications-secret` and define it in `<config-map-name>`
 
 ```yaml
 apiVersion: v1

--- a/docs/generated/notification-services/teams.md
+++ b/docs/generated/notification-services/teams.md
@@ -12,13 +12,13 @@ The Teams notification service send message notifications using Teams bot and re
 2. Find `Incoming Webhook` microsoft app and click on it
 3. Press `Add to a team` -> select team and channel -> press `Set up a connector`
 4. Enter webhook name and upload image (optional)
-5. Press `Create` then copy webhook url and store it in `argocd-notifications-secret` and define it in `<config-map-name>`
+5. Press `Create` then copy webhook url and store it in `argo-rollouts-notification-secret` and define it in `argo-rollouts-notification-configmap`
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.teams: |
     recipientUrls:

--- a/docs/generated/notification-services/telegram.md
+++ b/docs/generated/notification-services/telegram.md
@@ -33,3 +33,12 @@ metadata:
   annotations:
     notifications.argoproj.io/subscribe.on-sync-succeeded.telegram: -1000000000000
 ```
+
+If your private chat contains threads, you can optionally specify a thread id by seperating it with a `|`:
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-succeeded.telegram: -1000000000000|2
+```

--- a/docs/generated/notification-services/telegram.md
+++ b/docs/generated/notification-services/telegram.md
@@ -2,13 +2,13 @@
 
 1. Get an API token using [@Botfather](https://t.me/Botfather).
 2. Store token in `<secret-name>` Secret and configure telegram integration
-in `<config-map-name>` ConfigMap:
+in `argo-rollouts-notification-configmap` ConfigMap:
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.telegram: |
     token: $telegram-token

--- a/docs/generated/notification-services/webex.md
+++ b/docs/generated/notification-services/webex.md
@@ -9,7 +9,7 @@ The Webex Teams notification service configuration includes following settings:
 ## Configuration
 
 1. Create a Webex [Bot](https://developer.webex.com/docs/bots)
-1. Copy the bot access [token](https://developer.webex.com/my-apps) and store it in the `argocd-notifications-secret` Secret and configure Webex Teams integration in `argocd-notifications-cm` ConfigMap
+1. Copy the bot access [token](https://developer.webex.com/my-apps) and store it in the `argocd-notifications-secret` Secret and configure Webex Teams integration in `<config-map-name>` ConfigMap
 
     ``` yaml
     apiVersion: v1

--- a/docs/generated/notification-services/webex.md
+++ b/docs/generated/notification-services/webex.md
@@ -9,7 +9,7 @@ The Webex Teams notification service configuration includes following settings:
 ## Configuration
 
 1. Create a Webex [Bot](https://developer.webex.com/docs/bots)
-1. Copy the bot access [token](https://developer.webex.com/my-apps) and store it in the `argocd-notifications-secret` Secret and configure Webex Teams integration in `<config-map-name>` ConfigMap
+1. Copy the bot access [token](https://developer.webex.com/my-apps) and store it in the `argo-rollouts-notification-secret` Secret and configure Webex Teams integration in `argo-rollouts-notification-configmap` ConfigMap
 
     ``` yaml
     apiVersion: v1
@@ -24,7 +24,7 @@ The Webex Teams notification service configuration includes following settings:
     apiVersion: v1
     kind: ConfigMap
     metadata:
-    name: <config-map-name>
+    name: argo-rollouts-notification-configmap
     data:
     service.webex: |
         token: $webex-token

--- a/docs/generated/notification-services/webhook.md
+++ b/docs/generated/notification-services/webhook.md
@@ -25,13 +25,13 @@ The wait time between retries is between `retryWaitMin` and `retryWaitMax`. If a
 
 Use the following steps to configure webhook:
 
-1 Register webhook in `<config-map-name>` ConfigMap:
+1 Register webhook in `argo-rollouts-notification-configmap` ConfigMap:
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.webhook.<webhook-name>: |
     url: https://<hostname>/<optional-path>
@@ -50,7 +50,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   template.github-commit-status: |
     webhook:
@@ -82,7 +82,7 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.webhook.github: |
     url: https://api.github.com
@@ -97,7 +97,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.webhook.github: |
     url: https://api.github.com
@@ -128,7 +128,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.webhook.jenkins: |
     url: http://<jenkins-host>/job/<job-name>/build?token=<job-secret>
@@ -145,7 +145,7 @@ type: Opaque
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.webhook.form: |
     url: https://form.example.com
@@ -166,7 +166,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config-map-name>
+  name: argo-rollouts-notification-configmap
 data:
   service.webhook.slack_webhook: |
     url: https://hooks.slack.com/services/xxxxx

--- a/docs/generated/notification-services/webhook.md
+++ b/docs/generated/notification-services/webhook.md
@@ -25,7 +25,7 @@ The wait time between retries is between `retryWaitMin` and `retryWaitMax`. If a
 
 Use the following steps to configure webhook:
 
-1 Register webhook in `argocd-notifications-cm` ConfigMap:
+1 Register webhook in `<config-map-name>` ConfigMap:
 
 ```yaml
 apiVersion: v1

--- a/go.mod
+++ b/go.mod
@@ -202,6 +202,7 @@ require (
 
 replace (
 	github.com/go-check/check => github.com/go-check/check v0.0.0-20180628173108-788fd7840127
+	github.com/go-telegram-bot-api/telegram-bot-api/v5 => github.com/OvyFlash/telegram-bot-api/v5 v5.0.0-20240108230938-63e5c59035bf
 	k8s.io/api v0.0.0 => k8s.io/api v0.26.11
 	k8s.io/apiextensions-apiserver v0.0.0 => k8s.io/apiextensions-apiserver v0.26.11
 	k8s.io/apimachinery v0.0.0 => k8s.io/apimachinery v0.26.11

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/antonmedv/expr v1.15.5
-	github.com/argoproj/notifications-engine v0.4.1-0.20231213155711-c02dc5fdb5e1
+	github.com/argoproj/notifications-engine v0.4.1-0.20240219110818-7a069766e954
 	github.com/argoproj/pkg v0.13.6
 	github.com/aws/aws-sdk-go-v2 v1.25.0
 	github.com/aws/aws-sdk-go-v2/config v1.27.0
@@ -84,7 +84,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sqs v1.20.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sqs v1.29.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.19.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.22.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.27.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,7 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.0 h1:SHN/umDLT
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.0/go.mod h1:l8gPU5RYGOFHJqWEpPMoRTP0VoaWQSkJdKo+hwWnnDA=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.20.0 h1:tQoMg8i4nFAB70cJ4wiAYEiZRYo2P6uDmU2D6ys/igo=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.20.0/go.mod h1:jQhN5f4p3PALMNlUtfb/0wGIFlV7vGtJlPDVfxfNfPY=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.29.7 h1:tRNrFDGRm81e6nTX5Q4CFblea99eAfm0dxXazGpLceU=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.29.7/go.mod h1:8GWUDux5Z2h6z2efAtr54RdHXtLm8sq7Rg85ZNY/CZM=
 github.com/aws/aws-sdk-go-v2/service/sso v1.19.0 h1:u6OkVDxtBPnxPkZ9/63ynEe+8kHbtS5IfaC4PzVxzWM=
 github.com/aws/aws-sdk-go-v2/service/sso v1.19.0/go.mod h1:YqbU3RS/pkDVu+v+Nwxvn0i1WB0HkNWEePWbmODEbbs=

--- a/go.sum
+++ b/go.sum
@@ -38,17 +38,13 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
-github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=
 github.com/Azure/go-autorest/autorest/date v0.1.0/go.mod h1:plvfp3oPSKwf2DNjlBjWF/7vwR+cUD/ELuzDCXwHUVA=
-github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
 github.com/Azure/go-autorest/autorest/mocks v0.1.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
 github.com/Azure/go-autorest/autorest/mocks v0.2.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=
-github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
-github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Jeffail/gabs v1.4.0 h1://5fYRRTq1edjfIrQGvdkcd22pkYUrHZ5YC/H2GJVAo=
@@ -63,6 +59,8 @@ github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/OvyFlash/telegram-bot-api/v5 v5.0.0-20240108230938-63e5c59035bf h1:a7VKhbjKYPO8twGy/1AxMpM2Fp0qT7bf25fmCVMVu4s=
+github.com/OvyFlash/telegram-bot-api/v5 v5.0.0-20240108230938-63e5c59035bf/go.mod h1:A2S0CWkNylc2phvKXWBBdD3K0iGnDBGbzRpISP2zBl8=
 github.com/PagerDuty/go-pagerduty v1.7.0 h1:S1NcMKECxT5hJwV4VT+QzeSsSiv4oWl1s2821dUqG/8=
 github.com/PagerDuty/go-pagerduty v1.7.0/go.mod h1:PuFyJKRz1liIAH4h5KVXVD18Obpp1ZXRdxHvmGXooro=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 h1:wPbRQzjjwFc0ih8puEVAOFGELsn1zoIIYdxvML7mDxA=
@@ -85,19 +83,15 @@ github.com/antonmedv/expr v1.15.5/go.mod h1:0E/6TxnOlRNp81GMzX9QfDPAmHo2Phg00y4J
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/appscode/go v0.0.0-20191119085241-0887d8ec2ecc/go.mod h1:OawnOmAL4ZX3YaPdN+8HTNwBveT1jMsqP74moa9XUbE=
-github.com/argoproj/notifications-engine v0.4.1-0.20231213155711-c02dc5fdb5e1 h1:MYlXNoATpyNCYXlh0iMs1xd2Q+VWzNbl8Zg6G/lQjKQ=
-github.com/argoproj/notifications-engine v0.4.1-0.20231213155711-c02dc5fdb5e1/go.mod h1:E/vv4+by868m0mmflaRfGBmKBtAupoF+mmyfekP8QCk=
 github.com/argoproj/notifications-engine v0.4.1-0.20240219110818-7a069766e954 h1:4jbSTsw6/9pulz2eVoLnKtn75FYIeaLCNBOA1LjG1fA=
 github.com/argoproj/notifications-engine v0.4.1-0.20240219110818-7a069766e954/go.mod h1:E4gOYnn452S8c10UucTztrZx/cTGU+jgMZiqfH9HUck=
 github.com/argoproj/pkg v0.13.6 h1:36WPD9MNYECHcO1/R1pj6teYspiK7uMQLCgLGft2abM=
 github.com/argoproj/pkg v0.13.6/go.mod h1:I698DoJBKuvNFaixh4vFl2C88cNIT1WS7KCbz5ewyF8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
-github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.38.35/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.44.39/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go v1.44.116 h1:NpLIhcvLWXJZAEwvPj3TDHeqp7DleK6ZUVYyW01WNHY=
 github.com/aws/aws-sdk-go v1.44.116/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
-github.com/aws/aws-sdk-go-v2 v1.17.3/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2 v1.25.0 h1:sv7+1JVJxOu/dD/sz/csHX7jFqmP001TIY7aytBWDSQ=
 github.com/aws/aws-sdk-go-v2 v1.25.0/go.mod h1:G104G1Aho5WqF+SR3mDIobTABQzpYV0WxMsKxlMggOA=
 github.com/aws/aws-sdk-go-v2/config v1.27.0 h1:J5sdGCAHuWKIXLeXiqr8II/adSvetkx0qdZwdbXXpb0=
@@ -106,10 +100,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.17.0 h1:lMW2x6sKBsiAJrpi1doOXqWFyEPo
 github.com/aws/aws-sdk-go-v2/credentials v1.17.0/go.mod h1:uT41FIH8cCIxOdUYIL0PYyHlL1NoneDuDSCwg5VE/5o=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.15.0 h1:xWCwjjvVz2ojYTP4kBKUuUh9ZrXfcAXpflhOUUeXg1k=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.15.0/go.mod h1:j3fACuqXg4oMTQOR2yY7m0NmJY0yBK4L4sLsRXq1Ins=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.27/go.mod h1:a1/UpzeyBBerajpnP5nGZa9mGzsBn5cOKxm6NWQsvoI=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.0 h1:NPs/EqVO+ajwOoq56EfcGKa3L3ruWuazkIw1BqxwOPw=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.0/go.mod h1:D+duLy2ylgatV+yTlQ8JTuLfDD0BnFvnQRc+o6tbZ4M=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.21/go.mod h1:+Gxn8jYn5k9ebfHEqlhrMirFjSW0v0C9fI+KN5vk2kE=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.0 h1:ks7KGMVUMoDzcxNWUlEdI+/lokMFD136EL6DWmUOV80=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.0/go.mod h1:hL6BWM/d/qz113fVitZjbXR0E+RCTU1+x+1Idyn5NgE=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 h1:hT8rVHwugYE2lEfdFE0QWVo81lF7jMrYJVDWI+f+VxU=
@@ -122,8 +114,6 @@ github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.0 h1:a33HuFl
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.0/go.mod h1:SxIkWpByiGbhbHYTo9CMTUnx2G4p4ZQMrDPcRRy//1c=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.0 h1:SHN/umDLTmFTmYfI+gkanz6da3vK8Kvj/5wkqnTHbuA=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.0/go.mod h1:l8gPU5RYGOFHJqWEpPMoRTP0VoaWQSkJdKo+hwWnnDA=
-github.com/aws/aws-sdk-go-v2/service/sqs v1.20.0 h1:tQoMg8i4nFAB70cJ4wiAYEiZRYo2P6uDmU2D6ys/igo=
-github.com/aws/aws-sdk-go-v2/service/sqs v1.20.0/go.mod h1:jQhN5f4p3PALMNlUtfb/0wGIFlV7vGtJlPDVfxfNfPY=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.29.7 h1:tRNrFDGRm81e6nTX5Q4CFblea99eAfm0dxXazGpLceU=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.29.7/go.mod h1:8GWUDux5Z2h6z2efAtr54RdHXtLm8sq7Rg85ZNY/CZM=
 github.com/aws/aws-sdk-go-v2/service/sso v1.19.0 h1:u6OkVDxtBPnxPkZ9/63ynEe+8kHbtS5IfaC4PzVxzWM=
@@ -132,7 +122,6 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.22.0 h1:6DL0qu5+315wbsAEEmzK+P9l
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.22.0/go.mod h1:olUAyg+FaoFaL/zFaeQQONjOZ9HXoxgvI/c7mQTYz7M=
 github.com/aws/aws-sdk-go-v2/service/sts v1.27.0 h1:cjTRjh700H36MQ8M0LnDn33W3JmwC77mdxIIyPWCdpM=
 github.com/aws/aws-sdk-go-v2/service/sts v1.27.0/go.mod h1:nXfOBMWPokIbOY+Gi7a1psWMSvskUCemZzI+SMB7Akc=
-github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aws/smithy-go v1.20.0 h1:6+kZsCXZwKxZS9RfISnPc4EXlHoyAkm2hPuM8X2BrrQ=
 github.com/aws/smithy-go v1.20.0/go.mod h1:uo5RKksAl4PzhqaAbjd4rLgFoq5koTsQKYuGe7dklGc=
 github.com/beevik/ntp v0.2.0/go.mod h1:hIHWr+l3+/clUnF44zdK+CWW7fO8dR5cIylAQ76NRpg=
@@ -218,7 +207,6 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM0rVwpMwimd3F3N0=
-github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -237,7 +225,6 @@ github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vb
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
-github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
@@ -262,8 +249,6 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.21.1 h1:wm0rhTb5z7qpJRHBdPOMuY4QjVUMbF6/kwoYeRAOrKU=
 github.com/go-openapi/swag v0.21.1/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1 h1:wG8n/XJQ07TmjbITcGiUaOtXxdrINDz1b0J1w0SzqDc=
-github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1/go.mod h1:A2S0CWkNylc2phvKXWBBdD3K0iGnDBGbzRpISP2zBl8=
 github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gobuffalo/envy v1.7.0/go.mod h1:n7DRkBerg/aorDM8kbduw5dN3oXGswK5liaSCx4T5NI=
@@ -355,7 +340,6 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
-github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/s2a-go v0.1.7 h1:60BLSyTrOV4/haCDW4zb1guZItoSq8foHCXrAnjBo/o=
 github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8F0Qdw=
@@ -374,7 +358,6 @@ github.com/googleapis/gax-go/v2 v2.12.0/go.mod h1:y+aIqrI5eb1YGMVJfuV3185Ts/D7qK
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.2.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
-github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
 github.com/gopackage/ddp v0.0.0-20170117053602-652027933df4 h1:4EZlYQIiyecYJlUbVkFXCXHz1QPhVXcHnQKAzBTPfQo=
 github.com/gopackage/ddp v0.0.0-20170117053602-652027933df4/go.mod h1:lEO7XoHJ/xNRBCxrn4h/CEB67h0kW1B0t4ooP2yrjUA=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=

--- a/go.sum
+++ b/go.sum
@@ -38,13 +38,17 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=
 github.com/Azure/go-autorest/autorest/date v0.1.0/go.mod h1:plvfp3oPSKwf2DNjlBjWF/7vwR+cUD/ELuzDCXwHUVA=
+github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
 github.com/Azure/go-autorest/autorest/mocks v0.1.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
 github.com/Azure/go-autorest/autorest/mocks v0.2.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=
+github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
+github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Jeffail/gabs v1.4.0 h1://5fYRRTq1edjfIrQGvdkcd22pkYUrHZ5YC/H2GJVAo=
@@ -83,9 +87,12 @@ github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP
 github.com/appscode/go v0.0.0-20191119085241-0887d8ec2ecc/go.mod h1:OawnOmAL4ZX3YaPdN+8HTNwBveT1jMsqP74moa9XUbE=
 github.com/argoproj/notifications-engine v0.4.1-0.20231213155711-c02dc5fdb5e1 h1:MYlXNoATpyNCYXlh0iMs1xd2Q+VWzNbl8Zg6G/lQjKQ=
 github.com/argoproj/notifications-engine v0.4.1-0.20231213155711-c02dc5fdb5e1/go.mod h1:E/vv4+by868m0mmflaRfGBmKBtAupoF+mmyfekP8QCk=
+github.com/argoproj/notifications-engine v0.4.1-0.20240219110818-7a069766e954 h1:4jbSTsw6/9pulz2eVoLnKtn75FYIeaLCNBOA1LjG1fA=
+github.com/argoproj/notifications-engine v0.4.1-0.20240219110818-7a069766e954/go.mod h1:E4gOYnn452S8c10UucTztrZx/cTGU+jgMZiqfH9HUck=
 github.com/argoproj/pkg v0.13.6 h1:36WPD9MNYECHcO1/R1pj6teYspiK7uMQLCgLGft2abM=
 github.com/argoproj/pkg v0.13.6/go.mod h1:I698DoJBKuvNFaixh4vFl2C88cNIT1WS7KCbz5ewyF8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.38.35/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.44.39/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go v1.44.116 h1:NpLIhcvLWXJZAEwvPj3TDHeqp7DleK6ZUVYyW01WNHY=
@@ -117,6 +124,7 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.0 h1:SHN/umDLT
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.0/go.mod h1:l8gPU5RYGOFHJqWEpPMoRTP0VoaWQSkJdKo+hwWnnDA=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.20.0 h1:tQoMg8i4nFAB70cJ4wiAYEiZRYo2P6uDmU2D6ys/igo=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.20.0/go.mod h1:jQhN5f4p3PALMNlUtfb/0wGIFlV7vGtJlPDVfxfNfPY=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.29.7/go.mod h1:8GWUDux5Z2h6z2efAtr54RdHXtLm8sq7Rg85ZNY/CZM=
 github.com/aws/aws-sdk-go-v2/service/sso v1.19.0 h1:u6OkVDxtBPnxPkZ9/63ynEe+8kHbtS5IfaC4PzVxzWM=
 github.com/aws/aws-sdk-go-v2/service/sso v1.19.0/go.mod h1:YqbU3RS/pkDVu+v+Nwxvn0i1WB0HkNWEePWbmODEbbs=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.22.0 h1:6DL0qu5+315wbsAEEmzK+P9leRwNbkp+lGjPC+CEvb8=
@@ -209,6 +217,7 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM0rVwpMwimd3F3N0=
+github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -227,6 +236,7 @@ github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vb
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
@@ -344,6 +354,7 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/s2a-go v0.1.7 h1:60BLSyTrOV4/haCDW4zb1guZItoSq8foHCXrAnjBo/o=
 github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8F0Qdw=
@@ -362,6 +373,7 @@ github.com/googleapis/gax-go/v2 v2.12.0/go.mod h1:y+aIqrI5eb1YGMVJfuV3185Ts/D7qK
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.2.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
+github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
 github.com/gopackage/ddp v0.0.0-20170117053602-652027933df4 h1:4EZlYQIiyecYJlUbVkFXCXHz1QPhVXcHnQKAzBTPfQo=
 github.com/gopackage/ddp v0.0.0-20170117053602-652027933df4/go.mod h1:lEO7XoHJ/xNRBCxrn4h/CEB67h0kW1B0t4ooP2yrjUA=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=

--- a/hack/gen-docs/main.go
+++ b/hack/gen-docs/main.go
@@ -36,7 +36,10 @@ func generateNotificationsDocs() {
 		if e := updateMkDocsNav("Notifications", "Services", files); e != nil {
 			log.Fatal(e)
 		}
-		if e := strReplaceDocFiles("argocd-notifications-cm", "<config-map-name>", files); e != nil {
+		if e := strReplaceDocFiles("argocd-notifications-cm", "argo-rollouts-notification-configmap", files); e != nil {
+			log.Fatal(e)
+		}
+		if e := strReplaceDocFiles("argocd-notifications-secret", "argo-rollouts-notification-secret", files); e != nil {
 			log.Fatal(e)
 		}
 	}

--- a/hack/gen-docs/main.go
+++ b/hack/gen-docs/main.go
@@ -36,6 +36,9 @@ func generateNotificationsDocs() {
 		if e := updateMkDocsNav("Notifications", "Services", files); e != nil {
 			log.Fatal(e)
 		}
+		if e := strReplaceDocFiles("argocd-notifications-cm", "<config-map-name>", files); e != nil {
+			log.Fatal(e)
+		}
 	}
 }
 
@@ -262,6 +265,22 @@ func normalizeKubectlCmd(cmd string) string {
 
 func commandName(cmd string) string {
 	return strings.Replace(cmd, "kubectl-argo-", "", 1)
+}
+
+// strReplaceDocFiles replaces old string with new string in list of document files
+func strReplaceDocFiles(old string, new string, files []string) error {
+	baseDir := "./docs/"
+	for _, file := range files {
+		data, err := os.ReadFile(baseDir + file)
+		if err != nil {
+			return err
+		}
+		newdata := strings.ReplaceAll(string(data), old, new)
+		if err := os.WriteFile(baseDir+file, []byte(newdata), 0644); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type byName []*cobra.Command


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-rollouts/issues/3049

## What
1. Updates in this latest version https://github.com/argoproj/notifications-engine/commit/7a069766e95476e1074eeed6145085160e2fec63 of `notifications-engine`:
  - https://github.com/argoproj/notifications-engine/pull/259
  - **SQS**:
    - https://github.com/argoproj/notifications-engine/pull/261
  - **GitHub**:
    - https://github.com/argoproj/notifications-engine/pull/260
    - https://github.com/argoproj/notifications-engine/pull/235
  - **Slack**:
    - https://github.com/argoproj/notifications-engine/pull/242
  - **Opsgenie**:
    - https://github.com/argoproj/notifications-engine/pull/267
    - https://github.com/argoproj/notifications-engine/pull/268
  - **Telegram**:
    - https://github.com/argoproj/notifications-engine/pull/265

2. Updating `notifications` documentation generator to replace some `argocd-` prefixed strings.

3. Adding documentation for contributors on how to update `notifications-engine` like in this PR.

## Checklist

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).