### PR TITLE
fix(metricprovider): not require address in kubernetes secret for Datadog. Fixes #4103

### DIFF
--- a/metricproviders/datadog/datadog.go
+++ b/metricproviders/datadog/datadog.go
@@ -451,7 +451,7 @@ func findCredentials(logCtx log.Entry, kubeclientset kubernetes.Interface, names
 	}
 	for _, finder := range finders {
 		address, apiKey, appKey := finder.FindCredentials(logCtx)
-		if address != "" && apiKey != "" && appKey != "" {
+		if apiKey != "" && appKey != "" {
 			return address, apiKey, appKey, nil
 		}
 	}

--- a/metricproviders/datadog/datadog_test.go
+++ b/metricproviders/datadog/datadog_test.go
@@ -188,15 +188,22 @@ func TestValidateIncomingProps(t *testing.T) {
 func TestFindCredentials(t *testing.T) {
 
 	testCases := []struct {
-		name         string
-		secret       *corev1.Secret
-		expectsError bool
-		metric       v1alpha1.Metric
+		name                string
+		secret              *corev1.Secret
+		expectsError        bool
+		expectsEmptyAddress bool
+		metric              v1alpha1.Metric
 	}{
 		{
 			name:   "when secretRef is set and secret found, should success",
 			secret: NewSecretBuilderDefaultData().Build(),
 			metric: newMetric("datadog", true),
+		},
+		{
+			name:                "when secretRef without address is set and secret found, should success",
+			secret:              NewSecretBuilder().WithData("api-key", []byte("apiKey")).WithData("app-key", []byte("appKey")).Build(),
+			metric:              newMetric("datadog", true),
+			expectsEmptyAddress: true,
 		},
 		{
 			name:         "when secretRef is set but secret not found, should fail",
@@ -223,7 +230,11 @@ func TestFindCredentials(t *testing.T) {
 			address, apiKey, appKey, err := findCredentials(logCtx, fakeClient, "namespace", testCase.metric)
 			assert.Equal(t, err != nil, testCase.expectsError)
 			if !testCase.expectsError {
-				assert.Equal(t, string(testCase.secret.Data["address"]), address)
+				if testCase.expectsEmptyAddress {
+					assert.Empty(t, address)
+				} else {
+					assert.Equal(t, string(testCase.secret.Data["address"]), address)
+				}
 				assert.Equal(t, string(testCase.secret.Data["api-key"]), apiKey)
 				assert.Equal(t, string(testCase.secret.Data["app-key"]), appKey)
 			}


### PR DESCRIPTION
Fix https://github.com/argoproj/argo-rollouts/issues/4103

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
