### PR TITLE
docs: fix markdown rendering

### DIFF
--- a/docs/analysis/datadog.md
+++ b/docs/analysis/datadog.md
@@ -57,29 +57,29 @@ stringData:
 
 Let me know if there's anything else you'd like to adjust!
 
-    ```yaml
-    apiVersion: argoproj.io/v1alpha1
-    kind: AnalysisTemplate
-    metadata:
-      name: loq-error-rate
-    spec:
-      args:
-      - name: service-name
-      metrics:
-      - name: error-rate
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: loq-error-rate
+spec:
+  args:
+  - name: service-name
+  metrics:
+  - name: error-rate
+    interval: 5m
+    successCondition: result <= 0.01
+    failureLimit: 3
+    provider:
+      datadog:
+        apiVersion: v2
         interval: 5m
-        successCondition: result <= 0.01
-        failureLimit: 3
-        provider:
-          datadog:
-            apiVersion: v2
-            interval: 5m
-            secretRef:
-              name: "mysecret"
-              namespaced: true
-            query: |
-              sum:requests.error.rate{service:{{args.service-name}}}
-    ```
+        secretRef:
+          name: "mysecret"
+          namespaced: true
+        query: |
+          sum:requests.error.rate{service:{{args.service-name}}}
+  ```
 
 
 


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).


Currently in https://argoproj.github.io/argo-rollouts/analysis/datadog/ the following would occur
![image](https://github.com/user-attachments/assets/9337f6dd-7c2f-46c0-b9c5-e97ea12750b3)

this PR addresses it by fixing the rendering of the YAML.

