### PR TITLE
fix(controller): Fix a bug where pod Metadata is not updated

### DIFF
--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -832,6 +832,12 @@ func (f *fixture) expectListPodAction(namespace string) int {
 	return len
 }
 
+func (f *fixture) expectGetPodAction(p *corev1.Pod) int {
+	len := len(f.kubeactions)
+	f.kubeactions = append(f.kubeactions, core.NewGetAction(schema.GroupVersionResource{Resource: "pods"}, p.Namespace, p.Name))
+	return len
+}
+
 func (f *fixture) expectGetRolloutAction(rollout *v1alpha1.Rollout) int { //nolint:unused
 	len := len(f.actions)
 	f.kubeactions = append(f.actions, core.NewGetAction(schema.GroupVersionResource{Resource: "rollouts"}, rollout.Namespace, rollout.Name))

--- a/rollout/ephemeralmetadata_test.go
+++ b/rollout/ephemeralmetadata_test.go
@@ -135,6 +135,7 @@ func TestSyncCanaryEphemeralMetadataSecondRevision(t *testing.T) {
 	rs2idx := f.expectCreateReplicaSetAction(rs2) // Create revision 2 ReplicaSet
 	rs1idx := f.expectUpdateReplicaSetAction(rs1) // update stable replicaset with stable metadata
 	f.expectListPodAction(r1.Namespace)           // list pods to patch ephemeral data on revision 1 ReplicaSets pods
+	f.expectGetPodAction(&pod)                    // Get Pod latest version before Updating
 	podIdx := f.expectUpdatePodAction(&pod)       // Update pod with ephemeral data
 	f.expectUpdateReplicaSetAction(rs1)           // scale revision 1 ReplicaSet down
 	f.expectPatchRolloutAction(r2)                // Patch Rollout status
@@ -215,6 +216,7 @@ func TestSyncBlueGreenEphemeralMetadataSecondRevision(t *testing.T) {
 	f.expectUpdateReplicaSetAction(rs2)                // scale revision 2 ReplicaSet up
 	rs1idx := f.expectUpdateReplicaSetAction(rs1)      // update stable replicaset with stable metadata
 	f.expectListPodAction(r1.Namespace)                // list pods to patch ephemeral data on revision 1 ReplicaSets pods`
+	f.expectGetPodAction(&pod)                         // Get Pod latest version before Updating
 	podIdx := f.expectUpdatePodAction(&pod)            // Update pod with ephemeral data
 	f.expectPatchRolloutAction(r2)                     // Patch Rollout status
 


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-rollouts/issues/4256

This PR tackles a critical bug that leads to inaccurate pod metadata (labels/annotations) in setups with high Pod Counts. Updates currently fail silently when pods are modified concurrently (triggering resourceVersion mismatches for the Update API) or when pods are deleted unexpectedly. These failures cascade, preventing subsequent pods from being updated and compromising data used for analysis.

The solution significantly enhances the update process's resilience. It now fetches the latest pod information right before attempting an update, gracefully skipping deleted pods and accounting for any changes in the object that happened after the List call. Furthermore, it isolates update failures, allowing the process to continue with other pods even if one encounters an error.

The reason for opening the PR against `1.8` because I feel this needs to be released as a patch in the current stable version. and it will be difficult to cherry-pick given that there are changes in that area that is already merged related to parallelization.

I will draft another one against master, keeping in mind the changes related to parallelizing the Update calls that have already been merged.

