### PR TITLE
chore: fix unit test data races (#3478)

### DIFF
--- a/experiments/controller_test.go
+++ b/experiments/controller_test.go
@@ -116,13 +116,15 @@ func newFixture(t *testing.T, objects ...runtime.Object) *fixture {
 	f.kubeclient = k8sfake.NewSimpleClientset(f.kubeobjects...)
 	f.enqueuedObjects = make(map[string]int)
 	now := time.Now()
-	timeutil.Now = func() time.Time {
+
+	timeutil.SetNowTimeFunc(func() time.Time {
 		return now
-	}
+	})
 	f.unfreezeTime = func() error {
-		timeutil.Now = time.Now
+		timeutil.SetNowTimeFunc(time.Now)
 		return nil
 	}
+
 	return f
 }
 

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -1156,6 +1156,8 @@ func TestSyncRolloutWaitAddToQueue(t *testing.T) {
 	f.runController(key, true, false, c, i, k8sI)
 
 	// When the controller starts, it will enqueue the rollout while syncing the informer and during the reconciliation step
+	f.enqueuedObjectsLock.Lock()
+	defer f.enqueuedObjectsLock.Unlock()
 	assert.Equal(t, 2, f.enqueuedObjects[key])
 }
 
@@ -1204,6 +1206,8 @@ func TestSyncRolloutIgnoreWaitOutsideOfReconciliationPeriod(t *testing.T) {
 	c, i, k8sI := f.newController(func() time.Duration { return 30 * time.Minute })
 	f.runController(key, true, false, c, i, k8sI)
 	// When the controller starts, it will enqueue the rollout so we expect the rollout to enqueue at least once.
+	f.enqueuedObjectsLock.Lock()
+	defer f.enqueuedObjectsLock.Unlock()
 	assert.Equal(t, 1, f.enqueuedObjects[key])
 }
 

--- a/rollout/sync_test.go
+++ b/rollout/sync_test.go
@@ -455,7 +455,7 @@ func TestSendStateChangeEvents(t *testing.T) {
 		recorder := record.NewFakeEventRecorder()
 		roCtx.recorder = recorder
 		roCtx.sendStateChangeEvents(&test.prevStatus, &test.newStatus)
-		assert.Equal(t, test.expectedEventReasons, recorder.Events)
+		assert.Equal(t, test.expectedEventReasons, recorder.Events())
 	}
 }
 

