### PR TITLE
fix: add update verb to ClusterRole permissions for scaleDown feature. Fixes #3672

### DIFF
--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -16417,6 +16417,7 @@ rules:
   - get
   - list
   - watch
+  - update
 - apiGroups:
   - ""
   resources:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -75,6 +75,7 @@ rules:
   - get
   - list
   - watch
+  - update
 - apiGroups:
   - ""
   resources:

--- a/manifests/role/argo-rollouts-clusterrole.yaml
+++ b/manifests/role/argo-rollouts-clusterrole.yaml
@@ -67,6 +67,7 @@ rules:
   - get
   - list
   - watch
+  - update
 # services patch needed to update selector of canary/stable/active/preview services
 # services create needed to create and delete services for experiments
 - apiGroups:


### PR DESCRIPTION
Fixes: #3672 

Add the `update` verb in the ClusterRole permissions to allow argo-rollouts to update deployments. This fixes the issue with the scaleDown feature not working due to missing permissions. (#3672)

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).