### PR TITLE
fix(controller): use the stableRS from the rollout context rather tha…

### DIFF
--- a/rollout/analysis_test.go
+++ b/rollout/analysis_test.go
@@ -2532,7 +2532,7 @@ func TestRolloutPostPromotionAnalysisSuccess(t *testing.T) {
 		Status: v1alpha1.AnalysisPhaseRunning,
 	}
 
-	rs1 := newReplicaSetWithStatus(r1, 0, 0)
+	rs1 := newReplicaSetWithStatus(r1, 1, 1)
 	rs2 := newReplicaSetWithStatus(r2, 1, 1)
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
@@ -2558,6 +2558,7 @@ func TestRolloutPostPromotionAnalysisSuccess(t *testing.T) {
 	patch := f.getPatchedRollout(patchIndex)
 	expectedPatch := fmt.Sprintf(`{
 		"status": {
+			"replicas":2,
 			"stableRS": "%s",
 			"blueGreen": {
 				"postPromotionAnalysisRunStatus":{"status":"Successful"}

--- a/rollout/bluegreen.go
+++ b/rollout/bluegreen.go
@@ -71,18 +71,14 @@ func (c *rolloutContext) rolloutBlueGreen() error {
 	return c.syncRolloutStatusBlueGreen(previewSvc, activeSvc)
 }
 
-func (c *rolloutContext) reconcileBlueGreenStableReplicaSet(activeSvc *corev1.Service) error {
-	if _, ok := activeSvc.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey]; !ok {
-		return nil
-	}
-	activeRS, _ := replicasetutil.GetReplicaSetByTemplateHash(c.allRSs, activeSvc.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey])
-	if activeRS == nil {
-		c.log.Warn("There shouldn't be a nil active replicaset if the active Service selector is set")
+func (c *rolloutContext) reconcileBlueGreenStableReplicaSet() error {
+	if c.stableRS == nil {
+		c.log.Info("stableRS is nil on first deployment, we don't need to scale it in this case")
 		return nil
 	}
 
-	c.log.Infof("Reconciling stable ReplicaSet '%s'", activeRS.Name)
-	_, _, err := c.scaleReplicaSetAndRecordEvent(activeRS, defaults.GetReplicasOrDefault(c.rollout.Spec.Replicas))
+	c.log.Infof("Reconciling stable ReplicaSet '%s'", c.stableRS.Name)
+	_, _, err := c.scaleReplicaSetAndRecordEvent(c.stableRS, defaults.GetReplicasOrDefault(c.rollout.Spec.Replicas))
 	if err != nil {
 		return fmt.Errorf("failed to scaleReplicaSetAndRecordEvent in reconcileBlueGreenStableReplicaSet: %w", err)
 	}
@@ -94,7 +90,7 @@ func (c *rolloutContext) reconcileBlueGreenReplicaSets(activeSvc *corev1.Service
 	if err != nil {
 		return err
 	}
-	err = c.reconcileBlueGreenStableReplicaSet(activeSvc)
+	err = c.reconcileBlueGreenStableReplicaSet()
 	if err != nil {
 		return err
 	}

--- a/rollout/bluegreen.go
+++ b/rollout/bluegreen.go
@@ -73,7 +73,7 @@ func (c *rolloutContext) rolloutBlueGreen() error {
 
 func (c *rolloutContext) reconcileBlueGreenStableReplicaSet() error {
 	if c.stableRS == nil {
-		c.log.Info("stableRS is nil on first deployment, we don't need to scale it in this case")
+		c.log.Info("Stable ReplicaSet doesn't exist and hence no reconciliation is required.")
 		return nil
 	}
 

--- a/rollout/ephemeralmetadata_test.go
+++ b/rollout/ephemeralmetadata_test.go
@@ -169,7 +169,7 @@ func TestSyncBlueGreenEphemeralMetadataSecondRevision(t *testing.T) {
 	f := newFixture(t)
 	defer f.Close()
 
-	r1 := newBlueGreenRollout("foo", 1, nil, "active", "preview")
+	r1 := newBlueGreenRollout("foo", 3, nil, "active", "preview")
 	r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
 	r1.Annotations[annotations.RevisionAnnotation] = "1"
 	r1.Spec.Strategy.BlueGreen.PreviewMetadata = &v1alpha1.PodTemplateMetadata{


### PR DESCRIPTION
…n inferring it from the active selector, to deal with the edge case where the stableRS != activeRS during analysis templates. Fixes #3663

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).