### PR TITLE
docs: new syntax for docs conf

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,6 +1,7 @@
 version: 2
 formats: all
 mkdocs:
+  configuration: mkdocs.yml
   fail_on_warning: false
 python:
   install:


### PR DESCRIPTION
Updating Read-the-docs conf. New syntax will be required in January 2025 

See  https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/
