### PR TITLE
fix(trafficrouting): patch VirtualService when there is only one named route

### DIFF
--- a/rollout/trafficrouting/istio/istio.go
+++ b/rollout/trafficrouting/istio/istio.go
@@ -904,8 +904,13 @@ func (r *Reconciler) VerifyWeight(desiredWeight int32, additionalDestinations ..
 // getHttpRouteIndexesToPatch returns array indices of the httpRoutes which need to be patched when updating weights
 func getHttpRouteIndexesToPatch(routeNames []string, httpRoutes []VirtualServiceHTTPRoute) ([]int, error) {
 	//We have no routes listed in spec.strategy.canary.trafficRouting.istio.virtualService.routes so find index
-	//of the first empty named route
+	//of the first empty named route.
+	// If there is only one HTTPRoute defined in the VirtualService, then we can patch it without a name.
 	if len(routeNames) == 0 {
+		if len(httpRoutes) == 1 {
+			return []int{0}, nil
+		}
+
 		for i, route := range httpRoutes {
 			if route.Name == "" {
 				return []int{i}, nil

--- a/rollout/trafficrouting/istio/istio_test.go
+++ b/rollout/trafficrouting/istio/istio_test.go
@@ -3156,3 +3156,45 @@ spec:
 	actions := client.Actions()
 	assert.Len(t, actions, 0)
 }
+
+func TestGetHttpRouteIndexesToPatch(t *testing.T) {
+
+	// Test case when the rollout has no managed routes defined
+	httpRoutes := []VirtualServiceHTTPRoute{
+		{Name: "foo", Match: nil},
+		{Name: "", Match: nil},
+	}
+
+	indexes, err := getHttpRouteIndexesToPatch([]string{}, httpRoutes)
+	assert.NoError(t, err)
+	assert.Equal(t, []int{1}, indexes)
+
+	// Test case when the rollout has managed routes defined
+	httpRoutes = []VirtualServiceHTTPRoute{
+		{Name: "foo", Match: nil},
+		{Name: "bar", Match: nil},
+	}
+
+	indexes, err = getHttpRouteIndexesToPatch([]string{"foo", "bar"}, httpRoutes)
+	assert.NoError(t, err)
+	assert.Equal(t, []int{0, 1}, indexes)
+
+	// Test case when the rollout has only one managed route defined
+	httpRoutes = []VirtualServiceHTTPRoute{
+		{Name: "foo", Match: nil},
+	}
+
+	indexes, err = getHttpRouteIndexesToPatch([]string{}, httpRoutes)
+	assert.NoError(t, err)
+	assert.Equal(t, []int{0}, indexes)
+
+	// Test case when http route is not found
+	httpRoutes = []VirtualServiceHTTPRoute{
+		{Name: "foo", Match: nil},
+	}
+
+	indexes, err = getHttpRouteIndexesToPatch([]string{"bar"}, httpRoutes)
+	assert.Equal(t, "HTTP Route 'bar' is not found in the defined Virtual Service.", err.Error())
+	assert.Nil(t, indexes)
+
+}

--- a/rollout/trafficrouting/istio/istio_test.go
+++ b/rollout/trafficrouting/istio/istio_test.go
@@ -3158,43 +3158,45 @@ spec:
 }
 
 func TestGetHttpRouteIndexesToPatch(t *testing.T) {
+	t.Run("the rollout has no managed routes defined", func(t *testing.T) {
+		httpRoutes := []VirtualServiceHTTPRoute{
+			{Name: "foo", Match: nil},
+			{Name: "", Match: nil},
+		}
 
-	// Test case when the rollout has no managed routes defined
-	httpRoutes := []VirtualServiceHTTPRoute{
-		{Name: "foo", Match: nil},
-		{Name: "", Match: nil},
-	}
+		indexes, err := getHttpRouteIndexesToPatch([]string{}, httpRoutes)
+		assert.NoError(t, err)
+		assert.Equal(t, []int{1}, indexes)
+	})
 
-	indexes, err := getHttpRouteIndexesToPatch([]string{}, httpRoutes)
-	assert.NoError(t, err)
-	assert.Equal(t, []int{1}, indexes)
+	t.Run("the rollout has managed routes defined", func(t *testing.T) {
+		httpRoutes := []VirtualServiceHTTPRoute{
+			{Name: "foo", Match: nil},
+			{Name: "bar", Match: nil},
+		}
 
-	// Test case when the rollout has managed routes defined
-	httpRoutes = []VirtualServiceHTTPRoute{
-		{Name: "foo", Match: nil},
-		{Name: "bar", Match: nil},
-	}
+		indexes, err := getHttpRouteIndexesToPatch([]string{"foo", "bar"}, httpRoutes)
+		assert.NoError(t, err)
+		assert.Equal(t, []int{0, 1}, indexes)
+	})
 
-	indexes, err = getHttpRouteIndexesToPatch([]string{"foo", "bar"}, httpRoutes)
-	assert.NoError(t, err)
-	assert.Equal(t, []int{0, 1}, indexes)
+	t.Run("the rollout has only one managed route defined", func(t *testing.T) {
+		httpRoutes := []VirtualServiceHTTPRoute{
+			{Name: "foo", Match: nil},
+		}
 
-	// Test case when the rollout has only one managed route defined
-	httpRoutes = []VirtualServiceHTTPRoute{
-		{Name: "foo", Match: nil},
-	}
+		indexes, err := getHttpRouteIndexesToPatch([]string{}, httpRoutes)
+		assert.NoError(t, err)
+		assert.Equal(t, []int{0}, indexes)
+	})
 
-	indexes, err = getHttpRouteIndexesToPatch([]string{}, httpRoutes)
-	assert.NoError(t, err)
-	assert.Equal(t, []int{0}, indexes)
+	t.Run("http route is not found", func(t *testing.T) {
+		httpRoutes := []VirtualServiceHTTPRoute{
+			{Name: "foo", Match: nil},
+		}
 
-	// Test case when http route is not found
-	httpRoutes = []VirtualServiceHTTPRoute{
-		{Name: "foo", Match: nil},
-	}
-
-	indexes, err = getHttpRouteIndexesToPatch([]string{"bar"}, httpRoutes)
-	assert.Equal(t, "HTTP Route 'bar' is not found in the defined Virtual Service.", err.Error())
-	assert.Nil(t, indexes)
-
+		indexes, err := getHttpRouteIndexesToPatch([]string{"bar"}, httpRoutes)
+		assert.Equal(t, "HTTP Route 'bar' is not found in the defined Virtual Service.", err.Error())
+		assert.Nil(t, indexes)
+	})
 }


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-rollouts/issues/3884

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
