### PR TITLE
chore: just run test reverts service selector back to stable

### DIFF
--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -179,22 +179,10 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			}
 		} else if c.pauseContext.IsAborted() {
 			desiredWeight = c.calculateDesiredWeightOnAbortOrStableRollback()
-			if (c.rollout.Spec.Strategy.Canary.DynamicStableScale && desiredWeight == 0) || !c.rollout.Spec.Strategy.Canary.DynamicStableScale {
-				// If we are using dynamic stable scale we need to also make sure that desiredWeight=0 aka we are completely
-				// done with aborting before resetting the canary service selectors back to stable. For non-dynamic scale we do not check for availability because we are
-				// fully aborted and stable pods will be there, if we check for availability it causes issues with ALB readiness gates if all stable pods
-				// have the desired readiness gate on them during an abort we get stuck in a loop because all the stable go unready and rollouts won't be able
-				// to switch the desired services because there is no ready pods which causes pods to get stuck progressing forever waiting for readiness.
-				err = c.ensureSVCTargets(c.rollout.Spec.Strategy.Canary.CanaryService, c.stableRS, false)
-				if err != nil {
-					return err
-				}
-			}
 			err := reconciler.RemoveManagedRoutes()
 			if err != nil {
 				return err
 			}
-
 		} else if c.newRS == nil || c.newRS.Status.AvailableReplicas == 0 {
 			// when newRS is not available or replicas num is 0. never weight to canary
 			weightDestinations = append(weightDestinations, c.calculateWeightDestinationsFromExperiment()...)

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -1095,7 +1095,7 @@ func TestDynamicScalingDecreaseWeightAccordingToStableAvailabilityWhenAbortedAnd
 	f.objects = append(f.objects, r2)
 
 	f.expectPatchRolloutAction(r2)
-	//f.expectPatchServiceAction(canarySvc, rs1PodHash)
+	f.expectPatchServiceAction(canarySvc, rs1PodHash)
 
 	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
 	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -1095,7 +1095,6 @@ func TestDynamicScalingDecreaseWeightAccordingToStableAvailabilityWhenAbortedAnd
 	f.objects = append(f.objects, r2)
 
 	f.expectPatchRolloutAction(r2)
-	f.expectPatchServiceAction(canarySvc, rs1PodHash)
 
 	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
 	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -952,7 +952,6 @@ func TestDynamicScalingDontIncreaseWeightWhenAborted(t *testing.T) {
 	f.objects = append(f.objects, r2)
 
 	f.expectPatchRolloutAction(r2)
-	f.expectPatchServiceAction(canarySvc, rs1PodHash)
 
 	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
 	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -1096,7 +1095,7 @@ func TestDynamicScalingDecreaseWeightAccordingToStableAvailabilityWhenAbortedAnd
 	f.objects = append(f.objects, r2)
 
 	f.expectPatchRolloutAction(r2)
-	f.expectPatchServiceAction(canarySvc, rs1PodHash)
+	//f.expectPatchServiceAction(canarySvc, rs1PodHash)
 
 	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
 	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)

--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -567,13 +567,6 @@ func (s *CanarySuite) TestCanaryScaleDownOnAbort() {
 		WaitForRolloutStatus("Paused").
 		AbortRollout().
 		WaitForRolloutStatus("Degraded").
-<<<<<<< HEAD
-		Then().
-		// Expect that the canary service selector has been moved back to stable
-		ExpectServiceSelector("canary-scaledowndelay-canary", map[string]string{"app": "canary-scaledowndelay", "rollouts-pod-template-hash": "66597877b7"}, false).
-		When().
-=======
->>>>>>> parent of 81b015d15 (fix: switch service selector back to stable on canary service when aborted (#2540))
 		Sleep(3*time.Second).
 		Then().
 		ExpectRevisionPodCount("2", 0)

--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -650,24 +650,11 @@ func (s *CanarySuite) TestCanaryDynamicStableScale() {
 		WaitForRevisionPodCount("2", 1).
 		Then().
 		ExpectRevisionPodCount("1", 4).
-<<<<<<< HEAD
-		// Assert that the canary service selector is still not set to stable rs because of dynamic stable scale still in progress
-		Assert(func(t *fixtures.Then) {
-			canarySvc, stableSvc := t.GetServices()
-			assert.NotEqual(s.T(), canarySvc.Spec.Selector["rollouts-pod-template-hash"], stableSvc.Spec.Selector["rollouts-pod-template-hash"])
-		}).
-=======
->>>>>>> parent of 81b015d15 (fix: switch service selector back to stable on canary service when aborted (#2540))
 		When().
 		MarkPodsReady("1", 1). // mark last remaining stable pod as ready (4/4 stable are ready)
 		WaitForRevisionPodCount("2", 0).
 		Sleep(2*time.Second). //WaitForRevisionPodCount does not wait for terminating pods and so ExpectServiceSelector fails sleep a bit for the terminating pods to be deleted
 		Then().
-<<<<<<< HEAD
-		// Expect that the canary service selector is now set to stable because of dynamic stable scale is over and we have all pods up on stable rs
-		ExpectServiceSelector("dynamic-stable-scale-canary", map[string]string{"app": "dynamic-stable-scale", "rollouts-pod-template-hash": "868d98995b"}, false).
-=======
->>>>>>> parent of 81b015d15 (fix: switch service selector back to stable on canary service when aborted (#2540))
 		ExpectRevisionPodCount("1", 4)
 }
 

--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -567,10 +567,13 @@ func (s *CanarySuite) TestCanaryScaleDownOnAbort() {
 		WaitForRolloutStatus("Paused").
 		AbortRollout().
 		WaitForRolloutStatus("Degraded").
+<<<<<<< HEAD
 		Then().
 		// Expect that the canary service selector has been moved back to stable
 		ExpectServiceSelector("canary-scaledowndelay-canary", map[string]string{"app": "canary-scaledowndelay", "rollouts-pod-template-hash": "66597877b7"}, false).
 		When().
+=======
+>>>>>>> parent of 81b015d15 (fix: switch service selector back to stable on canary service when aborted (#2540))
 		Sleep(3*time.Second).
 		Then().
 		ExpectRevisionPodCount("2", 0)
@@ -654,18 +657,24 @@ func (s *CanarySuite) TestCanaryDynamicStableScale() {
 		WaitForRevisionPodCount("2", 1).
 		Then().
 		ExpectRevisionPodCount("1", 4).
+<<<<<<< HEAD
 		// Assert that the canary service selector is still not set to stable rs because of dynamic stable scale still in progress
 		Assert(func(t *fixtures.Then) {
 			canarySvc, stableSvc := t.GetServices()
 			assert.NotEqual(s.T(), canarySvc.Spec.Selector["rollouts-pod-template-hash"], stableSvc.Spec.Selector["rollouts-pod-template-hash"])
 		}).
+=======
+>>>>>>> parent of 81b015d15 (fix: switch service selector back to stable on canary service when aborted (#2540))
 		When().
 		MarkPodsReady("1", 1). // mark last remaining stable pod as ready (4/4 stable are ready)
 		WaitForRevisionPodCount("2", 0).
 		Sleep(2*time.Second). //WaitForRevisionPodCount does not wait for terminating pods and so ExpectServiceSelector fails sleep a bit for the terminating pods to be deleted
 		Then().
+<<<<<<< HEAD
 		// Expect that the canary service selector is now set to stable because of dynamic stable scale is over and we have all pods up on stable rs
 		ExpectServiceSelector("dynamic-stable-scale-canary", map[string]string{"app": "dynamic-stable-scale", "rollouts-pod-template-hash": "868d98995b"}, false).
+=======
+>>>>>>> parent of 81b015d15 (fix: switch service selector back to stable on canary service when aborted (#2540))
 		ExpectRevisionPodCount("1", 4)
 }
 


### PR DESCRIPTION
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
