### PR TITLE
fix: set formatter for klog logger

### DIFF
--- a/cmd/rollouts-controller/main.go
+++ b/cmd/rollouts-controller/main.go
@@ -89,11 +89,13 @@ func newCommand() *cobra.Command {
 				fmt.Println(version.GetVersion())
 				return nil
 			}
+			logger := log.New()
 			setLogLevel(logLevel)
 			if logFormat != "" {
 				log.SetFormatter(createFormatter(logFormat))
+				logger.SetFormatter(createFormatter(logFormat))
 			}
-			logutil.SetKLogLogger(log.New())
+			logutil.SetKLogLogger(logger)
 			logutil.SetKLogLevel(klogLevel)
 			log.WithField("version", version.GetVersion()).Info("Argo Rollouts starting")
 


### PR DESCRIPTION
We set the logger for klog and the client-go library uses it. This fix sets the formatter for the logger so that the logs from klog stay consistent with the log format set by the user.

Before:

Logs from client-go don't follow the right format

```
cbanavik@cbanavik-mac argo-rollouts % go run cmd/rollouts-controller/main.go --logformat="json"

{"level":"info","msg":"Argo Rollouts starting","time":"2024-04-02T13:16:31+05:30","version":
{"level":"info","msg":"Leaderelection get id cbanavik-mac_11377322-2859-434d-8f46-121b1438e6b2","time":"2024-04-02T13:16:31+05:30"}
{"level":"info","msg":"Starting Metric Server at 0.0.0.0:8090","time":"2024-04-02T13:16:31+05:30"}
INFO[0000] attempting to acquire leader lease argo-rollouts/argo-rollouts-controller-lock... 
{"level":"info","msg":"New leader elected: cbanavik-mac_0b485ea3-1a2b-4418-8be8-6b572a7c168f","time":"2024-04-02T13:16:31+05:30"}
{"level":"info","msg":"New leader elected: cbanavik-mac_11377322-2859-434d-8f46-121b1438e6b2","time":"2024-04-02T13:16:49+05:30"}
INFO[0017] successfully acquired lease argo-rollouts/argo-rollouts-controller-lock 

```


After:

```
cbanavik@cbanavik-mac argo-rollouts % go run cmd/rollouts-controller/main.go --logformat="json"

{"level":"info","msg":"Argo Rollouts starting","time":"2024-04-02T13:09:20+05:30","version":
{"level":"info","msg":"Leaderelection get id cbanavik-mac_0b485ea3-1a2b-4418-8be8-6b572a7c168f","time":"2024-04-02T13:09:20+05:30"}
{"level":"info","msg":"attempting to acquire leader lease argo-rollouts/argo-rollouts-controller-lock...\n","time":"2024-04-02T13:09:20+05:30"}
{"level":"info","msg":"Starting Metric Server at 0.0.0.0:8090","time":"2024-04-02T13:09:20+05:30"}
{"level":"info","msg":"New leader elected: cbanavik-mac_24066bb3-0dcf-4115-bfbc-af7c6ee68fa5","time":"2024-04-02T13:09:20+05:30"}
{"level":"info","msg":"New leader elected: cbanavik-mac_0b485ea3-1a2b-4418-8be8-6b572a7c168f","time":"2024-04-02T13:09:37+05:30"}
{"level":"info","msg":"successfully acquired lease argo-rollouts/argo-rollouts-controller-lock\n","time":"2024-04-02T13:09:37+05:30"}
```

Fixes: https://github.com/argoproj/argo-rollouts/issues/3041
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).