### PR TITLE
feat(controller): enable pprof profiling support

### DIFF
--- a/cmd/rollouts-controller/main.go
+++ b/cmd/rollouts-controller/main.go
@@ -80,8 +80,7 @@ func newCommand() *cobra.Command {
 		printVersion                   bool
 		selfServiceNotificationEnabled bool
 		controllersEnabled             []string
-		pprofEnabled                   bool
-		pprofPort                      int
+		pprofAddress                   string
 	)
 	electOpts := controller.NewLeaderElectionOptions()
 	var command = cobra.Command{
@@ -207,9 +206,9 @@ func newCommand() *cobra.Command {
 			ingressWrapper, err := ingressutil.NewIngressWrapper(mode, kubeClient, kubeInformerFactory)
 			checkError(err)
 
-			if pprofEnabled {
+			if pprofAddress != "" {
 				mux := controller.NewPProfServer()
-				go func() { log.Println(http.ListenAndServe(fmt.Sprintf("localhost:%d", pprofPort), mux)) }()
+				go func() { log.Println(http.ListenAndServe(pprofAddress, mux)) }()
 			}
 
 			var cm *controller.Manager
@@ -291,7 +290,6 @@ func newCommand() *cobra.Command {
 	command.Flags().IntVar(&klogLevel, "kloglevel", 0, "Set the klog logging level")
 	command.Flags().IntVar(&metricsPort, "metricsport", controller.DefaultMetricsPort, "Set the port the metrics endpoint should be exposed over")
 	command.Flags().IntVar(&healthzPort, "healthzPort", controller.DefaultHealthzPort, "Set the port the healthz endpoint should be exposed over")
-	command.Flags().IntVar(&pprofPort, "pprof-port", controller.DefaultPProfPort, "Set the port the pprof endpoint should be exposed over")
 	command.Flags().StringVar(&instanceID, "instance-id", "", "Indicates which argo rollout objects the controller should operate on")
 	command.Flags().Float32Var(&qps, "qps", defaults.DefaultQPS, "Maximum QPS (queries per second) to the K8s API server")
 	command.Flags().IntVar(&burst, "burst", defaults.DefaultBurst, "Maximum burst for throttle.")
@@ -319,7 +317,7 @@ func newCommand() *cobra.Command {
 	command.Flags().DurationVar(&electOpts.LeaderElectionRetryPeriod, "leader-election-retry-period", controller.DefaultLeaderElectionRetryPeriod, "The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled.")
 	command.Flags().BoolVar(&selfServiceNotificationEnabled, "self-service-notification-enabled", false, "Allows rollouts controller to pull notification config from the namespace that the rollout resource is in. This is useful for self-service notification.")
 	command.Flags().StringSliceVar(&controllersEnabled, "controllers", nil, "Explicitly specify the list of controllers to run, currently only supports 'analysis', eg. --controller=analysis. Default: all controllers are enabled")
-	command.Flags().BoolVar(&pprofEnabled, "enable-pprof", false, "Enable pprof profiling on controller. Default endpoint exposed via :6060/debug/pprof. Change the port with the --pprof-port flag.")
+	command.Flags().StringVar(&pprofAddress, "enable-pprof-address", "", "Enable pprof profiling on controller by providing a server address.")
 	return &command
 }
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -69,9 +69,6 @@ const (
 	// DefaultMetricsPort is the default port to expose the metrics endpoint
 	DefaultMetricsPort = 8090
 
-	// DefaultPProfPort is the default port to expose the pprof endpoint
-	DefaultPProfPort = 6060
-
 	// DefaultRolloutThreads is the default number of rollout worker threads to start with the controller
 	DefaultRolloutThreads = 10
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -69,6 +69,9 @@ const (
 	// DefaultMetricsPort is the default port to expose the metrics endpoint
 	DefaultMetricsPort = 8090
 
+	// DefaultPProfPort is the default port to expose the pprof endpoint
+	DefaultPProfPort = 6060
+
 	// DefaultRolloutThreads is the default number of rollout worker threads to start with the controller
 	DefaultRolloutThreads = 10
 

--- a/controller/profiling.go
+++ b/controller/profiling.go
@@ -10,7 +10,7 @@ const (
 	ProfilingPath = "/debug/pprof"
 )
 
-// NewPProfServer returns a new pprof server to gather to gather runtime profiling data
+// NewPProfServer returns a new pprof server to gather runtime profiling data
 func NewPProfServer() *http.ServeMux {
 	mux := http.NewServeMux()
 

--- a/controller/profiling.go
+++ b/controller/profiling.go
@@ -1,0 +1,24 @@
+package controller
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/pprof"
+)
+
+const (
+	ProfilingPath = "/debug/pprof"
+)
+
+// NewPProfServer returns a new pprof server to gather to gather runtime profiling data
+func NewPProfServer() *http.ServeMux {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc(ProfilingPath, pprof.Index)
+	mux.HandleFunc(fmt.Sprintf("%s/cmdline", ProfilingPath), pprof.Cmdline)
+	mux.HandleFunc(fmt.Sprintf("%s/profile", ProfilingPath), pprof.Profile)
+	mux.HandleFunc(fmt.Sprintf("%s/symbol", ProfilingPath), pprof.Symbol)
+	mux.HandleFunc(fmt.Sprintf("%s/trace", ProfilingPath), pprof.Trace)
+
+	return mux
+}


### PR DESCRIPTION
This PR enables pprof profiling on the Argo Rollouts controller via the `--enable-pprof` flag.  

Issue: [#3757](https://github.com/argoproj/argo-rollouts/issues/3757)

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).