### PR TITLE
chore: read the docs new requirement

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,6 +2,7 @@ version: 2
 formats: all
 mkdocs:
   fail_on_warning: false
+  configuration: mkdocs.yml
 python:
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
Read the docs will disable our builds without this configuration come Jan 6 2025.