### PR TITLE
fix(dashboard): Handle NaN values when rendering analysis in the UI

### DIFF
--- a/ui/src/app/components/analysis-modal/transforms.ts
+++ b/ui/src/app/components/analysis-modal/transforms.ts
@@ -618,9 +618,11 @@ const transformMeasurementValue = (conditionKeys: string[], value?: string): Mea
         };
     }
 
+    const safeValue = value.replace(/\bNaN\b/g, 'null');
+    
     let parsedValue;
     try {
-        parsedValue = JSON.parse(value);
+        parsedValue = JSON.parse(safeValue);
     } catch {
         return {
             canChart: true,


### PR DESCRIPTION
Handle NaN values

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

----

Hi!

I have this analysis metric:

```yaml
- name: ingress success rate
  successCondition: len(result) == 0 || isNaN(result[0]) || result[0] >= 0.99  # allow some room for rounding error
  failureLimit: 3
  inconclusiveLimit: 10
  consecutiveSuccessLimit: 5
  interval: 1m
  provider:
    prometheus:
      address: "{{args.prometheus-address}}"
      query: >-
        sum(rate(nginx_ingress_controller_requests{ingress="service-ingress", status!~"[5].*|499"}[1m]))
        /
        sum(rate(nginx_ingress_controller_requests{ingress="service-ingress", status_code!~"499"}[1m]))
```

Which returns data like this:

```json
{
  "value": "[NaN]",
  "status": "Successful",
  "metricName": "ingress success rate",
  "startedAt": "2025-03-24T13:25:22Z"
},
{
  "value": "[NaN]",
  "status": "Successful",
  "metricName": "ingress success rate",
  "startedAt": "2025-03-24T13:26:22Z"
},
{
  "value": "[1]",
  "status": "Successful",
  "metricName": "ingress success rate",
  "startedAt": "2025-03-24T13:27:22Z"
},
{
  "value": "[1]",
  "status": "Successful",
  "metricName": "ingress success rate",
  "startedAt": "2025-03-24T13:28:22Z"
}
```

When I try to view the analysis in the dashboard, the rendering fails and I see this error in the console:

![image](https://github.com/user-attachments/assets/e17162a7-48c4-4c34-9a0a-c39ff936da1d)

I believe this fixes the issue, though I haven't written the tests to prove it yet - sorry about that!

I'm on version 1.8.1.