### PR TITLE
fix(analysis): explicitly set datadog aggregator to last only on v2

### DIFF
--- a/metricproviders/datadog/datadog.go
+++ b/metricproviders/datadog/datadog.go
@@ -224,6 +224,10 @@ func (p *Provider) createRequestV2(queries map[string]string, formula string, no
 			"formula": formula,
 		}}
 	}
+	// we cannot leave aggregator empty as it will be passed as such to datadog API and fail
+	if aggregator == "" {
+		aggregator = "last"
+	}
 
 	attribs := datadogQueryAttributes{
 		// Datadog requires milliseconds for v2 api


### PR DESCRIPTION
the field is required by the v2 API and we currently leave it empty string.

@zachaller you removed it in https://github.com/argoproj/argo-rollouts/pull/3643 and that is fine. this PR will not add it back to the schema and not break the v1 API. 

without this change and without aggregator set on a v2 metric, one gets:

```
received non 2xx response code: 400 {"errors":["Value of parameter
            'aggregator' should be any of these [None, 'avg', 'min', 'max',
            'sum', 'last', 'mean', 'area', 'l2norm', 'percentile', 'stddev']"]}
```

If we set it to None, according to datadog docs it will default to `avg`. According to rollouts docs, we should default to `last` (which makes sense for analysis)

<img width="1365" alt="Screenshot 2024-07-18 at 11 46 40" src="https://github.com/user-attachments/assets/57a99097-b439-4ba9-a53e-ddd848c9694f">

https://docs.datadoghq.com/api/latest/metrics/#query-scalar-data-across-multiple-products

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).