### PR TITLE
fix: docs site version selector broken

### DIFF
--- a/docs/assets/versions.js
+++ b/docs/assets/versions.js
@@ -1,15 +1,40 @@
-setTimeout(function() {
-  const callbackName = 'callback_' + new Date().getTime();
-  window[callbackName] = function (response) {
-  const div = document.createElement('div');
-  div.innerHTML = response.html;
-  document.querySelector(".md-header__inner > .md-header__title").appendChild(div);
-  const container = div.querySelector('.rst-versions');
-  var caret = document.createElement('div');
-  caret.innerHTML = "<i class='fa fa-caret-down dropdown-caret'></i>"
-  caret.classList.add('dropdown-caret')
-  div.querySelector('.rst-current-version').appendChild(caret);
+const targetNode = document.querySelector('.md-header__inner');
+const observerOptions = {
+  childList: true,
+  subtree: true
+};
+
+const observerCallback = function(mutationsList, observer) {
+  for (let mutation of mutationsList) {
+    if (mutation.type === 'childList') {
+      const titleElement = document.querySelector('.md-header__inner > .md-header__title');
+      if (titleElement) {
+        initializeVersionDropdown();
+        observer.disconnect();
+      }
+    }
   }
+};
+
+const observer = new MutationObserver(observerCallback);
+observer.observe(targetNode, observerOptions);
+
+function initializeVersionDropdown() {
+  const callbackName = 'callback_' + new Date().getTime();
+  window[callbackName] = function(response) {
+    const div = document.createElement('div');
+    div.innerHTML = response.html;
+    document.querySelector(".md-header__inner > .md-header__title").appendChild(div);
+    const container = div.querySelector('.rst-versions');
+    var caret = document.createElement('div');
+    caret.innerHTML = "<i class='fa fa-caret-down dropdown-caret'></i>";
+    caret.classList.add('dropdown-caret');
+    div.querySelector('.rst-current-version').appendChild(caret);
+
+    div.querySelector('.rst-current-version').addEventListener('click', function() {
+      container.classList.toggle('shift-up');
+    });
+  };
 
   var CSSLink = document.createElement('link');
   CSSLink.rel='stylesheet';
@@ -20,6 +45,31 @@ setTimeout(function() {
   script.src = 'https://argo-rollouts.readthedocs.io/_/api/v2/footer_html/?'+
       'callback=' + callbackName + '&project=argo-rollouts&page=&theme=mkdocs&format=jsonp&docroot=docs&source_suffix=.md&version=' + (window['READTHEDOCS_DATA'] || { version: 'latest' }).version;
   document.getElementsByTagName('head')[0].appendChild(script);
-}, 0);
+}
 
-
+// VERSION WARNINGS
+window.addEventListener("DOMContentLoaded", function() {
+  var currentVersion = window.location.href.match(/\/en\/(release-(?:v\d+|\w+)|latest|stable)\//);
+  var margin = 30;
+  var headerHeight = document.getElementsByClassName("md-header")[0].offsetHeight;
+  if (currentVersion && currentVersion.length > 1) {
+    currentVersion = currentVersion[1];
+    if (currentVersion === "latest") {
+      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for an unreleased version of Argo Rollouts, <a href='https://argoproj.github.io/argo-rollouts/'>click here to go to the latest stable version.</a></div>";
+      var bannerHeight = document.getElementById('announce-msg').offsetHeight + margin;
+      document.querySelector("header.md-header").style.top = bannerHeight + "px";
+      document.querySelector('style').textContent +=
+          "@media screen and (min-width: 76.25em){ .md-sidebar { height: 0;  top:" + (bannerHeight + headerHeight) + "px !important; }}";
+      document.querySelector('style').textContent +=
+          "@media screen and (min-width: 60em){ .md-sidebar--secondary { height: 0;  top:" + (bannerHeight + headerHeight) + "px !important; }}";
+    } else if (currentVersion !== "stable") {
+      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for a previous version of Argo Rollouts, <a href='https://argoproj.github.io/argo-rollouts/'>click here to go to the latest stable version.</a></div>";
+      var bannerHeight = document.getElementById('announce-msg').offsetHeight + margin;
+      document.querySelector("header.md-header").style.top = bannerHeight + "px";
+      document.querySelector('style').textContent +=
+          "@media screen and (min-width: 76.25em){ .md-sidebar { height: 0;  top:" + (bannerHeight + headerHeight) + "px !important; }}";
+      document.querySelector('style').textContent +=
+          "@media screen and (min-width: 60em){ .md-sidebar--secondary { height: 0;  top:" + (bannerHeight + headerHeight) + "px !important; }}";
+    }
+  }
+});


### PR DESCRIPTION
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

the [docs site]( https://argoproj.github.io/argo-rollouts/ ) version selector dropdown is broken
<img width="642" alt="image" src="https://github.com/argoproj/argo-rollouts/assets/34639446/748b985a-763e-4e2c-a4cc-2137082bdd86">

Fixed the version selector.  Also added version information warning as with ArgoCD

<img width="1046" alt="image" src="https://github.com/argoproj/argo-rollouts/assets/34639446/4a69c155-4ee7-478b-8f74-0fbeb5918470">

