### PR TITLE
fix: fix the issue that when max weight is 100000000, and the replicas> 20,  the trafficWeightToReplicas will return negative value.

### DIFF
--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -383,7 +383,7 @@ func CalculateReplicaCountsForTrafficRoutedCanary(rollout *v1alpha1.Rollout, wei
 // trafficWeightToReplicas returns the appropriate replicas given the full spec.replicas and a weight
 // Rounds up if not evenly divisible.
 func trafficWeightToReplicas(replicas, weight, maxWeight int32) int32 {
-	return int32(math.Ceil(float64(weight*replicas) / float64(maxWeight)))
+	return int32(math.Ceil(float64(weight) * float64(replicas) / float64(maxWeight)))
 }
 
 func max(left, right int32) int32 {

--- a/utils/replicaset/canary_test.go
+++ b/utils/replicaset/canary_test.go
@@ -960,6 +960,7 @@ func TestTrafficWeightToReplicas(t *testing.T) {
 	assert.Equal(t, int32(4), trafficWeightToReplicas(10, 33, 100))
 	assert.Equal(t, int32(10), trafficWeightToReplicas(10, 99, 100))
 	assert.Equal(t, int32(10), trafficWeightToReplicas(10, 100, 100))
+	assert.Equal(t, int32(23), trafficWeightToReplicas(23, 100000000, 100000000))
 }
 
 func TestGetOtherRSs(t *testing.T) {


### PR DESCRIPTION
when we set the max weight as 100000000, and when the replicas set to > 20. then the trafficWeightToReplicas will be a negative value.
and cause the rollout to stuck in the "min" replicas.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).