--- a/rollout/trafficrouting/apisix/apisix_test.go
+++ b/rollout/trafficrouting/apisix/apisix_test.go
@@ -116,10 +116,6 @@ spec:
       priority: 2
 `
 
-var (
-	client *mocks.FakeClient = &mocks.FakeClient{}
-)
-
 const (
 	stableServiceName     string = "stable-rollout"
 	fakeStableServiceName string = "fake-stable-rollout"
@@ -135,7 +131,7 @@ func TestUpdateHash(t *testing.T) {
 		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, apisixRouteName),
-			Client:  client,
+			Client:  &mocks.FakeClient{},
 		}
 		r := NewReconciler(&cfg)
 
@@ -152,10 +148,9 @@ func TestSetWeight(t *testing.T) {
 	mocks.ErrorApisixRouteObj = toUnstructured(t, errorApisixRoute)
 	t.Run("SetWeight", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, apisixRouteName),
-			Client:  client,
+			Client:  &mocks.FakeClient{},
 		}
 		r := NewReconciler(&cfg)
 
@@ -195,7 +190,6 @@ func TestSetWeight(t *testing.T) {
 	})
 	t.Run("SetWeightWithError", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, apisixRouteName),
 			Client: &mocks.FakeClient{
@@ -212,7 +206,6 @@ func TestSetWeight(t *testing.T) {
 	})
 	t.Run("SetWeightWithErrorManifest", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, apisixRouteName),
 			Client: &mocks.FakeClient{
@@ -229,10 +222,9 @@ func TestSetWeight(t *testing.T) {
 	})
 	t.Run("SetWeightWithErrorStableName", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(fakeStableServiceName, canaryServiceName, apisixRouteName),
-			Client:  client,
+			Client:  &mocks.FakeClient{},
 		}
 		r := NewReconciler(&cfg)
 
@@ -244,10 +236,9 @@ func TestSetWeight(t *testing.T) {
 	})
 	t.Run("SetWeightWithErrorCanaryName", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, fakeCanaryServiceName, apisixRouteName),
-			Client:  client,
+			Client:  &mocks.FakeClient{},
 		}
 		r := NewReconciler(&cfg)
 
@@ -259,7 +250,6 @@ func TestSetWeight(t *testing.T) {
 	})
 	t.Run("ApisixUpdateError", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, apisixRouteName),
 			Client: &mocks.FakeClient{
@@ -380,7 +370,6 @@ func TestSetHeaderRoute(t *testing.T) {
 	mocks.DuplicateSetHeaderApisixRouteObj = toUnstructured(t, apisixSetHeaderDuplicateRoute)
 	mocks.ErrorApisixRouteObj = toUnstructured(t, errorApisixRoute)
 	t.Run("SetHeaderGetRouteError", func(t *testing.T) {
-		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, apisixRouteName),
 			Client: &mocks.FakeClient{
@@ -397,7 +386,6 @@ func TestSetHeaderRoute(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("SetHeaderGetManagedRouteError", func(t *testing.T) {
-		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, apisixRouteName),
 			Client: &mocks.FakeClient{
@@ -420,7 +408,6 @@ func TestSetHeaderRoute(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("SetHeaderDuplicateManagedRouteError", func(t *testing.T) {
-		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, apisixRouteName),
 			Client: &mocks.FakeClient{
@@ -445,7 +432,6 @@ func TestSetHeaderRoute(t *testing.T) {
 	})
 	t.Run("SetHeaderRouteNilMatchWithNew", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, apisixRouteName),
 			Client: &mocks.FakeClient{
@@ -466,7 +452,6 @@ func TestSetHeaderRoute(t *testing.T) {
 	t.Run("SetHeaderRouteNilMatch", func(t *testing.T) {
 		client := &mocks.FakeClient{}
 		// Given
-		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, apisixRouteName),
 			Client:  client,
@@ -485,7 +470,6 @@ func TestSetHeaderRoute(t *testing.T) {
 	})
 	t.Run("SetHeaderRoutePriorityWithNew", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		client := &mocks.FakeClient{
 			IsGetNotFoundError: true,
 		}
@@ -521,7 +505,6 @@ func TestSetHeaderRoute(t *testing.T) {
 	})
 	t.Run("SetHeaderRoutePriorityWithNew", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		client := &mocks.FakeClient{
 			IsGetNotFoundError: false,
 		}
@@ -558,7 +541,6 @@ func TestSetHeaderRoute(t *testing.T) {
 
 	t.Run("SetHeaderRouteExprsWithNew", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		client := &mocks.FakeClient{
 			IsGetNotFoundError: true,
 		}
@@ -613,7 +595,6 @@ func TestSetHeaderRoute(t *testing.T) {
 	})
 	t.Run("SetHeaderRouteExprs", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		client := &mocks.FakeClient{
 			IsGetNotFoundError: false,
 		}
@@ -668,7 +649,6 @@ func TestSetHeaderRoute(t *testing.T) {
 	})
 	t.Run("SetHeaderDeleteError", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		client := &mocks.FakeClient{
 			IsDeleteError: true,
 		}
@@ -686,7 +666,6 @@ func TestSetHeaderRoute(t *testing.T) {
 	})
 	t.Run("SetHeaderCreateError", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		client := &mocks.FakeClient{
 			IsCreateError:      true,
 			IsGetNotFoundError: true,
@@ -710,7 +689,6 @@ func TestSetHeaderRoute(t *testing.T) {
 	})
 	t.Run("SetHeaderUpdateError", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		client := &mocks.FakeClient{
 			UpdateError:        true,
 			IsGetNotFoundError: false,
@@ -734,7 +712,6 @@ func TestSetHeaderRoute(t *testing.T) {
 	})
 	t.Run("RemoveManagedRoutesDeleteError", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		client := &mocks.FakeClient{
 			IsDeleteError: true,
 		}
@@ -749,7 +726,6 @@ func TestSetHeaderRoute(t *testing.T) {
 	})
 	t.Run("RemoveManagedRoutesNilManagedRoutes", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		client := &mocks.FakeClient{
 			IsDeleteError: true,
 		}
@@ -799,7 +775,7 @@ func TestSetMirrorRoute(t *testing.T) {
 		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, apisixRouteName),
-			Client:  client,
+			Client:  &mocks.FakeClient{},
 		}
 		r := NewReconciler(&cfg)
 
@@ -826,7 +802,6 @@ func TestRemoveManagedRoutes(t *testing.T) {
 	t.Run("RemoveManagedRoutes", func(t *testing.T) {
 		client := &mocks.FakeClient{}
 		// Given
-		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, apisixRouteName),
 			Client:  client,
@@ -842,7 +817,6 @@ func TestRemoveManagedRoutes(t *testing.T) {
 			IsGetManagedRouteError: true,
 		}
 		// Given
-		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, apisixRouteName),
 			Client:  client,
@@ -858,7 +832,6 @@ func TestRemoveManagedRoutes(t *testing.T) {
 			IsGetNotFoundError: true,
 		}
 		// Given
-		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, apisixRouteName),
 			Client:  client,
@@ -889,7 +862,7 @@ func TestVerifyWeight(t *testing.T) {
 		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, apisixRouteName),
-			Client:  client,
+			Client:  &mocks.FakeClient{},
 		}
 		r := NewReconciler(&cfg)
 
@@ -906,10 +879,9 @@ func TestType(t *testing.T) {
 	mocks.ApisixRouteObj = toUnstructured(t, apisixRoute)
 	t.Run("Type", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, apisixRouteName),
-			Client:  client,
+			Client:  &mocks.FakeClient{},
 		}
 		r := NewReconciler(&cfg)
 

--- a/rollout/trafficrouting/traefik/traefik_test.go
+++ b/rollout/trafficrouting/traefik/traefik_test.go
@@ -38,10 +38,6 @@ metadata:
   name: mocks-service
 `
 
