### PR TITLE
docs: blue green w/ ALB not supported without downtime

### DIFF
--- a/docs/features/bluegreen.md
+++ b/docs/features/bluegreen.md
@@ -15,7 +15,7 @@ When there is a change to the `.spec.template` field of a rollout, the controlle
     ALB Ingress with Rollouts blue-green strategy is not supported without a chance of downtime.
 
 When using an AWS ALB to route traffic to a service, the ALB Ingress Controller does not update the target groups in an atomic or safe manner. This can result in a situation where, during a deployment, the stable target group temporarily has no pods registered. This occurs because the ALB Controller removes all current pods from the target group before registering pods from the desired ReplicaSet.
-    The desired pods need to pass their inital configured health check on the stable target group to be considered healthy from the ALB's perspective. This means that there is a chance that the ALB will not have any healthy pods registered to the target group depending on the ordering of deregistraion and timing of registration of new pods. This can cause downtime for the application that the rollouts controller can not mitigate.
+The desired pods must pass their initial configured health check on the stable target group to be considered healthy by the ALB. This creates a risk where the ALB may temporarily have no healthy pods registered to the target group, depending on the timing of deregistration and registration of new pods. This can lead to application downtime that the rollouts controller cannot prevent.
 
 ## Example
 

--- a/docs/features/bluegreen.md
+++ b/docs/features/bluegreen.md
@@ -14,7 +14,7 @@ When there is a change to the `.spec.template` field of a rollout, the controlle
 !!! important
     ALB Ingress with Rollouts blue-green strategy is not supported without a chance of downtime.
 
-    When using an AWS ALB to ingress traffic to the service, the ALB Ingress controller does not update the target groups in an atomic/safe order. This means that when the service selectors are changed on the stable blue-green service, at the end of the deployment. There is a chance that the ALB will not have any pods registered to the stable target group. Because, we asked the ALB controller to remove all current pods from the target group by switching to pods from the desired replicaset.
+When using an AWS ALB to route traffic to a service, the ALB Ingress Controller does not update the target groups in an atomic or safe manner. This can result in a situation where, during a deployment, the stable target group temporarily has no pods registered. This occurs because the ALB Controller removes all current pods from the target group before registering pods from the desired ReplicaSet.
     The desired pods need to pass their inital configured health check on the stable target group to be considered healthy from the ALB's perspective. This means that there is a chance that the ALB will not have any healthy pods registered to the target group depending on the ordering of deregistraion and timing of registration of new pods. This can cause downtime for the application that the rollouts controller can not mitigate.
 
 ## Example

--- a/docs/features/bluegreen.md
+++ b/docs/features/bluegreen.md
@@ -12,7 +12,7 @@ When there is a change to the `.spec.template` field of a rollout, the controlle
     When the rollout changes the selector on a service, there is a propagation delay before all the nodes update their IP tables to send traffic to the new pods instead of the old. During this delay, traffic will be directed to the old pods if the nodes have not been updated yet. In order to prevent the packets from being sent to a node that killed the old pod, the rollout uses the scaleDownDelaySeconds field to give nodes enough time to broadcast the IP table changes.
 
 !!! important
-    ALB Ingress with Rollout blue-green strategy is not support!
+    ALB Ingress with Rollout blue-green strategy is not support without chance of downtime.
 
     When using an AWS ALB to ingress traffic to the service, the ALB Ingress controller does not update the target groups in an atomic/safe order. This means that when the service selectors are changed on the stable blue-green service, at the end of the deployment. There is a chance that the ALB will not have any pods registered to the stable target group. Because, we asked the ALB controller to remove all current pods from the target group by switching to pods from the desired replicaset.
     The desired pods need to pass their inital configured health check on the stable target group to be considered healthy from the ALB's perspective. This means that there is a chance that the ALB will not have any healthy pods registered to the target group depending on the ordering of deregistraion and timing of registration of new pods. This can cause downtime for the application that the rollouts controller can not mitigate.

