### PR TITLE
fix: Revert "fix(controller):  rollout stuck in `Progressing`. fixes #3988"

### DIFF
--- a/rollout/bluegreen_test.go
+++ b/rollout/bluegreen_test.go
@@ -1406,7 +1406,6 @@ func TestBlueGreenReadyToScaleDownOldReplica(t *testing.T) {
 	f.objects = append(f.objects, r2)
 	f.serviceLister = append(f.serviceLister, s)
 
-	f.expectPatchReplicaSetAction(rs2)
 	updatedRSIndex := f.expectUpdateReplicaSetAction(rs2)
 	patchIndex := f.expectPatchRolloutAction(r2)
 	f.run(getKey(r2, t))

--- a/rollout/replicaset.go
+++ b/rollout/replicaset.go
@@ -107,16 +107,6 @@ func (c *rolloutContext) removeScaleDownDeadlines() error {
 			toRemove = append(toRemove, c.stableRS)
 		}
 	}
-	for _, rs := range c.otherRSs {
-		remainScaleDownDeadlines, err := replicasetutil.GetTimeRemainingBeforeScaleDownDeadline(rs)
-		if err != nil {
-			c.log.Warnf("%v", err)
-			continue
-		}
-		if replicasetutil.HasScaleDownDeadline(rs) && remainScaleDownDeadlines == nil {
-			toRemove = append(toRemove, rs)
-		}
-	}
 	for _, rs := range toRemove {
 		err := c.removeScaleDownDelay(rs)
 		if err != nil {


### PR DESCRIPTION
Reverts argoproj/argo-rollouts#4072

This PR breaks normal bluegreen deployments, need to see why no e2e or unit tests caught this as well. Will need to implement the bug fix in a different manor.

The issue with this PR is we remove the annotation before scaling down the replicaset so we get in a loop of continuously adding the scale down annotation without actually scaling down the replicaset.