### PR TITLE
chore: add condition to enable docker push on hot-fix

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,14 +10,7 @@ on:
 
   # Run tests for any PRs.
   pull_request:
-    pull_request:
-    types:
-      - opened
-    # Specify a regex pattern to match the names of the labels that will trigger the workflow
-    types:
-      - labeled:
-          name: '1.6-hot-fix'
-
+    types: [labeled]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -28,12 +21,13 @@ jobs:
   set-vars:
     permissions:
       contents: read
+    
     runs-on: ubuntu-latest
     outputs:
       controller-meta-tags: ${{ steps.controller-meta.outputs.tags }}
       plugin-meta-tags: ${{ steps.plugin-meta.outputs.tags }}
       platforms: ${{ steps.platform-matrix.outputs.platform-matrix }}
-
+    if: ${{contains(github.event.pull_request.labels.*.name, 'hot-fix') }}
     steps:
       - name: Docker meta (controller)
         id: controller-meta
@@ -43,6 +37,8 @@ jobs:
             quay.io/argoproj/argo-rollouts
           tags: |
             type=ref,event=branch,enable=${{ github.ref != 'refs/heads/master'}}
+            type=ref,event=branch,enable=${{ github.ref != 'refs/heads/master'}}
+
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
 
       - name: Docker meta (plugin)

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,9 +5,18 @@ on:
     branches:
       - master
       - release-*
+    
+        
 
   # Run tests for any PRs.
   pull_request:
+    pull_request:
+    types:
+      - opened
+    # Specify a regex pattern to match the names of the labels that will trigger the workflow
+    types:
+      - labeled:
+          name: '1.6-hot-fix'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,9 +36,8 @@ jobs:
           tags: |
             type=ref,event=branch,enable=${{ github.ref != 'refs/heads/master'}}
             type=ref,event=branch,enable=${{ github.ref != 'refs/heads/master'}}
-            if [["${{ contains(github.event.pull_request.labels.*.name, 'hot-fix') }}" == "true" ]]
-            then
-              type=ref,value=github.event.,enable=${{ github.ref != 'refs/heads/master'}}
+            if [ "${{ contains(github.event.pull_request.labels.*.name, 'hot-fix') }}" = "true" ]; then
+             type=ref,value=pr-${{ github.event.pull_request.number }},enable=true
             fi
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,12 +5,11 @@ on:
     branches:
       - master
       - release-*
-    
-        
-
+  
   # Run tests for any PRs.
   pull_request:
-    types: [labeled]
+
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -27,7 +26,6 @@ jobs:
       controller-meta-tags: ${{ steps.controller-meta.outputs.tags }}
       plugin-meta-tags: ${{ steps.plugin-meta.outputs.tags }}
       platforms: ${{ steps.platform-matrix.outputs.platform-matrix }}
-    if: ${{contains(github.event.pull_request.labels.*.name, 'hot-fix') }}
     steps:
       - name: Docker meta (controller)
         id: controller-meta
@@ -38,7 +36,10 @@ jobs:
           tags: |
             type=ref,event=branch,enable=${{ github.ref != 'refs/heads/master'}}
             type=ref,event=branch,enable=${{ github.ref != 'refs/heads/master'}}
-
+            if [["${{ contains(github.event.pull_request.labels.*.name, 'hot-fix') }}" == "true" ]]
+            then
+              type=ref,value=github.event.,enable=${{ github.ref != 'refs/heads/master'}}
+            fi
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
 
       - name: Docker meta (plugin)


### PR DESCRIPTION
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).