### PR TITLE
fix(controller): stuck in scale event after canary service switch delay. Fixes #3412

### DIFF
--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -187,6 +187,7 @@ func (c *rolloutContext) scaleDownOldReplicaSetsForCanary(oldRSs []*appsv1.Repli
 		if c.rollout.Spec.Strategy.Canary.TrafficRouting != nil && c.isReplicaSetReferenced(targetRS) {
 			// We might get here if user interrupted an an update in order to move back to stable.
 			c.log.Infof("Skip scale down of older RS '%s': still referenced", targetRS.Name)
+			c.reconcileStableAndCanaryService()
 			continue
 		}
 		if maxScaleDown <= 0 {

--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -222,6 +222,24 @@ spec:
 		ExpectCanaryStablePodCount(2, 4)
 }
 
+func (s *CanarySuite) TestRolloutScalingWithServiceSwitchDelay() {
+	s.Given().
+		RolloutObjects(`@functional/alb-canary-rollout-with-delay.yaml`).
+		When().
+		ApplyManifests().
+		WaitForRolloutStatus("Healthy").
+		UpdateSpec().
+		WaitForRolloutStatus("Paused").
+		UpdateSpec().
+		Sleep(1*time.Second).
+		ScaleRollout(3).
+		WaitForRolloutStatus("Paused").
+		Then().
+		ExpectRevisionPodCount("1", 3).
+		ExpectRevisionPodCount("2", 0).
+		ExpectRevisionPodCount("3", 1)
+}
+
 // TestReduceWeightAndHonorMaxUnavailable verifies we honor maxUnavailable when decreasing weight or aborting
 func (s *CanarySuite) TestReduceWeightAndHonorMaxUnavailable() {
 	s.Given().

--- a/test/e2e/functional/alb-canary-rollout-with-delay.yaml
+++ b/test/e2e/functional/alb-canary-rollout-with-delay.yaml
@@ -1,0 +1,104 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: alb-canary-with-delay-root
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app: alb-canary-with-delay
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: alb-canary-with-delay-desired
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app: alb-canary-with-delay
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: alb-canary-with-delay-stable
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app: alb-canary-with-delay
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: alb-canary-with-delay-ingress
+  annotations:
+    kubernetes.io/ingress.class: alb
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /*
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: alb-canary-with-delay-root
+            port:
+              name: use-annotation
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: alb-canary-with-delay
+spec:
+  selector:
+    matchLabels:
+      app: alb-canary-with-delay
+  template:
+    metadata:
+      labels:
+        app: alb-canary-with-delay
+    spec:
+      containers:
+      - name: alb-canary-with-delay
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - sleep
+              - "2"
+        image: nginx:1.19-alpine
+        ports:
+        - name: http
+          containerPort: 80
+          protocol: TCP
+        resources:
+          requests:
+            memory: 16Mi
+            cpu: 5m
+  strategy:
+    canary:
+      canaryService: alb-canary-with-delay-desired
+      stableService: alb-canary-with-delay-stable
+      trafficRouting:
+        alb:
+          ingress: alb-canary-with-delay-ingress
+          rootService: alb-canary-with-delay-root
+          servicePort: 80
+      steps:
+      - setWeight: 10
+      - pause: {duration: 5s}
+      - setWeight: 20
+      - pause: {duration: 5s}


### PR DESCRIPTION
Start a service reconcile if a rs is "still referenced" to fix [this issue](https://github.com/argoproj/argo-rollouts/issues/3412).

WIP - e2e test

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
