### PR TITLE
fix: add secrets so we can download across workflows

### DIFF
--- a/.github/workflows/testing-results.yml
+++ b/.github/workflows/testing-results.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           run-id: ${{ github.event.workflow_run.id }}
           path: artifacts
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2


### PR DESCRIPTION
This used to be done like this: https://github.com/argoproj/argo-rollouts/blob/5dbd7a8efc6922d2f8875a457c791f01ddebcb46/.github/workflows/e2e-test-results.yml#L20-L33

Changed the code to use the action provided by github which is the suggested way. Docs on required permission: https://github.com/actions/download-artifact#download-artifacts-from-other-workflow-runs-or-repositories