### PR TITLE
fix(experiments): fire rollout event on experiment step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 dist/
 *.iml
 # delve debug binaries
-__debug_bin
+__debug_bin*
 cmd/**/debug
 debug.test
 coverage.out

--- a/experiments/controller.go
+++ b/experiments/controller.go
@@ -81,7 +81,7 @@ type Controller struct {
 	resyncPeriod time.Duration
 }
 
-// ControllerConfig describes the data required to instantiate a new analysis controller
+// ControllerConfig describes the data required to instantiate a new experiments controller
 type ControllerConfig struct {
 	KubeClientSet                   kubernetes.Interface
 	ArgoProjClientset               clientset.Interface
@@ -100,7 +100,6 @@ type ControllerConfig struct {
 
 // NewController returns a new experiment controller
 func NewController(cfg ControllerConfig) *Controller {
-
 	replicaSetControl := controller.RealRSControl{
 		KubeClient: cfg.KubeClientSet,
 		Recorder:   cfg.Recorder.K8sRecorder(),

--- a/experiments/experiment.go
+++ b/experiments/experiment.go
@@ -419,14 +419,8 @@ func (ec *experimentContext) reconcileAnalysisRun(analysis v1alpha1.ExperimentAn
 			// Handle the case where the Analysis Run belongs to an Experiment, and the Experiment is a Step in the Rollout
 			// This makes sure the rollout gets the Analysis Run events, which will then trigger any subscribed notifications
 			// #4009
-			if experimentutil.BelongsToRollout(ec.ex) {
-				var roRef metav1.OwnerReference
-				for _, owner := range ec.ex.OwnerReferences {
-					if owner.Kind == "Rollout" {
-						roRef = owner
-					}
-				}
-
+			roRef := experimentutil.GetRolloutOwnerRef(ec.ex)
+			if roRef != nil {
 				rollout, err := ec.argoProjClientset.ArgoprojV1alpha1().Rollouts(ec.ex.Namespace).Get(context.TODO(), roRef.Name, metav1.GetOptions{})
 				if err != nil {
 					ec.log.Warnf("Failed to get parent Rollout of the Experiment '%s': %v", roRef.Name, err)

--- a/experiments/experiment.go
+++ b/experiments/experiment.go
@@ -420,7 +420,13 @@ func (ec *experimentContext) reconcileAnalysisRun(analysis v1alpha1.ExperimentAn
 			// This makes sure the rollout gets the Analysis Run events, which will then trigger any subscribed notifications
 			// #4009
 			if experimentutil.BelongsToRollout(ec.ex) {
-				roRef := ec.ex.OwnerReferences[0]
+				var roRef metav1.OwnerReference
+				for _, owner := range ec.ex.OwnerReferences {
+					if owner.Kind == "Rollout" {
+						roRef = owner
+					}
+				}
+
 				rollout, err := ec.argoProjClientset.ArgoprojV1alpha1().Rollouts(ec.ex.Namespace).Get(context.TODO(), roRef.Name, metav1.GetOptions{})
 				if err != nil {
 					ec.log.Warnf("Failed to get parent Rollout of the Experiment '%s': %v", roRef.Name, err)

--- a/experiments/experiment.go
+++ b/experiments/experiment.go
@@ -72,7 +72,6 @@ func newExperimentContext(
 	resyncPeriod time.Duration,
 	enqueueExperimentAfter func(obj any, duration time.Duration),
 ) *experimentContext {
-
 	exCtx := experimentContext{
 		ex:                            experiment,
 		templateRSs:                   templateRSs,
@@ -416,6 +415,19 @@ func (ec *experimentContext) reconcileAnalysisRun(analysis v1alpha1.ExperimentAn
 				eventType = corev1.EventTypeWarning
 			}
 			ec.recorder.Eventf(ec.ex, record.EventOptions{EventType: eventType, EventReason: "AnalysisRun" + string(newStatus.Phase)}, msg)
+
+			// Handle the case where the Analysis Run belongs to an Experiment, and the Experiment is a Step in the Rollout
+			// This makes sure the rollout gets the Analysis Run events, which will then trigger any subscribed notifications
+			// #4009
+			if experimentutil.BelongsToRollout(ec.ex) {
+				roRef := ec.ex.OwnerReferences[0]
+				rollout, err := ec.argoProjClientset.ArgoprojV1alpha1().Rollouts(ec.ex.Namespace).Get(context.TODO(), roRef.Name, metav1.GetOptions{})
+				if err != nil {
+					ec.log.Warnf("Failed to get parent Rollout of the Experiment '%s': %v", roRef.Name, err)
+				} else {
+					ec.recorder.Eventf(rollout, record.EventOptions{EventType: corev1.EventTypeWarning, EventReason: "AnalysisRun" + string(newStatus.Phase)}, msg)
+				}
+			}
 		}
 		experimentutil.SetAnalysisRunStatus(ec.newStatus, *newStatus)
 	}()
@@ -627,7 +639,6 @@ func (ec *experimentContext) assessAnalysisRuns() (v1alpha1.AnalysisPhase, strin
 
 // newAnalysisRun generates an AnalysisRun from the experiment and template
 func (ec *experimentContext) newAnalysisRun(analysis v1alpha1.ExperimentAnalysisTemplateRef, args []v1alpha1.Argument, dryRunMetrics []v1alpha1.DryRun, measurementRetentionMetrics []v1alpha1.MeasurementRetention, analysisRunMetadata *v1alpha1.AnalysisRunMetadata) (*v1alpha1.AnalysisRun, error) {
-
 	if analysis.ClusterScope {
 		analysisTemplates, clusterAnalysisTemplates, err := ec.getAnalysisTemplatesFromClusterAnalysis(analysis)
 		if err != nil {
@@ -772,7 +783,6 @@ func (ec *experimentContext) getAnalysisTemplatesFromRefs(templateRefs *[]v1alph
 				templates = append(templates, innerTemplates...)
 			}
 		}
-
 	}
 	uniqueTemplates, uniqueClusterTemplates := analysisutil.FilterUniqueTemplates(templates, clusterTemplates)
 	return uniqueTemplates, uniqueClusterTemplates, nil

--- a/utils/experiment/experiment.go
+++ b/utils/experiment/experiment.go
@@ -18,6 +18,14 @@ import (
 
 var terminateExperimentPatch = []byte(`{"spec":{"terminate":true}}`)
 
+func BelongsToRollout(experiment *v1alpha1.Experiment) bool {
+	if len(experiment.OwnerReferences) == 0 {
+		return false
+	}
+
+	return experiment.OwnerReferences[0].Kind == "Rollout"
+}
+
 func HasFinished(experiment *v1alpha1.Experiment) bool {
 	return experiment.Status.Phase.Completed()
 }

--- a/utils/experiment/experiment.go
+++ b/utils/experiment/experiment.go
@@ -23,7 +23,12 @@ func BelongsToRollout(experiment *v1alpha1.Experiment) bool {
 		return false
 	}
 
-	return experiment.OwnerReferences[0].Kind == "Rollout"
+	for _, owner := range experiment.OwnerReferences {
+		if owner.Kind == "Rollout" {
+			return true
+		}
+	}
+	return false
 }
 
 func HasFinished(experiment *v1alpha1.Experiment) bool {

--- a/utils/experiment/experiment.go
+++ b/utils/experiment/experiment.go
@@ -18,17 +18,13 @@ import (
 
 var terminateExperimentPatch = []byte(`{"spec":{"terminate":true}}`)
 
-func BelongsToRollout(experiment *v1alpha1.Experiment) bool {
-	if len(experiment.OwnerReferences) == 0 {
-		return false
-	}
-
+func GetRolloutOwnerRef(experiment *v1alpha1.Experiment) *metav1.OwnerReference {
 	for _, owner := range experiment.OwnerReferences {
 		if owner.Kind == "Rollout" {
-			return true
+			return &owner
 		}
 	}
-	return false
+	return nil
 }
 
 func HasFinished(experiment *v1alpha1.Experiment) bool {


### PR DESCRIPTION
This fix (feat?) resolves the issue raised in #4009. 

I think this meets what users would expect from the use of an Experiment as a Step in a Rollout. 

As a user, if I setup notifications on AnalysisRun events, I would expect an AnalysisRun that fails should generate a notification. To be clear, this is ONLY when the Analysis Run belongs to an Experiment, which itself belongs to the Rollout (As a Step in that Rollout).  https://argo-rollouts.readthedocs.io/en/stable/features/experiment/#integration-with-rollouts

Please let me know if you would like to discuss this further, but this feels like a 'safe' change. It should even be good to backport to 1.7x (which is what I developed it against).  

I could use some guidance around testing this - I didn't see any prior integration test for this code path. But maybe there's some e2e and I wasn't having success finding it.  

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
