### PR TITLE
fix(dashboard): fix container image input

### DIFF
--- a/ui/src/app/components/rollout/containers.tsx
+++ b/ui/src/app/components/rollout/containers.tsx
@@ -52,10 +52,10 @@ export const ContainersWidget = (props: ContainersWidgetProps) => {
                                 danger={error}
                                 onClick={() => {
                                     for (const container of Object.keys(inputs)) {
-                                        const split = inputs[container].split(':');
-                                        if (split.length > 1) {
-                                            const image = split[0];
-                                            const tag = split[1];
+                                        const index = inputs[container].lastIndexOf(':');
+                                        if (index > 0 && index !== inputs[container].length -1) {
+                                            const image = inputs[container].substring(0, index);
+                                            const tag = inputs[container].substring(index + 1);
                                             interactive.setImage(container, image, tag);
                                             setTimeout(() => {
                                                 setEditing(false);


### PR DESCRIPTION
When rewriting containers from the UI dashboard, if port numbers are included, as in the image, they cannot be deployed properly. 
(e.g. `10.0.2.15:5000/my-app:v1` → image=`10.10.2.15`, tag=`5000/my-app`)
This is because the input is simply split with a colon.
In this PR, the image and tag are extracted by the colon at the end of the input string.

![image](https://github.com/user-attachments/assets/d39991cb-ad14-4816-9202-b5fd7453752f)


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
