### PR TITLE
fix(controller): Reduce Cardinality for controller_clientset_k8s_request_total metrics

### DIFF
--- a/controller/metrics/client.go
+++ b/controller/metrics/client.go
@@ -27,7 +27,7 @@ func (m *K8sRequestsCountProvider) IncKubernetesRequest(resourceInfo kubeclientm
 	namespace := resourceInfo.Namespace
 	kind := resourceInfo.Kind
 	statusCode := strconv.Itoa(resourceInfo.StatusCode)
-	if resourceInfo.Verb == kubeclientmetrics.List || kind == "events" || kind == "replicasets" {
+	if resourceInfo.Verb == kubeclientmetrics.List || kind == "events" || kind == "replicasets" || kind == "analysisruns" || kind == "jobs" || kind == "experiments" {
 		name = "N/A"
 	}
 	if resourceInfo.Verb == kubeclientmetrics.Unknown {


### PR DESCRIPTION
Following on from https://github.com/argoproj/argo-rollouts/pull/2851

We see very high cardinality for these 3 additional objects (experiments, analysisruns and jobs). So much so that our argo-rollouts controller runs out of memory and restarts after a week or two.

![image](https://github.com/user-attachments/assets/3e3dad8b-b9b6-41b4-9773-41ab5c04b40f)

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).