### PR TITLE
fix(trafficrouting): Fix rollback behavior for canary with trafficrouting and .DynamicStableScale=true

### DIFF
--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -113,7 +113,7 @@ func (c *rolloutContext) reconcileCanaryStableReplicaSet() (bool, error) {
 		// causing us to flap and scale up the stable 100 temporarily (before scaling down to 0 later).
 		// Therefore, we send c.rollout.Status.Canary.Weights so that the stable scaling happens in
 		// a *susbsequent*, follow-up reconciliation, lagging behind the setWeight and service switch.
-		_, desiredStableRSReplicaCount = replicasetutil.CalculateReplicaCountsForTrafficRoutedCanary(c.rollout, c.rollout.Status.Canary.Weights)
+		_, desiredStableRSReplicaCount = replicasetutil.CalculateReplicaCountsForTrafficRoutedCanary(c.rollout, c.newRS, c.stableRS, c.rollout.Status.Canary.Weights)
 	}
 	scaled, _, err := c.scaleReplicaSetAndRecordEvent(c.stableRS, desiredStableRSReplicaCount)
 	if err != nil {

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -967,9 +967,9 @@ func TestDynamicScalingDontIncreaseWeightWhenAborted(t *testing.T) {
 	f.run(getKey(r1, t))
 }
 
-// TestDynamicScalingDecreaseWeightAccordingToStableAvailabilityWhenAborted verifies we decrease the weight
-// to the canary depending on the availability of the stable ReplicaSet when aborting
-func TestDynamicScalingDecreaseWeightAccordingToStableAvailabilityWhenAborted(t *testing.T) {
+// TestDynamicScalingDecreaseWeightAccordingToStepWeightsAvailabilityWhenAborted verifies we decrease the weight
+// to the canary depending on the weight in previous Step when aborting
+func TestDynamicScalingDecreaseWeightAccordingToStepWeightsAvailabilityWhenAborted(t *testing.T) {
 	f := newFixture(t)
 	defer f.Close()
 
@@ -977,6 +977,75 @@ func TestDynamicScalingDecreaseWeightAccordingToStableAvailabilityWhenAborted(t 
 		{
 			SetWeight: pointer.Int32Ptr(50),
 		},
+		{
+			Pause: &v1alpha1.RolloutPause{},
+		},
+	}
+	r1 := newCanaryRollout("foo", 5, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(1))
+	r1.Spec.Strategy.Canary.DynamicStableScale = true
+	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
+		SMI: &v1alpha1.SMITrafficRouting{},
+	}
+	r1.Spec.Strategy.Canary.CanaryService = "canary"
+	r1.Spec.Strategy.Canary.StableService = "stable"
+	r1.Status.ReadyReplicas = 5
+	r1.Status.AvailableReplicas = 5
+	r1.Status.Abort = true
+	r1.Status.AbortedAt = &metav1.Time{Time: time.Now().Add(-1 * time.Minute)}
+	r2 := bumpVersion(r1)
+
+	rs1 := newReplicaSetWithStatus(r1, 5, 3)
+	rs2 := newReplicaSetWithStatus(r2, 4, 4)
+
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	canarySelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}
+	stableSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}
+	canarySvc := newService("canary", 80, canarySelector, r1)
+	stableSvc := newService("stable", 80, stableSelector, r1)
+	r2.Status.StableRS = rs1PodHash
+	r2.Status.Canary.Weights = &v1alpha1.TrafficWeights{
+		Canary: v1alpha1.WeightDestination{
+			Weight:          100,
+			ServiceName:     "canary",
+			PodTemplateHash: rs2PodHash,
+		},
+		Stable: v1alpha1.WeightDestination{
+			Weight:          0,
+			ServiceName:     "stable",
+			PodTemplateHash: rs1PodHash,
+		},
+	}
+
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2, canarySvc, stableSvc)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2)
+
+	f.expectPatchRolloutAction(r2)
+	f.expectUpdateReplicaSetAction(rs1)
+
+	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, additionalDestinations ...v1alpha1.WeightDestination) error {
+		// make sure SetWeight was called with correct value
+		assert.Equal(t, int32(50), desiredWeight)
+		return nil
+	})
+	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("RemoveManagedRoutes", mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(pointer.BoolPtr(true), nil)
+	f.run(getKey(r1, t))
+}
+
+// TestDynamicScalingDecreaseWeightAccordingToStableAvailabilityWhenAborted verifies we decrease the weight
+// to the canary depending on the availability of the stable ReplicaSet when aborting
+func TestDynamicScalingDecreaseWeightAccordingToStableAvailabilityWhenAborted(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{
 		{
 			Pause: &v1alpha1.RolloutPause{},
 		},

--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -652,8 +652,8 @@ func (s *CanarySuite) TestCanaryDynamicStableScale() {
 		AbortRollout().
 		MarkPodsReady("1", 2). // mark 2 stable pods as ready (3/4 stable are ready)
 		WaitForRevisionPodCount("2", 1).
+		WaitForRevisionPodCount("1", 4).
 		Then().
-		ExpectRevisionPodCount("1", 4).
 		// Assert that the canary service selector is still not set to stable rs because of dynamic stable scale still in progress
 		Assert(func(t *fixtures.Then) {
 			canarySvc, stableSvc := t.GetServices()

--- a/utils/replicaset/canary_test.go
+++ b/utils/replicaset/canary_test.go
@@ -755,7 +755,7 @@ func TestCalculateReplicaCountsForCanary(t *testing.T) {
 			}
 			var newRSReplicaCount, stableRSReplicaCount int32
 			if test.trafficRouting != nil {
-				newRSReplicaCount, stableRSReplicaCount = CalculateReplicaCountsForTrafficRoutedCanary(rollout, nil)
+				newRSReplicaCount, stableRSReplicaCount = CalculateReplicaCountsForTrafficRoutedCanary(rollout, nil, nil, nil)
 			} else {
 				newRSReplicaCount, stableRSReplicaCount = CalculateReplicaCountsForBasicCanary(rollout, canaryRS, stableRS, []*appsv1.ReplicaSet{test.olderRS})
 			}
@@ -863,7 +863,7 @@ func TestCalculateReplicaCountsForNewDeployment(t *testing.T) {
 func TestCalculateReplicaCountsForCanaryTrafficRouting(t *testing.T) {
 	rollout := newRollout(10, 10, intstr.FromInt(0), intstr.FromInt(1), "canary", "stable", nil, nil)
 	rollout.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
-	newRSReplicaCount, stableRSReplicaCount := CalculateReplicaCountsForTrafficRoutedCanary(rollout, rollout.Status.Canary.Weights)
+	newRSReplicaCount, stableRSReplicaCount := CalculateReplicaCountsForTrafficRoutedCanary(rollout, nil, nil, rollout.Status.Canary.Weights)
 	assert.Equal(t, int32(1), newRSReplicaCount)
 	assert.Equal(t, int32(10), stableRSReplicaCount)
 }
@@ -882,7 +882,7 @@ func TestCalculateReplicaCountsForCanaryTrafficRoutingDynamicScale(t *testing.T)
 				Weight: 90,
 			},
 		}
-		newRSReplicaCount, stableRSReplicaCount := CalculateReplicaCountsForTrafficRoutedCanary(rollout, &weights)
+		newRSReplicaCount, stableRSReplicaCount := CalculateReplicaCountsForTrafficRoutedCanary(rollout, nil, nil, &weights)
 		assert.Equal(t, int32(1), newRSReplicaCount)
 		assert.Equal(t, int32(9), stableRSReplicaCount)
 	}
@@ -899,7 +899,7 @@ func TestCalculateReplicaCountsForCanaryTrafficRoutingDynamicScale(t *testing.T)
 				Weight: 90,
 			},
 		}
-		newRSReplicaCount, stableRSReplicaCount := CalculateReplicaCountsForTrafficRoutedCanary(rollout, &weights)
+		newRSReplicaCount, stableRSReplicaCount := CalculateReplicaCountsForTrafficRoutedCanary(rollout, nil, nil, &weights)
 		assert.Equal(t, int32(2), newRSReplicaCount)
 		assert.Equal(t, int32(9), stableRSReplicaCount)
 	}
