### PR TITLE
feat(dashboard): change the color of the current rollout step

### DIFF
--- a/ui/src/app/components/rollout/rollout.scss
+++ b/ui/src/app/components/rollout/rollout.scss
@@ -7,7 +7,7 @@
 
     background: $argo-color-gray-1;
     border-radius: 5px;
-    
+
     &__header {
         display: flex;
         align-items: center;
@@ -53,11 +53,11 @@
         }
 
         &--current {
-            border: 2px solid $sherbert;
+            border: 2px solid $argo-running-color;
         }
 
         &--current:hover {
-            border: 2px solid $sherbert;
+            border: 2px solid $argo-running-color;
         }
 
         &-title {


### PR DESCRIPTION
I feel that having the current (running) step in orange color is misleading, as orange
usually means warning.

This commit changes the color to the `$argo-running-color`.

After:
![Screenshot 2024-04-15 at 12 34 22](https://github.com/argoproj/argo-rollouts/assets/15221596/22cbd2a9-c6d7-459d-b82f-910cb7a1ce00)


Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).