### PR TITLE
fix: don't over reconcile on error

### DIFF
--- a/rollout/controller.go
+++ b/rollout/controller.go
@@ -561,7 +561,7 @@ func (c *Controller) newRolloutContext(rollout *v1alpha1.Rollout) (*rolloutConte
 			if err != nil {
 				return nil, err
 			}
-			return &roCtx, vErr // return the rollout cone text with the validation error so that we can still use the context to update the rollout
+			return nil, vErr
 		}
 		return nil, err
 	}

--- a/rollout/controller.go
+++ b/rollout/controller.go
@@ -434,7 +434,7 @@ func (c *Controller) syncHandler(ctx context.Context, key string) error {
 	if resolveErr != nil {
 		err := roCtx.createInvalidRolloutCondition(resolveErr, r)
 		if err != nil {
-			return fmt.Errorf("failed to create invalid rollout condition during resovling the rollout: %w", err)
+			return fmt.Errorf("failed to create invalid rollout condition during resolving the rollout: %w", err)
 		}
 		return fmt.Errorf("failed to resolve rollout: %w", resolveErr)
 	}

--- a/rollout/controller.go
+++ b/rollout/controller.go
@@ -413,7 +413,7 @@ func (c *Controller) syncHandler(ctx context.Context, key string) error {
 	}()
 
 	resolveErr := c.refResolver.Resolve(r)
-	// We should probably lose the error condition here, and just log the error to clean up the logic
+	// We should probably lose setting the error condition from the below if resolveErr != nil {}, and just log the error to clean up the logic
 	//if resolveErr != nil {
 	//	logCtx.Errorf("refResolver.Resolve err %v", resolveErr)
 	//	return resolveErr
@@ -435,7 +435,7 @@ func (c *Controller) syncHandler(ctx context.Context, key string) error {
 		return err
 	}
 	// We should probably delete this if block and just log the error to clean up the logic, a bigger change would be to add a new
-	// field to the status and store the errors there from the processNextWorkItem function in controller/controller.go
+	// field to the status maybe (reconcileErrMsg) and store the errors there from the processNextWorkItem function in controller/controller.go
 	if resolveErr != nil {
 		roCtx.createInvalidRolloutCondition(resolveErr, r)
 		return resolveErr


### PR DESCRIPTION
This change keeps the logic working the same way as it did in 1.7.x where we did not return any errors on validation issues because we re-queue at 20 seconds instead. There are some interesting logic issues here that have existed for ever that I commented some possible improvement's on but have not done.