### PR TITLE
fix(controller): Prevents patching of DestinationRule before stable ReplicaSet is available. Fixes #2507

### DIFF
--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -159,7 +159,7 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 
 		var canaryHash, stableHash string
 		if c.stableRS != nil {
-			if !replicasetutil.IsReplicaSetAvailable(c.stableRS) {
+			if !replicasetutil.IsReplicaSetPartiallyAvailable(c.stableRS) {
 				c.log.Infof("Stable ReplicaSet is not available")
 				return nil
 			}

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -159,6 +159,10 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 
 		var canaryHash, stableHash string
 		if c.stableRS != nil {
+			if !replicasetutil.IsReplicaSetAvailable(c.stableRS) {
+				c.log.Infof("Stable ReplicaSet is not available")
+				return nil
+			}
 			stableHash = c.stableRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 		}
 		if c.newRS != nil {


### PR DESCRIPTION
Relevant to #2507 

During the migration of an existing service to use canary deployments:
When I create (apply) the rollouts resource, I experience several 503s calling that service. Upon inspecting the DestinationRule I see that as soon as the rollout resource is created, it creates a new ReplicaSet of the service and immediately changes its DestinationRule so that it points to the new RS, however such RS is not ready yet and so that leads to the 503s.
This PR makes sure the ReplicaSet is available before it patches the DestinationRule. After doing this, I no longer see 503s in my migration of existing services to subset-based traffic Splitting canary deployments.

Checklist:

* This is a bugfix to #2507 
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).