### PR TITLE
fix: check ephemeral metadata is set before delete

### DIFF
--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -640,18 +640,26 @@ func SyncEphemeralPodMetadata(metadata *metav1.ObjectMeta, existingPodMetadata, 
 	if existingPodMetadata != nil {
 		for k := range existingPodMetadata.Annotations {
 			if desiredPodMetadata == nil || !isMetadataStillDesired(k, desiredPodMetadata.Annotations) {
-				if metadata.Annotations != nil {
-					delete(metadata.Annotations, k)
-					modified = true
+				if metadata.Annotations == nil {
+					continue
 				}
+				if _, ok := metadata.Annotations[k]; !ok {
+					continue
+				}
+				delete(metadata.Annotations, k)
+				modified = true
 			}
 		}
 		for k := range existingPodMetadata.Labels {
 			if desiredPodMetadata == nil || !isMetadataStillDesired(k, desiredPodMetadata.Labels) {
-				if metadata.Labels != nil {
-					delete(metadata.Labels, k)
-					modified = true
+				if metadata.Labels == nil {
+					continue
 				}
+				if _, ok := metadata.Labels[k]; !ok {
+					continue
+				}
+				delete(metadata.Labels, k)
+				modified = true
 			}
 		}
 	}

--- a/utils/replicaset/canary_test.go
+++ b/utils/replicaset/canary_test.go
@@ -1339,23 +1339,19 @@ func TestSyncEphemeralPodMetadata(t *testing.T) {
 			"ddd": "444",
 		},
 	}
-	{
-		// verify modified is false if there are no changes
+	t.Run("verify modified is false if there are no changes", func(t *testing.T) {
 		newMetadata, modified := SyncEphemeralPodMetadata(&meta, &existing, &existing)
 		assert.False(t, modified)
 		assert.Equal(t, meta, *newMetadata)
-	}
-	{
-		// verify modified is false if there are no actual deletions
-		desired := existing.DeepCopy()
-		existing.Labels["foo"] = "bar"
-		newMetadata, modified := SyncEphemeralPodMetadata(&meta, &existing, desired)
+	})
+	t.Run("verify modified is false if there are no actual deletions", func(t *testing.T) {
+		existingWithExtraLabel := existing.DeepCopy()
+		existingWithExtraLabel.Labels["foo"] = "bar"
+		newMetadata, modified := SyncEphemeralPodMetadata(&meta, existingWithExtraLabel, &existing)
 		assert.False(t, modified)
 		assert.Equal(t, meta, *newMetadata)
-		delete(existing.Labels, "foo")
-	}
-	{
-		// verify we don't touch metadata that we did not inject ourselves
+	})
+	t.Run("verify we don't touch metadata that we did not inject ourselves", func(t *testing.T) {
 		desired := v1alpha1.PodTemplateMetadata{
 			Labels: map[string]string{
 				"aaa": "222",
@@ -1365,7 +1361,6 @@ func TestSyncEphemeralPodMetadata(t *testing.T) {
 			},
 		}
 		newMetadata, modified := SyncEphemeralPodMetadata(&meta, &existing, &desired)
-		assert.True(t, modified)
 		expected := metav1.ObjectMeta{
 			Labels: map[string]string{
 				"aaa":    "222",
@@ -1376,8 +1371,9 @@ func TestSyncEphemeralPodMetadata(t *testing.T) {
 				"do-not": "touch",
 			},
 		}
+		assert.True(t, modified)
 		assert.Equal(t, expected, *newMetadata)
-	}
+	})
 }
 
 func TestGetReplicasForScaleDown(t *testing.T) {

--- a/utils/replicaset/canary_test.go
+++ b/utils/replicaset/canary_test.go
@@ -1346,6 +1346,15 @@ func TestSyncEphemeralPodMetadata(t *testing.T) {
 		assert.Equal(t, meta, *newMetadata)
 	}
 	{
+		// verify modified is false if there are no actual deletions
+		desired := existing.DeepCopy()
+		existing.Labels["foo"] = "bar"
+		newMetadata, modified := SyncEphemeralPodMetadata(&meta, &existing, desired)
+		assert.False(t, modified)
+		assert.Equal(t, meta, *newMetadata)
+		delete(existing.Labels, "foo")
+	}
+	{
 		// verify we don't touch metadata that we did not inject ourselves
 		desired := v1alpha1.PodTemplateMetadata{
 			Labels: map[string]string{
@@ -1367,10 +1376,8 @@ func TestSyncEphemeralPodMetadata(t *testing.T) {
 				"do-not": "touch",
 			},
 		}
-		assert.True(t, modified)
 		assert.Equal(t, expected, *newMetadata)
 	}
-
 }
 
 func TestGetReplicasForScaleDown(t *testing.T) {


### PR DESCRIPTION
We're seeing issues with rollout sync failing due to errors like this:
```
roCtx.reconcile err Operation cannot be fulfilled on pods \"REDACTED\": the object has been modified; please apply your changes to the latest version and try again"
```

It seems that we're trying to delete the metadata on every pod every sync, even if the pod doesn't have the keys. This means that in environments with high pod churn, this loop can get stuck for a very long time. This simply adds a check to make sure the key is actually present in the metadata before we delete it and mark it as modified.

Before the fix with the new test:
```
go test ./utils/replicaset/...
--- FAIL: TestSyncEphemeralPodMetadata (0.00s)
    canary_test.go:1353:
        	Error Trace:	/Users/jrodgers/argo-rollouts/utils/replicaset/canary_test.go:1353
        	Error:      	Should be false
        	Test:       	TestSyncEphemeralPodMetadata
time="2025-01-30T13:43:28-08:00" level=warning msg="Failed to determine existing ephemeral metadata from annotation: foo"
time="2025-01-30T13:43:28-08:00" level=info msg="ComputePodTemplateHash hash changed (new hash: 6c8776dbbb, old hash: fcb6c6ff9)" namespace=default rollout=red
time="2025-01-30T13:43:28-08:00" level=info msg="Pod template change detected (new: 8657b54cf, old: different-hash)" namespace=default rollout=nginx
time="2025-01-30T13:43:28-08:00" level=info msg="Canary steps change detected (new: 5ffbfbbd64, old: different-hash)" namespace=default rollout=nginx
time="2025-01-30T13:43:28-08:00" level=warning msg="Unable to convert ReplicaSet revision to int: strconv.Atoi: parsing \"not-an-int\": invalid syntax" ReplicaSet= namespace= rollout=ro
time="2025-01-30T13:43:28-08:00" level=warning msg="Unable to convert ReplicaSet revision to int: strconv.Atoi: parsing \"not-an-int\": invalid syntax" ReplicaSet= namespace= rollout=ro
FAIL
FAIL	github.com/argoproj/argo-rollouts/utils/replicaset	0.685s
FAIL
```

After the fix with the new test:
```
go test ./utils/replicaset/...
ok  	github.com/argoproj/argo-rollouts/utils/replicaset	(cached)
```

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
