### PR TITLE
fix(dashboard): Cleanup viewcontroller after each request. Fixes #2095

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -179,7 +179,10 @@ func (s *ArgoRolloutsServer) initRolloutViewController(namespace string, name st
 }
 
 func (s *ArgoRolloutsServer) getRolloutInfo(namespace string, name string) (*rollout.RolloutInfo, error) {
-	controller := s.initRolloutViewController(namespace, name, context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	controller := s.initRolloutViewController(namespace, name, ctx)
 	ri, err := controller.GetRolloutInfo()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes: #2095

Every time `GetRolloutInfo` route is called it creates a new `RolloutViewController`, but the context passed into the view controller was never cancelled. This resulted in the informers never being cleaned up which manifested as a memory leak. Cancelling the view controllers context after the request has processed eliminates the "memory leak".

The graph below shows our production instance (pod named `argo-rollouts-dashboard-8dfdc4bd6-vkhkp`) vs the test instance with the fix applied (pod named `argo-rollouts-dashtest`). Both instances were receiving API requests every 15seconds.

<img width="969" alt="Screenshot 2024-11-29 at 3 09 20 PM" src="https://github.com/user-attachments/assets/7c782f99-33ca-481b-a4b3-0f6832c16ee6">


Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [X] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.
* [X] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My builds are green. Try syncing with master if they are not.
* [X] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