--- a/docs/features/bluegreen.md
+++ b/docs/features/bluegreen.md
@@ -12,7 +12,7 @@ When there is a change to the `.spec.template` field of a rollout, the controlle
     When the rollout changes the selector on a service, there is a propagation delay before all the nodes update their IP tables to send traffic to the new pods instead of the old. During this delay, traffic will be directed to the old pods if the nodes have not been updated yet. In order to prevent the packets from being sent to a node that killed the old pod, the rollout uses the scaleDownDelaySeconds field to give nodes enough time to broadcast the IP table changes.
 
 !!! important
-    ALB Ingress with Rollout blue-green strategy is not support without chance of downtime.
+    ALB Ingress with Rollouts blue-green strategy is not supported without a chance of downtime.
 
     When using an AWS ALB to ingress traffic to the service, the ALB Ingress controller does not update the target groups in an atomic/safe order. This means that when the service selectors are changed on the stable blue-green service, at the end of the deployment. There is a chance that the ALB will not have any pods registered to the stable target group. Because, we asked the ALB controller to remove all current pods from the target group by switching to pods from the desired replicaset.
     The desired pods need to pass their inital configured health check on the stable target group to be considered healthy from the ALB's perspective. This means that there is a chance that the ALB will not have any healthy pods registered to the target group depending on the ordering of deregistraion and timing of registration of new pods. This can cause downtime for the application that the rollouts controller can not mitigate.

--- a/docs/features/bluegreen.md
+++ b/docs/features/bluegreen.md
@@ -15,7 +15,7 @@ When there is a change to the `.spec.template` field of a rollout, the controlle
     ALB Ingress with Rollout blue-green strategy is not support!
 
     When using and AWS ALB to ingress traffic to the service, the ALB Ingress controller does not update the target groups in an atomic/safe order. This means that when the service selectors are changed on the stable blue-green service, at the end of the deployment. There is a chance that the ALB will not have any pods registered to the stable target group. Because, we asked the ALB controller to remove all current pods from the target group by switching to pods from the desired replicaset.
-    The desired pods need to pass their inital configured health check to be considered healthy from the ALB's perspective. This means that there is a chance that the ALB will not have any healthy pods registered to the target group depending on the ordering of deregistraion and timing of registration of new pods. This can cause downtime for the application that the rollouts controller can not mitigate.
+    The desired pods need to pass their inital configured health check on the stable target group to be considered healthy from the ALB's perspective. This means that there is a chance that the ALB will not have any healthy pods registered to the target group depending on the ordering of deregistraion and timing of registration of new pods. This can cause downtime for the application that the rollouts controller can not mitigate.
 
 ## Example
 

--- a/docs/features/bluegreen.md
+++ b/docs/features/bluegreen.md
@@ -14,8 +14,8 @@ When there is a change to the `.spec.template` field of a rollout, the controlle
 !!! important
     ALB Ingress with Rollouts blue-green strategy is not supported without a chance of downtime.
 
-When using an AWS ALB to route traffic to a service, the ALB Ingress Controller does not update the target groups in an atomic or safe manner. This can result in a situation where, during a deployment, the stable target group temporarily has no pods registered. This occurs because the ALB Controller removes all current pods from the target group before registering pods from the desired ReplicaSet.
-The desired pods must pass their initial configured health check on the stable target group to be considered healthy by the ALB. This creates a risk where the ALB may temporarily have no healthy pods registered to the target group, depending on the timing of deregistration and registration of new pods. This can lead to application downtime that the rollouts controller cannot prevent.
+    When using an AWS ALB to route traffic to a service, the ALB Ingress Controller does not update the target groups in an atomic or safe manner. This can result in a situation where, during a deployment, the stable target group temporarily has no pods registered. This occurs because the ALB Controller removes all current pods from the target group before registering pods from the desired ReplicaSet.
+    The desired pods must pass their initial configured health check on the stable target group to be considered healthy by the ALB. This creates a risk where the ALB may temporarily have no healthy pods registered to the target group, depending on the timing of deregistration and registration of new pods. This can lead to application downtime that the rollouts controller cannot prevent.
 
 ## Example
 

