### PR TITLE
fix(controller): Fix a bug where failure to update pod Metadata cascades to all other pods

### DIFF
--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -833,6 +833,12 @@ func (f *fixture) expectListPodAction(namespace string) int {
 	return len
 }
 
+func (f *fixture) expectGetPodAction(p *corev1.Pod) int {
+	len := len(f.kubeactions)
+	f.kubeactions = append(f.kubeactions, core.NewGetAction(schema.GroupVersionResource{Resource: "pods"}, p.Namespace, p.Name))
+	return len
+}
+
 func (f *fixture) expectGetRolloutAction(rollout *v1alpha1.Rollout) int { //nolint:unused
 	len := len(f.actions)
 	f.kubeactions = append(f.actions, core.NewGetAction(schema.GroupVersionResource{Resource: "rollouts"}, rollout.Namespace, rollout.Name))

--- a/rollout/ephemeralmetadata_test.go
+++ b/rollout/ephemeralmetadata_test.go
@@ -137,7 +137,9 @@ func TestSyncCanaryEphemeralMetadataSecondRevision(t *testing.T) {
 	rs2idx := f.expectCreateReplicaSetAction(rs2) // Create revision 2 ReplicaSet
 	rs1idx := f.expectUpdateReplicaSetAction(rs1) // update stable replicaset with stable metadata
 	f.expectListPodAction(r1.Namespace)           // list pods to patch ephemeral data on revision 1 ReplicaSets pods
+	f.expectGetPodAction(&pod1)                   // Get Pod1 latest version before Updating
 	pod1Idx := f.expectUpdatePodAction(&pod1)     // Update pod1 with ephemeral data
+	f.expectGetPodAction(pod2)                    // Get Pod2 latest version before Updating
 	pod2Idx := f.expectUpdatePodAction(pod2)      // Update pod2 with ephemeral data
 	f.expectUpdateReplicaSetAction(rs1)           // scale revision 1 ReplicaSet down
 	f.expectPatchRolloutAction(r2)                // Patch Rollout status
@@ -222,7 +224,9 @@ func TestSyncBlueGreenEphemeralMetadataSecondRevision(t *testing.T) {
 	f.expectUpdateReplicaSetAction(rs2)                // scale revision 2 ReplicaSet up
 	rs1idx := f.expectUpdateReplicaSetAction(rs1)      // update stable replicaset with stable metadata
 	f.expectListPodAction(r1.Namespace)                // list pods to patch ephemeral data on revision 1 ReplicaSets pods`
+	f.expectGetPodAction(&pod1)                        // Get Pod1 latest version before Updating
 	pod1Idx := f.expectUpdatePodAction(&pod1)          // Update pod1 with ephemeral data
+	f.expectGetPodAction(pod2)                         // Get Pod2 latest version before Updating
 	pod2Idx := f.expectUpdatePodAction(pod2)           // Update pod2 with ephemeral data
 	f.expectPatchRolloutAction(r2)                     // Patch Rollout status
 


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-rollouts/issues/4256

This PR tackles a critical bug that leads to inaccurate pod metadata (labels/annotations) in setups with high Pod Counts. Updates currently fail silently when pods are modified concurrently (triggering resourceVersion mismatches for the Update API) or when pods are deleted unexpectedly. These failures cascade, preventing subsequent pods from being updated and compromising data used for analysis.

The solution significantly enhances the update process's resilience. It now fetches the latest pod information right before attempting an update, gracefully skipping deleted pods and accounting for any changes in the object that happened after the List call. Furthermore, it isolates update failures, allowing the process to continue with other pods even if one encounters an error.

