### PR TITLE
chore: don't fail code-cov on failure

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -93,7 +93,7 @@ jobs:
         uses: codecov/codecov-action@v4.5.0
         with:
           file: coverage.out
-          fail_ci_if_error: true
+          fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
Codecov is going through a change requiring tokens, they are suppose to auto figure out if it's a PR and do a tokenless but they are having issue making it flaking this has been going on for a while now. Let's not fail pipeline on failures for the time being.

https://github.com/DSpace/DSpace/issues/9630

https://github.com/codecov/engineering-team/issues/1574#issuecomment-2059856841