### PR TITLE
fix!: subresource scale selector changed for traffic routed canary

### DIFF
--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -361,7 +361,7 @@ func (c *rolloutContext) syncRolloutStatusCanary() error {
 	newStatus.HPAReplicas = replicasetutil.GetActualReplicaCountForReplicaSets(c.allRSs)
 	newStatus.Selector = metav1.FormatLabelSelector(c.rollout.Spec.Selector)
 
-	if c.rollout.Spec.Strategy.Canary != nil && !c.rollout.Spec.Strategy.Canary.DynamicStableScale && c.stableRS != nil {
+	if c.rollout.Spec.Strategy.Canary != nil && c.rollout.Spec.Strategy.Canary.TrafficRouting != nil && !c.rollout.Spec.Strategy.Canary.DynamicStableScale && c.stableRS != nil {
 		newStatus.Selector = metav1.FormatLabelSelector(c.stableRS.Spec.Selector)
 	}
 

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -362,6 +362,11 @@ func (c *rolloutContext) syncRolloutStatusCanary() error {
 	newStatus.Selector = metav1.FormatLabelSelector(c.rollout.Spec.Selector)
 
 	if c.rollout.Spec.Strategy.Canary != nil && c.rollout.Spec.Strategy.Canary.TrafficRouting != nil && !c.rollout.Spec.Strategy.Canary.DynamicStableScale && c.stableRS != nil {
+		// When using traffic routed canary without scaling down the stable replicaset, the number of pods
+		// selected by the rollout selector will be up to twice the amount of desired spec.replicas.
+		// We update the selector to select the stable pods since the Scale subresource expects a
+		// label that queries over pods that should match the replicas count, because that is the number
+		// of pods that will be receiving traffic.
 		newStatus.Selector = metav1.FormatLabelSelector(c.stableRS.Spec.Selector)
 	}
 

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -360,6 +360,11 @@ func (c *rolloutContext) syncRolloutStatusCanary() error {
 	newStatus.AvailableReplicas = replicasetutil.GetAvailableReplicaCountForReplicaSets(c.allRSs)
 	newStatus.HPAReplicas = replicasetutil.GetActualReplicaCountForReplicaSets(c.allRSs)
 	newStatus.Selector = metav1.FormatLabelSelector(c.rollout.Spec.Selector)
+
+	if c.rollout.Spec.Strategy.Canary != nil && !c.rollout.Spec.Strategy.Canary.DynamicStableScale && c.stableRS != nil {
+		newStatus.Selector = metav1.FormatLabelSelector(c.stableRS.Spec.Selector)
+	}
+
 	newStatus.Canary.StablePingPong = c.rollout.Status.Canary.StablePingPong
 	newStatus.Canary.StepPluginStatuses = c.rollout.Status.Canary.StepPluginStatuses
 	c.stepPluginContext.updateStatus(&newStatus)

--- a/rollout/service_test.go
+++ b/rollout/service_test.go
@@ -495,10 +495,14 @@ func TestCanaryAWSVerifyTargetGroupsNotYetReady(t *testing.T) {
 	f.ingressLister = append(f.ingressLister, ingressutil.NewLegacyIngress(ing))
 
 	f.expectGetEndpointsAction(ep)
+	rolloutPatchIndex := f.expectPatchRolloutAction(r2)
 	f.run(getKey(r2, t))
 	f.assertEvents([]string{
 		conditions.TargetGroupUnverifiedReason,
 	})
+	patch := f.getPatchedRollout(rolloutPatchIndex)
+	expectedPatch := `{"status":{"selector":"foo=bar,rollouts-pod-template-hash=58c48fdff5"}}`
+	assert.JSONEq(t, expectedPatch, patch)
 }
 
 // TestCanaryAWSVerifyTargetGroupsReady verifies we proceed with scale down of old
@@ -595,11 +599,16 @@ func TestCanaryAWSVerifyTargetGroupsReady(t *testing.T) {
 
 	f.expectGetEndpointsAction(ep)
 	scaleDownRSIndex := f.expectPatchReplicaSetAction(rs1)
+
+	rolloutPatchIndex := f.expectPatchRolloutAction(r2)
 	f.run(getKey(r2, t))
 	f.verifyPatchedReplicaSet(scaleDownRSIndex, 30)
 	f.assertEvents([]string{
 		conditions.TargetGroupVerifiedReason,
 	})
+	patch := f.getPatchedRollout(rolloutPatchIndex)
+	expectedPatch := `{"status":{"selector":"foo=bar,rollouts-pod-template-hash=58c48fdff5"}}`
+	assert.JSONEq(t, expectedPatch, patch)
 }
 
 // TestCanaryAWSVerifyTargetGroupsSkip verifies we skip unnecessary verification if scaledown
@@ -657,8 +666,12 @@ func TestCanaryAWSVerifyTargetGroupsSkip(t *testing.T) {
 	f.serviceLister = append(f.serviceLister, rootSvc, canarySvc, stableSvc)
 	f.ingressLister = append(f.ingressLister, ingressutil.NewLegacyIngress(ing))
 
+	patchIndex := f.expectPatchRolloutAction(r2)
 	f.run(getKey(r2, t)) // there should be no api calls
 	f.assertEvents(nil)
+
+	patch := f.getPatchedRollout(patchIndex)
+	assert.Equal(t, "{\"status\":{\"selector\":\"foo=bar,rollouts-pod-template-hash=58c48fdff5\"}}", patch)
 }
 
 // TestShouldVerifyTargetGroups returns whether or not we should verify the target group

--- a/rollout/service_test.go
+++ b/rollout/service_test.go
@@ -671,7 +671,8 @@ func TestCanaryAWSVerifyTargetGroupsSkip(t *testing.T) {
 	f.assertEvents(nil)
 
 	patch := f.getPatchedRollout(patchIndex)
-	assert.Equal(t, "{\"status\":{\"selector\":\"foo=bar,rollouts-pod-template-hash=58c48fdff5\"}}", patch)
+	expectedPatch := `{"status":{"selector":"foo=bar,rollouts-pod-template-hash=58c48fdff5"}}`
+	assert.Equal(t, expectedPatch, patch)
 }
 
 // TestShouldVerifyTargetGroups returns whether or not we should verify the target group

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -846,7 +846,7 @@ func TestCanaryWithTrafficRoutingAddScaleDownDelay(t *testing.T) {
 	f.verifyPatchedReplicaSet(rs1Patch, 30)
 	updatedRollout := f.getPatchedRollout(rolloutPatchIndex)
 	expectedRolloutPatch := `{"status":{"selector":"foo=bar,rollouts-pod-template-hash=58c48fdff5"}}`
-	assert.JSONEq(t, expectedRolloutPatch, string(updatedRollout))
+	assert.JSONEq(t, expectedRolloutPatch, updatedRollout)
 }
 
 // Verifies with a canary using traffic routing, we scale down old ReplicaSets which exceed our limit

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -839,10 +839,14 @@ func TestCanaryWithTrafficRoutingAddScaleDownDelay(t *testing.T) {
 	f.rolloutLister = append(f.rolloutLister, r2)
 	f.objects = append(f.objects, r2)
 
-	rs1Patch := f.expectPatchReplicaSetAction(rs1) // set scale-down-deadline annotation
+	rs1Patch := f.expectPatchReplicaSetAction(rs1)      // set scale-down-deadline annotation
+	rolloutPatchIndex := f.expectPatchRolloutAction(r2) // patch to update rollout status, hpa selector
 	f.run(getKey(r2, t))
 
 	f.verifyPatchedReplicaSet(rs1Patch, 30)
+	updatedRollout := f.getPatchedRollout(rolloutPatchIndex)
+	expectedRolloutPatch := `{"status":{"selector":"foo=bar,rollouts-pod-template-hash=58c48fdff5"}}`
+	assert.JSONEq(t, expectedRolloutPatch, string(updatedRollout))
 }
 
 // Verifies with a canary using traffic routing, we scale down old ReplicaSets which exceed our limit


### PR DESCRIPTION
BREAKING CHANGE

We are changing rollouts `.status.selector` field to report only the stable replicaset for traffic routed canaries that do not use dynamicStableScale. This is needed in order to be able to use HPA's reliably. A little explanation on how HPA. calculate desired pods. There are two methods and formulas for calculating desired pods counts we will be focusing on `Value` type metrics.

The formula for `Value` type metrics is as follows `desiredReplicas = ceil[currentReplicas * ( currentMetricValue / desiredMetricValue )]` The `currentReplicas` count comes from the selector defined in `.status.selector` for Argo Rollouts. Before we merge this PR this would be all pods under the Rollout. This causes issues because as we shift traffic to the desired state we end up with a whole bunch of pods not taking any traffic. In theory the number of pods taking traffic will always be equal to `.spec.replicas` which is also the same value as the stable replicaset, therefore we should report to the HPA the number of pods behind the stable replicaset as a proxy to `.spec.replicas`.

This change does have the possibility to affect your current HPA configurations. You should make sure that you understand the new behavior and that it works with your HPA's metrics. Chances are high that what you currently have configured is actually broken due to this issue.

Two examples before and after of the formula:

Before this PR
```
.spec.replicas = 10
setWeight = 50
desiredMetricValue = 50
currentMetricValue = 50
canaryPodCount = 5
stablePodCont = 10
 
desiredReplicas = ceil[currentReplicas * ( currentMetricValue / desiredMetricValue )]
15 = ceil[ (10 + 5) * ( 50 / 50) ]

Here we would want to scale up to 15 pods incorrectly.
```

After this PR
```
.spec.replicas = 10
setWeight = 50
desiredMetricValue = 50
currentMetricValue = 50
canaryPodCount = 5
stablePodCont = 10
 
desiredReplicas = ceil[currentReplicas * ( currentMetricValue / desiredMetricValue )]
10 = ceil[ (10) * ( 50 / 50) ]

Here we keep the pod count at 10 correctly.
```

This is a simplified example due to the dynamic nature of shifting weights during a rollout and metrics changing during those shifts. However, this new behavior is more correct and allows you to construct a metric that is more reliable.

There is also an assumption that all pods are taking traffic according to their weight. If you detach the number of pods from the weight by using setCanaryScale your risk affecting scaling again.