-var (
-	client *mocks.FakeClient = &mocks.FakeClient{}
-)
-
 const (
 	stableServiceName     string = "stable-rollout"
 	fakeStableServiceName string = "fake-stable-rollout"
@@ -67,7 +63,7 @@ func TestUpdateHash(t *testing.T) {
 		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, traefikServiceName),
-			Client:  client,
+			Client:  &mocks.FakeClient{},
 		}
 		r := NewReconciler(&cfg)
 
@@ -84,10 +80,9 @@ func TestSetWeight(t *testing.T) {
 	mocks.ErrorTraefikServiceObj = toUnstructured(t, errorTraefikService)
 	t.Run("SetWeight", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, traefikServiceName),
-			Client:  client,
+			Client:  &mocks.FakeClient{},
 		}
 		r := NewReconciler(&cfg)
 
@@ -114,7 +109,6 @@ func TestSetWeight(t *testing.T) {
 	})
 	t.Run("SetWeightWithError", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, traefikServiceName),
 			Client: &mocks.FakeClient{
@@ -131,7 +125,6 @@ func TestSetWeight(t *testing.T) {
 	})
 	t.Run("SetWeightWithErrorManifest", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, traefikServiceName),
 			Client: &mocks.FakeClient{
@@ -148,10 +141,9 @@ func TestSetWeight(t *testing.T) {
 	})
 	t.Run("SetWeightWithErrorStableName", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(fakeStableServiceName, canaryServiceName, traefikServiceName),
-			Client:  client,
+			Client:  &mocks.FakeClient{},
 		}
 		r := NewReconciler(&cfg)
 
