### PR TITLE
docs: fix a link to e2e.yaml

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -116,7 +116,7 @@ docker run quay.io/argoproj/kubectl-argo-rollouts:master version
 
 ## Supported versions
 
-Check [e2e testing file]( https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/e2e.yaml#L40-L44) to see what the Kubernetes version is being fully tested.
+Check [e2e testing file](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/testing.yaml#L82-L89) to see what the Kubernetes version is being fully tested.
 
 You can switch to different tags to see what relevant Kubernetes versions were being tested for the respective version.
 


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).