### PR TITLE
fix: Add volume for plugin and tmp folder

### DIFF
--- a/manifests/base/argo-rollouts-deployment.yaml
+++ b/manifests/base/argo-rollouts-deployment.yaml
@@ -52,7 +52,20 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        resources:
+          limits:
+            ephemeral-storage: 1Gi
+        volumeMounts:
+        - name: plugin-bin
+          mountPath: /home/argo-rollouts/plugin-bin
+        - name: tmp
+          mountPath: /tmp
       securityContext:
         runAsNonRoot: true
+      volumes:
+      - name: plugin-bin
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
   strategy:
     type: RollingUpdate

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -16757,6 +16757,9 @@ spec:
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 4
+        resources:
+          limits:
+            ephemeral-storage: 1Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -16765,6 +16768,16 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /home/argo-rollouts/plugin-bin
+          name: plugin-bin
+        - mountPath: /tmp
+          name: tmp
       securityContext:
         runAsNonRoot: true
       serviceAccountName: argo-rollouts
+      volumes:
+      - emptyDir: {}
+        name: plugin-bin
+      - emptyDir: {}
+        name: tmp

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -413,6 +413,9 @@ spec:
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 4
+        resources:
+          limits:
+            ephemeral-storage: 1Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -421,6 +424,16 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /home/argo-rollouts/plugin-bin
+          name: plugin-bin
+        - mountPath: /tmp
+          name: tmp
       securityContext:
         runAsNonRoot: true
       serviceAccountName: argo-rollouts
+      volumes:
+      - emptyDir: {}
+        name: plugin-bin
+      - emptyDir: {}
+        name: tmp


### PR DESCRIPTION
The latest manifests (v1.7.0-rc1) throws the following error during plugin download. The reason probably is the stricter security context introduced in #3424. I added a new volume for downloaded plugin files.

```
time="2024-04-30T06:38:26Z" level=fatal msg="Failed to download plugins: failed to create plugin folder for plugin (argoproj-labs/gatewayAPI): (mkdir /home/argo-rollouts/plugin-bin: read-only file system)"
```

~It seems files in `emptyDir` is not executable even if `securityContext.fsGroup` is set. I'm still investigating.~ Fixed by adding `tmp` volume.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).