### PR TITLE
fix(analysis): prevent promotion on inconclusive background run. Fixes: #3850

### DIFF
--- a/rollout/analysis.go
+++ b/rollout/analysis.go
@@ -169,7 +169,10 @@ func needsNewAnalysisRun(currentAr *v1alpha1.AnalysisRun, rollout *v1alpha1.Roll
 	// is set and then seeing if the last status was inconclusive.
 	// There is an additional check for the BlueGreen Pause because the prepromotion analysis always has the BlueGreen
 	// Pause and that causes controllerPause to be set. The extra check for the BlueGreen Pause ensures that a new Analysis
-	// Run is created only when the previous AnalysisRun is inconclusive
+	// Run is created only when the previous AnalysisRun is inconclusive.
+	// Additional check for the Canary Pause prevents Canary promotion when AnalysisRun is inconclusive and reached
+	// inconclusiveLimit. Otherwise, another AnalysisRun will be spawned and can cause Success status,
+	// because of termination when the AnalysisRun is still in-flight.
 	if rollout.Status.ControllerPause &&
 		getPauseCondition(rollout, v1alpha1.PauseReasonCanaryPauseStep) == nil &&
 		getPauseCondition(rollout, v1alpha1.PauseReasonBlueGreenPause) == nil {

--- a/rollout/analysis.go
+++ b/rollout/analysis.go
@@ -170,7 +170,10 @@ func needsNewAnalysisRun(currentAr *v1alpha1.AnalysisRun, rollout *v1alpha1.Roll
 	// There is an additional check for the BlueGreen Pause because the prepromotion analysis always has the BlueGreen
 	// Pause and that causes controllerPause to be set. The extra check for the BlueGreen Pause ensures that a new Analysis
 	// Run is created only when the previous AnalysisRun is inconclusive
-	if rollout.Status.ControllerPause && getPauseCondition(rollout, v1alpha1.PauseReasonBlueGreenPause) == nil {
+	if rollout.Status.ControllerPause &&
+		getPauseCondition(rollout, v1alpha1.PauseReasonCanaryPauseStep) == nil &&
+		getPauseCondition(rollout, v1alpha1.PauseReasonBlueGreenPause) == nil {
+
 		return currentAr.Status.Phase == v1alpha1.AnalysisPhaseInconclusive
 	}
 	return rollout.Status.AbortedAt != nil

--- a/test/e2e/analysis_test.go
+++ b/test/e2e/analysis_test.go
@@ -80,9 +80,9 @@ func (s *AnalysisSuite) TestCanaryInconclusiveBackgroundAnalysis() {
 		When().
 		UpdateSpec().
 		WaitForRolloutStatus("Paused").
+		WaitForBackgroundAnalysisRunPhase("Running").
 		Then().
 		ExpectAnalysisRunCount(1).
-		ExpectBackgroundAnalysisRunPhase("Running").
 		When().
 		WaitForBackgroundAnalysisRunPhase("Inconclusive").
 		WaitForRolloutMessage("InconclusiveAnalysisRun").

--- a/test/e2e/functional/analysistemplate-web-background-inconclusive.yaml
+++ b/test/e2e/functional/analysistemplate-web-background-inconclusive.yaml
@@ -1,4 +1,4 @@
-# A dummy web metric which uses the kubernetes version endpoint as a metric provider
+# A web metric which uses the httpbin service as a metric provider
 apiVersion: argoproj.io/v1alpha1
 kind: AnalysisTemplate
 metadata:
@@ -6,14 +6,17 @@ metadata:
 spec:
   args:
     - name: url-val
-      value: "https://kubernetes.default.svc/version"
+      value: "https://httpbin.org/anything"
   metrics:
-  - name: web
-    interval: 7s
-    inconclusiveLimit: 3
-    successCondition: result.major == '2000'
-    failureCondition: result.major == '1000'
-    provider:
-      web:
-        url: "{{args.url-val}}"
-        insecure: true
+    - name: web
+      interval: 7s
+      inconclusiveLimit: 3
+      successCondition: result.status == "success"
+      failureCondition: result.status == "failure"
+      provider:
+        web:
+          url: "{{args.url-val}}"
+          method: POST
+          jsonBody:
+            status: "inconclusive"
+          jsonPath: "{$.json}"

--- a/test/e2e/functional/analysistemplate-web-background-inconclusive.yaml
+++ b/test/e2e/functional/analysistemplate-web-background-inconclusive.yaml
@@ -1,0 +1,19 @@
+# A dummy web metric which uses the kubernetes version endpoint as a metric provider
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: web-background-inconclusive
+spec:
+  args:
+    - name: url-val
+      value: "https://kubernetes.default.svc/version"
+  metrics:
+  - name: web
+    interval: 7s
+    inconclusiveLimit: 3
+    successCondition: result.major == '2000'
+    failureCondition: result.major == '1000'
+    provider:
+      web:
+        url: "{{args.url-val}}"
+        insecure: true

--- a/test/e2e/functional/rollout-background-analysis-inconclusive.yaml
+++ b/test/e2e/functional/rollout-background-analysis-inconclusive.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: rollout-background-analysis-inconclusive
+spec:
+  replicas: 2
+  strategy:
+    canary:
+      steps:
+      - setWeight: 10
+      - pause: { duration: 30s }
+      analysis:
+        templates:
+        - templateName: web-background-inconclusive
+        startingStep: 1
+  selector:
+    matchLabels:
+      app: rollout-background-analysis-inconclusive
+  template:
+    metadata:
+      labels:
+        app: rollout-background-analysis-inconclusive
+    spec:
+      containers:
+      - name: rollouts-demo
+        image: nginx:1.19-alpine
+        resources:
+          requests:
+            memory: 16Mi
+            cpu: 5m

--- a/test/fixtures/then.go
+++ b/test/fixtures/then.go
@@ -56,6 +56,18 @@ func (t *Then) ExpectRolloutStatus(expectedStatus string) *Then {
 	return t
 }
 
+func (t *Then) ExpectRolloutMessage(expectedMessage string) *Then {
+	ro, err := t.rolloutClient.ArgoprojV1alpha1().Rollouts(t.namespace).Get(t.Context, t.rollout.GetName(), metav1.GetOptions{})
+	t.CheckError(err)
+	_, message := rolloututil.GetRolloutPhase(ro)
+	if message != expectedMessage {
+		t.log.Errorf("Rollout message expected to be '%s'. actual: %s", expectedMessage, message)
+		t.t.FailNow()
+	}
+	t.log.Infof("Rollout expectation status=%s met", expectedMessage)
+	return t
+}
+
 func (t *Then) ExpectReplicaCounts(desired, current, updated, ready, available any) *Then {
 	ro, err := t.rolloutClient.ArgoprojV1alpha1().Rollouts(t.namespace).Get(t.Context, t.rollout.GetName(), metav1.GetOptions{})
 	t.CheckError(err)

--- a/test/fixtures/when.go
+++ b/test/fixtures/when.go
@@ -278,6 +278,14 @@ func (w *When) WaitForRolloutStatus(status string, timeout ...time.Duration) *Wh
 	return w.WaitForRolloutCondition(checkStatus, fmt.Sprintf("status=%s", status), timeout...)
 }
 
+func (w *When) WaitForRolloutMessage(message string, timeout ...time.Duration) *When {
+	checkStatus := func(ro *rov1.Rollout) bool {
+		_, m := rolloututil.GetRolloutPhase(ro)
+		return m == message
+	}
+	return w.WaitForRolloutCondition(checkStatus, fmt.Sprintf("message=%s", message), timeout...)
+}
+
 func (w *When) MarkPodsReady(revision string, count int, timeouts ...time.Duration) *When {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()


### PR DESCRIPTION
The current patch is applied for background analysis runs. It fixes unexpected promotion of a Rollout on the canary pause step and background analysis run with `Inconclusive` results. Instead of promoting on `Inconclusive` result reconciler must keep `Pause` phase/status of the Rollout for manual intervention (promote/abort) similarly to step analysis runs.
In addition, the PR adds an end-to-end test for this specific edge case.

Fixes: #3850 

Current behavior:
```
Name:            rollout-background-analysis-inconclusive
Namespace:       user-ypopivniak
Status:          ✔ Healthy
Strategy:        Canary
  Step:          2/2
  SetWeight:     100
  ActualWeight:  100
Images:          nginx:1.19-alpine (stable)
Replicas:
  Desired:       2
  Current:       2
  Updated:       2
  Ready:         2
  Available:     2

NAME                                                                  KIND         STATUS          AGE  INFO
⟳ rollout-background-analysis-inconclusive                            Rollout      ✔ Healthy       37s
├──# revision:2
│  ├──⧉ rollout-background-analysis-inconclusive-867588b79c           ReplicaSet   ✔ Healthy       36s  stable
│  │  ├──□ rollout-background-analysis-inconclusive-867588b79c-mrcdl  Pod          ✔ Running       36s  ready:1/1
│  │  └──□ rollout-background-analysis-inconclusive-867588b79c-ff52h  Pod          ✔ Running       5s   ready:1/1
│  ├──α rollout-background-analysis-inconclusive-867588b79c-2         AnalysisRun  ? Inconclusive  35s  ? 4
│  └──α rollout-background-analysis-inconclusive-867588b79c-2.1       AnalysisRun  ✔ Successful    14s  ? 2
└──# revision:1
   └──⧉ rollout-background-analysis-inconclusive-6854cdf769           ReplicaSet   • ScaledDown    37s
```

Expected behavior:
```
Name:            rollout-background-analysis-inconclusive
Namespace:       user-ypopivniak
Status:          ॥ Paused
Message:         InconclusiveAnalysisRun
Strategy:        Canary
  Step:          2/2
  SetWeight:     100
  ActualWeight:  100
Images:          nginx:1.19-alpine (canary, stable)
Replicas:
  Desired:       2
  Current:       3
  Updated:       1
  Ready:         3
  Available:     3

NAME                                                                  KIND         STATUS          AGE  INFO
⟳ rollout-background-analysis-inconclusive                            Rollout      ॥ Paused        35s
├──# revision:2
│  ├──⧉ rollout-background-analysis-inconclusive-587f48cf55           ReplicaSet   ✔ Healthy       34s  canary
│  │  └──□ rollout-background-analysis-inconclusive-587f48cf55-94vb5  Pod          ✔ Running       34s  ready:1/1
│  └──α rollout-background-analysis-inconclusive-587f48cf55-2         AnalysisRun  ? Inconclusive  33s  ? 4
└──# revision:1
   └──⧉ rollout-background-analysis-inconclusive-6854cdf769           ReplicaSet   ✔ Healthy       35s  stable
      ├──□ rollout-background-analysis-inconclusive-6854cdf769-7l9kr  Pod          ✔ Running       35s  ready:1/1
      └──□ rollout-background-analysis-inconclusive-6854cdf769-8lkfp  Pod          ✔ Running       35s  ready:1/1
```

To reproduce the described issue without a patch and with the new end-to-end test, it can be run separately on the commit:
```
git checkout ec03c7e094addebf1e850b3fccbf12edeafb9235 # Updated due to commits re-signing
E2E_TEST_OPTIONS="-run 'TestAnalysisSuite' -testify.m 'TestCanaryInconclusiveBackgroundAnalysis'" make test-e2e
```

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [X] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [X] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).