### PR TITLE
fix: retain non-nginx canary annotations. Fixes: #1070

### DIFF
--- a/rollout/trafficrouting/nginx/nginx.go
+++ b/rollout/trafficrouting/nginx/nginx.go
@@ -325,6 +325,7 @@ func (r *Reconciler) SetWeightPerIngress(desiredWeight int32, ingresses []string
 		}
 
 		// Make patches
+		desiredCanaryIngress.SetAnnotations(getDesiredAnnotations(canaryIngress, desiredCanaryIngress))
 		patch, modified, err := ingressutil.BuildIngressPatch(canaryIngress.Mode(), canaryIngress,
 			desiredCanaryIngress, ingressutil.WithAnnotations(), ingressutil.WithLabels(), ingressutil.WithSpec())
 
@@ -370,4 +371,17 @@ func (r *Reconciler) SetMirrorRoute(setMirrorRoute *v1alpha1.SetMirrorRoute) err
 
 func (r *Reconciler) RemoveManagedRoutes() error {
 	return nil
+}
+
+func getDesiredAnnotations(current, desired *ingressutil.Ingress) map[string]string {
+	// Merge existing annotations into the desired Ingress (giving precedence to the desired values)
+	// This is necessary because the desired Ingress may not have all annotations previously added
+	// by other controllers (e.g. Rancher)
+	desiredAnnotations := desired.GetAnnotations()
+	for k, v := range current.GetAnnotations() {
+		if _, ok := desiredAnnotations[k]; !ok {
+			desiredAnnotations[k] = v
+		}
+	}
+	return desiredAnnotations
 }

--- a/rollout/trafficrouting/nginx/nginx_test.go
+++ b/rollout/trafficrouting/nginx/nginx_test.go
@@ -614,6 +614,37 @@ func TestCanaryIngressAdditionalAnnotationsNewIngress(t *testing.T) {
 	}
 }
 
+func TestCanaryIngressRetainCurrentAnnotations(t *testing.T) {
+	tests := generateMultiIngressTestData()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for _, ing := range test.ingresses {
+				r := Reconciler{
+					cfg: ReconcilerConfig{
+						Rollout: fakeRollout(stableService, canaryService, test.singleIngress, test.multiIngress),
+					},
+				}
+				stable := networkingIngress(StableIngress, 80, stableService)
+				stableIngress := ingressutil.NewIngress(stable)
+				canary := networkingIngress(ingressutil.GetCanaryIngressName(r.cfg.Rollout.GetName(), ing), 80, canaryService)
+				canary.SetAnnotations(map[string]string{
+					"nginx.ingress.kubernetes.io/canary":    "false",
+					"annotation-prefix.some.group/some-key": "some-value",
+				})
+				canaryIngress := ingressutil.NewIngress(canary)
+
+				desiredCanaryIngress, err := r.canaryIngress(stableIngress, ingressutil.GetCanaryIngressName(r.cfg.Rollout.GetName(), ing), 15)
+				assert.Nil(t, err, "No error returned when calling canaryIngress")
+
+				annotations := getDesiredAnnotations(canaryIngress, desiredCanaryIngress)
+				assert.Equal(t, "true", annotations["nginx.ingress.kubernetes.io/canary"], "canary annotation set to true")
+				assert.Equal(t, "15", annotations["nginx.ingress.kubernetes.io/canary-weight"], "canary-weight annotation set to expected value")
+				assert.Equal(t, "some-value", annotations["annotation-prefix.some.group/some-key"], "existing canary annotation is retained")
+			}
+		})
+	}
+}
+
 func TestCanaryIngressMaxWeightInTrafficRouting(t *testing.T) {
 	maxWeights := []*int32{nil, pointer.Int32(1000)}
 	for _, maxWeight := range maxWeights {


### PR DESCRIPTION
The current patch applied for nginx canaries does not play nicely with other controller that may be modifying Ingress annotations. In our case, the Rancher `field.cattle.io/publicEndpoints` is repeatedly added/removed, resulting in a significant amount of updates to Ingress resources in the cluster. 

With this fix, before building and applying the canary ingress patch, all annotations from the existing canary ingress will be copied over to the desired Ingress. 

fixes: https://github.com/argoproj/argo-rollouts/issues/1070

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).