### PR TITLE
chore: set webpack hashFunction to modern sha256, remove legacy-provider. Fixes #2609

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -26,8 +26,8 @@
         "web-vitals": "^1.0.1"
     },
     "scripts": {
-        "start": "NODE_OPTIONS=--openssl-legacy-provider webpack serve --config ./src/app/webpack.dev.js",
-        "build": "rm -rf dist && NODE_OPTIONS=--openssl-legacy-provider webpack --config ./src/app/webpack.prod.js",
+        "start": "webpack serve --config ./src/app/webpack.dev.js",
+        "build": "rm -rf dist && webpack --config ./src/app/webpack.prod.js",
         "test": "jest",
         "eject": "react-scripts eject",
         "protogen": "../hack/swagger-codegen.sh generate -i ../pkg/apiclient/rollout/rollout.swagger.json -l typescript-fetch -o src/models/rollout/generated"

--- a/ui/src/app/webpack.common.js
+++ b/ui/src/app/webpack.common.js
@@ -1,5 +1,9 @@
 'use strict;';
 
+const crypto = require("crypto");
+const crypto_orig_createHash = crypto.createHash;
+crypto.createHash = algorithm => crypto_orig_createHash(algorithm == "md4" ? "sha256" : algorithm);
+
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-rollouts/issues/2609

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

This is volunteer work to remove obsolete cryptography from all open source projects. See https://github.com/sponsors/xnox for more details.