### PR TITLE
fix(metricprovider): fix handling null values in datadog

### DIFF
--- a/metricproviders/datadog/datadog.go
+++ b/metricproviders/datadog/datadog.go
@@ -67,7 +67,7 @@ type datadogResponseV2 struct {
 	Data struct {
 		Attributes struct {
 			Columns []struct {
-				Values []float64
+				Values []*float64
 			}
 		}
 		Errors string
@@ -320,7 +320,7 @@ func (p *Provider) parseResponseV2(metric v1alpha1.Metric, response *http.Respon
 	}
 
 	// Handle an empty query result
-	if reflect.ValueOf(res.Data.Attributes).IsZero() || len(res.Data.Attributes.Columns) == 0 || len(res.Data.Attributes.Columns[0].Values) == 0 {
+	if reflect.ValueOf(res.Data.Attributes).IsZero() || len(res.Data.Attributes.Columns) == 0 || len(res.Data.Attributes.Columns[0].Values) == 0 || res.Data.Attributes.Columns[0].Values[0] == nil {
 		var nilFloat64 *float64
 		status, err := evaluate.EvaluateResult(nilFloat64, metric, p.logCtx)
 
@@ -343,7 +343,7 @@ func (p *Provider) parseResponseV2(metric v1alpha1.Metric, response *http.Respon
 
 	// Handle a populated query result
 	column := res.Data.Attributes.Columns[0]
-	value := column.Values[0]
+	value := *column.Values[0]
 	status, err := evaluate.EvaluateResult(value, metric, p.logCtx)
 	return strconv.FormatFloat(value, 'f', -1, 64), status, err
 }

--- a/metricproviders/datadog/datadogV2_test.go
+++ b/metricproviders/datadog/datadogV2_test.go
@@ -248,7 +248,7 @@ func TestRunSuiteV2(t *testing.T) {
 			},
 			expectedIntervalSeconds: 300,
 			expectedPhase:           v1alpha1.AnalysisPhaseError,
-			expectedErrorMessage:    "Could not parse JSON body: json: cannot unmarshal string into Go struct field .Data.Attributes.Columns.Values of type []float64",
+			expectedErrorMessage:    "Could not parse JSON body: json: cannot unmarshal string into Go struct field .Data.Attributes.Columns.Values of type []*float64",
 			useEnvVarForKeys:        false,
 		},
 


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).


When Datadog returns a values list with JSON `null` value, instead of an empty slice, it gets unmarshalled to a float64 value of 0, which is not what should happen (should be treated as if an empty slice). This is because `values` is a `[]float64`. Switching it to `[]*float64` fixes this issue. 

I've encountered this issue when doing zero/zero division. For example in `a/(a+b)`, where `a` and `b` are both zeros, the `a/(a+b)` formula returns `null`. I'm sure this could happen in other cases but I'm not aware of them.

For reference, this is what the datadog response would look like:
```json
{
    "data": {
        "attributes": {
            "columns": [
                {
                    "meta": {
                        "unit": null
                    },
                    "name": "a/(a+b)",
                    "type": "number",
                    "values": [
                        null
                    ]
                }
            ]
        },
        "type": "scalar_response"
    }
}
```

For the numerator and denominator
```json
                {
                    "meta": {
                        "unit": null
                    },
                    "name": "a",
                    "type": "number",
                    "values": [
                        0.0
                    ]
                },
                {
                    "meta": {
                        "unit": null
                    },
                    "name": "b",
                    "type": "number",
                    "values": [
                        0.0
                    ]
                },
                {
                    "meta": {
                        "unit": null
                    },
                    "name": "a+b",
                    "type": "number",
                    "values": [
                        0.0
                    ]
                },
``` 

I've built and tested the image. No need for additional unit tests.