### PR TITLE
fix(metricprovider): reuse http.Transport for http.Client

### DIFF
--- a/metricproviders/prometheus/prometheus.go
+++ b/metricproviders/prometheus/prometheus.go
@@ -209,6 +209,21 @@ func NewPrometheusProvider(api v1.API, logCtx log.Entry, metric v1alpha1.Metric)
 	return provider, nil
 }
 
+func newHTTPTransport(insecureSkipVerify bool) *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:     &tls.Config{InsecureSkipVerify: insecureSkipVerify},
+	}
+}
+
+var secureTransport *http.Transport = newHTTPTransport(false)
+var insecureTransport *http.Transport = newHTTPTransport(true)
+
 // NewPrometheusAPI generates a prometheus API from the metric configuration
 func NewPrometheusAPI(metric v1alpha1.Metric) (v1.API, error) {
 	envValuesByKey := make(map[string]string)
@@ -232,15 +247,10 @@ func NewPrometheusAPI(metric v1alpha1.Metric) (v1.API, error) {
 	}
 
 	var roundTripper http.RoundTripper
-
-	roundTripper = &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		TLSHandshakeTimeout: 10 * time.Second,
-		TLSClientConfig:     &tls.Config{InsecureSkipVerify: metric.Provider.Prometheus.Insecure},
+	if metric.Provider.Prometheus.Insecure {
+		roundTripper = insecureTransport
+	} else {
+		roundTripper = secureTransport
 	}
 
 	// attach custom headers to api requests, if specified

--- a/metricproviders/webmetric/webmetric.go
+++ b/metricproviders/webmetric/webmetric.go
@@ -176,6 +176,10 @@ func (p *Provider) GarbageCollect(run *v1alpha1.AnalysisRun, metric v1alpha1.Met
 	return nil
 }
 
+var insecureTransport *http.Transport = &http.Transport{
+	TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+}
+
 func NewWebMetricHttpClient(metric v1alpha1.Metric) (*http.Client, error) {
 	var timeout time.Duration
 	var oauthCfg clientcredentials.Config
@@ -191,10 +195,7 @@ func NewWebMetricHttpClient(metric v1alpha1.Metric) (*http.Client, error) {
 		Timeout: timeout,
 	}
 	if metric.Provider.Web.Insecure {
-		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-		c.Transport = tr
+		c.Transport = insecureTransport
 	}
 	if metric.Provider.Web.Authentication.OAuth2.TokenURL != "" {
 		if metric.Provider.Web.Authentication.OAuth2.ClientID == "" || metric.Provider.Web.Authentication.OAuth2.ClientSecret == "" {


### PR DESCRIPTION
The current code creates a new http.Transport for each http.Client that is created, which leads to a leak in TCP connections due to keep-alive.

Instead, reuse the same http.Transport between requests. According to the http.Transport docs, this is safe for concurrent use.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).