### PR TITLE
fix: restarts during updates could cause downtime

### DIFF
--- a/rollout/bluegreen.go
+++ b/rollout/bluegreen.go
@@ -36,7 +36,7 @@ func (c *rolloutContext) rolloutBlueGreen() error {
 		return c.syncRolloutStatusBlueGreen(previewSvc, activeSvc)
 	}
 
-	err = c.podRestarter.Reconcile(c)
+	_, err = c.podRestarter.Reconcile(c)
 	if err != nil {
 		return err
 	}

--- a/rollout/restart_test.go
+++ b/rollout/restart_test.go
@@ -162,9 +162,10 @@ func TestRestartReconcile(t *testing.T) {
 			rollout: noRestartRo,
 			log:     log.WithRollout(noRestartRo),
 		}
-		err := r.Reconcile(roCtx)
+		restarted, err := r.Reconcile(roCtx)
 		assert.Nil(t, err)
 		assert.Len(t, client.Actions(), 0)
+		assert.Equal(t, 0, restarted)
 	})
 
 	t.Run("Not all ReplicaSets are fully available", func(t *testing.T) {
@@ -184,10 +185,11 @@ func TestRestartReconcile(t *testing.T) {
 			resyncPeriod: 2 * time.Minute,
 			enqueueAfter: func(obj any, duration time.Duration) {},
 		}
-		err := r.Reconcile(roCtx)
+		restarted, err := r.Reconcile(roCtx)
 		assert.Nil(t, err)
 		assert.Len(t, client.Actions(), 1) // list pods
 		assert.Contains(t, buf.String(), "all 0 pods are current. setting restartedAt")
+		assert.Equal(t, 0, restarted)
 	})
 	t.Run("Fails to delete Pod", func(t *testing.T) {
 		expectedErrMsg := "big bad error"
@@ -205,8 +207,9 @@ func TestRestartReconcile(t *testing.T) {
 			client:       client,
 			enqueueAfter: func(obj any, duration time.Duration) {},
 		}
-		err := r.Reconcile(roCtx)
+		restarted, err := r.Reconcile(roCtx)
 		assert.Errorf(t, err, expectedErrMsg)
+		assert.Equal(t, 0, restarted)
 	})
 	t.Run("Deletes Pod", func(t *testing.T) {
 		client := fake.NewSimpleClientset(rs, olderPod)
@@ -219,8 +222,9 @@ func TestRestartReconcile(t *testing.T) {
 			client:       client,
 			enqueueAfter: func(obj any, duration time.Duration) {},
 		}
-		err := r.Reconcile(roCtx)
+		restarted, err := r.Reconcile(roCtx)
 		assert.Nil(t, err)
+		assert.Equal(t, 1, restarted)
 		actions := client.Actions()
 		assert.Len(t, actions, 2)
 		_, ok := actions[1].(k8stesting.CreateAction) // eviction
@@ -237,8 +241,9 @@ func TestRestartReconcile(t *testing.T) {
 			client:       client,
 			enqueueAfter: func(obj any, duration time.Duration) {},
 		}
-		err := r.Reconcile(roCtx)
+		restarted, err := r.Reconcile(roCtx)
 		assert.Nil(t, err)
+		assert.Equal(t, 0, restarted)
 		assert.Len(t, client.Actions(), 1)
 		assert.Equal(t, now, *roCtx.newStatus.RestartedAt)
 	})
@@ -254,8 +259,9 @@ func TestRestartReconcile(t *testing.T) {
 			client:       client,
 			enqueueAfter: func(obj any, duration time.Duration) {},
 		}
-		err := r.Reconcile(roCtx)
+		restarted, err := r.Reconcile(roCtx)
 		assert.Nil(t, err)
+		assert.Equal(t, 0, restarted)
 		assert.Len(t, client.Actions(), 1)
 		assert.Equal(t, now, *roCtx.newStatus.RestartedAt)
 	})
