### PR TITLE
fix(controller): Get the right resourceName for traefik.io.Fixes #3615

### DIFF
--- a/rollout/trafficrouting/traefik/traefik.go
+++ b/rollout/trafficrouting/traefik/traefik.go
@@ -23,12 +23,6 @@ const Type = "Traefik"
 const traefikServices = "traefikservices"
 const TraefikServiceUpdateError = "TraefikServiceUpdateError"
 
-var (
-	apiGroupToResource = map[string]string{
-		defaults.GetTraefikAPIGroup(): traefikServices,
-	}
-)
-
 type ReconcilerConfig struct {
 	Rollout  *v1alpha1.Rollout
 	Client   ClientInterface
@@ -39,6 +33,13 @@ type Reconciler struct {
 	Rollout  *v1alpha1.Rollout
 	Client   ClientInterface
 	Recorder record.EventRecorder
+}
+
+func apiGroupToResource(group string) string {
+	apiGroupToResource := map[string]string{
+		defaults.GetTraefikAPIGroup(): traefikServices,
+	}
+	return apiGroupToResource[group]
 }
 
 func (r *Reconciler) sendWarningEvent(id, msg string) {
@@ -71,7 +72,8 @@ func GetMappingGVR() schema.GroupVersionResource {
 	group := defaults.GetTraefikAPIGroup()
 	parts := strings.Split(defaults.GetTraefikVersion(), "/")
 	version := parts[len(parts)-1]
-	resourceName := apiGroupToResource[group]
+	resourceName := apiGroupToResource(group)
+
 	return schema.GroupVersionResource{
 		Group:    group,
 		Version:  version,


### PR DESCRIPTION
When the var(apiGroupToResource) is executed and we set the traefik api to traefik.io, using the cli flag, the value is not yet setted with SetTraefikAPIGroup(). So the value for traefik.io is not in the map. I changed to a function that is only executed when it is called.

This try to fix the #3615 issue.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
