### PR TITLE
fix: remove condition where header routes can stay directed at empty service in preemption

### DIFF
--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -1348,7 +1348,7 @@ func TestDontWeightToZeroWhenDynamicallyRollingBackToStable(t *testing.T) {
 
 // TestDontWeightOrHaveManagedRoutesDuringInterruptedUpdate builds off of TestCanaryDontScaleDownOldRsDuringInterruptedUpdate
 // in canary_test when we scale down an intermediate V2 ReplicaSet when applying a V3 spec in the middle of updating.
-// We want to make sure that traffic routing is cleared in both weight AND managed routes when the V2 rs is 
+// We want to make sure that traffic routing is cleared in both weight AND managed routes when the V2 rs is
 // nil or has 0 available replicas.
 func TestDontWeightOrHaveManagedRoutesDuringInterruptedUpdate(t *testing.T) {
 	f := newFixture(t)
@@ -1381,7 +1381,7 @@ func TestDontWeightOrHaveManagedRoutesDuringInterruptedUpdate(t *testing.T) {
 			Ingress: "test-ingress",
 		},
 		ManagedRoutes: []v1alpha1.MangedRoutes{
-			{ Name: "test-header" },
+			{Name: "test-header"},
 		},
 	}
 
@@ -1431,4 +1431,3 @@ func TestDontWeightOrHaveManagedRoutesDuringInterruptedUpdate(t *testing.T) {
 	f.fakeTrafficRouting.AssertCalled(t, "RemoveManagedRoutes", mock.Anything, mock.Anything)
 
 }
-

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -33,8 +33,10 @@ import (
 	traefikMocks "github.com/argoproj/argo-rollouts/rollout/trafficrouting/traefik/mocks"
 	testutil "github.com/argoproj/argo-rollouts/test/util"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
+	ingressutil "github.com/argoproj/argo-rollouts/utils/ingress"
 	istioutil "github.com/argoproj/argo-rollouts/utils/istio"
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
+	replicasetutil "github.com/argoproj/argo-rollouts/utils/replicaset"
 	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
@@ -1343,3 +1345,90 @@ func TestDontWeightToZeroWhenDynamicallyRollingBackToStable(t *testing.T) {
 	rs1Updated := f.getUpdatedReplicaSet(scaleUpIndex)
 	assert.Equal(t, int32(10), *rs1Updated.Spec.Replicas)
 }
+
+// TestDontWeightOrHaveManagedRoutesDuringInterruptedUpdate builds off of TestCanaryDontScaleDownOldRsDuringInterruptedUpdate
+// in canary_test when we scale down an intermediate V2 ReplicaSet when applying a V3 spec in the middle of updating.
+// We want to make sure that traffic routing is cleared in both weight AND managed routes when the V2 rs is 
+// nil or has 0 available replicas.
+func TestDontWeightOrHaveManagedRoutesDuringInterruptedUpdate(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{
+		{
+			SetHeaderRoute: &v1alpha1.SetHeaderRoute{
+				Name: "test-header",
+				Match: []v1alpha1.HeaderRoutingMatch{
+					{
+						HeaderName: "test",
+						HeaderValue: &v1alpha1.StringMatch{
+							Exact: "test",
+						},
+					},
+				},
+			},
+		},
+		{
+			SetWeight: pointer.Int32(90),
+		},
+		{
+			Pause: &v1alpha1.RolloutPause{},
+		},
+	}
+	r1 := newCanaryRollout("foo", 5, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
+		ALB: &v1alpha1.ALBTrafficRouting{
+			Ingress: "test-ingress",
+		},
+		ManagedRoutes: []v1alpha1.MangedRoutes{
+			{ Name: "test-header" },
+		},
+	}
+
+	r1.Spec.Strategy.Canary.StableService = "stable-svc"
+	r1.Spec.Strategy.Canary.CanaryService = "canary-svc"
+	r2 := bumpVersion(r1)
+	r3 := bumpVersion(r2)
+
+	stableSvc := newService("stable-svc", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: r1.Status.CurrentPodHash}, r1)
+	canarySvc := newService("canary-svc", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: r3.Status.CurrentPodHash}, r3)
+	r3.Status.StableRS = r1.Status.CurrentPodHash
+
+	ingress := newIngress("test-ingress", canarySvc, stableSvc)
+	ingress.Spec.Rules[0].HTTP.Paths[0].Backend.ServiceName = stableSvc.Name
+
+	rs1 := newReplicaSetWithStatus(r1, 5, 5)
+	rs2 := newReplicaSetWithStatus(r2, 5, 5)
+	rs3 := newReplicaSetWithStatus(r3, 5, 0)
+	r3.Status.Canary.Weights = &v1alpha1.TrafficWeights{
+		Canary: v1alpha1.WeightDestination{
+			PodTemplateHash: replicasetutil.GetPodTemplateHash(rs2),
+		},
+	}
+
+	f.objects = append(f.objects, r3)
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2, rs3, canarySvc, stableSvc, ingress)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2, rs3)
+	f.serviceLister = append(f.serviceLister, canarySvc, stableSvc)
+	f.ingressLister = append(f.ingressLister, ingressutil.NewLegacyIngress(ingress))
+
+	f.expectPatchRolloutAction(r3)
+	f.run(getKey(r3, t))
+
+	r3.Status.Canary.Weights = &v1alpha1.TrafficWeights{
+		Canary: v1alpha1.WeightDestination{
+			PodTemplateHash: replicasetutil.GetPodTemplateHash(rs3),
+		},
+	}
+
+	f.expectUpdateReplicaSetAction(rs3)
+	f.run(getKey(r3, t))
+
+	// Make sure that our weight is zero
+	assert.Equal(t, int32(0), r3.Status.Canary.Weights.Canary.Weight)
+	assert.Equal(t, replicasetutil.GetPodTemplateHash(rs3), r3.Status.Canary.Weights.Canary.PodTemplateHash)
+	// Make sure that RemoveManagedRoutes was called
+	f.fakeTrafficRouting.AssertCalled(t, "RemoveManagedRoutes", mock.Anything, mock.Anything)
+
+}
+


### PR DESCRIPTION
Attempts to address some concerns with behavior in:
- https://github.com/argoproj/argo-rollouts/issues/3617

It seems like we are forgetting to remove the managed routes when the following occurs:
1. Rollout is stable on V1
2. Rollout is updated with V2, and begins to progress
3. Managed routes are defined (e.g. to send traffic with specific header values to the canary service)
4. Rollout is updated with V3, and must start back at the beginning again where V1 is still considered stable (ditching any ongoing progress with V2)
5. Canary service selector is swapped to V3 replicaset
6. Traffic weights are set back to 0 

It does not seem like any managed routes are considered between steps 4-6. I believe this code that I've made an addition to is where this would need to occur, but would love some feedback.

NOTE: I still don't think this fixes another situation where the service selector is swapped to the new replicaset before the traffic can be reconciled back at the 0% weight, but this at least allows the managed routes to fall back to the stable V1 version, instead of the behavior in the graph below:

![image](https://github.com/user-attachments/assets/adbd1ccb-a731-48c5-a7fa-2bfcb14df533)
> `c8e` is `V1` `5ba` is `V2` and `aa9` is `V3`. Note how for a client meeting the requirements for the managed route, it never actually falls back to `V1` but simply 503's until the replicaset for `V3` can finally mark ready (it is never taken away from the canary service)


Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).