### PR TITLE
fix: include the correct response error in the plugin init error message

### DIFF
--- a/rollout/trafficrouting/plugin/client/client.go
+++ b/rollout/trafficrouting/plugin/client/client.go
@@ -83,7 +83,7 @@ func (t *trafficPlugin) startPlugin(pluginName string) (rpc.TrafficRouterPlugin,
 
 		resp := t.plugin[pluginName].InitPlugin()
 		if resp.HasError() {
-			return nil, fmt.Errorf("unable to initialize plugin via rpc (%s): %w", pluginName, err)
+			return nil, fmt.Errorf("unable to initialize plugin via rpc (%s): %w", pluginName, resp)
 		}
 	}
 


### PR DESCRIPTION
Update the plugin init error message to include the correct response error

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).