@@ -277,9 +283,10 @@ func TestRestartReplicaSetPod(t *testing.T) {
 	t.Run("Finds no pods to delete to due to different label selector", func(t *testing.T) {
 		client := fake.NewSimpleClientset(rs, differentSelector)
 		r := RolloutPodRestarter{client: client}
-		err := r.Reconcile(roCtx)
+		restarted, err := r.Reconcile(roCtx)
 		assert.Nil(t, err)
 		assert.Equal(t, now, *roCtx.newStatus.RestartedAt)
+		assert.Equal(t, 0, restarted)
 
 		// Client uses list API but not the delete API
 		assert.Len(t, client.Actions(), 1)
@@ -287,9 +294,10 @@ func TestRestartReplicaSetPod(t *testing.T) {
 	t.Run("Delete Pod successfully", func(t *testing.T) {
 		client := fake.NewSimpleClientset(rs, olderPod)
 		r := RolloutPodRestarter{client: client}
-		err := r.Reconcile(roCtx)
+		restarted, err := r.Reconcile(roCtx)
 		assert.NotNil(t, roCtx.newStatus.RestartedAt)
 		assert.Nil(t, err)
+		assert.Equal(t, 1, restarted)
 		actions := client.Actions()
 		// Client uses list and evict API
 		assert.Len(t, actions, 2)
@@ -299,9 +307,10 @@ func TestRestartReplicaSetPod(t *testing.T) {
 	t.Run("No Pod Deletion required", func(t *testing.T) {
 		client := fake.NewSimpleClientset(rs, newerPod)
 		r := RolloutPodRestarter{client: client}
-		err := r.Reconcile(roCtx)
+		restarted, err := r.Reconcile(roCtx)
 		assert.Equal(t, now, *roCtx.newStatus.RestartedAt)
 		assert.Nil(t, err)
+		assert.Equal(t, 0, restarted)
 		// Client uses list API but not the evict API
 		assert.Len(t, client.Actions(), 1)
 	})
@@ -316,7 +325,8 @@ func TestRestartReplicaSetPod(t *testing.T) {
 			rollout: ro,
 			log:     log.WithRollout(ro),
 		}
-		err := r.Reconcile(roCtx)
+		restarted, err := r.Reconcile(roCtx)
+		assert.Equal(t, 0, restarted)
 		assert.Nil(t, roCtx.newStatus.RestartedAt)
 		assert.Error(t, err, expectedErrMsg)
 	})
@@ -343,7 +353,8 @@ func TestRestartDoNotDeleteOtherPods(t *testing.T) {
 	}
 	client := fake.NewSimpleClientset(rolloutRS, otherRS, newerPod, otherPod)
 	r := RolloutPodRestarter{client: client}
-	err := r.Reconcile(roCtx)
+	restarted, err := r.Reconcile(roCtx)
+	assert.Equal(t, 0, restarted)
 	assert.Equal(t, now, *roCtx.newStatus.RestartedAt)
 	assert.Nil(t, err)
 	// Client uses list API but not the delete API
@@ -445,8 +456,9 @@ func TestRestartMaxUnavailable(t *testing.T) {
 		}
 		client := fake.NewSimpleClientset(rs, olderPod1, olderPod2, newerPod)
 		r := RolloutPodRestarter{client: client}
-		err := r.Reconcile(roCtx)
+		restarted, err := r.Reconcile(roCtx)
 		assert.NotNil(t, roCtx.newStatus.RestartedAt)
+		assert.Equal(t, 2, restarted)
 		assert.Nil(t, err)
 		actions := client.Actions()
 		// Client uses list and two evict API
@@ -473,9 +485,10 @@ func TestRestartMaxUnavailable(t *testing.T) {
 				enqueued = true
 			},
 		}
-		err := r.Reconcile(roCtx)
+		restarted, err := r.Reconcile(roCtx)
 		assert.Nil(t, roCtx.newStatus.RestartedAt)
 		assert.Nil(t, err)
+		assert.Equal(t, 1, restarted)
 		actions := client.Actions()
 		// Client uses list and one evict API
 		assert.Len(t, actions, 2)
@@ -501,9 +514,10 @@ func TestRestartMaxUnavailable(t *testing.T) {
 				enqueued = true
 			},
 		}
-		err := r.Reconcile(roCtx)
+		restarted, err := r.Reconcile(roCtx)
 		assert.Nil(t, roCtx.newStatus.RestartedAt)
 		assert.Nil(t, err)
+		assert.Equal(t, 1, restarted)
 		actions := client.Actions()
 		// Client uses list and one evict API
 		assert.Len(t, actions, 2)
@@ -529,9 +543,10 @@ func TestRestartMaxUnavailable(t *testing.T) {
 				enqueued = true
 			},
 		}
-		err := r.Reconcile(roCtx)
+		restarted, err := r.Reconcile(roCtx)
 		assert.NotNil(t, roCtx.newStatus.RestartedAt)
 		assert.Nil(t, err)
+		assert.Equal(t, 2, restarted)
 		actions := client.Actions()
 		// Client uses list and two evict API
 		assert.Len(t, actions, 3)
@@ -562,11 +577,12 @@ func TestRestartMaxUnavailable(t *testing.T) {
 				enqueued = true
 			},
 		}
-		err := r.Reconcile(roCtx)
+		restarted, err := r.Reconcile(roCtx)
 		assert.Nil(t, roCtx.newStatus.RestartedAt)
 		assert.Nil(t, err)
+		assert.Equal(t, 1, restarted)
 		actions := client.Actions()
-		// Client uses list and two evict API
+		// Client uses list and on evict API
 		assert.Len(t, actions, 2)
 		_, ok := actions[1].(k8stesting.CreateAction)
 		assert.True(t, ok)
@@ -596,9 +612,10 @@ func TestRestartMaxUnavailable(t *testing.T) {
 				enqueued = true
 			},
 		}