@@ -917,7 +917,7 @@ func TestCalculateReplicaCountsForCanaryTrafficRoutingDynamicScale(t *testing.T)
 				Weight: 80,
 			},
 		}
-		newRSReplicaCount, stableRSReplicaCount := CalculateReplicaCountsForTrafficRoutedCanary(rollout, &weights)
+		newRSReplicaCount, stableRSReplicaCount := CalculateReplicaCountsForTrafficRoutedCanary(rollout, nil, nil, &weights)
 		assert.Equal(t, int32(2), newRSReplicaCount)
 		assert.Equal(t, int32(10), stableRSReplicaCount)
 	}
@@ -935,8 +935,115 @@ func TestCalculateReplicaCountsForCanaryTrafficRoutingDynamicScale(t *testing.T)
 				Weight: 90,
 			},
 		}
-		newRSReplicaCount, stableRSReplicaCount := CalculateReplicaCountsForTrafficRoutedCanary(rollout, &weights)
+		newRSReplicaCount, stableRSReplicaCount := CalculateReplicaCountsForTrafficRoutedCanary(rollout, nil, nil, &weights)
 		assert.Equal(t, int32(1), newRSReplicaCount)
+		assert.Equal(t, int32(10), stableRSReplicaCount)
+	}
+}
+
+func TestCalculateReplicaCountsForCanaryTrafficRoutingDynamicScaleBasedOnRSStatus(t *testing.T) {
+
+	{
+		// Should scale stable replica up depending on next expected canary downscale step
+		// E.g. if next step is to scale canary down to 2 and we have 10 replicas, we should scale stable up to 8
+		rollout := newRollout(10, 20, intstr.FromInt(0), intstr.FromInt(1), "canary", "stable", nil, nil)
+		rollout.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
+		rollout.Spec.Strategy.Canary.DynamicStableScale = true
+		rollout.Status.Abort = true
+		rollout.Spec.Strategy.Canary.Steps = append(rollout.Spec.Strategy.Canary.Steps, v1alpha1.CanaryStep{
+			SetWeight: pointer.Int32Ptr(60),
+		})
+		weights := v1alpha1.TrafficWeights{
+			Canary: v1alpha1.WeightDestination{
+				Weight: 60,
+			},
+			Stable: v1alpha1.WeightDestination{
+				Weight: 40,
+			},
+		}
+
+		stableRS := newRS("stable", 4, 4)
+		canaryRS := newRS("canary", 6, 6)
+
+		newRSReplicaCount, stableRSReplicaCount := CalculateReplicaCountsForTrafficRoutedCanary(rollout, canaryRS, stableRS, &weights)
+		assert.Equal(t, int32(6), newRSReplicaCount)
+		assert.Equal(t, int32(8), stableRSReplicaCount)
+	}
+
+	{
+		// Should scale stable replica up depending on available canary replicas
+		// if actual number of canaries is less than expected.
+		rollout := newRollout(10, 20, intstr.FromInt(0), intstr.FromInt(1), "canary", "stable", nil, nil)
+		rollout.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
+		rollout.Spec.Strategy.Canary.DynamicStableScale = true
+		rollout.Status.Abort = true
+		rollout.Spec.Strategy.Canary.Steps = append(rollout.Spec.Strategy.Canary.Steps, v1alpha1.CanaryStep{
+			SetWeight: pointer.Int32Ptr(60),
+		})
+		weights := v1alpha1.TrafficWeights{
+			Canary: v1alpha1.WeightDestination{
+				Weight: 60,
+			},
+			Stable: v1alpha1.WeightDestination{
+				Weight: 40,
+			},
+		}
+
+		stableRS := newRS("stable", 4, 4)
+		canaryRS := newRS("canary", 1, 1)
+
+		newRSReplicaCount, stableRSReplicaCount := CalculateReplicaCountsForTrafficRoutedCanary(rollout, canaryRS, stableRS, &weights)
+		assert.Equal(t, int32(6), newRSReplicaCount)
+		assert.Equal(t, int32(8), stableRSReplicaCount)
+	}
+
+	{
+		// Should scale stable replica up depending on available stable replicas
+		rollout := newRollout(10, 20, intstr.FromInt(0), intstr.FromInt(1), "canary", "stable", nil, nil)
+		rollout.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
+		rollout.Spec.Strategy.Canary.DynamicStableScale = true
+		rollout.Status.Abort = true
+		rollout.Spec.Strategy.Canary.Steps = append(rollout.Spec.Strategy.Canary.Steps, v1alpha1.CanaryStep{
+			SetWeight: pointer.Int32Ptr(60),
+		})
+		weights := v1alpha1.TrafficWeights{
+			Canary: v1alpha1.WeightDestination{
+				Weight: 60,
+			},
+			Stable: v1alpha1.WeightDestination{
+				Weight: 40,
+			},
+		}
+
+		stableRS := newRS("stable", 8, 4)
+		canaryRS := newRS("canary", 2, 2)
+
+		newRSReplicaCount, stableRSReplicaCount := CalculateReplicaCountsForTrafficRoutedCanary(rollout, canaryRS, stableRS, &weights)
+		assert.Equal(t, int32(6), newRSReplicaCount)
+		assert.Equal(t, int32(8), stableRSReplicaCount)
+	}
+
+	{
+		// Should scale stable up as if canaries are scaled down to 0
+		// if stable and canary replicas not passed
+		rollout := newRollout(10, 20, intstr.FromInt(0), intstr.FromInt(1), "canary", "stable", nil, nil)
+		rollout.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
+		rollout.Spec.Strategy.Canary.DynamicStableScale = true
+		rollout.Status.Abort = true
+		rollout.Spec.Strategy.Canary.Steps = append(rollout.Spec.Strategy.Canary.Steps, v1alpha1.CanaryStep{
+			SetWeight: pointer.Int32Ptr(60),
+		})
+		weights := v1alpha1.TrafficWeights{
+			Canary: v1alpha1.WeightDestination{
+				Weight: 60,
+			},
+			Stable: v1alpha1.WeightDestination{
+				Weight: 40,
+			},
+		}
+
+		newRSReplicaCount, stableRSReplicaCount := CalculateReplicaCountsForTrafficRoutedCanary(rollout, nil, nil, &weights)
+		assert.Equal(t, int32(6), newRSReplicaCount)
 		assert.Equal(t, int32(10), stableRSReplicaCount)
 	}
 }
