### PR TITLE
fix: verify the weight of the alb at the end of the rollout

### DIFF
--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -291,7 +291,7 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 				// At the end of the rollout we need to verify the weight is correct, and return an error if not because we don't want the rest of the
 				// reconcile process to continue. We don't need to do this if we are in the middle of the rollout because the rest of the reconcile
 				// process won't scale down the old replicasets yet due to being in the middle of some steps.
-				if *weightVerified == false && desiredWeight == weightutil.MaxTrafficWeight(c.rollout) && len(c.rollout.Spec.Strategy.Canary.Steps) >= int(*c.rollout.Status.CurrentStepIndex) {
+				if desiredWeight == weightutil.MaxTrafficWeight(c.rollout) && len(c.rollout.Spec.Strategy.Canary.Steps) >= int(*c.rollout.Status.CurrentStepIndex) {
 					return fmt.Errorf("end of rollout, desired weight %d not yet verified", desiredWeight)
 				}
 			}

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -274,12 +274,6 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: conditions.WeightVerifyErrorReason}, conditions.WeightVerifyErrorMessage, err)
 			return nil // return nil instead of error since we want to continue with normal reconciliation
 		}
-		// At the end of the rollout we need to verify the weight is correct, and return an error if not because we don't want the rest of the
-		// reconcile process to continue. We don't need to do this if we are in the middle of the rollout because the rest of the reconcile
-		// process won't scale down the old replicasets yet due to being in the middle of some steps.
-		if weightVerified != nil && *weightVerified == false && desiredWeight == weightutil.MaxTrafficWeight(c.rollout) && len(c.rollout.Spec.Strategy.Canary.Steps) >= int(*c.rollout.Status.CurrentStepIndex) {
-			return fmt.Errorf("end of rollout, desired weight %d not yet verified", desiredWeight)
-		}
 
 		var indexString string
 		if index != nil {
@@ -294,6 +288,12 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			} else {
 				c.log.Infof("Desired weight (stepIdx: %s) %d not yet verified", indexString, desiredWeight)
 				c.enqueueRolloutAfter(c.rollout, defaults.GetRolloutVerifyRetryInterval())
+				// At the end of the rollout we need to verify the weight is correct, and return an error if not because we don't want the rest of the
+				// reconcile process to continue. We don't need to do this if we are in the middle of the rollout because the rest of the reconcile
+				// process won't scale down the old replicasets yet due to being in the middle of some steps.
+				if *weightVerified == false && desiredWeight == weightutil.MaxTrafficWeight(c.rollout) && len(c.rollout.Spec.Strategy.Canary.Steps) >= int(*c.rollout.Status.CurrentStepIndex) {
+					return fmt.Errorf("end of rollout, desired weight %d not yet verified", desiredWeight)
+				}
 			}
 		}
 	}

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -274,6 +274,12 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: conditions.WeightVerifyErrorReason}, conditions.WeightVerifyErrorMessage, err)
 			return nil // return nil instead of error since we want to continue with normal reconciliation
 		}
