### PR TITLE
fix: check isScalingEvent only on stable and newRS

### DIFF
--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -327,7 +327,7 @@ func (c *rolloutContext) isScalingEvent() (bool, error) {
 	// We only care about scaling events on the newRS and stableRS because these are the only replicasets that we ever
 	// adjust the replicas counts on as well as the desired annotation. When we have stacked rollouts going the middle
 	// replicasets will never have the desired annotation updated this can cause a tight loop of isScalingEvent -> syncReplicasOnly -> isScalingEvent
-	for _, rs := range []*appsv1.ReplicaSet{c.newRS, c.stableRS} {
+	for _, rs := range controller.FilterActiveReplicaSets([]*appsv1.ReplicaSet{c.newRS, c.stableRS}) {
 		desired, ok := annotations.GetDesiredReplicasAnnotation(rs)
 		if !ok {
 			continue

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -324,7 +324,7 @@ func (c *rolloutContext) isScalingEvent() (bool, error) {
 		return false, fmt.Errorf("failed to getAllReplicaSetsAndSyncRevision in isScalingEvent: %w", err)
 	}
 
-	for _, rs := range controller.FilterActiveReplicaSets(c.allRSs) {
+	for _, rs := range []*appsv1.ReplicaSet{c.newRS, c.stableRS} {
 		desired, ok := annotations.GetDesiredReplicasAnnotation(rs)
 		if !ok {
 			continue

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -324,6 +324,9 @@ func (c *rolloutContext) isScalingEvent() (bool, error) {
 		return false, fmt.Errorf("failed to getAllReplicaSetsAndSyncRevision in isScalingEvent: %w", err)
 	}
 
+	// We only care about scaling events on the newRS and stableRS because these are the only replicasets that we ever
+	// adjust the replicas counts on. When we have stacked rollouts going on the middle replicaset will have the desired annotation
+	// updated this can cuase use to get into a tight loop of isScalingEvent -> syncReplicasOnly -> isScalingEvent
 	for _, rs := range []*appsv1.ReplicaSet{c.newRS, c.stableRS} {
 		desired, ok := annotations.GetDesiredReplicasAnnotation(rs)
 		if !ok {

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -325,8 +325,8 @@ func (c *rolloutContext) isScalingEvent() (bool, error) {
 	}
 
 	// We only care about scaling events on the newRS and stableRS because these are the only replicasets that we ever
-	// adjust the replicas counts on. When we have stacked rollouts going on the middle replicaset will have the desired annotation
-	// updated this can cuase use to get into a tight loop of isScalingEvent -> syncReplicasOnly -> isScalingEvent
+	// adjust the replicas counts on as well as the desired annotation. When we have stacked rollouts going the middle
+	// replicasets will never have the desired annotation updated this can cause a tight loop of isScalingEvent -> syncReplicasOnly -> isScalingEvent
 	for _, rs := range []*appsv1.ReplicaSet{c.newRS, c.stableRS} {
 		desired, ok := annotations.GetDesiredReplicasAnnotation(rs)
 		if !ok {

--- a/rollout/sync_test.go
+++ b/rollout/sync_test.go
@@ -698,8 +698,6 @@ func TestIsScalingEventMissMatchedDesiredOldReplicas(t *testing.T) {
 	err := json.Unmarshal([]byte(updateRO), &roStatus)
 	assert.Nil(t, err)
 
-	assert.Equal(t, int32(2), len(f.replicaSetLister))
-
 	// We have two ReplicaSets, one with 3 pods and one with 10
 	assert.Equal(t, int32(13), roStatus.Status.Replicas)
 	assert.Equal(t, int32(13), roStatus.Status.ReadyReplicas)

--- a/rollout/sync_test.go
+++ b/rollout/sync_test.go
@@ -673,7 +673,6 @@ func TestIsScalingEventMissMatchedDesiredOldReplicas(t *testing.T) {
 	r1.Status.StableRS = stableRs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 	r2 := bumpVersion(r1)
 	r2.Annotations[annotations.RevisionAnnotation] = "2"
-	//rs2 := newReplicaSetWithStatus(r2, , 0)
 
 	f.rolloutLister = append(f.rolloutLister, r2)
 	f.objects = append(f.objects, r2)

--- a/rollout/sync_test.go
+++ b/rollout/sync_test.go
@@ -1,6 +1,7 @@
 package rollout
 
 import (
+	"encoding/json"
 	"strconv"
 	"testing"
 	"time"
@@ -638,4 +639,69 @@ func TestScaleDownDeploymentOnSuccess(t *testing.T) {
 	err = ctx.promoteStable(newStatus, "reason")
 
 	assert.NotNil(t, err)
+}
+
+// This tests validates that when there are old replicasets that have miss matched desired-count annotations aka they do
+// not match the spec.replicas field. When this happens we get stuck in a reconcile loop of only trying to scale replicasets
+// only because of a supposed scaling event. This test validates that we do not get stuck in this loop by checking that status.replicas
+// and status.readyreplicas are updated because those will not be updated in that loop.
+func TestIsScalingEventMissMatchedDesiredOldReplicas(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	// these steps should be ignored
+	steps := []v1alpha1.CanaryStep{
+		{
+			SetWeight: int32Ptr(10),
+		},
+		{
+			Pause: &v1alpha1.RolloutPause{
+				Duration: v1alpha1.DurationFromInt(60),
+			},
+		},
+	}
+
+	r0 := newCanaryRollout("foo", 10, int32Ptr(4), steps, int32Ptr(0), intstr.FromInt(10), intstr.FromInt(0))
+	r0.Annotations[annotations.RevisionAnnotation] = "1"
+	rs0 := newReplicaSetWithStatus(r0, 3, 3)
+	rs0.Annotations[annotations.DesiredReplicasAnnotation] = "2"
+
+	r1 := bumpVersion(r0)
+
+	rs1 := newReplicaSetWithStatus(r1, 10, 10)
+	r1.Status.StableRS = rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	r2 := bumpVersion(r1)
+	r2.Annotations[annotations.RevisionAnnotation] = "2"
+	//rs2 := newReplicaSetWithStatus(r2, , 0)
+
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2)
+	f.kubeobjects = append(f.kubeobjects, rs0, rs1)
+	f.replicaSetLister = append(f.replicaSetLister, rs0, rs1)
+
+	f.expectUpdateRolloutAction(r2) // update rollout revision
+	f.expectUpdateRolloutStatusAction(r2)
+	updatedROIndex := f.expectPatchRolloutAction(r2)
+	createdRS2Index := f.expectCreateReplicaSetAction(rs1)
+	updatedRS2Index := f.expectUpdateReplicaSetAction(rs1)
+	f.run(getKey(r2, t))
+
+	createdRS2 := f.getCreatedReplicaSet(createdRS2Index)
+	assert.Equal(t, int32(0), *createdRS2.Spec.Replicas)
+	updatedRS2 := f.getUpdatedReplicaSet(updatedRS2Index)
+	assert.Equal(t, int32(1), *updatedRS2.Spec.Replicas)
+
+	updateRO := f.getPatchedRollout(updatedROIndex)
+
+	//Will only contain status
+	roStatus := v1alpha1.Rollout{}
+	err := json.Unmarshal([]byte(updateRO), &roStatus)
+	assert.Nil(t, err)
+
+	assert.Equal(t, int32(2), len(f.replicaSetLister))
+
+	// We have two ReplicaSets, one with 3 pods and one with 10
+	assert.Equal(t, int32(13), roStatus.Status.Replicas)
+	assert.Equal(t, int32(13), roStatus.Status.ReadyReplicas)
+	assert.Equal(t, int32(0), roStatus.Status.UpdatedReplicas)
 }


### PR DESCRIPTION
This bug can cause rollouts to get stuck in a tight loop of thinking it's constantly in a scaling event. Argo rollouts does not ever update the `/desired-replicas` annotation on ReplicaSets that are not stable or desired (newRs) there can be races where a ReplicaSet will get marked as old with a value in `/desired-replicas` that dose not match `spec.replicas` on the rollout this could either be due to a scaling event right after that rs gets moved to old or a code path that does not update the rs before marking it as old.

This change makes this loop not possible because we will not check all replicasets but instead only check stable and newRs which are the only ones we scale on scaling events.

Example state of issue below: We have an old replicaset that does not match spec.replicas of the rollout this causes isScalingEvent to get into a loop.

Rollout:
```
apiVersion: argoproj.io/v1alpha1
kind: Rollout
metadata:
spec:
  replicas: 10
```

Desired/Canary
```
apiVersion: apps/v1
kind: ReplicaSet
metadata:
  annotations:
    rollout.argoproj.io/desired-replicas: '10'
```

Old
```
apiVersion: apps/v1
kind: ReplicaSet
metadata:
  annotations:
    rollout.argoproj.io/desired-replicas: '9'
```

Stable
```
apiVersion: apps/v1
kind: ReplicaSet
metadata:
  annotations:
    rollout.argoproj.io/desired-replicas: '10'
```
