### PR TITLE
chore(deps): Updated go version in go.mod file (#4182)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj/argo-rollouts
 
-go 1.23
+go 1.23.4
 
 require (
 	github.com/antonmedv/expr v1.15.5


### PR DESCRIPTION
Updated go version in go.mod file

This change is required to support [Cachi2](https://github.com/hermetoproject/cachi2) based reproducible hermetic builds. The pre-fetching of dependencies fail if the go version does not include a z-stream version.

Two formats are supported by Cachi2. Either
```
module <module>
 
go 1.23.Z
```
or 
```
module <module>
 
go 1.23
toolchain go1.23.Z
```
Examples:
[grafana](https://github.com/grafana/grafana/blob/88a2485cc260eb5b2976ee67f201e591c56cf771/go.mod#L3)
[syft](https://github.com/anchore/syft/blob/fe0b78b7fe73b92ad76deed288d3b9b091a14d27/go.mod#L3)
[kubernetes](https://github.com/kubernetes/kubernetes/commit/e54f2296ed34fab6bdf260d20145c478eef9362b)
[argo-cd](https://github.com/argoproj/argo-cd/blob/43e594104212bae8ec15bacf7f31c504061842ee/go.mod#L3)
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