-		err := r.Reconcile(roCtx)
+		restarted, err := r.Reconcile(roCtx)
 		assert.Nil(t, roCtx.newStatus.RestartedAt)
 		assert.Nil(t, err)
+		assert.Equal(t, 0, restarted)
 		actions := client.Actions()
 		// Client uses list
 		assert.Len(t, actions, 1)
@@ -622,9 +639,10 @@ func TestRestartMaxUnavailable(t *testing.T) {
 				enqueued = true
 			},
 		}
-		err := r.Reconcile(roCtx)
+		restarted, err := r.Reconcile(roCtx)
 		assert.NotNil(t, roCtx.newStatus.RestartedAt)
 		assert.Nil(t, err)
+		assert.Equal(t, 0, restarted)
 		actions := client.Actions()
 		// Client uses list
 		assert.Len(t, actions, 1)
@@ -654,7 +672,8 @@ func TestRestartRespectPodDisruptionBudget(t *testing.T) {
 			enqueueCalled = true
 		},
 	}
-	err := r.Reconcile(roCtx)
+	restarted, err := r.Reconcile(roCtx)
 	assert.NoError(t, err)
+	assert.Equal(t, 0, restarted)
 	assert.True(t, enqueueCalled)
 }


### PR DESCRIPTION
A user had hit downtime when they were simultaneously restarting their rollout, while it was in the middle of an update. An unfortunate timing problem can result in the controller both:
1. restarting a pod that is older than restartedAt
2. scaling down the old ReplicSet as part of a normal canary update

The scaling down in step 2, had brought the total number of available pods below maxUnavailable.

Here is an example sequence of logs that happened in a single reconciliation. 

The rollout had:
* `replicas: 2`
* `maxUnavailable: 0`
* 3 available pods 

1. Reconciliation starts:
```
{"_time":"2025-02-24T20:51:19.551+0000","log":"level=info msg=\"Started syncing rollout\" generation=2504 namespace=my-namespace resourceVersion=7387666133 rollout=my-rollout"}
```

2. Restarter restarts `my-rollout-547965fffc-hlxtp` (part of the canary RS). 
```
{"_time":"2025-02-24T20:51:19.622+0000","log":"level=info msg=\"restarting Pod that's older than restartAt Time\" CreatedAt=\"2025-02-24T20:43:26Z\" Pod=my-rollout-547965fffc-hlxtp Reconciler=PodRestarter RestartAt=\"2025-02-24T20:44:24Z\" namespace=my-namespace rollout=my-rollout"}
{"_time":"2025-02-24T20:51:19.622+0000","log":"level=info msg=\"Reconcile pod restart (replicas:2, totalReplicas:3, available:3, maxUnavailable:0, effectiveMinAvailable:2, concurrentRestart:1, canRestart:1)\" Reconciler=PodRestarter namespace=my-namespace rollout=my-rollout"}
{"_time":"2025-02-24T20:51:19.669+0000","log":"level=info msg=\"4/4 pods require restart. restarted 1. retrying in 30s\" Reconciler=PodRestarter namespace=my-namespace rollout=my-rollout"}
```

