### PR TITLE
docs: Update specification document

### DIFF
--- a/docs/features/specification.md
+++ b/docs/features/specification.md
@@ -285,7 +285,8 @@ spec:
       - setCanaryScale:
           replicas: 3
 
-      # set canary scale to a percentage of spec.replicas without changing traffic weight
+      # set canary scale to spec.Replica * (setweight / maxTrafficWeight) without changing traffic weight
+      # if maxTrafficWeight unspecified, it defaults to 100
       # (supported only with trafficRouting)
       - setCanaryScale:
           weight: 25


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

description:
The "Rollout Specification" document does not include an explanation of maxTrafficWeight in the section on setCanaryScale. Specifically, the description regarding setting the setCanaryScale weight mentions it as a "percentage of spec.replicas", but in reality, it functions as "spec.replicas * (setWeight / maxTrafficWeight)". Therefore, I would like to propose updating the documentation to reflect this behavior.