### PR TITLE
chore: enrich controller startup log with namespace, ports, and insta…

### DIFF
--- a/cmd/rollouts-controller/main.go
+++ b/cmd/rollouts-controller/main.go
@@ -103,7 +103,6 @@ func newCommand() *cobra.Command {
 			}
 			logutil.SetKLogLogger(logger)
 			logutil.SetKLogLevel(klogLevel)
-			log.WithField("version", version.GetVersion()).Info("Argo Rollouts starting")
 
 			// set up signals so we handle the first shutdown signal gracefully
 			ctx := signals.SetupSignalHandlerContext()
@@ -125,8 +124,14 @@ func newCommand() *cobra.Command {
 			errors.CheckError(err)
 			if namespaced {
 				namespace = configNS
-				log.Infof("Using namespace %s", namespace)
 			}
+			log.WithFields(log.Fields{
+				"version":     version.GetVersion(),
+				"namespace":   namespace,
+				"instanceID":  instanceID,
+				"metricsPort": metricsPort,
+				"healthzPort": healthzPort,
+			}).Info("Argo Rollouts controller starting")
 
 			k8sRequestProvider := &metrics.K8sRequestsCountProvider{}
 			kubeclientmetrics.AddMetricsTransportWrapper(config, k8sRequestProvider.IncKubernetesRequest)


### PR DESCRIPTION
### What

Enriches the controller startup logs with structured fields:
- `version`
- `namespace`
- `instanceID`
- `metricsPort`
- `healthzPort`

### Why
Improves observability and operational clarity when managing multiple Argo Rollouts controllers. Provides immediate visibility into key configuration details at startup, simplifying debugging and diagnostics.

Example Log Output:
```
{
  "msg": "Argo Rollouts controller starting",
  "version": "v1.6.2",
  "namespace": "argo-rollouts",
  "instanceID": "",
  "metricsPort": 8090,
  "healthzPort": 8080
}
```

###Checklist:
- [x] Chore
- [x] PR title follows conventional commit guidelines
- [x] Signed commits with DCO
- [ ] Tests added (not applicable -- logging change)
- [ ] Builds passing (waiting for CI)
- [ ] Updated USERS.md (not applicable)
