### PR TITLE
chore: Add k8s 1.27, 1.28, 1.29 to e2e tests, remove 1.23

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -38,10 +38,12 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes-minor-version:
-          - 1.23
           - 1.24
           - 1.25
           - 1.26
+          - 1.27
+          - 1.28
+          - 1.29
     name: Run end-to-end tests
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Just kicking the actions to see what breaks.


1.27 had some errors in this PR: 
- https://github.com/argoproj/argo-rollouts/pull/3373


Ohh I just saw:
- https://github.com/argoproj/argo-rollouts/pull/3433

I'll close this one

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).