+		// At the end of the rollout we need to verify the weight is correct, and return an error if not because we don't want the rest of the
+		// reconcile process to continue. We don't need to do this if we are in the middle of the rollout because the rest of the reconcile
+		// process won't scale down the old replicasets yet due to being in the middle of some steps.
+		if weightVerified != nil && *weightVerified == false && desiredWeight == weightutil.MaxTrafficWeight(c.rollout) && len(c.rollout.Spec.Strategy.Canary.Steps) >= int(*c.rollout.Status.CurrentStepIndex) {
+			return fmt.Errorf("end of rollout, desired weight %d not yet verified", desiredWeight)
+		}
 
 		var indexString string
 		if index != nil {

--- a/rollout/trafficrouting/alb/alb.go
+++ b/rollout/trafficrouting/alb/alb.go
@@ -6,8 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/argoproj/argo-rollouts/utils/weightutil"
-
 	rolloututil "github.com/argoproj/argo-rollouts/utils/rollout"
 
 	"github.com/sirupsen/logrus"
@@ -204,7 +202,7 @@ func (r *Reconciler) VerifyWeight(desiredWeight int32, additionalDestinations ..
 		return nil, nil
 	}
 
-	if !rolloututil.ShouldVerifyWeight(r.cfg.Rollout) && desiredWeight != weightutil.MaxTrafficWeight(r.cfg.Rollout) {
+	if !rolloututil.ShouldVerifyWeight(r.cfg.Rollout, desiredWeight) {
 		// If we should not verify weight but the ALB status has not been set yet due to a Rollout resource just being
 		// installed in the cluster we want to actually run the rest of the function, so we do not return if
 		// r.cfg.Rollout.Status.ALB is nil. However, if we should not verify, and we have already updated the status once

--- a/rollout/trafficrouting/alb/alb.go
+++ b/rollout/trafficrouting/alb/alb.go
@@ -3,9 +3,10 @@ package alb
 import (
 	"context"
 	"fmt"
-	"github.com/argoproj/argo-rollouts/utils/weightutil"
 	"strconv"
 	"strings"
+
+	"github.com/argoproj/argo-rollouts/utils/weightutil"
 
 	rolloututil "github.com/argoproj/argo-rollouts/utils/rollout"
 

--- a/rollout/trafficrouting/alb/alb.go
+++ b/rollout/trafficrouting/alb/alb.go
@@ -3,6 +3,7 @@ package alb
 import (
 	"context"
 	"fmt"
+	"github.com/argoproj/argo-rollouts/utils/weightutil"
 	"strconv"
 	"strings"
 
@@ -202,7 +203,7 @@ func (r *Reconciler) VerifyWeight(desiredWeight int32, additionalDestinations ..
 		return nil, nil
 	}
 
-	if !rolloututil.ShouldVerifyWeight(r.cfg.Rollout) {
+	if !rolloututil.ShouldVerifyWeight(r.cfg.Rollout) && desiredWeight != weightutil.MaxTrafficWeight(r.cfg.Rollout) {
 		// If we should not verify weight but the ALB status has not been set yet due to a Rollout resource just being
 		// installed in the cluster we want to actually run the rest of the function, so we do not return if
 		// r.cfg.Rollout.Status.ALB is nil. However, if we should not verify, and we have already updated the status once

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -130,7 +130,7 @@ func TestReconcileTrafficRoutingVerifyWeightFalse(t *testing.T) {
 	assert.True(t, enqueued)
 }
 
-func TestReconcileTrafficRoutingVerifyWeightDesiredWeight100(t *testing.T) {
+func TestReconcileTrafficRoutingVerifyWeightEndOfRollout(t *testing.T) {
 	f := newFixture(t)
 	defer f.Close()
 

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -130,6 +130,53 @@ func TestReconcileTrafficRoutingVerifyWeightFalse(t *testing.T) {
 	assert.True(t, enqueued)
 }
 
+func TestReconcileTrafficRoutingVerifyWeightDesiredWeight100(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{
+		{
+			SetWeight: pointer.Int32Ptr(10),
+		},
+		{
+			Pause: &v1alpha1.RolloutPause{},
+		},
+	}
+	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(2), intstr.FromInt(1), intstr.FromInt(0))
+	r2 := bumpVersion(r1)
+	r2.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
+	r2.Spec.Strategy.Canary.CanaryService = "canary"
+	r2.Spec.Strategy.Canary.StableService = "stable"
+
+	rs1 := newReplicaSetWithStatus(r1, 10, 10)
+	rs2 := newReplicaSetWithStatus(r2, 10, 10)
+
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	canarySelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}
+	stableSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}
+	canarySvc := newService("canary", 80, canarySelector, r2)
+	stableSvc := newService("stable", 80, stableSelector, r2)
+
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2, canarySvc, stableSvc)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+
+	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 10, 0, 10, false)
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2)
+
+	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, additionalDestinations ...v1alpha1.WeightDestination) error {
+		// make sure SetWeight was called with correct value
+		assert.Equal(t, int32(100), desiredWeight)
+		return nil
+	})
+	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(pointer.BoolPtr(false), nil)
+	f.runExpectError(getKey(r2, t), true)
+}
+
 func TestRolloutUseDesiredWeight(t *testing.T) {
 	f := newFixture(t)
 	defer f.Close()

--- a/utils/rollout/rolloututil_test.go
+++ b/utils/rollout/rolloututil_test.go
@@ -422,15 +422,21 @@ func TestShouldVerifyWeight(t *testing.T) {
 	ro.Spec.Strategy.Canary.Steps = []v1alpha1.CanaryStep{{
 		SetWeight: pointer.Int32Ptr(20),
 	}}
-	assert.Equal(t, true, ShouldVerifyWeight(ro))
+	assert.Equal(t, true, ShouldVerifyWeight(ro, 20))
 
 	ro.Status.StableRS = ""
-	assert.Equal(t, false, ShouldVerifyWeight(ro))
+	assert.Equal(t, false, ShouldVerifyWeight(ro, 20))
 
 	ro.Status.StableRS = "34feab23f"
 	ro.Status.CurrentStepIndex = nil
 	ro.Spec.Strategy.Canary.Steps = nil
-	assert.Equal(t, false, ShouldVerifyWeight(ro))
+	assert.Equal(t, false, ShouldVerifyWeight(ro, 20))
+
+	// Test when the weight is 100, because we are at end of rollout
+	ro.Status.StableRS = "34feab23f"
+	ro.Status.CurrentStepIndex = nil
+	ro.Spec.Strategy.Canary.Steps = nil
+	assert.Equal(t, true, ShouldVerifyWeight(ro, 100))
 }
 
 func Test_isGenerationObserved(t *testing.T) {


### PR DESCRIPTION
At the end of the rollout when we auto set the weight to the max (100%) etc. we should verify the weight. If we don't this can actually cause issues even with target group verification at the end of the rollout. The reason is the ALB controller can be slow to update for many reasons, which means we can actually verify target groups successfully and start tearing down old pods before we have shifted the weight over to the new service.