@@ -163,10 +155,9 @@ func TestSetWeight(t *testing.T) {
 	})
 	t.Run("SetWeightWithErrorCanaryName", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, fakeCanaryServiceName, traefikServiceName),
-			Client:  client,
+			Client:  &mocks.FakeClient{},
 		}
 		r := NewReconciler(&cfg)
 
@@ -178,7 +169,6 @@ func TestSetWeight(t *testing.T) {
 	})
 	t.Run("TraefikUpdateError", func(t *testing.T) {
 		// Given
-		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, traefikServiceName),
 			Client: &mocks.FakeClient{
@@ -202,7 +192,7 @@ func TestSetHeaderRoute(t *testing.T) {
 		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, traefikServiceName),
-			Client:  client,
+			Client:  &mocks.FakeClient{},
 		}
 		r := NewReconciler(&cfg)
 
@@ -231,7 +221,7 @@ func TestSetMirrorRoute(t *testing.T) {
 		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, traefikServiceName),
-			Client:  client,
+			Client:  &mocks.FakeClient{},
 		}
 		r := NewReconciler(&cfg)
 
@@ -269,7 +259,7 @@ func TestVerifyWeight(t *testing.T) {
 		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, traefikServiceName),
-			Client:  client,
+			Client:  &mocks.FakeClient{},
 		}
 		r := NewReconciler(&cfg)
 
