### PR TITLE
docs: Improve Documentation for Scaledown on Aborted Rollout

### DIFF
--- a/docs/features/scaledown-aborted-rs.md
+++ b/docs/features/scaledown-aborted-rs.md
@@ -6,13 +6,15 @@ The following table summarizes the behavior under combinations of rollout strate
 `abortScaleDownDelaySeconds = nil` is the default, which means in v1.1 across all rollout strategies, the new replicaset
 is scaled down in 30 seconds on abort by default.
 
-|                                    strategy |         v1.0 behavior         | abortScaleDownDelaySeconds |         v1.1 behavior         |
-|--------------------------------------------:|:-----------------------------:|:--------------------------:|:-----------------------------:|
-|                                  blue-green | does not scale down           | nil                        | scales down after 30 seconds  |
-|                                  blue-green | does not scale down           | 0                          | does not scale down           |
-|                                  blue-green | does not scale down           | N                          | scales down after N seconds   |
-|                                basic canary | rolling update back to stable | N/A                        | rolling update back to stable |
-|                   canary w/ traffic routing | scales down immediately       | nil                        | scales down after 30 seconds  |
-|                   canary w/ traffic routing | scales down immediately       | 0                          | does not scale down           |
-|                   canary w/ traffic routing | scales down immediately       | N                          | scales down after N seconds   |
-| canary w/ traffic routing  + setCanaryScale | does not scale down (bug)     | *                          | should behave like  canary w/ traffic routing     |
+|                                    strategy |         v1.0 behavior         | abortScaleDownDelaySeconds |                 v1.1 behavior                 |
+|--------------------------------------------:|:-----------------------------:|:--------------------------:|:---------------------------------------------:|
+|                                  blue-green | does not scale down           | nil                        |         scales down after 30 seconds          |
+|                                  blue-green | does not scale down           | 0                          |              does not scale down              |
+|                                  blue-green | does not scale down           | N                          |          scales down after N seconds          |
+|                                basic canary | rolling update back to stable | N/A                        |         rolling update back to stable         |
+|                   canary w/ traffic routing | scales down immediately       | nil                        |         scales down after 30 seconds          |
+|                   canary w/ traffic routing | scales down immediately       | 0                          |            scales down immediately            |
+|                   canary w/ traffic routing | scales down immediately       | N                          |          scales down immediately              |
+| canary w/ traffic routing  + setCanaryScale | scales down immediately       | 0                          |              does not scale down              |
+| canary w/ traffic routing  + setCanaryScale | scales down immediately       | N                          |          scales down after N seconds          |
+| canary w/ traffic routing  + setCanaryScale | does not scale down (bug)     | *                          | should behave like  canary w/ traffic routing |


### PR DESCRIPTION
Improves understanding of how scaling down behaves depending on different configurations:

 • Canary with traffic routing + setCanaryScale does not scales down immediately  when `abortScaleDownDelaySeconds = 0`

 • Canary with traffic routing + setCanaryScale scales down after some  delay of N second `abortScaleDownDelaySeconds = N`
 
Addresses the following issue: https://github.com/argoproj/argo-rollouts/issues/1841


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).