3. It proceeds to scale down `my-rollout-584dc44757` (stable RS) from 1 to 0.
```
{"_time":"2025-02-24T20:51:19.671+0000","log":"level=info msg=\"No TrafficRouting Reconcilers found\" namespace=my-namespace rollout=my-rollout"}
{"_time":"2025-02-24T20:51:19.857+0000","log":"level=info msg=\"Not finished reconciling stableRS\" namespace=my-namespace rollout=my-rollout"}
{"_time":"2025-02-24T20:51:19.857+0000","log":"level=info msg=\"Scaled down ReplicaSet my-rollout-584dc44757 (revision 93) from 1 to 0\" event_reason=ScalingReplicaSet namespace=my-namespace rollout=my-rollout"}
{"_time":"2025-02-24T20:51:19.857+0000","log":"level=info msg=\"Not finished reconciling ReplicaSets\" namespace=my-namespace rollout=my-rollout"}
{"_time":"2025-02-24T20:51:19.857+0000","log":"level=info msg=\"Event(v1.ObjectReference{Kind:\\\"Rollout\\\", Namespace:\\\"my-namespace\\\", Name:\\\"my-rollout\\\", UID:\\\"966219eb-f43f-45c9-9fef-3cb2695d0797\\\", APIVersion:\\\"argoproj.io/v1alpha1\\\", ResourceVersion:\\\"7387666133\\\", FieldPath:\\\"\\\"}): type: 'Normal' reason: 'ScalingReplicaSet' Scaled down ReplicaSet my-rollout-584dc44757 (revision 93) from 1 to 0\""}
{"_time":"2025-02-24T20:51:19.872+0000","log":"level=info msg=\"Patched: {\\\"status\\\":{\\\"availableReplicas\\\":3,\\\"conditions\\\":[{\\\"lastTransitionTime\\\":\\\"2025-02-09T15:31:18Z\\\",\\\"lastUpdateTime\\\":\\\"2025-02-09T15:31:18Z\\\",\\\"message\\\":\\\"Rollout is paused\\\",\\\"reason\\\":\\\"RolloutPaused\\\",\\\"status\\\":\\\"False\\\",\\\"type\\\":\\\"Paused\\\"},{\\\"lastTransitionTime\\\":\\\"2025-02-24T13:59:04Z\\\",\\\"lastUpdateTime\\\":\\\"2025-02-24T13:59:04Z\\\",\\\"message\\\":\\\"Rollout has minimum availability\\\",\\\"reason\\\":\\\"AvailableReason\\\",\\\"status\\\":\\\"True\\\",\\\"type\\\":\\\"Available\\\"},{\\\"lastTransitionTime\\\":\\\"2025-02-24T20:43:25Z\\\",\\\"lastUpdateTime\\\":\\\"2025-02-24T20:43:25Z\\\",\\\"message\\\":\\\"Rollout is not healthy\\\",\\\"reason\\\":\\\"RolloutHealthy\\\",\\\"status\\\":\\\"False\\\",\\\"type\\\":\\\"Healthy\\\"},{\\\"lastTransitionTime\\\":\\\"2025-02-24T20:43:25Z\\\",\\\"lastUpdateTime\\\":\\\"2025-02-24T20:43:25Z\\\",\\\"message\\\":\\\"RolloutCompleted\\\",\\\"reason\\\":\\\"RolloutCompleted\\\",\\\"status\\\":\\\"False\\\",\\\"type\\\":\\\"Completed\\\"},{\\\"lastTransitionTime\\\":\\\"2025-02-09T15:31:18Z\\\",\\\"lastUpdateTime\\\":\\\"2025-02-24T20:51:19Z\\\",\\\"message\\\":\\\"ReplicaSet \\\\\\\"my-rollout-547965fffc\\\\\\\" is progressing.\\\",\\\"reason\\\":\\\"ReplicaSetUpdated\\\",\\\"status\\\":\\\"True\\\",\\\"type\\\":\\\"Progressing\\\"}],\\\"readyReplicas\\\":3}\" generation=2504 namespace=my-namespace resourceVersion=7387666133 rollout=my-rollout"}
{"_time":"2025-02-24T20:51:19.875+0000","log":"level=info msg=\"Processing completed\" resource=my-namespace/my-rollout"}
```

So in this single reconciliation, the controller had removed 2 out of 3 available pods. 

The fix is to short-circuit the reconciliation if we had restarted any pods. In other words, do not allow reconciliation to continue to the canary/stable scaling logic since it would be operating on stale availability counts. Instead we return early, so that the next reconciliation can make a proper canary/stable scale calculation factoring the pods that were just restarted.