@@ -289,7 +279,7 @@ func TestType(t *testing.T) {
 		t.Parallel()
 		cfg := ReconcilerConfig{
 			Rollout: newRollout(stableServiceName, canaryServiceName, traefikServiceName),
-			Client:  client,
+			Client:  &mocks.FakeClient{},
 		}
 		r := NewReconciler(&cfg)
 

--- a/utils/record/record.go
+++ b/utils/record/record.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	argoinformers "github.com/argoproj/argo-rollouts/pkg/client/informers/externalversions/rollouts/v1alpha1"
@@ -107,7 +108,29 @@ func NewEventRecorder(kubeclientset kubernetes.Interface, rolloutEventCounter *p
 // reasons which were emitted
 type FakeEventRecorder struct {
 	EventRecorderAdapter
-	Events []string
+	// acquire eventsLock before using events
+	events     []string
+	eventsLock sync.Mutex
+}
+
+func (e *FakeEventRecorder) appendEvents(events ...string) {
+	e.eventsLock.Lock()
+	defer e.eventsLock.Unlock()
+
+	e.events = append(e.events, events...)
+}
+
+// Events returns a list of received events, with thread safety
+func (e *FakeEventRecorder) Events() []string {
+
+	e.eventsLock.Lock()
+	defer e.eventsLock.Unlock()
+
+	if e.events == nil {
+		return nil
+	}
+
+	return append(make([]string, 0), e.events...)
 }
 
 func NewFakeApiFactory() api.Factory {
@@ -178,7 +201,7 @@ func NewFakeEventRecorder() *FakeEventRecorder {
 	fakeRecorder := &FakeEventRecorder{}
 	recorder.eventf = func(object runtime.Object, warn bool, opts EventOptions, messageFmt string, args ...any) {
 		recorder.defaultEventf(object, warn, opts, messageFmt, args...)
-		fakeRecorder.Events = append(fakeRecorder.Events, opts.EventReason)
+		fakeRecorder.appendEvents(opts.EventReason)
 	}
 	fakeRecorder.EventRecorderAdapter = *recorder
 	return fakeRecorder

--- a/utils/record/record_test.go
+++ b/utils/record/record_test.go
@@ -97,7 +97,7 @@ func TestIncCounter(t *testing.T) {
 	buf := dto.Metric{}
 	m.Write(&buf)
 	assert.Equal(t, float64(3), *buf.Counter.Value)
-	assert.Equal(t, []string{"FooReason", "FooReason", "FooReason"}, rec.Events)
+	assert.Equal(t, []string{"FooReason", "FooReason", "FooReason"}, rec.Events())
 }
 
 func TestSendNotifications(t *testing.T) {

--- a/utils/time/now.go
+++ b/utils/time/now.go
@@ -1,13 +1,36 @@
 package time
 
 import (
+	"sync"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var (
+	timeNowFunc = time.Now
+
+	// Acquire this mutex when accessing now function
+	nowLock sync.RWMutex
+)
+
 // Now is a wrapper around time.Now() and used to override behavior in tests.
-var Now = time.Now
+// Now invokes time.Now(), or its replacement function
+func Now() time.Time {
+	nowLock.RLock()
+	defer nowLock.RUnlock()
+
+	return timeNowFunc()
+}
+
+// Replace the function used to return the current time (defaults to time.Now() )
+func SetNowTimeFunc(f func() time.Time) {
+	nowLock.Lock()
+	defer nowLock.Unlock()
+
+	timeNowFunc = f
+
+}
 
 // MetaNow is a wrapper around metav1.Now() and used to override behavior in tests.
 var MetaNow = func() metav1.Time {


### PR DESCRIPTION
Fixes #3478

See parent issue for reproduction steps.

With this set of changes, `go test -race (...)` now passes:
```
go test -race `go list ./... | grep -v ./test/cmd/metrics-plugin-sample`
```
(I also used [this shell script](https://gist.github.com/jgwest/7048a765d398519837f990120cf3fdd0) to run the tests over and over for several hours, to ensure there are not remaining intermittent failures).

### Data races fixed

- Unsynchronized read/write to 'callbacks' within `pkg/kubectl-argo-rollouts/viewcontroller/viewcontroller.go`
	- Fix: Add mutexes where needed.

- Unsynchronized read/writes to 'rolloutUpdates' within `pkg/kubectl-argo-rollouts/cmd/get/get_rollout.go`:
	- Fix: Add mutexes where needed.

- Unsynchronized read/write to 'enqueuedObjects' in various test functions
	- Fix: Add mutexes where needed.

- Unsynchronized read/write to `utils/time`'s Now global variable, which is used by unit tests to simulate time changes by replacing default time.Now()
	- Fix: Preserve the logic, but use a mutex to control read/write of the function var.

- Ambassador unit test's fake client was allowing unintended modification of the mock object in memory, via k8s client Get() function
	- Fix: DeepCopy the mock object in Get() before returning it to callers

- APISix unit tests cannot be parallelized, due to the use of 4 global test variables that are shared between test threads in `rollout/trafficrouting/apisix/mocks/apisix.go`:
```
var (
	ApisixRouteObj                   *unstructured.Unstructured
	SetHeaderApisixRouteObj          *unstructured.Unstructured
	DuplicateSetHeaderApisixRouteObj *unstructured.Unstructured
	ErrorApisixRouteObj              *unstructured.Unstructured
)
```
- Fix:
    - Remove parallelism from these tests

- APIsix unit tests cannot share a single, global reference to `client *mocks.FakeClient`, when parallelized
	- Fix: Remove global reference, and switch to test-local reference to FakeClient

- Traefik unit tests also cannot share a single, global reference to `client *mocks.FakeClient`, when parallelized
	- Fix: Remove global reference, and switch to test-local reference to FakeClient

- Traefik unit tests cannot be parallelized, due to the use of 2 global test variables that are shared between test threads in `rollout/trafficrouting/traefik/mocks/traefik.go`:
```
var (
	TraefikServiceObj      *unstructured.Unstructured
	ErrorTraefikServiceObj *unstructured.Unstructured
)
```
- Fix:
    - Remove parallelism from these tests


- Unsynchronized read/write to events in `FakeEventRecorder`
	- Fix: Add a mutex, plus convenience functions that use that mutex for read/write


- A small number of miscellaneous tests that were not using mutexes when read/writing between go routines
	- Fix: Add mutexes where needed.



Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).