### PR TITLE
fix: Use correct type union in CRD spec for Quantity fields

### DIFF
--- a/docs/features/kustomize/rollout_cr_schema.json
+++ b/docs/features/kustomize/rollout_cr_schema.json
@@ -1796,10 +1796,30 @@
                                                                                                     "x-kubernetes-list-type": "map"
                                                                                                 },
                                                                                                 "limits": {
-                                                                                                    "x-kubernetes-preserve-unknown-fields": true
+                                                                                                    "additionalProperties": {
+                                                                                                        "oneOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "object"
                                                                                                 },
                                                                                                 "requests": {
-                                                                                                    "x-kubernetes-preserve-unknown-fields": true
+                                                                                                    "additionalProperties": {
+                                                                                                        "oneOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "object"
                                                                                                 }
                                                                                             },
                                                                                             "type": "object"
@@ -2810,10 +2830,30 @@
                                                                                                     "x-kubernetes-list-type": "map"
                                                                                                 },
                                                                                                 "limits": {
-                                                                                                    "x-kubernetes-preserve-unknown-fields": true
+                                                                                                    "additionalProperties": {
+                                                                                                        "oneOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "object"
                                                                                                 },
                                                                                                 "requests": {
-                                                                                                    "x-kubernetes-preserve-unknown-fields": true
+                                                                                                    "additionalProperties": {
+                                                                                                        "oneOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "object"
                                                                                                 }
                                                                                             },
                                                                                             "type": "object"
@@ -3834,10 +3874,30 @@
                                                                                                     "x-kubernetes-list-type": "map"
                                                                                                 },
                                                                                                 "limits": {
-                                                                                                    "x-kubernetes-preserve-unknown-fields": true
+                                                                                                    "additionalProperties": {
+                                                                                                        "oneOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "object"
                                                                                                 },
                                                                                                 "requests": {
-                                                                                                    "x-kubernetes-preserve-unknown-fields": true
+                                                                                                    "additionalProperties": {
+                                                                                                        "oneOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "object"
                                                                                                 }
                                                                                             },
                                                                                             "type": "object"
@@ -6673,10 +6733,30 @@
                                                                                                     "x-kubernetes-list-type": "map"
                                                                                                 },
                                                                                                 "limits": {
-                                                                                                    "x-kubernetes-preserve-unknown-fields": true
+                                                                                                    "additionalProperties": {
+                                                                                                        "oneOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "object"
                                                                                                 },
                                                                                                 "requests": {
-                                                                                                    "x-kubernetes-preserve-unknown-fields": true
+                                                                                                    "additionalProperties": {
+                                                                                                        "oneOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "object"
                                                                                                 }
                                                                                             },
                                                                                             "type": "object"
@@ -7687,10 +7767,30 @@
                                                                                                     "x-kubernetes-list-type": "map"
                                                                                                 },
                                                                                                 "limits": {
-                                                                                                    "x-kubernetes-preserve-unknown-fields": true
+                                                                                                    "additionalProperties": {
+                                                                                                        "oneOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "object"
                                                                                                 },
                                                                                                 "requests": {
-                                                                                                    "x-kubernetes-preserve-unknown-fields": true
+                                                                                                    "additionalProperties": {
+                                                                                                        "oneOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "object"
                                                                                                 }
                                                                                             },
                                                                                             "type": "object"
@@ -8711,10 +8811,30 @@
                                                                                                     "x-kubernetes-list-type": "map"
                                                                                                 },
                                                                                                 "limits": {
-                                                                                                    "x-kubernetes-preserve-unknown-fields": true
+                                                                                                    "additionalProperties": {
+                                                                                                        "oneOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "object"
                                                                                                 },
                                                                                                 "requests": {
-                                                                                                    "x-kubernetes-preserve-unknown-fields": true
+                                                                                                    "additionalProperties": {
+                                                                                                        "oneOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "object"
                                                                                                 }
                                                                                             },
                                                                                             "type": "object"
@@ -11563,10 +11683,30 @@
                                                                                                     "x-kubernetes-list-type": "map"
                                                                                                 },
                                                                                                 "limits": {
-                                                                                                    "x-kubernetes-preserve-unknown-fields": true
+                                                                                                    "additionalProperties": {
+                                                                                                        "oneOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "object"
                                                                                                 },
                                                                                                 "requests": {
-                                                                                                    "x-kubernetes-preserve-unknown-fields": true
+                                                                                                    "additionalProperties": {
+                                                                                                        "oneOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "object"
                                                                                                 }
                                                                                             },
                                                                                             "type": "object"
@@ -12577,10 +12717,30 @@
                                                                                                     "x-kubernetes-list-type": "map"
                                                                                                 },
                                                                                                 "limits": {
-                                                                                                    "x-kubernetes-preserve-unknown-fields": true
+                                                                                                    "additionalProperties": {
+                                                                                                        "oneOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "object"
                                                                                                 },
                                                                                                 "requests": {
-                                                                                                    "x-kubernetes-preserve-unknown-fields": true
+                                                                                                    "additionalProperties": {
+                                                                                                        "oneOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "object"
                                                                                                 }
                                                                                             },
                                                                                             "type": "object"
@@ -13601,10 +13761,30 @@
                                                                                                     "x-kubernetes-list-type": "map"
                                                                                                 },
                                                                                                 "limits": {
-                                                                                                    "x-kubernetes-preserve-unknown-fields": true
+                                                                                                    "additionalProperties": {
+                                                                                                        "oneOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "object"
                                                                                                 },
                                                                                                 "requests": {
-                                                                                                    "x-kubernetes-preserve-unknown-fields": true
+                                                                                                    "additionalProperties": {
+                                                                                                        "oneOf": [
+                                                                                                            {
+                                                                                                                "type": "string"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "number"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "type": "object"
                                                                                                 }
                                                                                             },
                                                                                             "type": "object"
@@ -16140,10 +16320,30 @@
                                                                             "x-kubernetes-list-type": "map"
                                                                         },
                                                                         "limits": {
-                                                                            "x-kubernetes-preserve-unknown-fields": true
+                                                                            "additionalProperties": {
+                                                                                "oneOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "object"
                                                                         },
                                                                         "requests": {
-                                                                            "x-kubernetes-preserve-unknown-fields": true
+                                                                            "additionalProperties": {
+                                                                                "oneOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "object"
                                                                         }
                                                                     },
                                                                     "type": "object"
@@ -17154,10 +17354,30 @@
                                                                             "x-kubernetes-list-type": "map"
                                                                         },
                                                                         "limits": {
-                                                                            "x-kubernetes-preserve-unknown-fields": true
+                                                                            "additionalProperties": {
+                                                                                "oneOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "object"
                                                                         },
                                                                         "requests": {
-                                                                            "x-kubernetes-preserve-unknown-fields": true
+                                                                            "additionalProperties": {
+                                                                                "oneOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "object"
                                                                         }
                                                                     },
                                                                     "type": "object"
@@ -18178,10 +18398,30 @@
                                                                             "x-kubernetes-list-type": "map"
                                                                         },
                                                                         "limits": {
-                                                                            "x-kubernetes-preserve-unknown-fields": true
+                                                                            "additionalProperties": {
+                                                                                "oneOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "object"
                                                                         },
                                                                         "requests": {
-                                                                            "x-kubernetes-preserve-unknown-fields": true
+                                                                            "additionalProperties": {
+                                                                                "oneOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "type": "object"
                                                                         }
                                                                     },
                                                                     "type": "object"
@@ -19844,10 +20084,30 @@
                                                                 "x-kubernetes-list-type": "map"
                                                             },
                                                             "limits": {
-                                                                "x-kubernetes-preserve-unknown-fields": true
+                                                                "additionalProperties": {
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "type": "object"
                                                             },
                                                             "requests": {
-                                                                "x-kubernetes-preserve-unknown-fields": true
+                                                                "additionalProperties": {
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "type": "object"
                                                             }
                                                         },
                                                         "type": "object"
@@ -20823,10 +21083,30 @@
                                                                 "x-kubernetes-list-type": "map"
                                                             },
                                                             "limits": {
-                                                                "x-kubernetes-preserve-unknown-fields": true
+                                                                "additionalProperties": {
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "type": "object"
                                                             },
                                                             "requests": {
-                                                                "x-kubernetes-preserve-unknown-fields": true
+                                                                "additionalProperties": {
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "type": "object"
                                                             }
                                                         },
                                                         "type": "object"
@@ -21838,10 +22118,30 @@
                                                                 "x-kubernetes-list-type": "map"
                                                             },
                                                             "limits": {
-                                                                "x-kubernetes-preserve-unknown-fields": true
+                                                                "additionalProperties": {
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "type": "object"
                                                             },
                                                             "requests": {
-                                                                "x-kubernetes-preserve-unknown-fields": true
+                                                                "additionalProperties": {
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "type": "object"
                                                             }
                                                         },
                                                         "type": "object"

--- a/manifests/crds/analysis-run-crd.yaml
+++ b/manifests/crds/analysis-run-crd.yaml
@@ -1199,9 +1199,17 @@ spec:
                                                     - name
                                                     x-kubernetes-list-type: map
                                                   limits:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                   requests:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                 type: object
                                               restartPolicy:
                                                 type: string
@@ -1847,9 +1855,17 @@ spec:
                                                     - name
                                                     x-kubernetes-list-type: map
                                                   limits:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                   requests:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                 type: object
                                               restartPolicy:
                                                 type: string
@@ -2502,9 +2518,17 @@ spec:
                                                     - name
                                                     x-kubernetes-list-type: map
                                                   limits:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                   requests:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                 type: object
                                               restartPolicy:
                                                 type: string

--- a/manifests/crds/analysis-template-crd.yaml
+++ b/manifests/crds/analysis-template-crd.yaml
@@ -1195,9 +1195,17 @@ spec:
                                                     - name
                                                     x-kubernetes-list-type: map
                                                   limits:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                   requests:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                 type: object
                                               restartPolicy:
                                                 type: string
@@ -1843,9 +1851,17 @@ spec:
                                                     - name
                                                     x-kubernetes-list-type: map
                                                   limits:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                   requests:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                 type: object
                                               restartPolicy:
                                                 type: string
@@ -2498,9 +2514,17 @@ spec:
                                                     - name
                                                     x-kubernetes-list-type: map
                                                   limits:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                   requests:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                 type: object
                                               restartPolicy:
                                                 type: string

--- a/manifests/crds/cluster-analysis-template-crd.yaml
+++ b/manifests/crds/cluster-analysis-template-crd.yaml
@@ -1195,9 +1195,17 @@ spec:
                                                     - name
                                                     x-kubernetes-list-type: map
                                                   limits:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                   requests:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                 type: object
                                               restartPolicy:
                                                 type: string
@@ -1843,9 +1851,17 @@ spec:
                                                     - name
                                                     x-kubernetes-list-type: map
                                                   limits:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                   requests:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                 type: object
                                               restartPolicy:
                                                 type: string
@@ -2498,9 +2514,17 @@ spec:
                                                     - name
                                                     x-kubernetes-list-type: map
                                                   limits:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                   requests:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                 type: object
                                               restartPolicy:
                                                 type: string

--- a/manifests/crds/experiment-crd.yaml
+++ b/manifests/crds/experiment-crd.yaml
@@ -1021,9 +1021,17 @@ spec:
                                         - name
                                         x-kubernetes-list-type: map
                                       limits:
-                                        x-kubernetes-preserve-unknown-fields: true
+                                        additionalProperties:
+                                          oneOf:
+                                          - type: string
+                                          - type: number
+                                        type: object
                                       requests:
-                                        x-kubernetes-preserve-unknown-fields: true
+                                        additionalProperties:
+                                          oneOf:
+                                          - type: string
+                                          - type: number
+                                        type: object
                                     type: object
                                   restartPolicy:
                                     type: string
@@ -1669,9 +1677,17 @@ spec:
                                         - name
                                         x-kubernetes-list-type: map
                                       limits:
-                                        x-kubernetes-preserve-unknown-fields: true
+                                        additionalProperties:
+                                          oneOf:
+                                          - type: string
+                                          - type: number
+                                        type: object
                                       requests:
-                                        x-kubernetes-preserve-unknown-fields: true
+                                        additionalProperties:
+                                          oneOf:
+                                          - type: string
+                                          - type: number
+                                        type: object
                                     type: object
                                   restartPolicy:
                                     type: string
@@ -2324,9 +2340,17 @@ spec:
                                         - name
                                         x-kubernetes-list-type: map
                                       limits:
-                                        x-kubernetes-preserve-unknown-fields: true
+                                        additionalProperties:
+                                          oneOf:
+                                          - type: string
+                                          - type: number
+                                        type: object
                                       requests:
-                                        x-kubernetes-preserve-unknown-fields: true
+                                        additionalProperties:
+                                          oneOf:
+                                          - type: string
+                                          - type: number
+                                        type: object
                                     type: object
                                   restartPolicy:
                                     type: string

--- a/manifests/crds/rollout-crd.yaml
+++ b/manifests/crds/rollout-crd.yaml
@@ -1831,9 +1831,17 @@ spec:
                                   - name
                                   x-kubernetes-list-type: map
                                 limits:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    oneOf:
+                                    - type: string
+                                    - type: number
+                                  type: object
                                 requests:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    oneOf:
+                                    - type: string
+                                    - type: number
+                                  type: object
                               type: object
                             restartPolicy:
                               type: string
@@ -2479,9 +2487,17 @@ spec:
                                   - name
                                   x-kubernetes-list-type: map
                                 limits:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    oneOf:
+                                    - type: string
+                                    - type: number
+                                  type: object
                                 requests:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    oneOf:
+                                    - type: string
+                                    - type: number
+                                  type: object
                               type: object
                             restartPolicy:
                               type: string
@@ -3134,9 +3150,17 @@ spec:
                                   - name
                                   x-kubernetes-list-type: map
                                 limits:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    oneOf:
+                                    - type: string
+                                    - type: number
+                                  type: object
                                 requests:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    oneOf:
+                                    - type: string
+                                    - type: number
+                                  type: object
                               type: object
                             restartPolicy:
                               type: string

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -1200,9 +1200,17 @@ spec:
                                                     - name
                                                     x-kubernetes-list-type: map
                                                   limits:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                   requests:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                 type: object
                                               restartPolicy:
                                                 type: string
@@ -1848,9 +1856,17 @@ spec:
                                                     - name
                                                     x-kubernetes-list-type: map
                                                   limits:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                   requests:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                 type: object
                                               restartPolicy:
                                                 type: string
@@ -2503,9 +2519,17 @@ spec:
                                                     - name
                                                     x-kubernetes-list-type: map
                                                   limits:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                   requests:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                 type: object
                                               restartPolicy:
                                                 type: string
@@ -4516,9 +4540,17 @@ spec:
                                                     - name
                                                     x-kubernetes-list-type: map
                                                   limits:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                   requests:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                 type: object
                                               restartPolicy:
                                                 type: string
@@ -5164,9 +5196,17 @@ spec:
                                                     - name
                                                     x-kubernetes-list-type: map
                                                   limits:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                   requests:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                 type: object
                                               restartPolicy:
                                                 type: string
@@ -5819,9 +5859,17 @@ spec:
                                                     - name
                                                     x-kubernetes-list-type: map
                                                   limits:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                   requests:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                 type: object
                                               restartPolicy:
                                                 type: string
@@ -7707,9 +7755,17 @@ spec:
                                                     - name
                                                     x-kubernetes-list-type: map
                                                   limits:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                   requests:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                 type: object
                                               restartPolicy:
                                                 type: string
@@ -8355,9 +8411,17 @@ spec:
                                                     - name
                                                     x-kubernetes-list-type: map
                                                   limits:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                   requests:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                 type: object
                                               restartPolicy:
                                                 type: string
@@ -9010,9 +9074,17 @@ spec:
                                                     - name
                                                     x-kubernetes-list-type: map
                                                   limits:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                   requests:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      oneOf:
+                                                      - type: string
+                                                      - type: number
+                                                    type: object
                                                 type: object
                                               restartPolicy:
                                                 type: string
@@ -10724,9 +10796,17 @@ spec:
                                         - name
                                         x-kubernetes-list-type: map
                                       limits:
-                                        x-kubernetes-preserve-unknown-fields: true
+                                        additionalProperties:
+                                          oneOf:
+                                          - type: string
+                                          - type: number
+                                        type: object
                                       requests:
-                                        x-kubernetes-preserve-unknown-fields: true
+                                        additionalProperties:
+                                          oneOf:
+                                          - type: string
+                                          - type: number
+                                        type: object
                                     type: object
                                   restartPolicy:
                                     type: string
@@ -11372,9 +11452,17 @@ spec:
                                         - name
                                         x-kubernetes-list-type: map
                                       limits:
-                                        x-kubernetes-preserve-unknown-fields: true
+                                        additionalProperties:
+                                          oneOf:
+                                          - type: string
+                                          - type: number
+                                        type: object
                                       requests:
-                                        x-kubernetes-preserve-unknown-fields: true
+                                        additionalProperties:
+                                          oneOf:
+                                          - type: string
+                                          - type: number
+                                        type: object
                                     type: object
                                   restartPolicy:
                                     type: string
@@ -12027,9 +12115,17 @@ spec:
                                         - name
                                         x-kubernetes-list-type: map
                                       limits:
-                                        x-kubernetes-preserve-unknown-fields: true
+                                        additionalProperties:
+                                          oneOf:
+                                          - type: string
+                                          - type: number
+                                        type: object
                                       requests:
-                                        x-kubernetes-preserve-unknown-fields: true
+                                        additionalProperties:
+                                          oneOf:
+                                          - type: string
+                                          - type: number
+                                        type: object
                                     type: object
                                   restartPolicy:
                                     type: string
@@ -14393,9 +14489,17 @@ spec:
                                   - name
                                   x-kubernetes-list-type: map
                                 limits:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    oneOf:
+                                    - type: string
+                                    - type: number
+                                  type: object
                                 requests:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    oneOf:
+                                    - type: string
+                                    - type: number
+                                  type: object
                               type: object
                             restartPolicy:
                               type: string
@@ -15041,9 +15145,17 @@ spec:
                                   - name
                                   x-kubernetes-list-type: map
                                 limits:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    oneOf:
+                                    - type: string
+                                    - type: number
+                                  type: object
                                 requests:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    oneOf:
+                                    - type: string
+                                    - type: number
+                                  type: object
                               type: object
                             restartPolicy:
                               type: string
@@ -15696,9 +15808,17 @@ spec:
                                   - name
                                   x-kubernetes-list-type: map
                                 limits:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    oneOf:
+                                    - type: string
+                                    - type: number
+                                  type: object
                                 requests:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    oneOf:
+                                    - type: string
+                                    - type: number
+                                  type: object
                               type: object
                             restartPolicy:
                               type: string


### PR DESCRIPTION
This fix sets the expected types based on the current K8S upstream OpenAPI v3 types: https://github.com/kubernetes/kubernetes/blob/release-1.32/api/openapi-spec/v3/api__v1_openapi.json#L8637