@@ -1521,7 +1628,7 @@ func TestGetCanaryReplicasOrWeight(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotReplicas, gotWeight := GetCanaryReplicasOrWeight(tt.rollout)
+			gotReplicas, gotWeight := GetCanaryReplicasOrWeight(tt.rollout, nil, nil)
 			assert.Equalf(t, tt.replicas, gotReplicas, "GetCanaryReplicasOrWeight(%v)", tt.rollout)
 			assert.Equalf(t, tt.weight, gotWeight, "GetCanaryReplicasOrWeight(%v)", tt.rollout)
 		})

--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -284,7 +284,7 @@ func NewRSNewReplicas(rollout *v1alpha1.Rollout, allRSs []*appsv1.ReplicaSet, ne
 			otherRSs := GetOtherRSs(rollout, newRS, stableRS, allRSs)
 			newRSReplicaCount, _ = CalculateReplicaCountsForBasicCanary(rollout, newRS, stableRS, otherRSs)
 		} else {
-			newRSReplicaCount, _ = CalculateReplicaCountsForTrafficRoutedCanary(rollout, weights)
+			newRSReplicaCount, _ = CalculateReplicaCountsForTrafficRoutedCanary(rollout, newRS, stableRS, weights)
 		}
 		return newRSReplicaCount, nil
 	}


### PR DESCRIPTION
Currently, in case of rollback controller always scales stable up to 100%, while dynamically scaling canary down. If rollback or abort occurs on later steps of rollout, it can cause various issues. For example, our deployment has several hundreds of pods, and rollback can cause surge hundreds of new pods.

This fix ensures that when a rollout is aborted and `DynamicStableScale` is enabled, the StableRS dynamically scales up to 100% as NewRS scales down based on steps in reverse order.
<br/><br/>
By spec, `SetCanaryScale` used to diverge from scaling canary according to traffic weights https://argo-rollouts.readthedocs.io/en/stable/features/canary/#dynamic-canary-scale-with-traffic-routing. Therefore, I expect it to be used only as an intermediate step in rollout that can be ignored.
Attempting to guess and handle all the combinations of setCanaryScale with matchWeights/weights/replicas is complex and I don't have a robust solution at hand (especially without actual use-cases).
<br/><br/>
Since I don't have comprehensive understanding of the argo-rollouts architecture, this fix might be somewhat clunky or suboptimal. Please feel free to suggest a better implementation.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [X] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [X] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
