### PR TITLE
feat(dashboard): improve pods visibility

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -16,6 +16,7 @@ Organizations below are **officially** using Argo Rollouts. Please send a PR wit
 1. [DaoCloud](https://daocloud.io)
 1. [Databricks](https://github.com/databricks)
 1. [Devtron Labs](https://github.com/devtron-labs/devtron)
+1. [Factorial](https://factorialhr.com)
 1. [Farfetch](https://www.farfetch.com/)
 1. [Flipkart](https://flipkart.com)
 1. [GetYourGuide](https://www.getyourguide.com)

--- a/ui/src/app/components/pods/pods.tsx
+++ b/ui/src/app/components/pods/pods.tsx
@@ -20,7 +20,17 @@ export enum PodStatus {
     Unknown = 'unknown',
 }
 
-export const ParsePodStatus = (status: string): PodStatus => {
+const isPodReady = (ready: string) => {
+    // Ready is a string in the format "0/1", "1/1", etc.
+    const [current, total] = ready.split('/');
+    return current === total;
+};
+
+export const ParsePodStatus = (status: string, ready: string): PodStatus => {
+    if (status === 'Running' && !isPodReady(ready)) {
+        return PodStatus.Pending;
+    }
+
     switch (status) {
         case 'Pending':
         case 'Terminating':
@@ -101,10 +111,12 @@ export const ReplicaSet = (props: {rs: RolloutReplicaSetInfo; showRevision?: boo
                               key={pod.objectMeta?.uid}
                               name={pod.objectMeta?.name}
                               status={pod.status}
+                              ready={pod.ready}
                               tooltip={
                                   <div>
-                                      <div>Status: {pod.status}</div>
                                       <div>{pod.objectMeta?.name}</div>
+                                      <div>Status: {pod.status}</div>
+                                      <div>Ready: {pod.ready}</div>
                                   </div>
                               }
                           />
@@ -115,7 +127,7 @@ export const ReplicaSet = (props: {rs: RolloutReplicaSetInfo; showRevision?: boo
     );
 };
 
-export const PodWidget = ({name, status, tooltip, customIcon}: {name: string; status: string; tooltip: React.ReactNode; customIcon?: IconDefinition}) => {
+export const PodWidget = ({name, status, ready, tooltip, customIcon}: {name: string; status: string; ready: string; tooltip: React.ReactNode; customIcon?: IconDefinition}) => {
     let icon: IconDefinition;
     let spin = false;
     if (status.startsWith('Init:')) {
@@ -129,7 +141,7 @@ export const PodWidget = ({name, status, tooltip, customIcon}: {name: string; st
         icon = faExclamationTriangle;
     }
 
-    const className = ParsePodStatus(status);
+    const className = ParsePodStatus(status, ready);
 
     if (customIcon) {
         icon = customIcon;

--- a/ui/src/app/components/rollout-grid-widget/rollout-grid-widget.tsx
+++ b/ui/src/app/components/rollout-grid-widget/rollout-grid-widget.tsx
@@ -21,7 +21,7 @@ import './rollout-grid-widget.scss';
 export const isInProgress = (rollout: RolloutInfo): boolean => {
     for (const rs of rollout.replicaSets || []) {
         for (const p of rs.pods || []) {
-            const status = ParsePodStatus(p.status);
+            const status = ParsePodStatus(p.status, p.ready);
             if (status === PodStatus.Pending) {
                 return true;
             }


### PR DESCRIPTION
This commit adds two improvements to the Pods view:
* Show spinner (pending status) while the pod is running but not ready (like ArgoCD UI does)
* Show the `ready` property on the tooltip

The motivation is that having them _green_ is a bit confusing when they are not ready to serve traffic, especially during the step of `setWeight` in a canary.

Some screenshots of the changes:

![Screenshot 2024-03-29 at 10 22 43](https://github.com/argoproj/argo-rollouts/assets/15221596/62cb349f-a539-4873-889a-24fc98a0cbf3)
![Screenshot 2024-03-29 at 10 16 18](https://github.com/argoproj/argo-rollouts/assets/15221596/76711876-b26a-47b8-9341-254c8e998e6d)


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).