### PR TITLE
fix: separate  e2e and unit test reporting uploads

### DIFF
--- a/.github/workflows/testing-results.yml
+++ b/.github/workflows/testing-results.yml
@@ -35,7 +35,7 @@ jobs:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json
           event_name: ${{ github.event.workflow_run.event }}
-          files: "artifacts/junit-e2e-test.xml/*.xml"
+          files: "artifacts/**/junit-e2e-test.xml"
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
@@ -46,4 +46,4 @@ jobs:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json
           event_name: ${{ github.event.workflow_run.event }}
-          files: "artifacts/junit-unit-test.xml/*.xml"
+          files: "artifacts/**/junit-unit-test.xml"

--- a/.github/workflows/testing-results.yml
+++ b/.github/workflows/testing-results.yml
@@ -25,14 +25,25 @@ jobs:
           path: artifacts
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish Test Results
+      - name: Publish E2E Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          check_name: "${{ github.event.workflow.name }} Published Test Results"
+          check_name: "Published E2E Test Results"
           compare_to_earlier_commit: false
           test_changes_limit: 0
           fail_on: "errors"
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json
           event_name: ${{ github.event.workflow_run.event }}
-          files: "artifacts/**/*.xml"
+          files: "artifacts/junit-e2e-test.xml/*.xml"
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          check_name: "Published Unit Test Results"
+          compare_to_earlier_commit: false
+          test_changes_limit: 0
+          fail_on: "errors"
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "artifacts/junit-unit-test.xml/*.xml"

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -67,7 +67,7 @@ jobs:
         with:
           name: Unit Test Results
           path: |
-            junit.xml
+            junit-unit-test.xml
       - name: Generate code coverage artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -134,7 +134,7 @@ jobs:
         with:
           name: E2E Test Results (k8s ${{ matrix.kubernetes.version }})
           path: |
-            junit.xml
+            junit-e2e-test.xml
       - name: Upload e2e-controller logs
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Report the status of E2E and unit tests seperatly to maintain the same behavior as before, a comment for each one on the PR.