### PR TITLE
fix: e2e test results processing change key name to run-id

### DIFF
--- a/.github/workflows/testing-results.yml
+++ b/.github/workflows/testing-results.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Download and Extract Artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          run_id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ github.event.workflow_run.id }}
           path: artifacts
 
       - name: Publish Test Results


### PR DESCRIPTION
example had a type of run_id, fix it to the proper run-id