--- a/docs/features/bluegreen.md
+++ b/docs/features/bluegreen.md
@@ -14,7 +14,7 @@ When there is a change to the `.spec.template` field of a rollout, the controlle
 !!! important
     ALB Ingress with Rollout blue-green strategy is not support!
 
-    When using and AWS ALB to ingress traffic to the service, the ALB Ingress controller does not update the target groups in an atomic/safe order. This means that when the service selectors are changed on the stable blue-green service, at the end of the deployment. There is a chance that the ALB will not have any pods registered to the stable target group. Because, we asked the ALB controller to remove all current pods from the target group by switching to pods from the desired replicaset.
+    When using an AWS ALB to ingress traffic to the service, the ALB Ingress controller does not update the target groups in an atomic/safe order. This means that when the service selectors are changed on the stable blue-green service, at the end of the deployment. There is a chance that the ALB will not have any pods registered to the stable target group. Because, we asked the ALB controller to remove all current pods from the target group by switching to pods from the desired replicaset.
     The desired pods need to pass their inital configured health check on the stable target group to be considered healthy from the ALB's perspective. This means that there is a chance that the ALB will not have any healthy pods registered to the target group depending on the ordering of deregistraion and timing of registration of new pods. This can cause downtime for the application that the rollouts controller can not mitigate.
 
 ## Example

--- a/docs/features/bluegreen.md
+++ b/docs/features/bluegreen.md
@@ -11,6 +11,12 @@ When there is a change to the `.spec.template` field of a rollout, the controlle
 !!! important
     When the rollout changes the selector on a service, there is a propagation delay before all the nodes update their IP tables to send traffic to the new pods instead of the old. During this delay, traffic will be directed to the old pods if the nodes have not been updated yet. In order to prevent the packets from being sent to a node that killed the old pod, the rollout uses the scaleDownDelaySeconds field to give nodes enough time to broadcast the IP table changes.
 
+!!! important
+    ALB Ingress with Rollout blue-green strategy is not support!
+
+    When using and AWS ALB to ingress traffic to the service, the ALB Ingress controller does not update the target group in an atomic/safe order. This means that when the service selectors are changed on the stable blue-green service, at the end of the deployment. There is a chance that the ALB will not have any pods registered to the stable target group. Because, we asked the ALB controller to remove all current pods from the target group by switching to pods from the desired.
+    The desired pods need to pass their inital configured health check to be considered healthy from the ALB's perspective. This means that there is a chance that the ALB will not have any healthy pods registered to the target group depending on the ordering of deregistraion and timing of registration of new pods. This can cause downtime for the application that the rollouts controller can not mitigate.
+
 ## Example
 
 ```yaml

--- a/docs/features/bluegreen.md
+++ b/docs/features/bluegreen.md
@@ -14,7 +14,7 @@ When there is a change to the `.spec.template` field of a rollout, the controlle
 !!! important
     ALB Ingress with Rollout blue-green strategy is not support!
 
-    When using and AWS ALB to ingress traffic to the service, the ALB Ingress controller does not update the target group in an atomic/safe order. This means that when the service selectors are changed on the stable blue-green service, at the end of the deployment. There is a chance that the ALB will not have any pods registered to the stable target group. Because, we asked the ALB controller to remove all current pods from the target group by switching to pods from the desired.
+    When using and AWS ALB to ingress traffic to the service, the ALB Ingress controller does not update the target groups in an atomic/safe order. This means that when the service selectors are changed on the stable blue-green service, at the end of the deployment. There is a chance that the ALB will not have any pods registered to the stable target group. Because, we asked the ALB controller to remove all current pods from the target group by switching to pods from the desired replicaset.
     The desired pods need to pass their inital configured health check to be considered healthy from the ALB's perspective. This means that there is a chance that the ALB will not have any healthy pods registered to the target group depending on the ordering of deregistraion and timing of registration of new pods. This can cause downtime for the application that the rollouts controller can not mitigate.
 
 ## Example


### PR DESCRIPTION
Blue green with ALB ingress can not guarantee 100% uptime during a rollout. 