### PR TITLE
chore: fix deprecation (pointer -> ptr)

### DIFF
--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -11,7 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	analysisutil "github.com/argoproj/argo-rollouts/utils/analysis"
@@ -145,7 +145,7 @@ func getResolvedMetricsWithoutSecrets(metrics []v1alpha1.Metric, args []v1alpha1
 		newArg := arg.DeepCopy()
 		if newArg.ValueFrom != nil && newArg.ValueFrom.SecretKeyRef != nil {
 			newArg.ValueFrom = nil
-			newArg.Value = pointer.StringPtr("temp-for-secret")
+			newArg.Value = ptr.To[string]("temp-for-secret")
 		}
 		newArgs = append(newArgs, *newArg)
 	}

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	k8stesting "k8s.io/client-go/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
@@ -1393,7 +1393,7 @@ func TestGarbageCollectArgResolution(t *testing.T) {
 	}
 	run.Spec.Args = append(run.Spec.Args, v1alpha1.Argument{
 		Name:  "port",
-		Value: pointer.String("8080"),
+		Value: ptr.To[string]("8080"),
 	})
 	var measurementRetentionMetricsMap = map[string]*v1alpha1.MeasurementRetention{}
 	measurementRetentionMetricsMap["metric2"] = &v1alpha1.MeasurementRetention{MetricName: "metric2", Limit: 2}
@@ -2071,7 +2071,7 @@ func StartTerminatingAnalysisRun(t *testing.T, isDryRun bool) *v1alpha1.Analysis
 			Args: []v1alpha1.Argument{
 				{
 					Name:  "service",
-					Value: pointer.StringPtr("rollouts-demo-canary.default.svc.cluster.local"),
+					Value: ptr.To[string]("rollouts-demo-canary.default.svc.cluster.local"),
 				},
 			},
 			Metrics: []v1alpha1.Metric{{
@@ -2130,7 +2130,7 @@ func TestInvalidDryRunConfigThrowsError(t *testing.T) {
 			Args: []v1alpha1.Argument{
 				{
 					Name:  "service",
-					Value: pointer.StringPtr("rollouts-demo-canary.default.svc.cluster.local"),
+					Value: ptr.To[string]("rollouts-demo-canary.default.svc.cluster.local"),
 				},
 			},
 			Metrics: []v1alpha1.Metric{{
@@ -2171,7 +2171,7 @@ func TestInvalidMeasurementsRetentionConfigThrowsError(t *testing.T) {
 			Args: []v1alpha1.Argument{
 				{
 					Name:  "service",
-					Value: pointer.StringPtr("rollouts-demo-canary.default.svc.cluster.local"),
+					Value: ptr.To[string]("rollouts-demo-canary.default.svc.cluster.local"),
 				},
 			},
 			Metrics: []v1alpha1.Metric{{
@@ -2315,7 +2315,7 @@ func TestExceededTtlChecked(t *testing.T) {
 	})
 	// Test success TTL overrides completed TTL.
 	testTTLStrategy(t, &v1alpha1.TTLStrategy{
-		SecondsAfterCompletion: pointer.Int32Ptr(100000),
+		SecondsAfterCompletion: ptr.To[int32](100000),
 		SecondsAfterSuccess:    &secondsOfOneDay,
 	}, &v1alpha1.AnalysisRunStatus{
 		CompletedAt: timePtr(metav1.NewTime(ttlExpiredCompletedTime)),
@@ -2326,7 +2326,7 @@ func TestExceededTtlChecked(t *testing.T) {
 	})
 	// Test failed TTL overrides completed TTL.
 	testTTLStrategy(t, &v1alpha1.TTLStrategy{
-		SecondsAfterCompletion: pointer.Int32Ptr(100000),
+		SecondsAfterCompletion: ptr.To[int32](100000),
 		SecondsAfterFailure:    &secondsOfOneDay,
 	}, &v1alpha1.AnalysisRunStatus{
 		CompletedAt: timePtr(metav1.NewTime(ttlExpiredCompletedTime)),
@@ -2338,7 +2338,7 @@ func TestExceededTtlChecked(t *testing.T) {
 	// Test completed TTL still evaluated when non-matching overrides exist.
 	testTTLStrategy(t, &v1alpha1.TTLStrategy{
 		SecondsAfterCompletion: &secondsOfOneDay,
-		SecondsAfterFailure:    pointer.Int32Ptr(86401),
+		SecondsAfterFailure:    ptr.To[int32](86401),
 	}, &v1alpha1.AnalysisRunStatus{
 		CompletedAt: timePtr(metav1.NewTime(ttlExpiredCompletedTime)),
 		Phase:       v1alpha1.AnalysisPhaseSuccessful,
@@ -2454,7 +2454,7 @@ func TestReconcileAnalysisRunOnRunNotFound(t *testing.T) {
 		},
 		Spec: v1alpha1.AnalysisRunSpec{
 			TTLStrategy: &v1alpha1.TTLStrategy{
-				SecondsAfterCompletion: pointer.Int32Ptr(1),
+				SecondsAfterCompletion: ptr.To[int32](1),
 			},
 		},
 		Status: v1alpha1.AnalysisRunStatus{
@@ -2491,7 +2491,7 @@ func TestReconcileAnalysisRunOnOtherRunErrors(t *testing.T) {
 		},
 		Spec: v1alpha1.AnalysisRunSpec{
 			TTLStrategy: &v1alpha1.TTLStrategy{
-				SecondsAfterCompletion: pointer.Int32Ptr(1),
+				SecondsAfterCompletion: ptr.To[int32](1),
 			},
 		},
 		Status: v1alpha1.AnalysisRunStatus{
@@ -2563,7 +2563,7 @@ func TestMaybeGarbageCollectAnalysisRunNoGCIfWithDeletionTimestamp(t *testing.T)
 		},
 		Spec: v1alpha1.AnalysisRunSpec{
 			TTLStrategy: &v1alpha1.TTLStrategy{
-				SecondsAfterCompletion: pointer.Int32Ptr(1),
+				SecondsAfterCompletion: ptr.To[int32](1),
 			},
 		},
 		Status: v1alpha1.AnalysisRunStatus{
@@ -2590,7 +2590,7 @@ func TestMaybeGarbageCollectAnalysisRunNoGCIfNoCompletedAt(t *testing.T) {
 		},
 		Spec: v1alpha1.AnalysisRunSpec{
 			TTLStrategy: &v1alpha1.TTLStrategy{
-				SecondsAfterCompletion: pointer.Int32Ptr(1),
+				SecondsAfterCompletion: ptr.To[int32](1),
 			},
 		},
 		Status: v1alpha1.AnalysisRunStatus{

--- a/experiments/analysisrun_test.go
+++ b/experiments/analysisrun_test.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubetesting "k8s.io/client-go/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 )
@@ -207,7 +207,7 @@ func TestCreateAnalysisRunWithArg(t *testing.T) {
 			TemplateName: aTemplates[0].Name,
 			Args: []v1alpha1.Argument{{
 				Name:  "test",
-				Value: pointer.StringPtr("sss"),
+				Value: ptr.To[string]("sss"),
 			}},
 		},
 	}
@@ -239,7 +239,7 @@ func TestCreateAnalysisRunWithClusterTemplate(t *testing.T) {
 			ClusterScope: true,
 			Args: []v1alpha1.Argument{{
 				Name:  "test",
-				Value: pointer.StringPtr("sss"),
+				Value: ptr.To[string]("sss"),
 			}},
 		},
 	}
@@ -271,7 +271,7 @@ func TestAnalysisRunFailToResolveArg(t *testing.T) {
 			Args: []v1alpha1.Argument{{
 
 				Name:  "test",
-				Value: pointer.StringPtr("{{not a real substitution}}"),
+				Value: ptr.To[string]("{{not a real substitution}}"),
 			}},
 		},
 	}
@@ -480,7 +480,7 @@ func TestAssessAnalysisRunStatusesAfterTemplateSuccess(t *testing.T) {
 func TestFailExperimentWhenAnalysisFails(t *testing.T) {
 	templates := generateTemplates("bar")
 	e := newExperiment("foo", templates, "")
-	e.Spec.ScaleDownDelaySeconds = pointer.Int32Ptr(0)
+	e.Spec.ScaleDownDelaySeconds = ptr.To[int32](0)
 	e.Spec.Analyses = []v1alpha1.ExperimentAnalysisTemplateRef{
 		{
 			Name:         "success-rate",
@@ -493,7 +493,7 @@ func TestFailExperimentWhenAnalysisFails(t *testing.T) {
 	}
 	e.Status.Phase = v1alpha1.AnalysisPhaseRunning
 	e.Spec.Duration = "5m"
-	e.Spec.ScaleDownDelaySeconds = pointer.Int32Ptr(0)
+	e.Spec.ScaleDownDelaySeconds = ptr.To[int32](0)
 	e.Status.AvailableAt = secondsAgo(60)
 	rs := templateToRS(e, templates[0], 1)
 	ar1 := analysisTemplateToRun("success-rate", e, &v1alpha1.AnalysisTemplateSpec{})
@@ -660,7 +660,7 @@ func TestDoNotCompleteExperimentWithRemainingRequiredAnalysisRun(t *testing.T) {
 func TestCompleteExperimentWithNoRequiredAnalysis(t *testing.T) {
 	templates := generateTemplates("bar")
 	e := newExperiment("foo", templates, "1m")
-	e.Spec.ScaleDownDelaySeconds = pointer.Int32Ptr(0)
+	e.Spec.ScaleDownDelaySeconds = ptr.To[int32](0)
 	e.Spec.Analyses = []v1alpha1.ExperimentAnalysisTemplateRef{
 		{
 			Name:         "success-rate",
@@ -700,7 +700,7 @@ func TestCompleteExperimentWithNoRequiredAnalysis(t *testing.T) {
 func TestTerminateAnalysisRuns(t *testing.T) {
 	templates := generateTemplates("bar")
 	e := newExperiment("foo", templates, "")
-	e.Spec.ScaleDownDelaySeconds = pointer.Int32Ptr(0)
+	e.Spec.ScaleDownDelaySeconds = ptr.To[int32](0)
 	e.Spec.Analyses = []v1alpha1.ExperimentAnalysisTemplateRef{
 		{
 			Name:         "success-rate",

--- a/experiments/conditions_test.go
+++ b/experiments/conditions_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
@@ -15,7 +15,7 @@ import (
 func TestUpdateProgressingLastUpdateTime(t *testing.T) {
 
 	templates := generateTemplates("bar")
-	templates[0].Replicas = pointer.Int32Ptr(2)
+	templates[0].Replicas = ptr.To[int32](2)
 	e := newExperiment("foo", templates, "")
 	e.Status.TemplateStatuses = []v1alpha1.TemplateStatus{{
 		Name: "bar",
@@ -53,7 +53,7 @@ func TestEnterTimeoutDegradedState(t *testing.T) {
 		Name:   "bar",
 		Status: v1alpha1.TemplateStatusProgressing,
 	}}
-	e.Spec.ProgressDeadlineSeconds = pointer.Int32Ptr(30)
+	e.Spec.ProgressDeadlineSeconds = ptr.To[int32](30)
 	prevTime := metav1.NewTime(timeutil.Now().Add(-1 * time.Minute).Truncate(time.Second))
 	e.Status.TemplateStatuses[0].LastTransitionTime = &prevTime
 

--- a/experiments/controller_test.go
+++ b/experiments/controller_test.go
@@ -31,7 +31,7 @@ import (
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/controller/metrics"
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
@@ -143,7 +143,7 @@ func generateTemplates(imageNames ...string) []v1alpha1.TemplateSpec {
 			Selector: &metav1.LabelSelector{
 				MatchLabels: selector,
 			},
-			Replicas: pointer.Int32Ptr(1),
+			Replicas: ptr.To[int32](1),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: selector,

--- a/experiments/experiment.go
+++ b/experiments/experiment.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	appslisters "k8s.io/client-go/listers/apps/v1"
 	v1 "k8s.io/client-go/listers/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -318,7 +318,7 @@ func (ec *experimentContext) createTemplateService(template *v1alpha1.TemplateSp
 
 // createReplicaSetForTemplate initializes ReplicaSet with zero replicas for given experiment template
 func (ec *experimentContext) createReplicaSetForTemplate(template v1alpha1.TemplateSpec, templateStatus *v1alpha1.TemplateStatus, logCtx *log.Entry, now metav1.Time) {
-	template.Replicas = pointer.Int32Ptr(0)
+	template.Replicas = ptr.To[int32](0)
 	rs, err := ec.createReplicaSet(template, templateStatus.CollisionCount)
 	if err != nil {
 		logCtx.Warnf("Failed to create ReplicaSet: %v", err)

--- a/experiments/experiment_test.go
+++ b/experiments/experiment_test.go
@@ -17,7 +17,7 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	kubetesting "k8s.io/client-go/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
@@ -129,7 +129,7 @@ func TestAddScaleDownDelayToRS(t *testing.T) {
 func TestRemoveScaleDownDelayFromRS(t *testing.T) {
 	templates := generateTemplates("bar")
 	e := newExperiment("foo", templates, "")
-	e.Spec.ScaleDownDelaySeconds = pointer.Int32Ptr(0)
+	e.Spec.ScaleDownDelaySeconds = ptr.To[int32](0)
 	e.Status.AvailableAt = now()
 	e.Status.Phase = v1alpha1.AnalysisPhaseRunning
 	cond := conditions.NewExperimentConditions(v1alpha1.ExperimentProgressing, corev1.ConditionTrue, conditions.NewRSAvailableReason, "Experiment \"foo\" is running.")
@@ -407,7 +407,7 @@ func TestFailAddScaleDownDelay(t *testing.T) {
 	templates := generateTemplates("bar")
 	templates[0].Service = &v1alpha1.TemplateService{}
 	ex := newExperiment("foo", templates, "")
-	ex.Spec.ScaleDownDelaySeconds = pointer.Int32Ptr(0)
+	ex.Spec.ScaleDownDelaySeconds = ptr.To[int32](0)
 	ex.Status.TemplateStatuses = []v1alpha1.TemplateStatus{
 		generateTemplatesStatus("bar", 1, 1, v1alpha1.TemplateStatusFailed, now()),
 	}
@@ -429,12 +429,12 @@ func TestFailAddScaleDownDelay(t *testing.T) {
 func TestFailAddScaleDownDelayIsConflict(t *testing.T) {
 	templates := generateTemplates("bar")
 	ex := newExperiment("foo", templates, "")
-	ex.Spec.ScaleDownDelaySeconds = pointer.Int32Ptr(0)
+	ex.Spec.ScaleDownDelaySeconds = ptr.To[int32](0)
 	ex.Status.TemplateStatuses = []v1alpha1.TemplateStatus{
 		generateTemplatesStatus("bar", 1, 1, v1alpha1.TemplateStatusRunning, now()),
 	}
 	rs := templateToRS(ex, templates[0], 1)
-	rs.Spec.Replicas = pointer.Int32(0)
+	rs.Spec.Replicas = ptr.To[int32](0)
 
 	exCtx := newTestContext(ex, rs)
 	exCtx.templateRSs["bar"] = rs
@@ -485,7 +485,7 @@ func TestDeleteOutdatedService(t *testing.T) {
 
 func TestDeleteServiceIfServiceFieldNil(t *testing.T) {
 	templates := generateTemplates("bar")
-	templates[0].Replicas = pointer.Int32Ptr(0)
+	templates[0].Replicas = ptr.To[int32](0)
 	ex := newExperiment("foo", templates, "")
 	ex.Status.TemplateStatuses = []v1alpha1.TemplateStatus{
 		generateTemplatesStatus("bar", 1, 1, v1alpha1.TemplateStatusRunning, now()),

--- a/experiments/replicaset_test.go
+++ b/experiments/replicaset_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
@@ -116,7 +116,7 @@ func TestNameCollision(t *testing.T) {
 		templateStatuses := []v1alpha1.TemplateStatus{
 			generateTemplatesStatus("bar", 0, 0, "", nil),
 		}
-		templateStatuses[0].CollisionCount = pointer.Int32Ptr(1)
+		templateStatuses[0].CollisionCount = ptr.To[int32](1)
 		validatePatch(t, patch, "", NoChange, templateStatuses, nil)
 	}
 	{
@@ -153,7 +153,7 @@ func TestNameCollisionWithEquivalentPodTemplateAndControllerUID(t *testing.T) {
 		templateStatuses := []v1alpha1.TemplateStatus{
 			generateTemplatesStatus("bar", 0, 0, "", nil),
 		}
-		templateStatuses[0].CollisionCount = pointer.Int32Ptr(1)
+		templateStatuses[0].CollisionCount = ptr.To[int32](1)
 		validatePatch(t, patch, "", NoChange, templateStatuses, nil)
 	}
 	{

--- a/ingress/alb.go
+++ b/ingress/alb.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	ingressutil "github.com/argoproj/argo-rollouts/utils/ingress"
@@ -103,7 +103,7 @@ func getResetALBActionStr(ingress *ingressutil.Ingress, action string) (string, 
 				{
 					ServiceName: service,
 					ServicePort: port,
-					Weight:      pointer.Int64Ptr(int64(100)),
+					Weight:      ptr.To[int64](int64(100)),
 				},
 			},
 		},

--- a/metricproviders/cloudwatch/cloudwatch_test.go
+++ b/metricproviders/cloudwatch/cloudwatch_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 )
@@ -242,65 +242,65 @@ func TestConvertType(t *testing.T) {
 			query: []v1alpha1.CloudWatchMetricDataQuery{
 				{
 					Id:         "rate",
-					Expression: pointer.StringPtr("errors / requests"),
+					Expression: ptr.To[string]("errors / requests"),
 				},
 				{
 					Id: "errors",
 					MetricStat: &v1alpha1.CloudWatchMetricStat{
 						Metric: v1alpha1.CloudWatchMetricStatMetric{
-							Namespace:  pointer.StringPtr("app"),
+							Namespace:  ptr.To[string]("app"),
 							MetricName: "errors",
 						},
 						Period: period,
 						Stat:   "Sum",
 						Unit:   "Count",
 					},
-					ReturnData: pointer.BoolPtr(false),
+					ReturnData: ptr.To[bool](false),
 				},
 				{
 					Id: "requests",
 					MetricStat: &v1alpha1.CloudWatchMetricStat{
 						Metric: v1alpha1.CloudWatchMetricStatMetric{
-							Namespace:  pointer.StringPtr("app"),
+							Namespace:  ptr.To[string]("app"),
 							MetricName: "requests",
 						},
 						Period: period,
 						Stat:   "Sum",
 						Unit:   "Count",
 					},
-					ReturnData: pointer.BoolPtr(false),
+					ReturnData: ptr.To[bool](false),
 				},
 			},
 			expected: []types.MetricDataQuery{
 				{
-					Id:         pointer.StringPtr("rate"),
-					Expression: pointer.StringPtr("errors / requests"),
+					Id:         ptr.To[string]("rate"),
+					Expression: ptr.To[string]("errors / requests"),
 				},
 				{
-					Id: pointer.StringPtr("errors"),
+					Id: ptr.To[string]("errors"),
 					MetricStat: &types.MetricStat{
 						Metric: &types.Metric{
-							Namespace:  pointer.StringPtr("app"),
-							MetricName: pointer.StringPtr("errors"),
+							Namespace:  ptr.To[string]("app"),
+							MetricName: ptr.To[string]("errors"),
 						},
-						Period: pointer.Int32Ptr(300),
-						Stat:   pointer.StringPtr("Sum"),
+						Period: ptr.To[int32](300),
+						Stat:   ptr.To[string]("Sum"),
 						Unit:   types.StandardUnitCount,
 					},
-					ReturnData: pointer.BoolPtr(false),
+					ReturnData: ptr.To[bool](false),
 				},
 				{
-					Id: pointer.StringPtr("requests"),
+					Id: ptr.To[string]("requests"),
 					MetricStat: &types.MetricStat{
 						Metric: &types.Metric{
-							Namespace:  pointer.StringPtr("app"),
-							MetricName: pointer.StringPtr("requests"),
+							Namespace:  ptr.To[string]("app"),
+							MetricName: ptr.To[string]("requests"),
 						},
-						Period: pointer.Int32Ptr(300),
-						Stat:   pointer.StringPtr("Sum"),
+						Period: ptr.To[int32](300),
+						Stat:   ptr.To[string]("Sum"),
 						Unit:   types.StandardUnitCount,
 					},
-					ReturnData: pointer.BoolPtr(false),
+					ReturnData: ptr.To[bool](false),
 				},
 			},
 		},
@@ -308,7 +308,7 @@ func TestConvertType(t *testing.T) {
 			query: []v1alpha1.CloudWatchMetricDataQuery{
 				{
 					Id:         "rate",
-					Expression: pointer.StringPtr("errors / requests"),
+					Expression: ptr.To[string]("errors / requests"),
 				},
 				{
 					Id: "errors",
@@ -320,65 +320,65 @@ func TestConvertType(t *testing.T) {
 									Value: "fuga",
 								},
 							},
-							Namespace:  pointer.StringPtr("app1"),
+							Namespace:  ptr.To[string]("app1"),
 							MetricName: "errors",
 						},
 						Period: period,
 						Stat:   "Max",
 						Unit:   "Count",
 					},
-					ReturnData: pointer.BoolPtr(false),
+					ReturnData: ptr.To[bool](false),
 				},
 				{
 					Id: "requests",
 					MetricStat: &v1alpha1.CloudWatchMetricStat{
 						Metric: v1alpha1.CloudWatchMetricStatMetric{
-							Namespace:  pointer.StringPtr("app2"),
+							Namespace:  ptr.To[string]("app2"),
 							MetricName: "requests",
 						},
 						Period: period,
 						Stat:   "Sum",
 						Unit:   "Bytes/Second",
 					},
-					ReturnData: pointer.BoolPtr(true),
+					ReturnData: ptr.To[bool](true),
 				},
 			},
 			expected: []types.MetricDataQuery{
 				{
-					Id:         pointer.StringPtr("rate"),
-					Expression: pointer.StringPtr("errors / requests"),
+					Id:         ptr.To[string]("rate"),
+					Expression: ptr.To[string]("errors / requests"),
 				},
 				{
-					Id: pointer.StringPtr("errors"),
+					Id: ptr.To[string]("errors"),
 					MetricStat: &types.MetricStat{
 						Metric: &types.Metric{
-							Namespace:  pointer.StringPtr("app1"),
-							MetricName: pointer.StringPtr("errors"),
+							Namespace:  ptr.To[string]("app1"),
+							MetricName: ptr.To[string]("errors"),
 							Dimensions: []types.Dimension{
 								{
-									Name:  pointer.StringPtr("hoge"),
-									Value: pointer.StringPtr("fuga"),
+									Name:  ptr.To[string]("hoge"),
+									Value: ptr.To[string]("fuga"),
 								},
 							},
 						},
-						Period: pointer.Int32Ptr(300),
-						Stat:   pointer.StringPtr("Max"),
+						Period: ptr.To[int32](300),
+						Stat:   ptr.To[string]("Max"),
 						Unit:   types.StandardUnitCount,
 					},
-					ReturnData: pointer.BoolPtr(false),
+					ReturnData: ptr.To[bool](false),
 				},
 				{
-					Id: pointer.StringPtr("requests"),
+					Id: ptr.To[string]("requests"),
 					MetricStat: &types.MetricStat{
 						Metric: &types.Metric{
-							Namespace:  pointer.StringPtr("app2"),
-							MetricName: pointer.StringPtr("requests"),
+							Namespace:  ptr.To[string]("app2"),
+							MetricName: ptr.To[string]("requests"),
 						},
-						Period: pointer.Int32Ptr(300),
-						Stat:   pointer.StringPtr("Sum"),
+						Period: ptr.To[int32](300),
+						Stat:   ptr.To[string]("Sum"),
 						Unit:   types.StandardUnitBytesSecond,
 					},
-					ReturnData: pointer.BoolPtr(true),
+					ReturnData: ptr.To[bool](true),
 				},
 			},
 		},
@@ -386,7 +386,7 @@ func TestConvertType(t *testing.T) {
 			query: []v1alpha1.CloudWatchMetricDataQuery{
 				{
 					Id:         "rate",
-					Expression: pointer.StringPtr("errors / requests"),
+					Expression: ptr.To[string]("errors / requests"),
 				},
 				{
 					Id: "errors",
@@ -402,69 +402,69 @@ func TestConvertType(t *testing.T) {
 									Value: "doge",
 								},
 							},
-							Namespace:  pointer.StringPtr("app1"),
+							Namespace:  ptr.To[string]("app1"),
 							MetricName: "errors",
 						},
 						Period: period,
 						Stat:   "Max",
 						Unit:   "Count",
 					},
-					ReturnData: pointer.BoolPtr(false),
+					ReturnData: ptr.To[bool](false),
 				},
 				{
 					Id: "requests",
 					MetricStat: &v1alpha1.CloudWatchMetricStat{
 						Metric: v1alpha1.CloudWatchMetricStatMetric{
-							Namespace:  pointer.StringPtr("app2"),
+							Namespace:  ptr.To[string]("app2"),
 							MetricName: "requests",
 						},
 						Period: period,
 						Stat:   "Sum",
 						Unit:   "Bytes/Second",
 					},
-					ReturnData: pointer.BoolPtr(true),
+					ReturnData: ptr.To[bool](true),
 				},
 			},
 			expected: []types.MetricDataQuery{
 				{
-					Id:         pointer.StringPtr("rate"),
-					Expression: pointer.StringPtr("errors / requests"),
+					Id:         ptr.To[string]("rate"),
+					Expression: ptr.To[string]("errors / requests"),
 				},
 				{
-					Id: pointer.StringPtr("errors"),
+					Id: ptr.To[string]("errors"),
 					MetricStat: &types.MetricStat{
 						Metric: &types.Metric{
-							Namespace:  pointer.StringPtr("app1"),
-							MetricName: pointer.StringPtr("errors"),
+							Namespace:  ptr.To[string]("app1"),
+							MetricName: ptr.To[string]("errors"),
 							Dimensions: []types.Dimension{
 								{
-									Name:  pointer.StringPtr("hoge"),
-									Value: pointer.StringPtr("fuga"),
+									Name:  ptr.To[string]("hoge"),
+									Value: ptr.To[string]("fuga"),
 								},
 								{
-									Name:  pointer.StringPtr("poge"),
-									Value: pointer.StringPtr("doge"),
+									Name:  ptr.To[string]("poge"),
+									Value: ptr.To[string]("doge"),
 								},
 							},
 						},
-						Period: pointer.Int32Ptr(300),
-						Stat:   pointer.StringPtr("Max"),
+						Period: ptr.To[int32](300),
+						Stat:   ptr.To[string]("Max"),
 						Unit:   types.StandardUnitCount,
 					},
-					ReturnData: pointer.BoolPtr(false),
+					ReturnData: ptr.To[bool](false),
 				},
 				{
-					Id: pointer.StringPtr("requests"),
+					Id: ptr.To[string]("requests"),
 					MetricStat: &types.MetricStat{
 						Metric: &types.Metric{
-							Namespace:  pointer.StringPtr("app2"),
-							MetricName: pointer.StringPtr("requests"),
+							Namespace:  ptr.To[string]("app2"),
+							MetricName: ptr.To[string]("requests"),
 						},
-						Period: pointer.Int32Ptr(300),
-						Stat:   pointer.StringPtr("Sum"),
+						Period: ptr.To[int32](300),
+						Stat:   ptr.To[string]("Sum"),
 						Unit:   types.StandardUnitBytesSecond,
 					},
-					ReturnData: pointer.BoolPtr(true),
+					ReturnData: ptr.To[bool](true),
 				},
 			},
 		},

--- a/pkg/apis/rollouts/validation/validation_references_test.go
+++ b/pkg/apis/rollouts/validation/validation_references_test.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	ingressutil "github.com/argoproj/argo-rollouts/utils/ingress"
@@ -674,8 +674,8 @@ func TestValidateAnalysisTemplatesWithType(t *testing.T) {
 	t.Run("failure - duplicate metrics", func(t *testing.T) {
 		rollout := getAlbRollout("alb-ingress")
 		templates := getAnalysisTemplatesWithType()
-		templates.AnalysisTemplates[0].Spec.Args = append(templates.AnalysisTemplates[0].Spec.Args, v1alpha1.Argument{Name: "metric1-name", Value: pointer.StringPtr("true")})
-		templates.AnalysisTemplates[0].Spec.Args[0] = v1alpha1.Argument{Name: "valid", Value: pointer.StringPtr("true")}
+		templates.AnalysisTemplates[0].Spec.Args = append(templates.AnalysisTemplates[0].Spec.Args, v1alpha1.Argument{Name: "metric1-name", Value: ptr.To[string]("true")})
+		templates.AnalysisTemplates[0].Spec.Args[0] = v1alpha1.Argument{Name: "valid", Value: ptr.To[string]("true")}
 		allErrs := ValidateAnalysisTemplatesWithType(rollout, templates)
 		assert.Empty(t, allErrs)
 	})
@@ -741,7 +741,7 @@ func TestValidateAnalysisTemplateWithType(t *testing.T) {
 		template.AnalysisTemplates[0].Spec.Args = []v1alpha1.Argument{
 			{
 				Name:  "service-name",
-				Value: pointer.StringPtr("service-name"),
+				Value: ptr.To[string]("service-name"),
 			},
 		}
 		allErrs := ValidateAnalysisTemplateWithType(rollout, template.AnalysisTemplates[0], nil, template.TemplateType, GetAnalysisTemplateWithTypeFieldPath(template.TemplateType, template.CanaryStepIndex))
@@ -800,7 +800,7 @@ func TestValidateAnalysisTemplateWithType(t *testing.T) {
 		templates.AnalysisTemplates[0].Spec.Args = []v1alpha1.Argument{
 			{
 				Name:  "service-name",
-				Value: pointer.StringPtr("service-name"),
+				Value: ptr.To[string]("service-name"),
 			},
 		}
 		rollout.Spec.Strategy.Canary.Analysis = &v1alpha1.RolloutAnalysisBackground{
@@ -1573,7 +1573,7 @@ func TestValidateAnalysisMetrics(t *testing.T) {
 	})
 
 	t.Run("Error: arg has both Value and ValueFrom", func(t *testing.T) {
-		args[2].Value = pointer.StringPtr("secret-value")
+		args[2].Value = ptr.To[string]("secret-value")
 		_, err := validateAnalysisMetrics(metrics, args)
 		assert.NotNil(t, err)
 		assert.Equal(t, "arg 'secret' has both Value and ValueFrom fields", err.Error())

--- a/pkg/apis/rollouts/validation/validation_test.go
+++ b/pkg/apis/rollouts/validation/validation_test.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
@@ -82,7 +82,7 @@ func TestValidateRollout(t *testing.T) {
 	t.Run("privileged container", func(t *testing.T) {
 		ro := ro.DeepCopy()
 		ro.Spec.Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
-			Privileged: pointer.BoolPtr(true),
+			Privileged: ptr.To[bool](true),
 		}
 		allErrs := ValidateRollout(ro)
 		assert.Empty(t, allErrs)
@@ -211,7 +211,7 @@ func TestValidateRolloutStrategyCanaryMissingServiceNames(t *testing.T) {
 			// Create a table of test cases
 			canaryStrategy := &v1alpha1.CanaryStrategy{
 				Steps: []v1alpha1.CanaryStep{{
-					SetWeight: pointer.Int32(10),
+					SetWeight: ptr.To[int32](10),
 				}},
 			}
 			ro := &v1alpha1.Rollout{}
@@ -263,14 +263,14 @@ func TestValidateRolloutStrategyCanary(t *testing.T) {
 
 	t.Run("valid rollout", func(t *testing.T) {
 		validRo := ro.DeepCopy()
-		validRo.Spec.Strategy.Canary.Steps[0].SetWeight = pointer.Int32(10)
+		validRo.Spec.Strategy.Canary.Steps[0].SetWeight = ptr.To[int32](10)
 		allErrs := ValidateRolloutStrategyCanary(validRo, field.NewPath(""))
 		assert.Empty(t, allErrs)
 	})
 
 	t.Run("valid plugin missing canary and stable service", func(t *testing.T) {
 		validRo := ro.DeepCopy()
-		validRo.Spec.Strategy.Canary.Steps[0].SetWeight = pointer.Int32(10)
+		validRo.Spec.Strategy.Canary.Steps[0].SetWeight = ptr.To[int32](10)
 		validRo.Spec.Strategy.Canary.CanaryService = ""
 		validRo.Spec.Strategy.Canary.StableService = ""
 		validRo.Spec.Strategy.Canary.TrafficRouting.ALB = nil
@@ -281,7 +281,7 @@ func TestValidateRolloutStrategyCanary(t *testing.T) {
 
 	t.Run("valid Istio missing canary and stable service", func(t *testing.T) {
 		validRo := ro.DeepCopy()
-		validRo.Spec.Strategy.Canary.Steps[0].SetWeight = pointer.Int32(10)
+		validRo.Spec.Strategy.Canary.Steps[0].SetWeight = ptr.To[int32](10)
 		validRo.Spec.Strategy.Canary.CanaryService = ""
 		validRo.Spec.Strategy.Canary.StableService = ""
 		validRo.Spec.Strategy.Canary.TrafficRouting.Istio = &v1alpha1.IstioTrafficRouting{DestinationRule: &v1alpha1.IstioDestinationRule{Name: "destination-rule"}}
@@ -292,7 +292,7 @@ func TestValidateRolloutStrategyCanary(t *testing.T) {
 
 	t.Run("valid Istio with ping pong", func(t *testing.T) {
 		validRo := ro.DeepCopy()
-		validRo.Spec.Strategy.Canary.Steps[0].SetWeight = pointer.Int32(10)
+		validRo.Spec.Strategy.Canary.Steps[0].SetWeight = ptr.To[int32](10)
 		validRo.Spec.Strategy.Canary.CanaryService = ""
 		validRo.Spec.Strategy.Canary.StableService = ""
 		validRo.Spec.Strategy.Canary.PingPong = &v1alpha1.PingPongSpec{
@@ -307,7 +307,7 @@ func TestValidateRolloutStrategyCanary(t *testing.T) {
 
 	t.Run("valid PingPong missing canary and stable service", func(t *testing.T) {
 		validRo := ro.DeepCopy()
-		validRo.Spec.Strategy.Canary.Steps[0].SetWeight = pointer.Int32(10)
+		validRo.Spec.Strategy.Canary.Steps[0].SetWeight = ptr.To[int32](10)
 		validRo.Spec.Strategy.Canary.CanaryService = ""
 		validRo.Spec.Strategy.Canary.StableService = ""
 		validRo.Spec.Strategy.Canary.PingPong = &v1alpha1.PingPongSpec{PingService: "ping", PongService: "pong"}
@@ -317,7 +317,7 @@ func TestValidateRolloutStrategyCanary(t *testing.T) {
 
 	t.Run("valid two plugins missing canary and stable service", func(t *testing.T) {
 		validRo := ro.DeepCopy()
-		validRo.Spec.Strategy.Canary.Steps[0].SetWeight = pointer.Int32(10)
+		validRo.Spec.Strategy.Canary.Steps[0].SetWeight = ptr.To[int32](10)
 		validRo.Spec.Strategy.Canary.CanaryService = ""
 		validRo.Spec.Strategy.Canary.StableService = ""
 		validRo.Spec.Strategy.Canary.PingPong = &v1alpha1.PingPongSpec{PingService: "ping", PongService: "pong"}
@@ -328,7 +328,7 @@ func TestValidateRolloutStrategyCanary(t *testing.T) {
 
 	t.Run("invalid two plugins missing canary and stable service", func(t *testing.T) {
 		validRo := ro.DeepCopy()
-		validRo.Spec.Strategy.Canary.Steps[0].SetWeight = pointer.Int32(10)
+		validRo.Spec.Strategy.Canary.Steps[0].SetWeight = ptr.To[int32](10)
 		validRo.Spec.Strategy.Canary.CanaryService = ""
 		validRo.Spec.Strategy.Canary.StableService = ""
 		validRo.Spec.Strategy.Canary.TrafficRouting.ALB = nil
@@ -876,7 +876,7 @@ func TestCanaryScaleDownDelaySeconds(t *testing.T) {
 				Canary: &v1alpha1.CanaryStrategy{
 					StableService:         "stable",
 					CanaryService:         "canary",
-					ScaleDownDelaySeconds: pointer.Int32(60),
+					ScaleDownDelaySeconds: ptr.To[int32](60),
 				},
 			},
 			Template: corev1.PodTemplateSpec{
@@ -943,7 +943,7 @@ func TestCanaryDynamicStableScale(t *testing.T) {
 	})
 	t.Run("dynamicStableScale with scaleDownDelaySeconds", func(t *testing.T) {
 		ro := ro.DeepCopy()
-		ro.Spec.Strategy.Canary.ScaleDownDelaySeconds = pointer.Int32(60)
+		ro.Spec.Strategy.Canary.ScaleDownDelaySeconds = ptr.To[int32](60)
 		ro.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 			SMI: &v1alpha1.SMITrafficRouting{},
 		}
@@ -1007,7 +1007,7 @@ func TestCanaryExperimentStepWithWeight(t *testing.T) {
 			Experiment: &v1alpha1.RolloutExperimentStep{
 				Templates: []v1alpha1.RolloutExperimentTemplate{{
 					Name:   "template",
-					Weight: pointer.Int32(20),
+					Weight: ptr.To[int32](20),
 				}},
 			},
 		}},

--- a/pkg/kubectl-argo-rollouts/cmd/create/create.go
+++ b/pkg/kubectl-argo-rollouts/cmd/create/create.go
@@ -14,7 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts"
@@ -372,7 +372,7 @@ func (c *CreateAnalysisRunOptions) ParseArgFlags() ([]v1alpha1.Argument, error) 
 		}
 		arg := v1alpha1.Argument{
 			Name:  argSplit[0],
-			Value: pointer.StringPtr(argSplit[1]),
+			Value: ptr.To[string](argSplit[1]),
 		}
 		args = append(args, arg)
 	}

--- a/pkg/kubectl-argo-rollouts/cmd/list/list_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/list/list_test.go
@@ -11,7 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	kubetesting "k8s.io/client-go/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	fakeroclient "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
@@ -25,12 +25,12 @@ func newCanaryRollout() *v1alpha1.Rollout {
 			Namespace: "test",
 		},
 		Spec: v1alpha1.RolloutSpec{
-			Replicas: pointer.Int32Ptr(5),
+			Replicas: ptr.To[int32](5),
 			Strategy: v1alpha1.RolloutStrategy{
 				Canary: &v1alpha1.CanaryStrategy{
 					Steps: []v1alpha1.CanaryStep{
 						{
-							SetWeight: pointer.Int32Ptr(10),
+							SetWeight: ptr.To[int32](10),
 						},
 						{
 							Pause: &v1alpha1.RolloutPause{
@@ -38,14 +38,14 @@ func newCanaryRollout() *v1alpha1.Rollout {
 							},
 						},
 						{
-							SetWeight: pointer.Int32Ptr(20),
+							SetWeight: ptr.To[int32](20),
 						},
 					},
 				},
 			},
 		},
 		Status: v1alpha1.RolloutStatus{
-			CurrentStepIndex:  pointer.Int32Ptr(1),
+			CurrentStepIndex:  ptr.To[int32](1),
 			Replicas:          4,
 			ReadyReplicas:     1,
 			UpdatedReplicas:   3,
@@ -61,13 +61,13 @@ func newBlueGreenRollout() *v1alpha1.Rollout {
 			Namespace: "test",
 		},
 		Spec: v1alpha1.RolloutSpec{
-			Replicas: pointer.Int32Ptr(5),
+			Replicas: ptr.To[int32](5),
 			Strategy: v1alpha1.RolloutStrategy{
 				BlueGreen: &v1alpha1.BlueGreenStrategy{},
 			},
 		},
 		Status: v1alpha1.RolloutStatus{
-			CurrentStepIndex:  pointer.Int32Ptr(1),
+			CurrentStepIndex:  ptr.To[int32](1),
 			Replicas:          4,
 			ReadyReplicas:     1,
 			UpdatedReplicas:   3,

--- a/pkg/kubectl-argo-rollouts/cmd/promote/promote_test.go
+++ b/pkg/kubectl-argo-rollouts/cmd/promote/promote_test.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubetesting "k8s.io/client-go/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	fakeroclient "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
@@ -130,10 +130,10 @@ func TestPromoteCmdSuccesSkipAllSteps(t *testing.T) {
 				Canary: &v1alpha1.CanaryStrategy{
 					Steps: []v1alpha1.CanaryStep{
 						{
-							SetWeight: pointer.Int32Ptr(1),
+							SetWeight: ptr.To[int32](1),
 						},
 						{
-							SetWeight: pointer.Int32Ptr(2),
+							SetWeight: ptr.To[int32](2),
 						},
 					},
 				},
@@ -180,10 +180,10 @@ func TestPromoteCmdSuccesFirstStepWithSkipFirstStep(t *testing.T) {
 				Canary: &v1alpha1.CanaryStrategy{
 					Steps: []v1alpha1.CanaryStep{
 						{
-							SetWeight: pointer.Int32Ptr(1),
+							SetWeight: ptr.To[int32](1),
 						},
 						{
-							SetWeight: pointer.Int32Ptr(2),
+							SetWeight: ptr.To[int32](2),
 						},
 					},
 				},
@@ -230,10 +230,10 @@ func TestPromoteCmdSuccesFirstStep(t *testing.T) {
 				Canary: &v1alpha1.CanaryStrategy{
 					Steps: []v1alpha1.CanaryStep{
 						{
-							SetWeight: pointer.Int32Ptr(1),
+							SetWeight: ptr.To[int32](1),
 						},
 						{
-							SetWeight: pointer.Int32Ptr(2),
+							SetWeight: ptr.To[int32](2),
 						},
 					},
 				},
@@ -280,17 +280,17 @@ func TestPromoteCmdSuccessDoNotGoPastLastStep(t *testing.T) {
 				Canary: &v1alpha1.CanaryStrategy{
 					Steps: []v1alpha1.CanaryStep{
 						{
-							SetWeight: pointer.Int32Ptr(1),
+							SetWeight: ptr.To[int32](1),
 						},
 						{
-							SetWeight: pointer.Int32Ptr(2),
+							SetWeight: ptr.To[int32](2),
 						},
 					},
 				},
 			},
 		},
 		Status: v1alpha1.RolloutStatus{
-			CurrentStepIndex: pointer.Int32Ptr(2),
+			CurrentStepIndex: ptr.To[int32](2),
 		},
 	}
 
@@ -503,10 +503,10 @@ func TestPromoteInconclusiveStep(t *testing.T) {
 				Canary: &v1alpha1.CanaryStrategy{
 					Steps: []v1alpha1.CanaryStep{
 						{
-							SetWeight: pointer.Int32Ptr(1),
+							SetWeight: ptr.To[int32](1),
 						},
 						{
-							SetWeight: pointer.Int32Ptr(2),
+							SetWeight: ptr.To[int32](2),
 						},
 					},
 				},

--- a/rollout/analysis_test.go
+++ b/rollout/analysis_test.go
@@ -15,7 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	analysisutil "github.com/argoproj/argo-rollouts/utils/analysis"
@@ -211,7 +211,7 @@ func TestCreateBackgroundAnalysisRun(t *testing.T) {
 		SetWeight: int32Ptr(10),
 	}}
 	at := analysisTemplate("bar")
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	ar := analysisRun(at, v1alpha1.RolloutTypeBackgroundRunLabel, r2)
 	r2.Spec.Strategy.Canary.Analysis = &v1alpha1.RolloutAnalysisBackground{
@@ -274,7 +274,7 @@ func TestCreateBackgroundAnalysisRunWithTemplates(t *testing.T) {
 		SetWeight: int32Ptr(10),
 	}}
 	at := analysisTemplate("bar")
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	ar := analysisRun(at, v1alpha1.RolloutTypeBackgroundRunLabel, r2)
 	r2.Spec.Strategy.Canary.Analysis = &v1alpha1.RolloutAnalysisBackground{
@@ -335,7 +335,7 @@ func TestCreateBackgroundAnalysisRunWithClusterTemplates(t *testing.T) {
 		SetWeight: int32Ptr(10),
 	}}
 	cat := clusterAnalysisTemplate("bar", "clusterexample")
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	ar := clusterAnalysisRun(cat, v1alpha1.RolloutTypeBackgroundRunLabel, r2)
 	r2.Spec.Strategy.Canary.Analysis = &v1alpha1.RolloutAnalysisBackground{
@@ -393,7 +393,7 @@ func TestInvalidSpecMissingClusterTemplatesBackgroundAnalysis(t *testing.T) {
 	f := newFixture(t)
 	defer f.Close()
 
-	r := newCanaryRollout("foo", 10, nil, nil, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r := newCanaryRollout("foo", 10, nil, nil, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r.Spec.Strategy.Canary.Analysis = &v1alpha1.RolloutAnalysisBackground{
 		RolloutAnalysis: v1alpha1.RolloutAnalysis{
 			Templates: []v1alpha1.AnalysisTemplateRef{{
@@ -434,7 +434,7 @@ func TestCreateBackgroundAnalysisRunWithClusterTemplatesAndTemplate(t *testing.T
 	}}
 	at := analysisTemplate("bar")
 	cat := clusterAnalysisTemplate("clusterbar", "clusterexample")
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 
 	ar := &v1alpha1.AnalysisRun{
@@ -515,7 +515,7 @@ func TestCreateBackgroundAnalysisRunWithClusterTemplatesAndTemplateAndInnerTempl
 	cat2 := clusterAnalysisTemplate("clusterbar2", "clusterexample-clusterbar2")
 	cat3 := clusterAnalysisTemplate("clusterbar3", "clusterexample-clusterbar3")
 	cat4 := clusterAnalysisTemplate("clusterbar4", "clusterexample-clusterbar4")
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 
 	ar := &v1alpha1.AnalysisRun{
@@ -597,7 +597,7 @@ func TestCreateBackgroundAnalysisRunWithTemplatesAndNoMetrics(t *testing.T) {
 	cat2 := clusterAnalysisTemplate("clusterbar2", "clusterexample-clusterbar2")
 	cat3 := clusterAnalysisTemplate("clusterbar3", "clusterexample-clusterbar3")
 	cat4 := clusterAnalysisTemplate("clusterbar4", "clusterexample-clusterbar4")
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 
 	ar := &v1alpha1.AnalysisRun{
@@ -675,7 +675,7 @@ func TestCreateAnalysisRunWithCollision(t *testing.T) {
 		SetWeight: int32Ptr(10),
 	}}
 	at := analysisTemplate("bar")
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	ar := analysisRun(at, v1alpha1.RolloutTypeBackgroundRunLabel, r2)
 	r2.Spec.Strategy.Canary.Analysis = &v1alpha1.RolloutAnalysisBackground{
@@ -746,7 +746,7 @@ func TestCreateAnalysisRunWithCollisionAndSemanticEquality(t *testing.T) {
 		SetWeight: int32Ptr(10),
 	}}
 	at := analysisTemplate("bar")
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	ar := analysisRun(at, v1alpha1.RolloutTypeBackgroundRunLabel, r2)
 	r2.Spec.Strategy.Canary.Analysis = &v1alpha1.RolloutAnalysisBackground{
@@ -814,7 +814,7 @@ func TestCreateAnalysisRunOnAnalysisStep(t *testing.T) {
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	ar := analysisRun(at, v1alpha1.RolloutTypeStepLabel, r2)
 	ar.Status.Phase = v1alpha1.AnalysisPhaseRunning
@@ -883,7 +883,7 @@ func TestCreateAnalysisRunOnPromotedAnalysisStepIfPreviousStepWasAnalysisToo(t *
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	ar0Step := analysisRun(at, v1alpha1.RolloutTypeStepLabel, r2)
 	ar0Step.Status.Phase = v1alpha1.AnalysisPhaseRunning
@@ -917,7 +917,7 @@ func TestCreateAnalysisRunOnPromotedAnalysisStepIfPreviousStepWasAnalysisToo(t *
 	index := f.expectPatchRolloutAction(r2)
 
 	// simulate promote action
-	r2.Status.CurrentStepIndex = pointer.Int32Ptr(1)
+	r2.Status.CurrentStepIndex = ptr.To[int32](1)
 
 	f.run(getKey(r2, t))
 
@@ -956,7 +956,7 @@ func TestFailCreateStepAnalysisRunIfInvalidTemplateRef(t *testing.T) {
 	at.Spec.Metrics = append(at.Spec.Metrics, at.Spec.Metrics[0])
 	f.analysisTemplateLister = append(f.analysisTemplateLister, at)
 
-	r := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	f.rolloutLister = append(f.rolloutLister, r)
 	f.objects = append(f.objects, r, at)
 
@@ -985,14 +985,14 @@ func TestFailCreateBackgroundAnalysisRunIfInvalidTemplateRef(t *testing.T) {
 	defer f.Close()
 
 	steps := []v1alpha1.CanaryStep{{
-		SetWeight: pointer.Int32Ptr(10),
+		SetWeight: ptr.To[int32](10),
 	}}
 
 	at := analysisTemplate("bad-template")
 	at.Spec.Metrics = append(at.Spec.Metrics, at.Spec.Metrics[0])
 	f.analysisTemplateLister = append(f.analysisTemplateLister, at)
 
-	r := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r.Spec.Strategy.Canary.Analysis = &v1alpha1.RolloutAnalysisBackground{
 		RolloutAnalysis: v1alpha1.RolloutAnalysis{
 			Templates: []v1alpha1.AnalysisTemplateRef{
@@ -1030,7 +1030,7 @@ func TestFailCreateBackgroundAnalysisRunIfMetricRepeated(t *testing.T) {
 	defer f.Close()
 
 	steps := []v1alpha1.CanaryStep{{
-		SetWeight: pointer.Int32Ptr(10),
+		SetWeight: ptr.To[int32](10),
 	}}
 
 	at := analysisTemplate("bad-template")
@@ -1039,7 +1039,7 @@ func TestFailCreateBackgroundAnalysisRunIfMetricRepeated(t *testing.T) {
 	at2.Spec.Metrics = append(at2.Spec.Metrics, at2.Spec.Metrics[0])
 	f.analysisTemplateLister = append(f.analysisTemplateLister, at, at2)
 
-	r := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r.Spec.Strategy.Canary.Analysis = &v1alpha1.RolloutAnalysisBackground{
 		RolloutAnalysis: v1alpha1.RolloutAnalysis{
 			Templates: []v1alpha1.AnalysisTemplateRef{
@@ -1080,10 +1080,10 @@ func TestDoNothingWithAnalysisRunsWhileBackgroundAnalysisRunRunning(t *testing.T
 
 	at := analysisTemplate("bar")
 	steps := []v1alpha1.CanaryStep{{
-		SetWeight: pointer.Int32Ptr(10),
+		SetWeight: ptr.To[int32](10),
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(1), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	r2.Spec.Strategy.Canary.Analysis = &v1alpha1.RolloutAnalysisBackground{
 		RolloutAnalysis: v1alpha1.RolloutAnalysis{
@@ -1142,7 +1142,7 @@ func TestDoNothingWhileStepBasedAnalysisRunRunning(t *testing.T) {
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(1), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	ar := analysisRun(at, v1alpha1.RolloutTypeStepLabel, r2)
 	ar.Status.Phase = v1alpha1.AnalysisPhaseRunning
@@ -1191,7 +1191,7 @@ func TestCancelOlderAnalysisRuns(t *testing.T) {
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	ar := analysisRun(at, v1alpha1.RolloutTypeStepLabel, r2)
 	olderAr := ar.DeepCopy()
@@ -1259,7 +1259,7 @@ func TestDeleteAnalysisRunsWithNoMatchingRS(t *testing.T) {
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	ar := analysisRun(at, v1alpha1.RolloutTypeStepLabel, r2)
 	arWithDiffPodHash := ar.DeepCopy()
@@ -1315,10 +1315,10 @@ func TestDeleteAnalysisRunsAfterRSDelete(t *testing.T) {
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	r3 := bumpVersion(r2)
-	r3.Spec.RevisionHistoryLimit = pointer.Int32Ptr(0)
+	r3.Spec.RevisionHistoryLimit = ptr.To[int32](0)
 	ar := analysisRun(at, v1alpha1.RolloutTypeStepLabel, r3)
 
 	rs1 := newReplicaSetWithStatus(r1, 0, 0)
@@ -1372,7 +1372,7 @@ func TestIncrementStepAfterSuccessfulAnalysisRun(t *testing.T) {
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	ar := analysisRun(at, v1alpha1.RolloutTypeStepLabel, r2)
 	ar.Status = v1alpha1.AnalysisRunStatus{
@@ -1418,12 +1418,12 @@ func TestPausedOnInconclusiveBackgroundAnalysisRun(t *testing.T) {
 
 	at := analysisTemplate("bar")
 	steps := []v1alpha1.CanaryStep{
-		{SetWeight: pointer.Int32Ptr(10)},
-		{SetWeight: pointer.Int32Ptr(20)},
-		{SetWeight: pointer.Int32Ptr(30)},
+		{SetWeight: ptr.To[int32](10)},
+		{SetWeight: ptr.To[int32](20)},
+		{SetWeight: ptr.To[int32](30)},
 	}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(1), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	ar := analysisRun(at, v1alpha1.RolloutTypeBackgroundRunLabel, r2)
 	r2.Spec.Strategy.Canary.Analysis = &v1alpha1.RolloutAnalysisBackground{
@@ -1496,7 +1496,7 @@ func TestPausedStepAfterInconclusiveAnalysisRun(t *testing.T) {
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	ar := analysisRun(at, v1alpha1.RolloutTypeStepLabel, r2)
 	ar.Status = v1alpha1.AnalysisRunStatus{
@@ -1559,7 +1559,7 @@ func TestErrorConditionAfterErrorAnalysisRunStep(t *testing.T) {
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	ar := analysisRun(at, v1alpha1.RolloutTypeStepLabel, r2)
 	ar.Status = v1alpha1.AnalysisRunStatus{
@@ -1617,12 +1617,12 @@ func TestErrorConditionAfterErrorAnalysisRunBackground(t *testing.T) {
 
 	at := analysisTemplate("bar")
 	steps := []v1alpha1.CanaryStep{
-		{SetWeight: pointer.Int32Ptr(10)},
-		{SetWeight: pointer.Int32Ptr(20)},
-		{SetWeight: pointer.Int32Ptr(40)},
+		{SetWeight: ptr.To[int32](10)},
+		{SetWeight: ptr.To[int32](20)},
+		{SetWeight: ptr.To[int32](40)},
 	}
 
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	r2.Spec.Strategy.Canary.Analysis = &v1alpha1.RolloutAnalysisBackground{
 		RolloutAnalysis: v1alpha1.RolloutAnalysis{
@@ -1702,7 +1702,7 @@ func TestCancelAnalysisRunsWhenAborted(t *testing.T) {
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	ar := analysisRun(at, v1alpha1.RolloutTypeStepLabel, r2)
 	olderAr := ar.DeepCopy()
@@ -1754,10 +1754,10 @@ func TestCancelBackgroundAnalysisRunWhenRolloutIsCompleted(t *testing.T) {
 
 	at := analysisTemplate("bar")
 	steps := []v1alpha1.CanaryStep{
-		{SetWeight: pointer.Int32Ptr(10)},
+		{SetWeight: ptr.To[int32](10)},
 	}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](1), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	r2.Spec.Strategy.Canary.Analysis = &v1alpha1.RolloutAnalysisBackground{
 		RolloutAnalysis: v1alpha1.RolloutAnalysis{
@@ -1800,10 +1800,10 @@ func TestDoNotCreateBackgroundAnalysisRunAfterInconclusiveRun(t *testing.T) {
 
 	at := analysisTemplate("bar")
 	steps := []v1alpha1.CanaryStep{
-		{SetWeight: pointer.Int32Ptr(10)},
+		{SetWeight: ptr.To[int32](10)},
 	}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(1), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	r2.Spec.Strategy.Canary.Analysis = &v1alpha1.RolloutAnalysisBackground{
 		RolloutAnalysis: v1alpha1.RolloutAnalysis{
@@ -1856,10 +1856,10 @@ func TestDoNotCreateBackgroundAnalysisRunOnNewCanaryRollout(t *testing.T) {
 
 	at := analysisTemplate("bar")
 	steps := []v1alpha1.CanaryStep{
-		{SetWeight: pointer.Int32Ptr(10)},
+		{SetWeight: ptr.To[int32](10)},
 	}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r1.Spec.Strategy.Canary.Analysis = &v1alpha1.RolloutAnalysisBackground{
 		RolloutAnalysis: v1alpha1.RolloutAnalysis{
 			Templates: []v1alpha1.AnalysisTemplateRef{
@@ -1891,10 +1891,10 @@ func TestDoNotCreateBackgroundAnalysisRunOnNewCanaryRolloutStableRSEmpty(t *test
 
 	at := analysisTemplate("bar")
 	steps := []v1alpha1.CanaryStep{
-		{SetWeight: pointer.Int32Ptr(10)},
+		{SetWeight: ptr.To[int32](10)},
 	}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r1.Spec.Strategy.Canary.Analysis = &v1alpha1.RolloutAnalysisBackground{
 		RolloutAnalysis: v1alpha1.RolloutAnalysis{
 			Templates: []v1alpha1.AnalysisTemplateRef{
@@ -1924,7 +1924,7 @@ func TestDoNotCreateBackgroundAnalysisRunWhenWithinRollbackWindow(t *testing.T) 
 
 	at := analysisTemplate("bar")
 
-	r1 := newCanaryRollout("foo", 1, nil, nil, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, nil, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r1.Spec.Strategy.Canary.Analysis = &v1alpha1.RolloutAnalysisBackground{
 		RolloutAnalysis: v1alpha1.RolloutAnalysis{
 			Templates: []v1alpha1.AnalysisTemplateRef{
@@ -1965,7 +1965,7 @@ func TestCreatePrePromotionAnalysisRun(t *testing.T) {
 
 	at := analysisTemplate("bar")
 	r1 := newBlueGreenRollout("foo", 1, nil, "active", "preview")
-	r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
+	r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = ptr.To[bool](false)
 	r2 := bumpVersion(r1)
 	r2.Spec.Strategy.BlueGreen.PrePromotionAnalysis = &v1alpha1.RolloutAnalysis{
 		Templates: []v1alpha1.AnalysisTemplateRef{{
@@ -2105,7 +2105,7 @@ func TestDoNotCreatePrePromotionAnalysisRunOnNotReadyReplicaSet(t *testing.T) {
 	defer f.Close()
 
 	r1 := newBlueGreenRollout("foo", 2, nil, "active", "preview")
-	r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
+	r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = ptr.To[bool](false)
 	r2 := bumpVersion(r1)
 	r2.Spec.Strategy.BlueGreen.PrePromotionAnalysis = &v1alpha1.RolloutAnalysis{
 		Templates: []v1alpha1.AnalysisTemplateRef{{
@@ -2147,7 +2147,7 @@ func TestRolloutPrePromotionAnalysisBecomesInconclusive(t *testing.T) {
 
 	at := analysisTemplate("bar")
 	r1 := newBlueGreenRollout("foo", 1, nil, "active", "")
-	r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
+	r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = ptr.To[bool](false)
 	r2 := bumpVersion(r1)
 	r2.Spec.Strategy.BlueGreen.PrePromotionAnalysis = &v1alpha1.RolloutAnalysis{
 		Templates: []v1alpha1.AnalysisTemplateRef{{
@@ -2217,7 +2217,7 @@ func TestRolloutPrePromotionAnalysisSwitchServiceAfterSuccess(t *testing.T) {
 
 	at := analysisTemplate("bar")
 	r1 := newBlueGreenRollout("foo", 1, nil, "active", "")
-	r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(true)
+	r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = ptr.To[bool](true)
 	r2 := bumpVersion(r1)
 	r2.Spec.Strategy.BlueGreen.PrePromotionAnalysis = &v1alpha1.RolloutAnalysis{
 		Templates: []v1alpha1.AnalysisTemplateRef{{
@@ -2281,7 +2281,7 @@ func TestRolloutPrePromotionAnalysisHonorAutoPromotionSeconds(t *testing.T) {
 
 	at := analysisTemplate("bar")
 	r1 := newBlueGreenRollout("foo", 1, nil, "active", "")
-	r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(true)
+	r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = ptr.To[bool](true)
 	r2 := bumpVersion(r1)
 	r2.Spec.Strategy.BlueGreen.AutoPromotionSeconds = 10
 	r2.Spec.Strategy.BlueGreen.PrePromotionAnalysis = &v1alpha1.RolloutAnalysis{
@@ -2347,7 +2347,7 @@ func TestRolloutPrePromotionAnalysisDoNothingOnInconclusiveAnalysis(t *testing.T
 
 	at := analysisTemplate("bar")
 	r1 := newBlueGreenRollout("foo", 1, nil, "active", "")
-	r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
+	r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = ptr.To[bool](false)
 	r2 := bumpVersion(r1)
 	r2.Spec.Strategy.BlueGreen.PrePromotionAnalysis = &v1alpha1.RolloutAnalysis{
 		Templates: []v1alpha1.AnalysisTemplateRef{{
@@ -2401,7 +2401,7 @@ func TestAbortRolloutOnErrorPrePromotionAnalysis(t *testing.T) {
 
 	at := analysisTemplate("bar")
 	r1 := newBlueGreenRollout("foo", 1, nil, "active", "")
-	r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
+	r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = ptr.To[bool](false)
 	r2 := bumpVersion(r1)
 	r2.Spec.Strategy.BlueGreen.PrePromotionAnalysis = &v1alpha1.RolloutAnalysis{
 		Templates: []v1alpha1.AnalysisTemplateRef{{
@@ -2713,7 +2713,7 @@ func TestCreateAnalysisRunWithCustomAnalysisRunMetadataAndROCopyLabels(t *testin
 		SetWeight: int32Ptr(10),
 	}}
 	at := analysisTemplate("bar")
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r1.ObjectMeta.Labels = make(map[string]string)
 	r1.Spec.Selector.MatchLabels["my-label"] = "1234"
 	r2 := bumpVersion(r1)
@@ -2765,10 +2765,10 @@ func TestCancelBackgroundAnalysisRunWhenRolloutAnalysisHasNoTemplate(t *testing.
 
 	at := analysisTemplate("bar")
 	steps := []v1alpha1.CanaryStep{
-		{SetWeight: pointer.Int32Ptr(10)},
+		{SetWeight: ptr.To[int32](10)},
 	}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](1), intstr.FromInt(0), intstr.FromInt(1))
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 	r1 = updateCanaryRolloutStatus(r1, rs1PodHash, 1, 1, 1, false)

--- a/rollout/bluegreen_test.go
+++ b/rollout/bluegreen_test.go
@@ -14,7 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	core "k8s.io/client-go/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/annotations"
@@ -268,7 +268,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		defer f.Close()
 
 		r1 := newBlueGreenRollout("foo", 2, nil, "active", "preview")
-		r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
+		r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = ptr.To[bool](false)
 		r2 := bumpVersion(r1)
 
 		rs1 := newReplicaSetWithStatus(r1, 2, 2)
@@ -300,7 +300,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		defer f.Close()
 
 		r1 := newBlueGreenRollout("foo", 1, nil, "active", "preview")
-		r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
+		r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = ptr.To[bool](false)
 		r2 := bumpVersion(r1)
 		rs1 := newReplicaSetWithStatus(r1, 1, 1)
 		rs2 := newReplicaSetWithStatus(r2, 1, 1)
@@ -347,7 +347,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		defer f.Close()
 
 		r1 := newBlueGreenRollout("foo", 1, nil, "active", "preview")
-		r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
+		r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = ptr.To[bool](false)
 		r2 := bumpVersion(r1)
 
 		rs1 := newReplicaSetWithStatus(r1, 1, 1)
@@ -387,7 +387,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		defer f.Close()
 
 		r1 := newBlueGreenRollout("foo", 1, nil, "active", "preview")
-		r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
+		r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = ptr.To[bool](false)
 		r2 := bumpVersion(r1)
 
 		rs1 := newReplicaSetWithStatus(r1, 1, 1)
@@ -428,7 +428,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		defer f.Close()
 
 		r1 := newBlueGreenRollout("foo", 1, nil, "active", "preview")
-		r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
+		r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = ptr.To[bool](false)
 		r2 := bumpVersion(r1)
 		r2.Spec.Strategy.BlueGreen.PrePromotionAnalysis = &v1alpha1.RolloutAnalysis{
 			Templates: []v1alpha1.AnalysisTemplateRef{{
@@ -634,7 +634,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
 		r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, rs1PodHash, 1, 1, 2, 1, false, true, false)
-		r2.Spec.Strategy.BlueGreen.ScaleDownDelaySeconds = pointer.Int32Ptr(10)
+		r2.Spec.Strategy.BlueGreen.ScaleDownDelaySeconds = ptr.To[int32](10)
 
 		progressingCondition, _ := newProgressingCondition(conditions.NewReplicaSetReason, rs2, "")
 		conditions.SetRolloutCondition(&r2.Status, progressingCondition)
@@ -677,7 +677,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		defer f.Close()
 
 		r1 := newBlueGreenRollout("foo", 1, nil, "active", "")
-		r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
+		r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = ptr.To[bool](false)
 		r2 := bumpVersion(r1)
 
 		rs1 := newReplicaSetWithStatus(r1, 1, 1)
@@ -725,7 +725,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		defer f.Close()
 
 		r1 := newBlueGreenRollout("foo", 1, nil, "active", "")
-		r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
+		r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = ptr.To[bool](false)
 
 		rs1 := newReplicaSetWithStatus(r1, 1, 1)
 		rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
@@ -773,7 +773,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		defer f.Close()
 
 		r1 := newBlueGreenRollout("foo", 1, nil, "active", "preview")
-		r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
+		r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = ptr.To[bool](false)
 		r2 := bumpVersion(r1)
 
 		rs1 := newReplicaSetWithStatus(r1, 1, 1)
@@ -781,7 +781,7 @@ func TestBlueGreenHandlePause(t *testing.T) {
 		rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 		rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-		r2.Spec.Strategy.BlueGreen.ScaleDownDelaySeconds = pointer.Int32Ptr(10)
+		r2.Spec.Strategy.BlueGreen.ScaleDownDelaySeconds = ptr.To[int32](10)
 		r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 1, 1, 2, 1, false, true, false)
 		r2.Status.ControllerPause = true
 		completedCondition, _ := newCompletedCondition(false)
@@ -856,7 +856,7 @@ func TestBlueGreenAddScaleDownDelayToPreviousActiveReplicaSet(t *testing.T) {
 	f.kubeobjects = append(f.kubeobjects, s, rs1, rs2)
 	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
 
-	r2.Spec.Strategy.BlueGreen.ScaleDownDelaySeconds = pointer.Int32Ptr(10)
+	r2.Spec.Strategy.BlueGreen.ScaleDownDelaySeconds = ptr.To[int32](10)
 	r2 = updateBlueGreenRolloutStatus(r2, "", rs1PodHash, rs1PodHash, 1, 1, 2, 1, false, true, false)
 	f.rolloutLister = append(f.rolloutLister, r2)
 	f.objects = append(f.objects, r2)
@@ -890,7 +890,7 @@ func TestBlueGreenRolloutStatusHPAStatusFieldsActiveSelectorSet(t *testing.T) {
 	defer f.Close()
 
 	r := newBlueGreenRollout("foo", 1, nil, "active", "preview")
-	r.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
+	r.Spec.Strategy.BlueGreen.AutoPromotionEnabled = ptr.To[bool](false)
 	r2 := bumpVersion(r)
 
 	rs1 := newReplicaSetWithStatus(r, 1, 1)
@@ -992,7 +992,7 @@ func TestBlueGreenRolloutScaleUpdateActiveRS(t *testing.T) {
 	f.kubeobjects = append(f.kubeobjects, rs1, rs2)
 	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
 
-	r2.Spec.Replicas = pointer.Int32Ptr(2)
+	r2.Spec.Replicas = ptr.To[int32](2)
 	f.rolloutLister = append(f.rolloutLister, r2)
 
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
@@ -1042,7 +1042,7 @@ func TestBlueGreenRolloutScaleUpdateStableRS(t *testing.T) {
 	// Patch the rollout to get it in the state we want (old RS is stable and new is active)
 	f.run(getKey(r2, t))
 	// Actually update the replicas now that we are in the desired state (old RS is stable and new is active)
-	r2.Spec.Replicas = pointer.Int32Ptr(2)
+	r2.Spec.Replicas = ptr.To[int32](2)
 
 	f.expectUpdateReplicaSetAction(rs1)
 	f.expectUpdateReplicaSetAction(rs2)
@@ -1104,7 +1104,7 @@ func TestPreviewReplicaCountHandleScaleUpPreviewCheckPoint(t *testing.T) {
 		defer f.Close()
 
 		r1 := newBlueGreenRollout("foo", 5, nil, "active", "")
-		r1.Spec.Strategy.BlueGreen.PreviewReplicaCount = pointer.Int32Ptr(3)
+		r1.Spec.Strategy.BlueGreen.PreviewReplicaCount = ptr.To[int32](3)
 		rs1 := newReplicaSetWithStatus(r1, 5, 5)
 		r2 := bumpVersion(r1)
 
@@ -1135,8 +1135,8 @@ func TestPreviewReplicaCountHandleScaleUpPreviewCheckPoint(t *testing.T) {
 		defer f.Close()
 
 		r1 := newBlueGreenRollout("foo", 5, nil, "active", "")
-		r1.Spec.Strategy.BlueGreen.PreviewReplicaCount = pointer.Int32Ptr(3)
-		r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
+		r1.Spec.Strategy.BlueGreen.PreviewReplicaCount = ptr.To[int32](3)
+		r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = ptr.To[bool](false)
 		rs1 := newReplicaSetWithStatus(r1, 5, 5)
 		r2 := bumpVersion(r1)
 
@@ -1167,7 +1167,7 @@ func TestPreviewReplicaCountHandleScaleUpPreviewCheckPoint(t *testing.T) {
 		defer f.Close()
 
 		r1 := newBlueGreenRollout("foo", 5, nil, "active", "")
-		r1.Spec.Strategy.BlueGreen.PreviewReplicaCount = pointer.Int32Ptr(3)
+		r1.Spec.Strategy.BlueGreen.PreviewReplicaCount = ptr.To[int32](3)
 		rs1 := newReplicaSetWithStatus(r1, 5, 5)
 		r2 := bumpVersion(r1)
 
@@ -1198,9 +1198,9 @@ func TestBlueGreenRolloutIgnoringScalingUsePreviewRSCount(t *testing.T) {
 	defer f.Close()
 
 	r1 := newBlueGreenRollout("foo", 1, nil, "active", "preview")
-	r1.Spec.Strategy.BlueGreen.PreviewReplicaCount = pointer.Int32Ptr(3)
+	r1.Spec.Strategy.BlueGreen.PreviewReplicaCount = ptr.To[int32](3)
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
-	rs1.Spec.Replicas = pointer.Int32Ptr(2)
+	rs1.Spec.Replicas = ptr.To[int32](2)
 	rs1.Annotations[annotations.DesiredReplicasAnnotation] = "2"
 	r2 := bumpVersion(r1)
 
@@ -1216,7 +1216,7 @@ func TestBlueGreenRolloutIgnoringScalingUsePreviewRSCount(t *testing.T) {
 
 	r2 = updateBlueGreenRolloutStatus(r2, rs2PodHash, rs1PodHash, rs1PodHash, 2, 1, 1, 1, false, true, true)
 	// Scaling up the rollout
-	r2.Spec.Replicas = pointer.Int32Ptr(2)
+	r2.Spec.Replicas = ptr.To[int32](2)
 	f.rolloutLister = append(f.rolloutLister, r2)
 	f.objects = append(f.objects, r2)
 	f.kubeobjects = append(f.kubeobjects, previewSvc, activeSvc)
@@ -1467,7 +1467,7 @@ func TestBlueGreenScaleDownLimit(t *testing.T) {
 	r1 := newBlueGreenRollout("foo", 1, nil, "bar", "")
 	r2 := bumpVersion(r1)
 	r3 := bumpVersion(r2)
-	r3.Spec.Strategy.BlueGreen.ScaleDownDelayRevisionLimit = pointer.Int32Ptr(1)
+	r3.Spec.Strategy.BlueGreen.ScaleDownDelayRevisionLimit = ptr.To[int32](1)
 
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
 	rs2 := newReplicaSetWithStatus(r2, 1, 1)

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -6,7 +6,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/rollout/trafficrouting"
@@ -429,7 +429,7 @@ func (c *rolloutContext) syncRolloutStatusCanary() error {
 			if newStatus.StableRS == newStatus.CurrentPodHash {
 				newStatus.CurrentStepIndex = &stepCount
 			} else {
-				newStatus.CurrentStepIndex = pointer.Int32Ptr(0)
+				newStatus.CurrentStepIndex = ptr.To[int32](0)
 			}
 		}
 		newStatus = c.calculateRolloutConditions(newStatus)

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	k8sinformers "k8s.io/client-go/informers"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
@@ -151,7 +151,7 @@ func TestCanaryRolloutEnterPauseState(t *testing.T) {
 			Pause: &v1alpha1.RolloutPause{},
 		},
 	}
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(1), intstr.FromInt(0))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(0))
 	r2 := bumpVersion(r1)
 
 	rs1 := newReplicaSetWithStatus(r1, 10, 10)
@@ -198,7 +198,7 @@ func TestCanaryRolloutNoProgressWhilePaused(t *testing.T) {
 			Pause: &v1alpha1.RolloutPause{},
 		},
 	}
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(1), intstr.FromInt(0))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(0))
 	r2 := bumpVersion(r1)
 
 	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, r2, "")
@@ -231,7 +231,7 @@ func TestCanaryRolloutUpdatePauseConditionWhilePaused(t *testing.T) {
 			Pause: &v1alpha1.RolloutPause{},
 		},
 	}
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(1), intstr.FromInt(0))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(0))
 	r2 := bumpVersion(r1)
 
 	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, r2, "")
@@ -273,7 +273,7 @@ func TestCanaryRolloutResetProgressDeadlineOnRetry(t *testing.T) {
 			Pause: &v1alpha1.RolloutPause{},
 		},
 	}
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(1), intstr.FromInt(0))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(0))
 	r2 := bumpVersion(r1)
 
 	progressingCondition, _ := newProgressingCondition(conditions.RolloutAbortedReason, r2, "")
@@ -316,7 +316,7 @@ func TestCanaryRolloutIncrementStepAfterUnPaused(t *testing.T) {
 			Pause: &v1alpha1.RolloutPause{},
 		},
 	}
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(1), intstr.FromInt(0))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(0))
 	rs1 := newReplicaSetWithStatus(r1, 10, 10)
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 	f.kubeobjects = append(f.kubeobjects, rs1)
@@ -358,7 +358,7 @@ func TestCanaryRolloutUpdateStatusWhenAtEndOfSteps(t *testing.T) {
 			Pause: &v1alpha1.RolloutPause{},
 		},
 	}
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
 	r2 := bumpVersion(r1)
 
 	expectedStableRS := r2.Status.CurrentPodHash
@@ -815,13 +815,13 @@ func TestCanaryDontScaleDownOldRsDuringInterruptedUpdate(t *testing.T) {
 
 	steps := []v1alpha1.CanaryStep{
 		{
-			SetWeight: pointer.Int32Ptr(100),
+			SetWeight: ptr.To[int32](100),
 		},
 		{
 			Pause: &v1alpha1.RolloutPause{},
 		},
 	}
-	r1 := newCanaryRollout("foo", 5, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+	r1 := newCanaryRollout("foo", 5, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
 	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 		SMI: &v1alpha1.SMITrafficRouting{},
 	}
@@ -862,13 +862,13 @@ func TestCanaryScaleDownOldRsDuringInterruptedUpdate(t *testing.T) {
 
 	steps := []v1alpha1.CanaryStep{
 		{
-			SetWeight: pointer.Int32Ptr(100),
+			SetWeight: ptr.To[int32](100),
 		},
 		{
 			Pause: &v1alpha1.RolloutPause{},
 		},
 	}
-	r1 := newCanaryRollout("foo", 5, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+	r1 := newCanaryRollout("foo", 5, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
 	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 		SMI: &v1alpha1.SMITrafficRouting{},
 	}
@@ -997,9 +997,9 @@ func TestGradualShiftToNewStable(t *testing.T) {
 	defer f.Close()
 
 	steps := []v1alpha1.CanaryStep{{
-		SetWeight: pointer.Int32Ptr(10),
+		SetWeight: ptr.To[int32](10),
 	}}
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(3), intstr.FromInt(0))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(3), intstr.FromInt(0))
 
 	r2 := bumpVersion(r1)
 	rs2 := newReplicaSetWithStatus(r2, 4, 4)
@@ -1054,7 +1054,7 @@ func TestRollBackToStableAndStepChange(t *testing.T) {
 	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
 
 	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 10, 9, 10, false)
-	r2.Spec.Strategy.Canary.Steps[0].SetWeight = pointer.Int32Ptr(20)
+	r2.Spec.Strategy.Canary.Steps[0].SetWeight = ptr.To[int32](20)
 	f.rolloutLister = append(f.rolloutLister, r2)
 	f.objects = append(f.objects, r2)
 
@@ -1282,12 +1282,12 @@ func TestCanaryRolloutStatusHPAStatusFields(t *testing.T) {
 
 	steps := []v1alpha1.CanaryStep{
 		{
-			SetWeight: pointer.Int32Ptr(20),
+			SetWeight: ptr.To[int32](20),
 		}, {
 			Pause: &v1alpha1.RolloutPause{},
 		},
 	}
-	r1 := newCanaryRollout("foo", 5, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+	r1 := newCanaryRollout("foo", 5, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
 	r1.Status.Selector = ""
 	r2 := bumpVersion(r1)
 	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, r2, "")
@@ -1401,7 +1401,7 @@ func TestCanarySVCSelectors(t *testing.T) {
 					},
 				},
 				Spec: v1.ReplicaSetSpec{
-					Replicas: pointer.Int32Ptr(tc.canaryReplicas),
+					Replicas: ptr.To[int32](tc.canaryReplicas),
 				},
 				Status: v1.ReplicaSetStatus{
 					AvailableReplicas: tc.canaryAvailReplicas,
@@ -1510,7 +1510,7 @@ func TestCanarySVCSelectorsBasicCanaryAbortServiceSwitchBack(t *testing.T) {
 					},
 				},
 				Spec: v1.ReplicaSetSpec{
-					Replicas: pointer.Int32Ptr(tc.canaryReplicas),
+					Replicas: ptr.To[int32](tc.canaryReplicas),
 				},
 				Status: v1.ReplicaSetStatus{
 					AvailableReplicas: tc.canaryAvailReplicas,
@@ -1525,7 +1525,7 @@ func TestCanarySVCSelectorsBasicCanaryAbortServiceSwitchBack(t *testing.T) {
 					},
 				},
 				Spec: v1.ReplicaSetSpec{
-					Replicas: pointer.Int32Ptr(tc.canaryReplicas),
+					Replicas: ptr.To[int32](tc.canaryReplicas),
 				},
 				Status: v1.ReplicaSetStatus{
 					AvailableReplicas: tc.canaryAvailReplicas,
@@ -1724,10 +1724,10 @@ func TestCanaryRolloutScaleWhilePaused(t *testing.T) {
 
 	steps := []v1alpha1.CanaryStep{
 		{
-			SetWeight: pointer.Int32Ptr(20),
+			SetWeight: ptr.To[int32](20),
 		},
 	}
-	r1 := newCanaryRollout("foo", 5, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(1), intstr.FromInt(0))
+	r1 := newCanaryRollout("foo", 5, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(0))
 	r2 := bumpVersion(r1)
 
 	rs1 := newReplicaSetWithStatus(r1, 5, 5)
@@ -1737,7 +1737,7 @@ func TestCanaryRolloutScaleWhilePaused(t *testing.T) {
 	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
 
 	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 5, 0, 5, true)
-	r2.Spec.Replicas = pointer.Int32Ptr(10)
+	r2.Spec.Replicas = ptr.To[int32](10)
 	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, rs2, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
 
@@ -1765,7 +1765,7 @@ func TestResumeRolloutAfterPauseDuration(t *testing.T) {
 
 	steps := []v1alpha1.CanaryStep{
 		{
-			SetWeight: pointer.Int32Ptr(10),
+			SetWeight: ptr.To[int32](10),
 		},
 		{
 			Pause: &v1alpha1.RolloutPause{
@@ -1773,10 +1773,10 @@ func TestResumeRolloutAfterPauseDuration(t *testing.T) {
 			},
 		},
 		{
-			SetWeight: pointer.Int32Ptr(20),
+			SetWeight: ptr.To[int32](20),
 		},
 	}
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
@@ -1815,7 +1815,7 @@ func TestNoResumeAfterPauseDurationIfUserPaused(t *testing.T) {
 
 	steps := []v1alpha1.CanaryStep{
 		{
-			SetWeight: pointer.Int32Ptr(10),
+			SetWeight: ptr.To[int32](10),
 		},
 		{
 			Pause: &v1alpha1.RolloutPause{
@@ -1823,10 +1823,10 @@ func TestNoResumeAfterPauseDurationIfUserPaused(t *testing.T) {
 			},
 		},
 		{
-			SetWeight: pointer.Int32Ptr(20),
+			SetWeight: ptr.To[int32](20),
 		},
 	}
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	rs1 := newReplicaSetWithStatus(r1, 0, 0)
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
@@ -1865,7 +1865,7 @@ func TestHandleNilNewRSOnScaleAndImageChange(t *testing.T) {
 
 	steps := []v1alpha1.CanaryStep{
 		{
-			SetWeight: pointer.Int32Ptr(10),
+			SetWeight: ptr.To[int32](10),
 		},
 		{
 			Pause: &v1alpha1.RolloutPause{
@@ -1873,14 +1873,14 @@ func TestHandleNilNewRSOnScaleAndImageChange(t *testing.T) {
 			},
 		},
 		{
-			SetWeight: pointer.Int32Ptr(20),
+			SetWeight: ptr.To[int32](20),
 		},
 	}
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(1))
 	rs1 := newReplicaSetWithStatus(r1, 3, 3)
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 	r2 := bumpVersion(r1)
-	r2.Spec.Replicas = pointer.Int32Ptr(3)
+	r2.Spec.Replicas = ptr.To[int32](3)
 	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 3, 0, 3, true)
 	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, rs1, "")
 	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
@@ -2071,7 +2071,7 @@ func TestIsDynamicallyRollingBackToStable(t *testing.T) {
 				},
 			},
 			rsHash:              "abc123",
-			rsAvailableReplicas: pointer.Int32(1),
+			rsAvailableReplicas: ptr.To[int32](1),
 			expectedResult:      true,
 		},
 		{

--- a/rollout/controller.go
+++ b/rollout/controller.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/kubectl/pkg/util/slice"
 	"k8s.io/kubernetes/pkg/controller"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts"
 
@@ -452,7 +452,7 @@ func (c *Controller) syncHandler(ctx context.Context, key string) error {
 	// the rollout to have the replicas field set to the default value. see https://github.com/argoproj/argo-rollouts/issues/119
 	if rollout.Spec.Replicas == nil {
 		logCtx.Info("Defaulting .spec.replica to 1")
-		r.Spec.Replicas = pointer.Int32Ptr(defaults.DefaultReplicas)
+		r.Spec.Replicas = ptr.To[int32](defaults.DefaultReplicas)
 		newRollout, err := c.argoprojclientset.ArgoprojV1alpha1().Rollouts(r.Namespace).Update(ctx, r, metav1.UpdateOptions{})
 		if err == nil {
 			c.writeBackToInformer(newRollout)

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	corev1defaults "k8s.io/kubernetes/pkg/apis/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
 	"github.com/argoproj/argo-rollouts/controller/metrics"
@@ -1311,12 +1311,12 @@ func TestRequeueStuckRollout(t *testing.T) {
 		},
 		{
 			name:               "Less than a second",
-			rollout:            rollout(conditions.ReplicaSetUpdatedReason, false, false, pointer.Int32Ptr(10)),
+			rollout:            rollout(conditions.ReplicaSetUpdatedReason, false, false, ptr.To[int32](10)),
 			requeueImmediately: true,
 		},
 		{
 			name:    "More than a second",
-			rollout: rollout(conditions.ReplicaSetUpdatedReason, false, false, pointer.Int32Ptr(20)),
+			rollout: rollout(conditions.ReplicaSetUpdatedReason, false, false, ptr.To[int32](20)),
 		},
 	}
 	for i := range tests {
@@ -1836,7 +1836,7 @@ func TestGetReferencedIngressesALB(t *testing.T) {
 				Namespace: metav1.NamespaceDefault,
 			},
 			Spec: extensionsv1beta1.IngressSpec{
-				IngressClassName: pointer.StringPtr("alb"),
+				IngressClassName: ptr.To[string]("alb"),
 				Backend: &extensionsv1beta1.IngressBackend{
 					ServiceName: "active-service",
 					ServicePort: intstr.IntOrString{IntVal: 80},
@@ -1947,7 +1947,7 @@ func TestGetReferencedIngressesALBMultiIngress(t *testing.T) {
 				Namespace: metav1.NamespaceDefault,
 			},
 			Spec: extensionsv1beta1.IngressSpec{
-				IngressClassName: pointer.StringPtr("alb"),
+				IngressClassName: ptr.To[string]("alb"),
 				Backend: &extensionsv1beta1.IngressBackend{
 					ServiceName: "active-service",
 					ServicePort: intstr.IntOrString{IntVal: 80},
@@ -1978,7 +1978,7 @@ func TestGetReferencedIngressesALBMultiIngress(t *testing.T) {
 				Namespace: metav1.NamespaceDefault,
 			},
 			Spec: extensionsv1beta1.IngressSpec{
-				IngressClassName: pointer.StringPtr("alb"),
+				IngressClassName: ptr.To[string]("alb"),
 				Backend: &extensionsv1beta1.IngressBackend{
 					ServiceName: "active-service",
 					ServicePort: intstr.IntOrString{IntVal: 80},
@@ -2057,7 +2057,7 @@ func TestGetReferencedIngressesNginx(t *testing.T) {
 				Namespace: metav1.NamespaceDefault,
 			},
 			Spec: extensionsv1beta1.IngressSpec{
-				IngressClassName: pointer.StringPtr("alb"),
+				IngressClassName: ptr.To[string]("alb"),
 				Backend: &extensionsv1beta1.IngressBackend{
 					ServiceName: "active-service",
 					ServicePort: intstr.IntOrString{IntVal: 80},
@@ -2176,7 +2176,7 @@ func TestGetReferencedIngressesNginxMultiIngress(t *testing.T) {
 				Namespace: metav1.NamespaceDefault,
 			},
 			Spec: extensionsv1beta1.IngressSpec{
-				IngressClassName: pointer.StringPtr("alb"),
+				IngressClassName: ptr.To[string]("alb"),
 				Backend: &extensionsv1beta1.IngressBackend{
 					ServiceName: "active-service",
 					ServicePort: intstr.IntOrString{IntVal: 80},
@@ -2207,7 +2207,7 @@ func TestGetReferencedIngressesNginxMultiIngress(t *testing.T) {
 				Namespace: metav1.NamespaceDefault,
 			},
 			Spec: extensionsv1beta1.IngressSpec{
-				IngressClassName: pointer.StringPtr("alb"),
+				IngressClassName: ptr.To[string]("alb"),
 				Backend: &extensionsv1beta1.IngressBackend{
 					ServiceName: "active-service",
 					ServicePort: intstr.IntOrString{IntVal: 80},

--- a/rollout/ephemeralmetadata_test.go
+++ b/rollout/ephemeralmetadata_test.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/annotations"
@@ -21,7 +21,7 @@ func TestSyncCanaryEphemeralMetadataInitialRevision(t *testing.T) {
 	f := newFixture(t)
 	defer f.Close()
 
-	r1 := newCanaryRollout("foo", 1, nil, nil, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, nil, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(1))
 	r1.Spec.Strategy.Canary.CanaryMetadata = &v1alpha1.PodTemplateMetadata{
 		Labels: map[string]string{
 			"role": "canary",
@@ -97,7 +97,7 @@ func TestSyncCanaryEphemeralMetadataSecondRevision(t *testing.T) {
 	f := newFixture(t)
 	defer f.Close()
 
-	r1 := newCanaryRollout("foo", 1, nil, nil, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, nil, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(1))
 	r1.Annotations[annotations.RevisionAnnotation] = "1"
 	r1.Spec.Strategy.Canary.CanaryMetadata = &v1alpha1.PodTemplateMetadata{
 		Labels: map[string]string{
@@ -175,7 +175,7 @@ func TestSyncBlueGreenEphemeralMetadataSecondRevision(t *testing.T) {
 	defer f.Close()
 
 	r1 := newBlueGreenRollout("foo", 3, nil, "active", "preview")
-	r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
+	r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = ptr.To[bool](false)
 	r1.Annotations[annotations.RevisionAnnotation] = "1"
 	r1.Spec.Strategy.BlueGreen.PreviewMetadata = &v1alpha1.PodTemplateMetadata{
 		Labels: map[string]string{

--- a/rollout/experiment_test.go
+++ b/rollout/experiment_test.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
@@ -27,7 +27,7 @@ func TestRolloutCreateExperiment(t *testing.T) {
 			Templates: []v1alpha1.RolloutExperimentTemplate{{
 				Name:     "stable-template",
 				SpecRef:  v1alpha1.StableSpecRef,
-				Replicas: pointer.Int32Ptr(1),
+				Replicas: ptr.To[int32](1),
 			}},
 			Analyses: []v1alpha1.RolloutExperimentStepAnalysisTemplateRef{{
 				Name:         "test",
@@ -36,7 +36,7 @@ func TestRolloutCreateExperiment(t *testing.T) {
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
@@ -83,7 +83,7 @@ func TestRolloutCreateClusterTemplateExperiment(t *testing.T) {
 			Templates: []v1alpha1.RolloutExperimentTemplate{{
 				Name:     "stable-template",
 				SpecRef:  v1alpha1.StableSpecRef,
-				Replicas: pointer.Int32Ptr(1),
+				Replicas: ptr.To[int32](1),
 			}},
 			Analyses: []v1alpha1.RolloutExperimentStepAnalysisTemplateRef{{
 				Name:         "test",
@@ -93,7 +93,7 @@ func TestRolloutCreateClusterTemplateExperiment(t *testing.T) {
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
@@ -139,12 +139,12 @@ func TestCreateExperimentWithCollision(t *testing.T) {
 			Templates: []v1alpha1.RolloutExperimentTemplate{{
 				Name:     "stable-template",
 				SpecRef:  v1alpha1.StableSpecRef,
-				Replicas: pointer.Int32Ptr(1),
+				Replicas: ptr.To[int32](1),
 			}},
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
@@ -191,12 +191,12 @@ func TestCreateExperimentWithCollisionAndSemanticEquality(t *testing.T) {
 			Templates: []v1alpha1.RolloutExperimentTemplate{{
 				Name:     "stable-template",
 				SpecRef:  v1alpha1.StableSpecRef,
-				Replicas: pointer.Int32Ptr(1),
+				Replicas: ptr.To[int32](1),
 			}},
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
@@ -241,7 +241,7 @@ func TestRolloutExperimentProcessingDoNothing(t *testing.T) {
 		Experiment: &v1alpha1.RolloutExperimentStep{},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
@@ -280,7 +280,7 @@ func TestAbortRolloutAfterFailedExperiment(t *testing.T) {
 		Experiment: &v1alpha1.RolloutExperimentStep{},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
@@ -326,7 +326,7 @@ func TestPauseRolloutAfterInconclusiveExperiment(t *testing.T) {
 		Experiment: &v1alpha1.RolloutExperimentStep{},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(1), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
@@ -362,10 +362,10 @@ func TestRolloutExperimentScaleDownExperimentFromPreviousStep(t *testing.T) {
 
 	steps := []v1alpha1.CanaryStep{
 		{Experiment: &v1alpha1.RolloutExperimentStep{}},
-		{SetWeight: pointer.Int32Ptr(1)},
+		{SetWeight: ptr.To[int32](1)},
 	}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
@@ -397,7 +397,7 @@ func TestRolloutExperimentScaleDownExtraExperiment(t *testing.T) {
 		Experiment: &v1alpha1.RolloutExperimentStep{},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
@@ -442,12 +442,12 @@ func TestRolloutExperimentFinishedIncrementStep(t *testing.T) {
 			Templates: []v1alpha1.RolloutExperimentTemplate{{
 				Name:     "stable-template",
 				SpecRef:  v1alpha1.StableSpecRef,
-				Replicas: pointer.Int32Ptr(1),
+				Replicas: ptr.To[int32](1),
 			}},
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
@@ -494,12 +494,12 @@ func TestRolloutDoNotCreateExperimentWithoutStableRS(t *testing.T) {
 			Templates: []v1alpha1.RolloutExperimentTemplate{{
 				Name:     "stable-template",
 				SpecRef:  v1alpha1.StableSpecRef,
-				Replicas: pointer.Int32Ptr(1),
+				Replicas: ptr.To[int32](1),
 			}},
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 
 	rs2 := newReplicaSetWithStatus(r2, 1, 1)
@@ -523,19 +523,19 @@ func TestGetExperimentFromTemplate(t *testing.T) {
 			Templates: []v1alpha1.RolloutExperimentTemplate{{
 				Name:     "stable-template",
 				SpecRef:  v1alpha1.StableSpecRef,
-				Replicas: pointer.Int32Ptr(1),
+				Replicas: ptr.To[int32](1),
 			}},
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
 	rs2 := newReplicaSetWithStatus(r2, 1, 1)
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-	r2.Status.CurrentStepIndex = pointer.Int32Ptr(0)
+	r2.Status.CurrentStepIndex = ptr.To[int32](0)
 	r2.Status.StableRS = rs1PodHash
 
 	stable, err := GetExperimentFromTemplate(r2, rs1, rs2)
@@ -583,12 +583,12 @@ func TestGetExperimentFromTemplateModifiedLabelsDoesntChangeRefReplicatSet(t *te
 			Templates: []v1alpha1.RolloutExperimentTemplate{{
 				Name:     "stable-template",
 				SpecRef:  v1alpha1.StableSpecRef,
-				Replicas: pointer.Int32Ptr(1),
+				Replicas: ptr.To[int32](1),
 			}},
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	r2.Spec.Strategy.Canary.Steps[0].Experiment.Templates[0].Metadata.Annotations = map[string]string{"abc": "def"}
 	r2.Spec.Strategy.Canary.Steps[0].Experiment.Templates[0].Metadata.Labels = map[string]string{"123": "456"}
@@ -599,7 +599,7 @@ func TestGetExperimentFromTemplateModifiedLabelsDoesntChangeRefReplicatSet(t *te
 	canaryRsTemplate := rs2.Spec.Template.DeepCopy()
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-	r2.Status.CurrentStepIndex = pointer.Int32Ptr(0)
+	r2.Status.CurrentStepIndex = ptr.To[int32](0)
 	r2.Status.StableRS = rs1PodHash
 
 	_, err := GetExperimentFromTemplate(r2, rs1, rs2)
@@ -620,7 +620,7 @@ func TestDeleteExperimentWithNoMatchingRS(t *testing.T) {
 		Experiment: &v1alpha1.RolloutExperimentStep{},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
@@ -665,10 +665,10 @@ func TestDeleteExperimentsAfterRSDelete(t *testing.T) {
 		Experiment: &v1alpha1.RolloutExperimentStep{},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	r3 := bumpVersion(r2)
-	r3.Spec.RevisionHistoryLimit = pointer.Int32Ptr(0)
+	r3.Spec.RevisionHistoryLimit = ptr.To[int32](0)
 
 	rs1 := newReplicaSetWithStatus(r1, 0, 0)
 	rs2 := newReplicaSetWithStatus(r2, 1, 1)
@@ -710,7 +710,7 @@ func TestCancelExperimentWhenAborted(t *testing.T) {
 		Experiment: &v1alpha1.RolloutExperimentStep{},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
@@ -745,7 +745,7 @@ func TestRolloutCreateExperimentWithInstanceID(t *testing.T) {
 			Templates: []v1alpha1.RolloutExperimentTemplate{{
 				Name:     "stable-template",
 				SpecRef:  v1alpha1.StableSpecRef,
-				Replicas: pointer.Int32Ptr(1),
+				Replicas: ptr.To[int32](1),
 			}},
 			Analyses: []v1alpha1.RolloutExperimentStepAnalysisTemplateRef{{
 				Name:         "test",
@@ -754,7 +754,7 @@ func TestRolloutCreateExperimentWithInstanceID(t *testing.T) {
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 	r2.Labels = map[string]string{v1alpha1.LabelKeyControllerInstanceID: "instance-id-test"}
 
@@ -789,27 +789,27 @@ func TestRolloutCreateExperimentWithService(t *testing.T) {
 				{
 					Name:     "stable-template",
 					SpecRef:  v1alpha1.StableSpecRef,
-					Replicas: pointer.Int32Ptr(1),
-					Weight:   pointer.Int32Ptr(5),
+					Replicas: ptr.To[int32](1),
+					Weight:   ptr.To[int32](5),
 				},
 				// Service should NOT be created for "canary-template"
 				{
 					Name:     "canary-template",
 					SpecRef:  v1alpha1.CanarySpecRef,
-					Replicas: pointer.Int32Ptr(1),
+					Replicas: ptr.To[int32](1),
 				},
 			},
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
 	rs2 := newReplicaSetWithStatus(r2, 1, 1)
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-	r2.Status.CurrentStepIndex = pointer.Int32Ptr(0)
+	r2.Status.CurrentStepIndex = ptr.To[int32](0)
 	r2.Status.StableRS = rs1PodHash
 
 	ex, err := GetExperimentFromTemplate(r2, rs1, rs2)
@@ -832,7 +832,7 @@ func TestRolloutCreateWeightlessExperimentWithServiceAndName(t *testing.T) {
 				{
 					Name:     "stable-weightless-named-template",
 					SpecRef:  v1alpha1.StableSpecRef,
-					Replicas: pointer.Int32Ptr(1),
+					Replicas: ptr.To[int32](1),
 					Service: &v1alpha1.TemplateService{
 						Name: "test-service",
 					},
@@ -841,20 +841,20 @@ func TestRolloutCreateWeightlessExperimentWithServiceAndName(t *testing.T) {
 				{
 					Name:     "canary-weightless-named-template",
 					SpecRef:  v1alpha1.CanarySpecRef,
-					Replicas: pointer.Int32Ptr(1),
+					Replicas: ptr.To[int32](1),
 				},
 			},
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
 	rs2 := newReplicaSetWithStatus(r2, 1, 1)
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-	r2.Status.CurrentStepIndex = pointer.Int32Ptr(0)
+	r2.Status.CurrentStepIndex = ptr.To[int32](0)
 	r2.Status.StableRS = rs1PodHash
 
 	ex, err := GetExperimentFromTemplate(r2, rs1, rs2)
@@ -876,27 +876,27 @@ func TestRolloutCreateWeightlessExperimentWithService(t *testing.T) {
 				{
 					Name:     "stable-weightless-template",
 					SpecRef:  v1alpha1.StableSpecRef,
-					Replicas: pointer.Int32Ptr(1),
+					Replicas: ptr.To[int32](1),
 					Service:  &v1alpha1.TemplateService{},
 				},
 				// Service should NOT be created for "canary-weightless-template"
 				{
 					Name:     "canary-weightless-template",
 					SpecRef:  v1alpha1.CanarySpecRef,
-					Replicas: pointer.Int32Ptr(1),
+					Replicas: ptr.To[int32](1),
 				},
 			},
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
 	rs2 := newReplicaSetWithStatus(r2, 1, 1)
 	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 
-	r2.Status.CurrentStepIndex = pointer.Int32Ptr(0)
+	r2.Status.CurrentStepIndex = ptr.To[int32](0)
 	r2.Status.StableRS = rs1PodHash
 
 	ex, err := GetExperimentFromTemplate(r2, rs1, rs2)
@@ -920,7 +920,7 @@ func TestRolloutCreateExperimentWithDryRunAndMetadata(t *testing.T) {
 			Templates: []v1alpha1.RolloutExperimentTemplate{{
 				Name:     "stable-template",
 				SpecRef:  v1alpha1.StableSpecRef,
-				Replicas: pointer.Int32(1),
+				Replicas: ptr.To[int32](1),
 			}},
 			Analyses: []v1alpha1.RolloutExperimentStepAnalysisTemplateRef{{
 				Name:         "test",
@@ -947,7 +947,7 @@ func TestRolloutCreateExperimentWithDryRunAndMetadata(t *testing.T) {
 		},
 	}}
 
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(0), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
 	r2 := bumpVersion(r1)
 
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)

--- a/rollout/replicaset_test.go
+++ b/rollout/replicaset_test.go
@@ -15,7 +15,7 @@ import (
 	k8sinformers "k8s.io/client-go/informers"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
@@ -367,7 +367,7 @@ func TestReconcileOldReplicaSet(t *testing.T) {
 			oldRS.Status.AvailableReplicas = int32(test.readyPodsFromOldRS)
 
 			rollout := newBlueGreenRollout("foo", test.rolloutReplicas, nil, "active-service", "preview-service")
-			rollout.Spec.Strategy.BlueGreen.ScaleDownDelayRevisionLimit = pointer.Int32Ptr(0)
+			rollout.Spec.Strategy.BlueGreen.ScaleDownDelayRevisionLimit = ptr.To[int32](0)
 			rollout.Spec.Selector = &metav1.LabelSelector{MatchLabels: newSelector}
 
 			activeService := newService("active-service", 80, nil, nil)

--- a/rollout/restart_test.go
+++ b/rollout/restart_test.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/log"
@@ -437,7 +437,7 @@ func TestRestartSortReplicaSetsByPriority(t *testing.T) {
 func TestRestartMaxUnavailable(t *testing.T) {
 	now := metav1.Now()
 	ro := rollout("test", now, nil)
-	ro.Spec.Replicas = pointer.Int32Ptr(3)
+	ro.Spec.Replicas = ptr.To[int32](3)
 	twoUnavailable := intstr.FromInt(2)
 	ro.Spec.Strategy.Canary = &v1alpha1.CanaryStrategy{
 		MaxUnavailable: &twoUnavailable,
@@ -558,7 +558,7 @@ func TestRestartMaxUnavailable(t *testing.T) {
 	})
 	t.Run("replicas:1 weight:50", func(t *testing.T) {
 		ro := ro.DeepCopy()
-		ro.Spec.Replicas = pointer.Int32Ptr(1)
+		ro.Spec.Replicas = ptr.To[int32](1)
 		ro.Spec.Strategy.Canary.MaxUnavailable = nil
 		rs2 := replicaSet("rollout-restart-def456", "test", 1, 1)
 		olderPod2 := pod("older2", "test", metav1.NewTime(now.Add(-10*time.Second)), rs2)
@@ -590,7 +590,7 @@ func TestRestartMaxUnavailable(t *testing.T) {
 	})
 	t.Run("replicas:1 weight:50, already at minAvailable", func(t *testing.T) {
 		ro := ro.DeepCopy()
-		ro.Spec.Replicas = pointer.Int32Ptr(1)
+		ro.Spec.Replicas = ptr.To[int32](1)
 		ro.Spec.Strategy.Canary.MaxUnavailable = nil
 		rs := replicaSet("rollout-restart-abc123", "test", 1, 1)
 		rs2 := replicaSet("rollout-restart-def456", "test", 1, 1)
@@ -623,7 +623,7 @@ func TestRestartMaxUnavailable(t *testing.T) {
 	})
 	t.Run("replicas:0", func(t *testing.T) {
 		ro := ro.DeepCopy()
-		ro.Spec.Replicas = pointer.Int32Ptr(0)
+		ro.Spec.Replicas = ptr.To[int32](0)
 		rs := replicaSet("rollout-restart-abc123", "test", 0, 0)
 		roCtx := &rolloutContext{
 			rollout:  ro,

--- a/rollout/service.go
+++ b/rollout/service.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	patchtypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/rollout/trafficrouting"
@@ -148,7 +148,7 @@ func (c *rolloutContext) awsVerifyTargetGroups(svc *corev1.Service) error {
 		return nil
 	}
 
-	c.targetsVerified = pointer.Bool(false)
+	c.targetsVerified = ptr.To[bool](false)
 
 	// get endpoints of service
 	endpoints, err := c.kubeclientset.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
@@ -180,7 +180,7 @@ func (c *rolloutContext) awsVerifyTargetGroups(svc *corev1.Service) error {
 		}
 		c.recorder.Eventf(c.rollout, record.EventOptions{EventReason: conditions.TargetGroupVerifiedReason}, conditions.TargetGroupVerifiedRegistrationMessage, svc.Name, tgb.Spec.TargetGroupARN, verifyRes.EndpointsRegistered)
 	}
-	c.targetsVerified = pointer.Bool(true)
+	c.targetsVerified = ptr.To[bool](true)
 	return nil
 }
 

--- a/rollout/service_test.go
+++ b/rollout/service_test.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/aws"
@@ -252,26 +252,26 @@ func TestBlueGreenAWSVerifyTargetGroupsNotYetReady(t *testing.T) {
 		TargetHealthDescriptions: []elbv2types.TargetHealthDescription{
 			{
 				Target: &elbv2types.TargetDescription{
-					Id:   pointer.StringPtr("1.2.3.4"),
-					Port: pointer.Int32Ptr(80),
+					Id:   ptr.To[string]("1.2.3.4"),
+					Port: ptr.To[int32](80),
 				},
 			},
 			{
 				Target: &elbv2types.TargetDescription{
-					Id:   pointer.StringPtr("5.6.7.8"),
-					Port: pointer.Int32Ptr(80),
+					Id:   ptr.To[string]("5.6.7.8"),
+					Port: ptr.To[int32](80),
 				},
 			},
 			{
 				Target: &elbv2types.TargetDescription{
-					Id:   pointer.StringPtr("2.4.6.8"), // irrelevant
-					Port: pointer.Int32Ptr(81),         // wrong port
+					Id:   ptr.To[string]("2.4.6.8"), // irrelevant
+					Port: ptr.To[int32](81),         // wrong port
 				},
 			},
 			{
 				Target: &elbv2types.TargetDescription{
-					Id:   pointer.StringPtr("9.8.7.6"), // irrelevant ip
-					Port: pointer.Int32Ptr(80),
+					Id:   ptr.To[string]("9.8.7.6"), // irrelevant ip
+					Port: ptr.To[int32](80),
 				},
 			},
 		},
@@ -337,26 +337,26 @@ func TestBlueGreenAWSVerifyTargetGroupsReady(t *testing.T) {
 		TargetHealthDescriptions: []elbv2types.TargetHealthDescription{
 			{
 				Target: &elbv2types.TargetDescription{
-					Id:   pointer.StringPtr("1.2.3.4"),
-					Port: pointer.Int32Ptr(80),
+					Id:   ptr.To[string]("1.2.3.4"),
+					Port: ptr.To[int32](80),
 				},
 			},
 			{
 				Target: &elbv2types.TargetDescription{
-					Id:   pointer.StringPtr("5.6.7.8"),
-					Port: pointer.Int32Ptr(80),
+					Id:   ptr.To[string]("5.6.7.8"),
+					Port: ptr.To[int32](80),
 				},
 			},
 			{
 				Target: &elbv2types.TargetDescription{
-					Id:   pointer.StringPtr("2.4.6.8"),
-					Port: pointer.Int32Ptr(80),
+					Id:   ptr.To[string]("2.4.6.8"),
+					Port: ptr.To[int32](80),
 				},
 			},
 			{
 				Target: &elbv2types.TargetDescription{
-					Id:   pointer.StringPtr("9.8.7.6"), // irrelevant ip
-					Port: pointer.Int32Ptr(80),
+					Id:   ptr.To[string]("9.8.7.6"), // irrelevant ip
+					Port: ptr.To[int32](80),
 				},
 			},
 		},
@@ -423,26 +423,26 @@ func TestCanaryAWSVerifyTargetGroupsNotYetReady(t *testing.T) {
 		TargetHealthDescriptions: []elbv2types.TargetHealthDescription{
 			{
 				Target: &elbv2types.TargetDescription{
-					Id:   pointer.String("1.2.3.4"),
-					Port: pointer.Int32(80),
+					Id:   ptr.To[string]("1.2.3.4"),
+					Port: ptr.To[int32](80),
 				},
 			},
 			{
 				Target: &elbv2types.TargetDescription{
-					Id:   pointer.String("5.6.7.8"),
-					Port: pointer.Int32(80),
+					Id:   ptr.To[string]("5.6.7.8"),
+					Port: ptr.To[int32](80),
 				},
 			},
 			{
 				Target: &elbv2types.TargetDescription{
-					Id:   pointer.String("2.4.6.8"), // irrelevant
-					Port: pointer.Int32(81),         // wrong port
+					Id:   ptr.To[string]("2.4.6.8"), // irrelevant
+					Port: ptr.To[int32](81),         // wrong port
 				},
 			},
 			{
 				Target: &elbv2types.TargetDescription{
-					Id:   pointer.String("9.8.7.6"), // irrelevant ip
-					Port: pointer.Int32(80),
+					Id:   ptr.To[string]("9.8.7.6"), // irrelevant ip
+					Port: ptr.To[int32](80),
 				},
 			},
 		},
@@ -450,8 +450,8 @@ func TestCanaryAWSVerifyTargetGroupsNotYetReady(t *testing.T) {
 	fakeELB.On("DescribeTargetHealth", mock.Anything, mock.Anything).Return(&thOut, nil)
 
 	r1 := newCanaryRollout("foo", 3, nil, []v1alpha1.CanaryStep{{
-		SetWeight: pointer.Int32(10),
-	}}, pointer.Int32(0), intstr.FromString("25%"), intstr.FromString("25%"))
+		SetWeight: ptr.To[int32](10),
+	}}, ptr.To[int32](0), intstr.FromString("25%"), intstr.FromString("25%"))
 
 	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 		ALB: &v1alpha1.ALBTrafficRouting{
@@ -477,7 +477,7 @@ func TestCanaryAWSVerifyTargetGroupsNotYetReady(t *testing.T) {
 	r2.Status.Message = ""
 	r2.Status.ObservedGeneration = strconv.Itoa(int(r2.Generation))
 	r2.Status.StableRS = rs2PodHash
-	r2.Status.CurrentStepIndex = pointer.Int32(1)
+	r2.Status.CurrentStepIndex = ptr.To[int32](1)
 	availableCondition, _ := newAvailableCondition(true)
 	conditions.SetRolloutCondition(&r2.Status, availableCondition)
 	healthyCondition, _ := newHealthyCondition(false)
@@ -527,26 +527,26 @@ func TestCanaryAWSVerifyTargetGroupsReady(t *testing.T) {
 		TargetHealthDescriptions: []elbv2types.TargetHealthDescription{
 			{
 				Target: &elbv2types.TargetDescription{
-					Id:   pointer.String("1.2.3.4"),
-					Port: pointer.Int32(80),
+					Id:   ptr.To[string]("1.2.3.4"),
+					Port: ptr.To[int32](80),
 				},
 			},
 			{
 				Target: &elbv2types.TargetDescription{
-					Id:   pointer.String("5.6.7.8"),
-					Port: pointer.Int32(80),
+					Id:   ptr.To[string]("5.6.7.8"),
+					Port: ptr.To[int32](80),
 				},
 			},
 			{
 				Target: &elbv2types.TargetDescription{
-					Id:   pointer.String("2.4.6.8"), // irrelevant
-					Port: pointer.Int32(80),         // wrong port
+					Id:   ptr.To[string]("2.4.6.8"), // irrelevant
+					Port: ptr.To[int32](80),         // wrong port
 				},
 			},
 			{
 				Target: &elbv2types.TargetDescription{
-					Id:   pointer.String("9.8.7.6"), // irrelevant ip
-					Port: pointer.Int32(80),
+					Id:   ptr.To[string]("9.8.7.6"), // irrelevant ip
+					Port: ptr.To[int32](80),
 				},
 			},
 		},
@@ -554,8 +554,8 @@ func TestCanaryAWSVerifyTargetGroupsReady(t *testing.T) {
 	fakeELB.On("DescribeTargetHealth", mock.Anything, mock.Anything).Return(&thOut, nil)
 
 	r1 := newCanaryRollout("foo", 3, nil, []v1alpha1.CanaryStep{{
-		SetWeight: pointer.Int32(10),
-	}}, pointer.Int32(0), intstr.FromString("25%"), intstr.FromString("25%"))
+		SetWeight: ptr.To[int32](10),
+	}}, ptr.To[int32](0), intstr.FromString("25%"), intstr.FromString("25%"))
 	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 		ALB: &v1alpha1.ALBTrafficRouting{
 			Ingress:     "ingress",
@@ -580,7 +580,7 @@ func TestCanaryAWSVerifyTargetGroupsReady(t *testing.T) {
 	r2.Status.Message = ""
 	r2.Status.ObservedGeneration = strconv.Itoa(int(r2.Generation))
 	r2.Status.StableRS = rs2PodHash
-	r2.Status.CurrentStepIndex = pointer.Int32(1)
+	r2.Status.CurrentStepIndex = ptr.To[int32](1)
 	availableCondition, _ := newAvailableCondition(true)
 	conditions.SetRolloutCondition(&r2.Status, availableCondition)
 	healthyCondition, _ := newHealthyCondition(false)
@@ -621,8 +621,8 @@ func TestCanaryAWSVerifyTargetGroupsSkip(t *testing.T) {
 	defer f.Close()
 
 	r1 := newCanaryRollout("foo", 3, nil, []v1alpha1.CanaryStep{{
-		SetWeight: pointer.Int32(10),
-	}}, pointer.Int32(0), intstr.FromString("25%"), intstr.FromString("25%"))
+		SetWeight: ptr.To[int32](10),
+	}}, ptr.To[int32](0), intstr.FromString("25%"), intstr.FromString("25%"))
 	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 		ALB: &v1alpha1.ALBTrafficRouting{
 			Ingress:     "ingress",
@@ -649,7 +649,7 @@ func TestCanaryAWSVerifyTargetGroupsSkip(t *testing.T) {
 	r2.Status.Message = ""
 	r2.Status.ObservedGeneration = strconv.Itoa(int(r2.Generation))
 	r2.Status.StableRS = rs2PodHash
-	r2.Status.CurrentStepIndex = pointer.Int32(1)
+	r2.Status.CurrentStepIndex = ptr.To[int32](1)
 	availableCondition, _ := newAvailableCondition(true)
 	conditions.SetRolloutCondition(&r2.Status, availableCondition)
 	healthyCondition, _ := newHealthyCondition(false)

--- a/rollout/stepplugin_test.go
+++ b/rollout/stepplugin_test.go
@@ -27,7 +27,7 @@ func newStepPluginRollout() *v1alpha1.Rollout {
 			},
 		},
 	}
-	return newCanaryRollout("foo", 3, nil, steps, ptr.To(int32(0)), intstr.FromInt(1), intstr.FromInt(0))
+	return newCanaryRollout("foo", 3, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(0))
 }
 
 func newStepPluginStatus(operation v1alpha1.StepPluginOperation, phase v1alpha1.StepPluginPhase) *v1alpha1.StepPluginStatus {
@@ -413,7 +413,7 @@ func Test_stepPluginContext_reconcile_FullyPromoted(t *testing.T) {
 		roCtx.rollout.Status.PromoteFull = false
 		roCtx.rollout.Status.StableRS = "stable-value"
 		roCtx.rollout.Status.CurrentPodHash = "stable-value"
-		roCtx.rollout.Status.CurrentStepIndex = ptr.To(int32(1))
+		roCtx.rollout.Status.CurrentStepIndex = ptr.To[int32](1)
 
 		runStatus := newStepPluginStatus(v1alpha1.StepPluginOperationTerminate, v1alpha1.StepPluginPhaseSuccessful)
 		roCtx.rollout.Status.Canary.StepPluginStatuses = []v1alpha1.StepPluginStatus{

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -14,7 +14,7 @@ import (
 	patchtypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/controller"
 	labelsutil "k8s.io/kubernetes/pkg/util/labels"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/rollout/trafficrouting"
@@ -162,7 +162,7 @@ func (c *rolloutContext) createDesiredReplicaSet() (*appsv1.ReplicaSet, error) {
 			Template:        newRSTemplate,
 		},
 	}
-	newRS.Spec.Replicas = pointer.Int32Ptr(0)
+	newRS.Spec.Replicas = ptr.To[int32](0)
 	// Set new replica set's annotation
 	annotations.SetNewReplicaSetAnnotations(c.rollout, newRS, newRevision, false)
 

--- a/rollout/sync_test.go
+++ b/rollout/sync_test.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	testclient "k8s.io/client-go/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 
@@ -358,7 +358,7 @@ func TestBlueGreenPromoteFull(t *testing.T) {
 
 	at := analysisTemplate("bar")
 	r1 := newBlueGreenRollout("foo", 10, nil, "active", "preview")
-	r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = pointer.BoolPtr(false)
+	r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = ptr.To[bool](false)
 	r1.Spec.Strategy.BlueGreen.PrePromotionAnalysis = &v1alpha1.RolloutAnalysis{
 		Templates: []v1alpha1.AnalysisTemplateRef{
 			{

--- a/rollout/trafficrouting/alb/alb_test.go
+++ b/rollout/trafficrouting/alb/alb_test.go
@@ -20,7 +20,7 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/aws"
@@ -804,7 +804,7 @@ func TestVerifyWeight(t *testing.T) {
 		ro := fakeRollout(STABLE_SVC, CANARY_SVC, nil, "ingress", 443)
 		ro.Status.StableRS = "a45fe23"
 		ro.Spec.Strategy.Canary.Steps = []v1alpha1.CanaryStep{{
-			SetWeight: pointer.Int32Ptr(10),
+			SetWeight: ptr.To[int32](10),
 		}}
 		i := ingress("ingress", STABLE_SVC, CANARY_SVC, STABLE_SVC, 443, 5, ro.Name, false)
 
@@ -829,7 +829,7 @@ func TestVerifyWeight(t *testing.T) {
 			Recorder:       record.NewFakeEventRecorder(),
 			ControllerKind: schema.GroupVersionKind{Group: "foo", Version: "v1", Kind: "Bar"},
 			IngressWrapper: ingressWrapper,
-			VerifyWeight:   pointer.BoolPtr(true),
+			VerifyWeight:   ptr.To[bool](true),
 			Status:         status,
 		})
 		assert.NoError(t, err)
@@ -880,28 +880,28 @@ func TestVerifyWeight(t *testing.T) {
 		r, fakeClient := newFakeReconciler(&status)
 		fakeClient.loadBalancers = []*elbv2types.LoadBalancer{
 			{
-				LoadBalancerName: pointer.StringPtr("lb-abc123-name"),
-				LoadBalancerArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-abc123-name/1234567890123456"),
-				DNSName:          pointer.StringPtr("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
+				LoadBalancerName: ptr.To[string]("lb-abc123-name"),
+				LoadBalancerArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-abc123-name/1234567890123456"),
+				DNSName:          ptr.To[string]("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
 			},
 		}
 		fakeClient.targetGroups = []aws.TargetGroupMeta{
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("canary-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/canary-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("canary-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/canary-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(11),
+				Weight: ptr.To[int32](11),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("stable-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/stable-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("stable-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/stable-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(89),
+				Weight: ptr.To[int32](89),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
 				},
@@ -922,28 +922,28 @@ func TestVerifyWeight(t *testing.T) {
 
 		fakeClient.loadBalancers = []*elbv2types.LoadBalancer{
 			{
-				LoadBalancerName: pointer.StringPtr("lb-abc123-name"),
-				LoadBalancerArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-abc123-name/1234567890123456"),
-				DNSName:          pointer.StringPtr("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
+				LoadBalancerName: ptr.To[string]("lb-abc123-name"),
+				LoadBalancerArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-abc123-name/1234567890123456"),
+				DNSName:          ptr.To[string]("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
 			},
 		}
 		fakeClient.targetGroups = []aws.TargetGroupMeta{
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("canary-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/canary-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("canary-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/canary-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(10),
+				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("stable-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/stable-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("stable-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/stable-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(11),
+				Weight: ptr.To[int32](11),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
 				},
@@ -960,32 +960,32 @@ func TestVerifyWeight(t *testing.T) {
 	// LoadBalancer found, at max weight, end of rollout
 	{
 		var status v1alpha1.RolloutStatus
-		status.CurrentStepIndex = pointer.Int32Ptr(2)
+		status.CurrentStepIndex = ptr.To[int32](2)
 		r, fakeClient := newFakeReconciler(&status)
 		fakeClient.loadBalancers = []*elbv2types.LoadBalancer{
 			{
-				LoadBalancerName: pointer.StringPtr("lb-abc123-name"),
-				LoadBalancerArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-abc123-name/1234567890123456"),
-				DNSName:          pointer.StringPtr("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
+				LoadBalancerName: ptr.To[string]("lb-abc123-name"),
+				LoadBalancerArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-abc123-name/1234567890123456"),
+				DNSName:          ptr.To[string]("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
 			},
 		}
 		fakeClient.targetGroups = []aws.TargetGroupMeta{
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("canary-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/canary-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("canary-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/canary-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(100),
+				Weight: ptr.To[int32](100),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("stable-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/stable-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("stable-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/stable-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(0),
+				Weight: ptr.To[int32](0),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
 				},
@@ -1005,28 +1005,28 @@ func TestVerifyWeight(t *testing.T) {
 		r, fakeClient := newFakeReconciler(&status)
 		fakeClient.loadBalancers = []*elbv2types.LoadBalancer{
 			{
-				LoadBalancerName: pointer.StringPtr("lb-abc123-name"),
-				LoadBalancerArn:  pointer.StringPtr("lb-abc123-arn"),
-				DNSName:          pointer.StringPtr("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
+				LoadBalancerName: ptr.To[string]("lb-abc123-name"),
+				LoadBalancerArn:  ptr.To[string]("lb-abc123-arn"),
+				DNSName:          ptr.To[string]("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
 			},
 		}
 		fakeClient.targetGroups = []aws.TargetGroupMeta{
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("canary-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("canary-tg-abc123-arn"),
+					TargetGroupName: ptr.To[string]("canary-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("canary-tg-abc123-arn"),
 				},
-				Weight: pointer.Int32Ptr(10),
+				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("stable-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("stable-tg-abc123-arn"),
+					TargetGroupName: ptr.To[string]("stable-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("stable-tg-abc123-arn"),
 				},
-				Weight: pointer.Int32Ptr(11),
+				Weight: ptr.To[int32](11),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
 				},
@@ -1048,7 +1048,7 @@ func TestVerifyWeightMultiIngress(t *testing.T) {
 		ro := fakeRolloutWithMultiIngress(STABLE_SVC, CANARY_SVC, nil, []string{"ingress", "multi-ingress"}, 443)
 		ro.Status.StableRS = "a45fe23"
 		ro.Spec.Strategy.Canary.Steps = []v1alpha1.CanaryStep{{
-			SetWeight: pointer.Int32Ptr(10),
+			SetWeight: ptr.To[int32](10),
 		}}
 		i := ingress("ingress", STABLE_SVC, CANARY_SVC, STABLE_SVC, 443, 5, ro.Name, false)
 		mi := ingress("multi-ingress", STABLE_SVC, CANARY_SVC, STABLE_SVC, 443, 5, ro.Name, false)
@@ -1081,7 +1081,7 @@ func TestVerifyWeightMultiIngress(t *testing.T) {
 			Recorder:       record.NewFakeEventRecorder(),
 			ControllerKind: schema.GroupVersionKind{Group: "foo", Version: "v1", Kind: "Bar"},
 			IngressWrapper: ingressWrapper,
-			VerifyWeight:   pointer.BoolPtr(true),
+			VerifyWeight:   ptr.To[bool](true),
 			Status:         status,
 		})
 		assert.NoError(t, err)
@@ -1143,53 +1143,53 @@ func TestVerifyWeightMultiIngress(t *testing.T) {
 		r, fakeClient := newFakeReconciler(&status)
 		fakeClient.loadBalancers = []*elbv2types.LoadBalancer{
 			{
-				LoadBalancerName: pointer.StringPtr("lb-abc123-name"),
-				LoadBalancerArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-abc123-name/1234567890123456"),
-				DNSName:          pointer.StringPtr("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
+				LoadBalancerName: ptr.To[string]("lb-abc123-name"),
+				LoadBalancerArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-abc123-name/1234567890123456"),
+				DNSName:          ptr.To[string]("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
 			},
 			{
-				LoadBalancerName: pointer.StringPtr("lb-multi-ingress-name"),
-				LoadBalancerArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-multi-ingress-name/1234567890123456"),
-				DNSName:          pointer.StringPtr("verify-weight-multi-ingress.us-west-2.elb.amazonaws.com"),
+				LoadBalancerName: ptr.To[string]("lb-multi-ingress-name"),
+				LoadBalancerArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-multi-ingress-name/1234567890123456"),
+				DNSName:          ptr.To[string]("verify-weight-multi-ingress.us-west-2.elb.amazonaws.com"),
 			},
 		}
 		fakeClient.targetGroups = []aws.TargetGroupMeta{
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("canary-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/canary-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("canary-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/canary-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(11),
+				Weight: ptr.To[int32](11),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("stable-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/stable-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("stable-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/stable-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(89),
+				Weight: ptr.To[int32](89),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("multi-ingress-canary-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/multi-ingress-canary-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("multi-ingress-canary-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/multi-ingress-canary-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(11),
+				Weight: ptr.To[int32](11),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/multi-ingress-canary-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("multi-ingress-stable-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/multi-ingress-stable-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("multi-ingress-stable-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/multi-ingress-stable-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(89),
+				Weight: ptr.To[int32](89),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/multi-ingress-stable-svc:443",
 				},
@@ -1209,53 +1209,53 @@ func TestVerifyWeightMultiIngress(t *testing.T) {
 		r, fakeClient := newFakeReconciler(&status)
 		fakeClient.loadBalancers = []*elbv2types.LoadBalancer{
 			{
-				LoadBalancerName: pointer.StringPtr("lb-abc123-name"),
-				LoadBalancerArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-abc123-name/1234567890123456"),
-				DNSName:          pointer.StringPtr("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
+				LoadBalancerName: ptr.To[string]("lb-abc123-name"),
+				LoadBalancerArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-abc123-name/1234567890123456"),
+				DNSName:          ptr.To[string]("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
 			},
 			{
-				LoadBalancerName: pointer.StringPtr("lb-multi-ingress-name"),
-				LoadBalancerArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-multi-ingress-name/1234567890123456"),
-				DNSName:          pointer.StringPtr("verify-weight-multi-ingress.us-west-2.elb.amazonaws.com"),
+				LoadBalancerName: ptr.To[string]("lb-multi-ingress-name"),
+				LoadBalancerArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-multi-ingress-name/1234567890123456"),
+				DNSName:          ptr.To[string]("verify-weight-multi-ingress.us-west-2.elb.amazonaws.com"),
 			},
 		}
 		fakeClient.targetGroups = []aws.TargetGroupMeta{
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("canary-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/canary-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("canary-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/canary-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(10),
+				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("stable-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/stable-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("stable-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/stable-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(90),
+				Weight: ptr.To[int32](90),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("multi-ingress-canary-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/multi-ingress-canary-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("multi-ingress-canary-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/multi-ingress-canary-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(10),
+				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/multi-ingress-canary-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("multi-ingress-stable-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/multi-ingress-stable-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("multi-ingress-stable-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/multi-ingress-stable-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(90),
+				Weight: ptr.To[int32](90),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/multi-ingress-stable-svc:443",
 				},
@@ -1383,7 +1383,7 @@ func TestVerifyWeightWithAdditionalDestinations(t *testing.T) {
 		ro := fakeRollout(STABLE_SVC, CANARY_SVC, nil, "ingress", 443)
 		ro.Status.StableRS = "a45fe23"
 		ro.Spec.Strategy.Canary.Steps = []v1alpha1.CanaryStep{{
-			SetWeight: pointer.Int32Ptr(10),
+			SetWeight: ptr.To[int32](10),
 		}}
 		i := ingress("ingress", STABLE_SVC, CANARY_SVC, STABLE_SVC, 443, 0, ro.Name, false)
 		i.Annotations["alb.ingress.kubernetes.io/actions.stable-svc"] = fmt.Sprintf(actionTemplateWithExperiments, CANARY_SVC, 443, 10, weightDestinations[0].ServiceName, 443, weightDestinations[0].Weight, weightDestinations[1].ServiceName, 443, weightDestinations[1].Weight, STABLE_SVC, 443, 85)
@@ -1409,7 +1409,7 @@ func TestVerifyWeightWithAdditionalDestinations(t *testing.T) {
 			Recorder:       record.NewFakeEventRecorder(),
 			ControllerKind: schema.GroupVersionKind{Group: "foo", Version: "v1", Kind: "Bar"},
 			IngressWrapper: ingressWrapper,
-			VerifyWeight:   pointer.BoolPtr(true),
+			VerifyWeight:   ptr.To[bool](true),
 			Status:         status,
 		})
 		assert.NoError(t, err)
@@ -1424,28 +1424,28 @@ func TestVerifyWeightWithAdditionalDestinations(t *testing.T) {
 		r, fakeClient := newFakeReconciler(&status)
 		fakeClient.loadBalancers = []*elbv2types.LoadBalancer{
 			{
-				LoadBalancerName: pointer.StringPtr("lb-abc123-name"),
-				LoadBalancerArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-abc123-name/1234567890123456"),
-				DNSName:          pointer.StringPtr("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
+				LoadBalancerName: ptr.To[string]("lb-abc123-name"),
+				LoadBalancerArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-abc123-name/1234567890123456"),
+				DNSName:          ptr.To[string]("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
 			},
 		}
 		fakeClient.targetGroups = []aws.TargetGroupMeta{
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("canary-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/canary-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("canary-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/canary-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(10),
+				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("stable-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/stable-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("stable-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/stable-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(90),
+				Weight: ptr.To[int32](90),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
 				},
@@ -1464,48 +1464,48 @@ func TestVerifyWeightWithAdditionalDestinations(t *testing.T) {
 		r, fakeClient := newFakeReconciler(&status)
 		fakeClient.loadBalancers = []*elbv2types.LoadBalancer{
 			{
-				LoadBalancerName: pointer.StringPtr("lb-abc123-name"),
-				LoadBalancerArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-abc123-name/1234567890123456"),
-				DNSName:          pointer.StringPtr("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
+				LoadBalancerName: ptr.To[string]("lb-abc123-name"),
+				LoadBalancerArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-abc123-name/1234567890123456"),
+				DNSName:          ptr.To[string]("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
 			},
 		}
 		fakeClient.targetGroups = []aws.TargetGroupMeta{
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("canary-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/canary-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("canary-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/canary-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(10),
+				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("ex-svc-1-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/ex-svc-1-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("ex-svc-1-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/ex-svc-1-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(100),
+				Weight: ptr.To[int32](100),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-ex-svc-1:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("ex-svc-2-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/ex-svc-2-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("ex-svc-2-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/ex-svc-2-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(100),
+				Weight: ptr.To[int32](100),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-ex-svc-2:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("stable-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/stable-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("stable-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/stable-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(85),
+				Weight: ptr.To[int32](85),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
 				},
@@ -1524,26 +1524,26 @@ func TestVerifyWeightWithAdditionalDestinations(t *testing.T) {
 		r, fakeClient := newFakeReconciler(&status)
 		fakeClient.loadBalancers = []*elbv2types.LoadBalancer{
 			{
-				LoadBalancerName: pointer.StringPtr("lb-abc123-name"),
-				LoadBalancerArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-abc123-name/1234567890123456"),
-				DNSName:          pointer.StringPtr("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
+				LoadBalancerName: ptr.To[string]("lb-abc123-name"),
+				LoadBalancerArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-abc123-name/1234567890123456"),
+				DNSName:          ptr.To[string]("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
 			},
 		}
 		fakeClient.targetGroups = []aws.TargetGroupMeta{
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("canary-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/canary-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("canary-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/canary-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(10),
+				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("ex-svc-1-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/ex-svc-1-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("ex-svc-1-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/ex-svc-1-tg-abc123-name/1234567890123456"),
 				},
 				Weight: &weightDestinations[0].Weight,
 				Tags: map[string]string{
@@ -1552,8 +1552,8 @@ func TestVerifyWeightWithAdditionalDestinations(t *testing.T) {
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("ex-svc-2-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/ex-svc-2-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("ex-svc-2-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/ex-svc-2-tg-abc123-name/1234567890123456"),
 				},
 				Weight: &weightDestinations[1].Weight,
 				Tags: map[string]string{
@@ -1562,10 +1562,10 @@ func TestVerifyWeightWithAdditionalDestinations(t *testing.T) {
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("stable-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/stable-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("stable-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/stable-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(85),
+				Weight: ptr.To[int32](85),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
 				},
@@ -1596,7 +1596,7 @@ func TestVerifyWeightWithAdditionalDestinationsMultiIngress(t *testing.T) {
 		ro := fakeRolloutWithMultiIngress(STABLE_SVC, CANARY_SVC, nil, []string{"ingress", "multi-ingress"}, 443)
 		ro.Status.StableRS = "a45fe23"
 		ro.Spec.Strategy.Canary.Steps = []v1alpha1.CanaryStep{{
-			SetWeight: pointer.Int32Ptr(10),
+			SetWeight: ptr.To[int32](10),
 		}}
 		i := ingress("ingress", STABLE_SVC, CANARY_SVC, STABLE_SVC, 443, 0, ro.Name, false)
 		mi := ingress("multi-ingress", STABLE_SVC, CANARY_SVC, STABLE_SVC, 443, 5, ro.Name, false)
@@ -1632,7 +1632,7 @@ func TestVerifyWeightWithAdditionalDestinationsMultiIngress(t *testing.T) {
 			Recorder:       record.NewFakeEventRecorder(),
 			ControllerKind: schema.GroupVersionKind{Group: "foo", Version: "v1", Kind: "Bar"},
 			IngressWrapper: ingressWrapper,
-			VerifyWeight:   pointer.BoolPtr(true),
+			VerifyWeight:   ptr.To[bool](true),
 			Status:         status,
 		})
 		assert.NoError(t, err)
@@ -1647,53 +1647,53 @@ func TestVerifyWeightWithAdditionalDestinationsMultiIngress(t *testing.T) {
 		r, fakeClient := newFakeReconciler(&status)
 		fakeClient.loadBalancers = []*elbv2types.LoadBalancer{
 			{
-				LoadBalancerName: pointer.StringPtr("lb-abc123-name"),
-				LoadBalancerArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-abc123-name/1234567890123456"),
-				DNSName:          pointer.StringPtr("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
+				LoadBalancerName: ptr.To[string]("lb-abc123-name"),
+				LoadBalancerArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-abc123-name/1234567890123456"),
+				DNSName:          ptr.To[string]("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
 			},
 			{
-				LoadBalancerName: pointer.StringPtr("lb-multi-ingress-name"),
-				LoadBalancerArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-multi-ingress-name/1234567890123456"),
-				DNSName:          pointer.StringPtr("verify-weight-multi-ingress.us-west-2.elb.amazonaws.com"),
+				LoadBalancerName: ptr.To[string]("lb-multi-ingress-name"),
+				LoadBalancerArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-multi-ingress-name/1234567890123456"),
+				DNSName:          ptr.To[string]("verify-weight-multi-ingress.us-west-2.elb.amazonaws.com"),
 			},
 		}
 		fakeClient.targetGroups = []aws.TargetGroupMeta{
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("canary-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/canary-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("canary-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/canary-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(10),
+				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("stable-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/stable-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("stable-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/stable-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(90),
+				Weight: ptr.To[int32](90),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("multi-ingress-canary-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/multi-ingress-canary-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("multi-ingress-canary-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/multi-ingress-canary-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(10),
+				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/multi-ingress-canary-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("multi-ingress-stable-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/multi-ingress-stable-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("multi-ingress-stable-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/multi-ingress-stable-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(90),
+				Weight: ptr.To[int32](90),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/multi-ingress-stable-svc:443",
 				},
@@ -1712,73 +1712,73 @@ func TestVerifyWeightWithAdditionalDestinationsMultiIngress(t *testing.T) {
 		r, fakeClient := newFakeReconciler(&status)
 		fakeClient.loadBalancers = []*elbv2types.LoadBalancer{
 			{
-				LoadBalancerName: pointer.StringPtr("lb-abc123-name"),
-				LoadBalancerArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-abc123-name/1234567890123456"),
-				DNSName:          pointer.StringPtr("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
+				LoadBalancerName: ptr.To[string]("lb-abc123-name"),
+				LoadBalancerArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-abc123-name/1234567890123456"),
+				DNSName:          ptr.To[string]("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
 			},
 			{
-				LoadBalancerName: pointer.StringPtr("lb-multi-ingress-name"),
-				LoadBalancerArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-multi-ingress-name/1234567890123456"),
-				DNSName:          pointer.StringPtr("verify-weight-multi-ingress.us-west-2.elb.amazonaws.com"),
+				LoadBalancerName: ptr.To[string]("lb-multi-ingress-name"),
+				LoadBalancerArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-multi-ingress-name/1234567890123456"),
+				DNSName:          ptr.To[string]("verify-weight-multi-ingress.us-west-2.elb.amazonaws.com"),
 			},
 		}
 		fakeClient.targetGroups = []aws.TargetGroupMeta{
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("canary-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/canary-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("canary-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/canary-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(10),
+				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("stable-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/stable-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("stable-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/stable-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(85),
+				Weight: ptr.To[int32](85),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("multi-ingress-canary-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/multi-ingress-canary-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("multi-ingress-canary-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/multi-ingress-canary-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(10),
+				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/multi-ingress-canary-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("multi-ingress-stable-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/app/multi-ingress-stable-tg-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("multi-ingress-stable-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/app/multi-ingress-stable-tg-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(85),
+				Weight: ptr.To[int32](85),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/multi-ingress-stable-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("ex-svc-1-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/ex-svc-1-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("ex-svc-1-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/ex-svc-1-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(100),
+				Weight: ptr.To[int32](100),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-ex-svc-1:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("ex-svc-2-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/ex-svc-2-tg-abc123-name/123456789012345"),
+					TargetGroupName: ptr.To[string]("ex-svc-2-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/ex-svc-2-tg-abc123-name/123456789012345"),
 				},
-				Weight: pointer.Int32Ptr(100),
+				Weight: ptr.To[int32](100),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-ex-svc-2:443",
 				},
@@ -1798,61 +1798,61 @@ func TestVerifyWeightWithAdditionalDestinationsMultiIngress(t *testing.T) {
 		r, fakeClient := newFakeReconciler(&status)
 		fakeClient.loadBalancers = []*elbv2types.LoadBalancer{
 			{
-				LoadBalancerName: pointer.StringPtr("lb-abc123-name"),
-				LoadBalancerArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-abc123-name/1234567890123456"),
-				DNSName:          pointer.StringPtr("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
+				LoadBalancerName: ptr.To[string]("lb-abc123-name"),
+				LoadBalancerArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-abc123-name/1234567890123456"),
+				DNSName:          ptr.To[string]("verify-weight-test-abc-123.us-west-2.elb.amazonaws.com"),
 			},
 			{
-				LoadBalancerName: pointer.StringPtr("lb-multi-ingress-name"),
-				LoadBalancerArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-multi-ingress-name/1234567890123456"),
-				DNSName:          pointer.StringPtr("verify-weight-multi-ingress.us-west-2.elb.amazonaws.com"),
+				LoadBalancerName: ptr.To[string]("lb-multi-ingress-name"),
+				LoadBalancerArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:loadbalancer/app/lb-multi-ingress-name/1234567890123456"),
+				DNSName:          ptr.To[string]("verify-weight-multi-ingress.us-west-2.elb.amazonaws.com"),
 			},
 		}
 		fakeClient.targetGroups = []aws.TargetGroupMeta{
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("canary-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/canary-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("canary-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/canary-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(10),
+				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("stable-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/stable-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("stable-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/stable-tg-abc123-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(85),
+				Weight: ptr.To[int32](85),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("multi-ingress-canary-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/app/multi-ingress-canary-tg-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("multi-ingress-canary-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/app/multi-ingress-canary-tg-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(10),
+				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/multi-ingress-canary-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("multi-ingress-stable-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/app/multi-ingress-stable-tg-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("multi-ingress-stable-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/app/multi-ingress-stable-tg-name/1234567890123456"),
 				},
-				Weight: pointer.Int32Ptr(85),
+				Weight: ptr.To[int32](85),
 				Tags: map[string]string{
 					aws.AWSLoadBalancerV2TagKeyResourceID: "default/multi-ingress-stable-svc:443",
 				},
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("ex-svc-1-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/ex-svc-1-tg-abc123-name/1234567890123456"),
+					TargetGroupName: ptr.To[string]("ex-svc-1-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/ex-svc-1-tg-abc123-name/1234567890123456"),
 				},
 				Weight: &weightDestinations[0].Weight,
 				Tags: map[string]string{
@@ -1861,8 +1861,8 @@ func TestVerifyWeightWithAdditionalDestinationsMultiIngress(t *testing.T) {
 			},
 			{
 				TargetGroup: elbv2types.TargetGroup{
-					TargetGroupName: pointer.StringPtr("ex-svc-2-tg-abc123-name"),
-					TargetGroupArn:  pointer.StringPtr("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/ex-svc-2-tg-abc123-name/123456789012345"),
+					TargetGroupName: ptr.To[string]("ex-svc-2-tg-abc123-name"),
+					TargetGroupArn:  ptr.To[string]("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/ex-svc-2-tg-abc123-name/123456789012345"),
 				},
 				Weight: &weightDestinations[1].Weight,
 				Tags: map[string]string{

--- a/rollout/trafficrouting/nginx/nginx_test.go
+++ b/rollout/trafficrouting/nginx/nginx_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"k8s.io/utils/pointer"
-
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -19,6 +17,7 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	fake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	ingressutil "github.com/argoproj/argo-rollouts/utils/ingress"
@@ -266,7 +265,7 @@ func TestCanaryIngressCreate(t *testing.T) {
 			for _, ing := range test.ingresses {
 
 				stableIngress := extensionsIngress(ing, 80, stableService)
-				stableIngress.Spec.IngressClassName = pointer.StringPtr("nginx-ext")
+				stableIngress.Spec.IngressClassName = ptr.To[string]("nginx-ext")
 				i := ingressutil.NewLegacyIngress(stableIngress)
 
 				desiredCanaryIngress, err := r.canaryIngress(i, ingressutil.GetCanaryIngressName(r.cfg.Rollout.GetName(), ing), 10)
@@ -646,7 +645,7 @@ func TestCanaryIngressRetainCurrentAnnotations(t *testing.T) {
 }
 
 func TestCanaryIngressMaxWeightInTrafficRouting(t *testing.T) {
-	maxWeights := []*int32{nil, pointer.Int32(1000)}
+	maxWeights := []*int32{nil, ptr.To[int32](1000)}
 	for _, maxWeight := range maxWeights {
 		tests := generateMultiIngressTestData()
 		for _, test := range tests {
@@ -705,7 +704,7 @@ func TestReconciler_canaryIngress(t *testing.T) {
 			}
 			for _, ing := range test.ingresses {
 				stableIngress := networkingIngress(ing, 80, stableService)
-				stableIngress.Spec.IngressClassName = pointer.StringPtr("nginx-ext")
+				stableIngress.Spec.IngressClassName = ptr.To[string]("nginx-ext")
 				i := ingressutil.NewIngress(stableIngress)
 
 				// when

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/dynamic/dynamiclister"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/rollout/mocks"
@@ -47,7 +47,7 @@ func newFakeSingleTrafficRoutingReconciler() *mocks.TrafficRoutingReconciler {
 	trafficRoutingReconciler.On("SetWeight", mock.Anything, mock.Anything).Return(nil)
 	trafficRoutingReconciler.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
 	trafficRoutingReconciler.On("SetMirrorRoute", mock.Anything, mock.Anything).Return(nil)
-	trafficRoutingReconciler.On("VerifyWeight", mock.Anything).Return(pointer.BoolPtr(true), nil)
+	trafficRoutingReconciler.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](true), nil)
 	trafficRoutingReconciler.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	trafficRoutingReconciler.On("RemoveManagedRoutes", mock.Anything, mock.Anything).Return(nil)
 	return &trafficRoutingReconciler
@@ -67,10 +67,10 @@ func newTrafficWeightFixture(t *testing.T) (*fixture, *v1alpha1.Rollout) {
 
 	steps := []v1alpha1.CanaryStep{
 		{
-			SetWeight: pointer.Int32Ptr(10),
+			SetWeight: ptr.To[int32](10),
 		},
 	}
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(1), intstr.FromInt(0))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(0))
 	r2 := bumpVersion(r1)
 	r2.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
 	r2.Spec.Strategy.Canary.CanaryService = "canary"
@@ -112,7 +112,7 @@ func TestReconcileTrafficRoutingVerifyWeightErr(t *testing.T) {
 	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(nil)
 	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
-	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(pointer.BoolPtr(false), errors.New("Error message"))
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](false), errors.New("Error message"))
 	f.expectPatchRolloutAction(ro)
 	f.run(getKey(ro, t))
 }
@@ -125,7 +125,7 @@ func TestReconcileTrafficRoutingVerifyWeightFalse(t *testing.T) {
 	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(nil)
 	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
-	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(pointer.BoolPtr(false), nil)
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](false), nil)
 	c, i, k8sI := f.newController(noResyncPeriodFunc)
 	enqueued := false
 	c.enqueueRolloutAfter = func(obj any, duration time.Duration) {
@@ -142,13 +142,13 @@ func TestReconcileTrafficRoutingVerifyWeightEndOfRollout(t *testing.T) {
 
 	steps := []v1alpha1.CanaryStep{
 		{
-			SetWeight: pointer.Int32Ptr(10),
+			SetWeight: ptr.To[int32](10),
 		},
 		{
 			Pause: &v1alpha1.RolloutPause{},
 		},
 	}
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(2), intstr.FromInt(1), intstr.FromInt(0))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](2), intstr.FromInt(1), intstr.FromInt(0))
 	r2 := bumpVersion(r1)
 	r2.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
 	r2.Spec.Strategy.Canary.CanaryService = "canary"
@@ -179,7 +179,7 @@ func TestReconcileTrafficRoutingVerifyWeightEndOfRollout(t *testing.T) {
 		return nil
 	})
 	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
-	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(pointer.BoolPtr(false), nil)
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](false), nil)
 	f.runExpectError(getKey(r2, t), true)
 }
 
@@ -189,13 +189,13 @@ func TestRolloutUseDesiredWeight(t *testing.T) {
 
 	steps := []v1alpha1.CanaryStep{
 		{
-			SetWeight: pointer.Int32Ptr(10),
+			SetWeight: ptr.To[int32](10),
 		},
 		{
 			Pause: &v1alpha1.RolloutPause{},
 		},
 	}
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
 	r2 := bumpVersion(r1)
 	r2.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
 	r2.Spec.Strategy.Canary.CanaryService = "canary"
@@ -234,7 +234,7 @@ func TestRolloutUseDesiredWeight(t *testing.T) {
 		return nil
 	})
 	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
-	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(pointer.BoolPtr(true), nil)
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](true), nil)
 	f.run(getKey(r2, t))
 }
 
@@ -244,13 +244,13 @@ func TestRolloutUseDesiredWeight100(t *testing.T) {
 
 	steps := []v1alpha1.CanaryStep{
 		{
-			SetWeight: pointer.Int32Ptr(10),
+			SetWeight: ptr.To[int32](10),
 		},
 		{
 			Pause: &v1alpha1.RolloutPause{},
 		},
 	}
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(2), intstr.FromInt(1), intstr.FromInt(0))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](2), intstr.FromInt(1), intstr.FromInt(0))
 	r2 := bumpVersion(r1)
 	r2.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
 	r2.Spec.Strategy.Canary.CanaryService = "canary"
@@ -283,7 +283,7 @@ func TestRolloutUseDesiredWeight100(t *testing.T) {
 		return nil
 	})
 	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
-	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(pointer.BoolPtr(true), nil)
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](true), nil)
 	f.run(getKey(r2, t))
 }
 
@@ -293,25 +293,25 @@ func TestRolloutWithExperimentStep(t *testing.T) {
 
 	steps := []v1alpha1.CanaryStep{
 		{
-			SetWeight: pointer.Int32Ptr(10),
+			SetWeight: ptr.To[int32](10),
 		},
 		{
 			Experiment: &v1alpha1.RolloutExperimentStep{
 				Templates: []v1alpha1.RolloutExperimentTemplate{{
 					Name:     "experiment-template",
 					SpecRef:  "canary",
-					Replicas: pointer.Int32Ptr(1),
-					Weight:   pointer.Int32Ptr(5),
+					Replicas: ptr.To[int32](1),
+					Weight:   ptr.To[int32](5),
 				},
 					{
 						Name:     "experiment-template-without-weight",
 						SpecRef:  "stable",
-						Replicas: pointer.Int32Ptr(1),
+						Replicas: ptr.To[int32](1),
 					}},
 			},
 		},
 	}
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
 	r2 := bumpVersion(r1)
 	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 		SMI: &v1alpha1.SMITrafficRouting{},
@@ -365,7 +365,7 @@ func TestRolloutWithExperimentStep(t *testing.T) {
 			return nil
 		})
 		f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
-		f.fakeTrafficRouting.On("VerifyWeight", mock.Anything, mock.Anything).Return(pointer.BoolPtr(true), nil)
+		f.fakeTrafficRouting.On("VerifyWeight", mock.Anything, mock.Anything).Return(ptr.To[bool](true), nil)
 		f.run(getKey(r2, t))
 	})
 
@@ -380,7 +380,7 @@ func TestRolloutWithExperimentStep(t *testing.T) {
 			return nil
 		})
 		f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
-		f.fakeTrafficRouting.On("VerifyWeight", mock.Anything, mock.Anything).Return(pointer.BoolPtr(true), nil)
+		f.fakeTrafficRouting.On("VerifyWeight", mock.Anything, mock.Anything).Return(ptr.To[bool](true), nil)
 		f.run(getKey(r2, t))
 	})
 }
@@ -391,13 +391,13 @@ func TestRolloutUsePreviousSetWeight(t *testing.T) {
 
 	steps := []v1alpha1.CanaryStep{
 		{
-			SetWeight: pointer.Int32Ptr(10),
+			SetWeight: ptr.To[int32](10),
 		},
 		{
-			SetWeight: pointer.Int32Ptr(20),
+			SetWeight: ptr.To[int32](20),
 		},
 	}
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
 	r2 := bumpVersion(r1)
 	r2.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
 	r2.Spec.Strategy.Canary.CanaryService = "canary"
@@ -431,7 +431,7 @@ func TestRolloutUsePreviousSetWeight(t *testing.T) {
 		return nil
 	})
 	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
-	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything, mock.Anything).Return(pointer.BoolPtr(true), nil)
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything, mock.Anything).Return(ptr.To[bool](true), nil)
 	f.fakeTrafficRouting.On("error patching alb ingress", mock.Anything, mock.Anything).Return(true, nil)
 	f.run(getKey(r2, t))
 }
@@ -442,13 +442,13 @@ func TestRolloutUseDynamicWeightOnPromoteFull(t *testing.T) {
 
 	steps := []v1alpha1.CanaryStep{
 		{
-			SetWeight: pointer.Int32Ptr(5),
+			SetWeight: ptr.To[int32](5),
 		},
 		{
-			SetWeight: pointer.Int32Ptr(25),
+			SetWeight: ptr.To[int32](25),
 		},
 	}
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
 	r2 := bumpVersion(r1)
 	r2.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
 	r2.Spec.Strategy.Canary.CanaryService = "canary"
@@ -498,7 +498,7 @@ func TestRolloutUseDynamicWeightOnPromoteFull(t *testing.T) {
 		})
 		f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
 		f.fakeTrafficRouting.On("RemoveManagedRoutes", mock.Anything, mock.Anything).Return(nil)
-		f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(pointer.BoolPtr(true), nil)
+		f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](true), nil)
 		f.run(getKey(r2, t))
 	})
 
@@ -512,7 +512,7 @@ func TestRolloutUseDynamicWeightOnPromoteFull(t *testing.T) {
 		})
 		f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
 		f.fakeTrafficRouting.On("RemoveManagedRoutes", mock.Anything, mock.Anything).Return(nil)
-		f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(pointer.BoolPtr(true), nil)
+		f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](true), nil)
 		f.run(getKey(r2, t))
 	})
 }
@@ -523,10 +523,10 @@ func TestRolloutSetWeightToZeroWhenFullyRolledOut(t *testing.T) {
 
 	steps := []v1alpha1.CanaryStep{
 		{
-			SetWeight: pointer.Int32Ptr(10),
+			SetWeight: ptr.To[int32](10),
 		},
 	}
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
 	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
 	r1.Spec.Strategy.Canary.CanaryService = "canary"
 	r1.Spec.Strategy.Canary.StableService = "stable"
@@ -557,7 +557,7 @@ func TestRolloutSetWeightToZeroWhenFullyRolledOut(t *testing.T) {
 	})
 	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
 	f.fakeTrafficRouting.On("RemoveManagedRoutes", mock.Anything, mock.Anything).Return(nil)
-	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(pointer.BoolPtr(true), nil)
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](true), nil)
 	f.run(getKey(r1, t))
 }
 
@@ -572,12 +572,12 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 
 	steps := []v1alpha1.CanaryStep{
 		{
-			SetWeight: pointer.Int32Ptr(10),
+			SetWeight: ptr.To[int32](10),
 		},
 	}
 
 	{
-		r := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+		r := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
 		roCtx := &rolloutContext{
 			rollout: r,
 			log:     logutil.WithRollout(r),
@@ -587,7 +587,7 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 		assert.Nil(t, networkReconciler)
 	}
 	{
-		r := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+		r := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
 		r.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
 		roCtx := &rolloutContext{
 			rollout: r,
@@ -599,7 +599,7 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 	}
 	{
 		// Without istioVirtualServiceLister
-		r := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+		r := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
 		r.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 			Istio: &v1alpha1.IstioTrafficRouting{},
 		}
@@ -621,7 +621,7 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 		dynamicInformerFactory.WaitForCacheSync(stopCh)
 		close(stopCh)
 		rc.IstioController.VirtualServiceLister = dynamiclister.New(rc.IstioController.VirtualServiceInformer.GetIndexer(), vsvcGVR)
-		r := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+		r := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
 		r.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 			Istio: &v1alpha1.IstioTrafficRouting{},
 		}
@@ -637,7 +637,7 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 		}
 	}
 	{
-		r := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+		r := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
 		r.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 			Nginx: &v1alpha1.NginxTrafficRouting{},
 		}
@@ -653,7 +653,7 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 		}
 	}
 	{
-		r := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+		r := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
 		r.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 			ALB: &v1alpha1.ALBTrafficRouting{},
 		}
@@ -670,7 +670,7 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 	}
 	{
 		tsController := Controller{}
-		r := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+		r := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
 		r.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 			SMI: &v1alpha1.SMITrafficRouting{},
 		}
@@ -687,7 +687,7 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 	}
 	{
 		tsController := Controller{}
-		r := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+		r := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
 		r.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 			AppMesh: &v1alpha1.AppMeshTrafficRouting{},
 		}
@@ -708,7 +708,7 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 				dynamicclientset: &traefikMocks.FakeDynamicClient{},
 			},
 		}
-		r := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+		r := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
 		r.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 			Traefik: &v1alpha1.TraefikTrafficRouting{
 				WeightedTraefikServiceName: "traefik-service",
@@ -731,7 +731,7 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 				dynamicclientset: &apisixMocks.FakeDynamicClient{},
 			},
 		}
-		r := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+		r := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
 		r.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 			Apisix: &v1alpha1.ApisixTrafficRouting{
 				Route: &v1alpha1.ApisixRoute{
@@ -753,7 +753,7 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 	{
 		// (2) Multiple Reconcilers (Nginx + SMI)
 		tsController := Controller{}
-		r := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+		r := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
 		r.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 			Nginx: &v1alpha1.NginxTrafficRouting{},
 			SMI:   &v1alpha1.SMITrafficRouting{},
@@ -776,7 +776,7 @@ func TestNewTrafficRoutingReconciler(t *testing.T) {
 	{
 		// (3) Multiple Reconcilers (ALB + Nginx + SMI)
 		tsController := Controller{}
-		r := newCanaryRollout("foo", 10, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+		r := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
 		r.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 			ALB:   &v1alpha1.ALBTrafficRouting{},
 			Nginx: &v1alpha1.NginxTrafficRouting{},
@@ -810,8 +810,8 @@ func TestCanaryWithTrafficRoutingAddScaleDownDelay(t *testing.T) {
 	defer f.Close()
 
 	r1 := newCanaryRollout("foo", 1, nil, []v1alpha1.CanaryStep{{
-		SetWeight: pointer.Int32(10),
-	}}, pointer.Int32(0), intstr.FromInt(1), intstr.FromInt(1))
+		SetWeight: ptr.To[int32](10),
+	}}, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(1))
 	r1.Spec.Strategy.Canary.CanaryService = "canary"
 	r1.Spec.Strategy.Canary.StableService = "stable"
 	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
@@ -823,7 +823,7 @@ func TestCanaryWithTrafficRoutingAddScaleDownDelay(t *testing.T) {
 	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
 	r2 = updateCanaryRolloutStatus(r2, rs2PodHash, 2, 1, 2, false)
 	r2.Status.ObservedGeneration = strconv.Itoa(int(r2.Generation))
-	r2.Status.CurrentStepIndex = pointer.Int32(1)
+	r2.Status.CurrentStepIndex = ptr.To[int32](1)
 	availableCondition, _ := newAvailableCondition(true)
 	conditions.SetRolloutCondition(&r2.Status, availableCondition)
 	completedCondition, _ := newCompletedCondition(true)
@@ -858,11 +858,11 @@ func TestCanaryWithTrafficRoutingScaleDownLimit(t *testing.T) {
 	inTheFuture := timeutil.MetaNow().Add(10 * time.Second).UTC().Format(time.RFC3339)
 
 	r1 := newCanaryRollout("foo", 1, nil, []v1alpha1.CanaryStep{{
-		SetWeight: pointer.Int32Ptr(10),
-	}}, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(1))
+		SetWeight: ptr.To[int32](10),
+	}}, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(1))
 	rs1 := newReplicaSetWithStatus(r1, 1, 1)
 	rs1.Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey] = inTheFuture
-	r1.Spec.Strategy.Canary.ScaleDownDelayRevisionLimit = pointer.Int32Ptr(1)
+	r1.Spec.Strategy.Canary.ScaleDownDelayRevisionLimit = ptr.To[int32](1)
 	r1.Spec.Strategy.Canary.CanaryService = "canary"
 	r1.Spec.Strategy.Canary.StableService = "stable"
 	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
@@ -907,13 +907,13 @@ func TestDynamicScalingDontIncreaseWeightWhenAborted(t *testing.T) {
 
 	steps := []v1alpha1.CanaryStep{
 		{
-			SetWeight: pointer.Int32Ptr(50),
+			SetWeight: ptr.To[int32](50),
 		},
 		{
 			Pause: &v1alpha1.RolloutPause{},
 		},
 	}
-	r1 := newCanaryRollout("foo", 5, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 5, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(1))
 	r1.Spec.Strategy.Canary.DynamicStableScale = true
 	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 		SMI: &v1alpha1.SMITrafficRouting{},
@@ -967,7 +967,7 @@ func TestDynamicScalingDontIncreaseWeightWhenAborted(t *testing.T) {
 	})
 	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
 	f.fakeTrafficRouting.On("RemoveManagedRoutes", mock.Anything, mock.Anything).Return(nil)
-	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(pointer.BoolPtr(true), nil)
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](true), nil)
 	f.run(getKey(r1, t))
 }
 
@@ -979,13 +979,13 @@ func TestDynamicScalingDecreaseWeightAccordingToStableAvailabilityWhenAborted(t 
 
 	steps := []v1alpha1.CanaryStep{
 		{
-			SetWeight: pointer.Int32Ptr(50),
+			SetWeight: ptr.To[int32](50),
 		},
 		{
 			Pause: &v1alpha1.RolloutPause{},
 		},
 	}
-	r1 := newCanaryRollout("foo", 5, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 5, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(1))
 	r1.Spec.Strategy.Canary.DynamicStableScale = true
 	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 		SMI: &v1alpha1.SMITrafficRouting{},
@@ -1038,7 +1038,7 @@ func TestDynamicScalingDecreaseWeightAccordingToStableAvailabilityWhenAborted(t 
 	})
 	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
 	f.fakeTrafficRouting.On("RemoveManagedRoutes", mock.Anything, mock.Anything).Return(nil)
-	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(pointer.BoolPtr(true), nil)
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](true), nil)
 	f.run(getKey(r1, t))
 }
 
@@ -1051,13 +1051,13 @@ func TestDynamicScalingDecreaseWeightAccordingToStableAvailabilityWhenAbortedAnd
 
 	steps := []v1alpha1.CanaryStep{
 		{
-			SetWeight: pointer.Int32Ptr(50),
+			SetWeight: ptr.To[int32](50),
 		},
 		{
 			Pause: &v1alpha1.RolloutPause{},
 		},
 	}
-	r1 := newCanaryRollout("foo", 5, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 5, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(1))
 	r1.Spec.Strategy.Canary.DynamicStableScale = true
 	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 		SMI: &v1alpha1.SMITrafficRouting{},
@@ -1111,7 +1111,7 @@ func TestDynamicScalingDecreaseWeightAccordingToStableAvailabilityWhenAbortedAnd
 	})
 	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
 	f.fakeTrafficRouting.On("RemoveManagedRoutes", mock.Anything, mock.Anything).Return(nil)
-	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(pointer.BoolPtr(true), nil)
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](true), nil)
 	f.run(getKey(r1, t))
 }
 
@@ -1121,7 +1121,7 @@ func TestRolloutReplicaIsAvailableAndGenerationNotBeModifiedShouldModifyVirtualS
 	steps := []v1alpha1.CanaryStep{
 		{
 			SetCanaryScale: &v1alpha1.SetCanaryScale{
-				Replicas: pointer.Int32(1),
+				Replicas: ptr.To[int32](1),
 			},
 		},
 		{
@@ -1141,7 +1141,7 @@ func TestRolloutReplicaIsAvailableAndGenerationNotBeModifiedShouldModifyVirtualS
 			Pause: &v1alpha1.RolloutPause{},
 		},
 	}
-	r1 := newCanaryRollout("foo", 1, nil, steps, pointer.Int32(1), intstr.FromInt(1), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 1, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(1))
 	vs := istio.VirtualService{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
@@ -1266,13 +1266,13 @@ func TestDontWeightToZeroWhenDynamicallyRollingBackToStable(t *testing.T) {
 
 	steps := []v1alpha1.CanaryStep{
 		{
-			SetWeight: pointer.Int32(90),
+			SetWeight: ptr.To[int32](90),
 		},
 		{
 			Pause: &v1alpha1.RolloutPause{},
 		},
 	}
-	r1 := newCanaryRollout("foo", 10, nil, steps, pointer.Int32(1), intstr.FromInt(1), intstr.FromInt(1))
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(1))
 	r1.Spec.Strategy.Canary.DynamicStableScale = true
 	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 		SMI: &v1alpha1.SMITrafficRouting{},
@@ -1342,7 +1342,7 @@ func TestDontWeightToZeroWhenDynamicallyRollingBackToStable(t *testing.T) {
 	})
 	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
 	f.fakeTrafficRouting.On("RemoveManagedRoutes", mock.Anything, mock.Anything).Return(nil)
-	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(pointer.BoolPtr(true), nil)
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](true), nil)
 	f.run(getKey(r1, t))
 
 	// Make sure we scale up stable ReplicaSet to 10
@@ -1373,13 +1373,13 @@ func TestDontWeightOrHaveManagedRoutesDuringInterruptedUpdate(t *testing.T) {
 			},
 		},
 		{
-			SetWeight: pointer.Int32(90),
+			SetWeight: ptr.To[int32](90),
 		},
 		{
 			Pause: &v1alpha1.RolloutPause{},
 		},
 	}
-	r1 := newCanaryRollout("foo", 5, nil, steps, pointer.Int32Ptr(1), intstr.FromInt(1), intstr.FromInt(0))
+	r1 := newCanaryRollout("foo", 5, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
 	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 		ALB: &v1alpha1.ALBTrafficRouting{
 			Ingress: "test-ingress",
@@ -1443,14 +1443,14 @@ func TestCheckReplicaSetAvailable(t *testing.T) {
 
 	steps := []v1alpha1.CanaryStep{
 		{
-			SetWeight: pointer.Int32(60),
+			SetWeight: ptr.To[int32](60),
 		},
 		{
 			Pause: &v1alpha1.RolloutPause{},
 		},
 	}
 
-	rollout1 := newCanaryRollout("test-rollout", 10, nil, steps, pointer.Int32(1), intstr.FromInt(1), intstr.FromInt(1))
+	rollout1 := newCanaryRollout("test-rollout", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(1))
 	rollout1.Spec.Strategy.Canary.DynamicStableScale = true
 	rollout1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 		SMI: &v1alpha1.SMITrafficRouting{},

--- a/test/cmd/step-plugin-sample/internal/plugin/plugin_test.go
+++ b/test/cmd/step-plugin-sample/internal/plugin/plugin_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/plugin/types"
 )
 
+// "k8s.io/utils/ptr"
+
 func new(logCtx *log.Entry, seed int64) *rpcPlugin {
 	return &rpcPlugin{
 		LogCtx: logCtx,
@@ -223,7 +225,7 @@ func Test_rpcPlugin_Run(t *testing.T) {
 				},
 			},
 		}
-		rollout.Status.CurrentStepIndex = ptr.To(int32(0))
+		rollout.Status.CurrentStepIndex = ptr.To[int32](0)
 		rollout.Status.Canary.StepPluginStatuses = []v1alpha1.StepPluginStatus{
 			{
 				Index: 0,
@@ -274,7 +276,7 @@ func Test_rpcPlugin_Run(t *testing.T) {
 				},
 			},
 		}
-		rollout.Status.CurrentStepIndex = ptr.To(int32(1))
+		rollout.Status.CurrentStepIndex = ptr.To[int32](1)
 		rollout.Status.Canary.StepPluginStatuses = []v1alpha1.StepPluginStatus{
 			{
 				Index: 0,
@@ -330,7 +332,7 @@ func Test_rpcPlugin_Run(t *testing.T) {
 				},
 			},
 		}
-		rollout.Status.CurrentStepIndex = ptr.To(int32(2))
+		rollout.Status.CurrentStepIndex = ptr.To[int32](2)
 		rollout.Status.Canary.StepPluginStatuses = []v1alpha1.StepPluginStatus{
 			{
 				Index: 0,

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"github.com/tj/assert"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/test/fixtures"
 	ingress2 "github.com/argoproj/argo-rollouts/utils/ingress"
@@ -472,7 +472,7 @@ func assertAlbActionServiceWeight(t *fixtures.Then, s *AWSSuite, actionName, ser
 	found := false
 	for _, group := range albAction.ForwardConfig.TargetGroups {
 		if group.ServiceName == serviceName {
-			assert.Equal(s.T(), pointer.Int64(expectedWeight), group.Weight)
+			assert.Equal(s.T(), ptr.To[int64](expectedWeight), group.Weight)
 			found = true
 		}
 	}
@@ -495,7 +495,7 @@ func assertAlbActionServiceWeightMultiIngress(t *fixtures.Then, s *AWSSuite, act
 		found := false
 		for _, group := range albAction.ForwardConfig.TargetGroups {
 			if group.ServiceName == serviceName {
-				assert.Equal(s.T(), pointer.Int64(expectedWeight), group.Weight)
+				assert.Equal(s.T(), ptr.To[int64](expectedWeight), group.Weight)
 				found = true
 			}
 		}

--- a/utils/analysis/factory_test.go
+++ b/utils/analysis/factory_test.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/annotations"
@@ -124,13 +124,13 @@ func TestBuildArgumentsForRolloutAnalysisRun(t *testing.T) {
 
 	args, err := BuildArgumentsForRolloutAnalysisRun(rolloutAnalysis.Args, stableRS, newRS, ro)
 	assert.NoError(t, err)
-	assert.Contains(t, args, v1alpha1.Argument{Name: "hard-coded-value-key", Value: pointer.StringPtr("hard-coded-value")})
-	assert.Contains(t, args, v1alpha1.Argument{Name: "stable-key", Value: pointer.StringPtr("abcdef")})
-	assert.Contains(t, args, v1alpha1.Argument{Name: "new-key", Value: pointer.StringPtr("123456")})
-	assert.Contains(t, args, v1alpha1.Argument{Name: "metadata.labels['app']", Value: pointer.StringPtr("app")})
-	assert.Contains(t, args, v1alpha1.Argument{Name: "metadata.labels['env']", Value: pointer.StringPtr("test")})
-	assert.Contains(t, args, v1alpha1.Argument{Name: annotationPath, Value: pointer.StringPtr("1")})
-	assert.Contains(t, args, v1alpha1.Argument{Name: "status.pauseConditions[0].reason", Value: pointer.StringPtr("test-reason")})
+	assert.Contains(t, args, v1alpha1.Argument{Name: "hard-coded-value-key", Value: ptr.To[string]("hard-coded-value")})
+	assert.Contains(t, args, v1alpha1.Argument{Name: "stable-key", Value: ptr.To[string]("abcdef")})
+	assert.Contains(t, args, v1alpha1.Argument{Name: "new-key", Value: ptr.To[string]("123456")})
+	assert.Contains(t, args, v1alpha1.Argument{Name: "metadata.labels['app']", Value: ptr.To[string]("app")})
+	assert.Contains(t, args, v1alpha1.Argument{Name: "metadata.labels['env']", Value: ptr.To[string]("test")})
+	assert.Contains(t, args, v1alpha1.Argument{Name: annotationPath, Value: ptr.To[string]("1")})
+	assert.Contains(t, args, v1alpha1.Argument{Name: "status.pauseConditions[0].reason", Value: ptr.To[string]("test-reason")})
 }
 
 func TestPrePromotionLabels(t *testing.T) {

--- a/utils/analysis/filter_test.go
+++ b/utils/analysis/filter_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 )
@@ -278,9 +278,9 @@ func TestSortAnalysisRunByPodHash(t *testing.T) {
 	}
 	ars := []*v1alpha1.AnalysisRun{
 		ar(nil),
-		ar(pointer.StringPtr("ab")),
-		ar(pointer.StringPtr("abc")),
-		ar(pointer.StringPtr("abc")),
+		ar(ptr.To[string]("ab")),
+		ar(ptr.To[string]("abc")),
+		ar(ptr.To[string]("abc")),
 	}
 	arMap := SortAnalysisRunByPodHash(ars)
 	assert.Len(t, arMap, 2)

--- a/utils/analysis/helpers_test.go
+++ b/utils/analysis/helpers_test.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	kubetesting "k8s.io/client-go/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
@@ -299,7 +299,7 @@ func TestCreateWithCollisionCounterError(t *testing.T) {
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					UID:        types.UID("fake-uid"),
-					Controller: pointer.BoolPtr(true),
+					Controller: ptr.To[bool](true),
 				},
 			},
 		},
@@ -322,7 +322,7 @@ func TestCreateWithCollisionCounterStillRunning(t *testing.T) {
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					UID:        types.UID("fake-uid"),
-					Controller: pointer.BoolPtr(true),
+					Controller: ptr.To[bool](true),
 				},
 			},
 		},
@@ -343,7 +343,7 @@ func TestCreateWithCollisionCounter(t *testing.T) {
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					UID:        types.UID("fake-uid"),
-					Controller: pointer.BoolPtr(true),
+					Controller: ptr.To[bool](true),
 				},
 			},
 		},
@@ -383,7 +383,7 @@ func TestFlattenTemplates(t *testing.T) {
 		orig := &v1alpha1.AnalysisTemplate{
 			Spec: v1alpha1.AnalysisTemplateSpec{
 				Metrics: []v1alpha1.Metric{metric("foo", "{{args.test}}")},
-				Args:    []v1alpha1.Argument{arg("test", pointer.StringPtr("true"))},
+				Args:    []v1alpha1.Argument{arg("test", ptr.To[string]("true"))},
 			},
 		}
 		template, err := FlattenTemplates([]*v1alpha1.AnalysisTemplate{orig}, []*v1alpha1.ClusterAnalysisTemplate{})
@@ -545,8 +545,8 @@ func TestFlattenTemplates(t *testing.T) {
 		assert.Equal(t, err, fmt.Errorf("two Measurement Retention metric rules have the same name 'foo'"))
 	})
 	t.Run("Merge multiple args successfully", func(t *testing.T) {
-		fooArgs := arg("foo", pointer.StringPtr("true"))
-		barArgs := arg("bar", pointer.StringPtr("true"))
+		fooArgs := arg("foo", ptr.To[string]("true"))
+		barArgs := arg("bar", ptr.To[string]("true"))
 		template, err := FlattenTemplates([]*v1alpha1.AnalysisTemplate{
 			{
 				Spec: v1alpha1.AnalysisTemplateSpec{
@@ -566,7 +566,7 @@ func TestFlattenTemplates(t *testing.T) {
 		assert.Equal(t, barArgs, template.Spec.Args[1])
 	})
 	t.Run(" Merge args with same name but only one has value", func(t *testing.T) {
-		fooArgsValue := arg("foo", pointer.StringPtr("true"))
+		fooArgsValue := arg("foo", ptr.To[string]("true"))
 		fooArgsNoValue := arg("foo", nil)
 		template, err := FlattenTemplates([]*v1alpha1.AnalysisTemplate{
 			{
@@ -586,8 +586,8 @@ func TestFlattenTemplates(t *testing.T) {
 		assert.Contains(t, template.Spec.Args, fooArgsValue)
 	})
 	t.Run("Error: merge args with same name and both have values", func(t *testing.T) {
-		fooArgs := arg("foo", pointer.StringPtr("true"))
-		fooArgsWithDiffValue := arg("foo", pointer.StringPtr("false"))
+		fooArgs := arg("foo", ptr.To[string]("true"))
+		fooArgsWithDiffValue := arg("foo", ptr.To[string]("false"))
 		template, err := FlattenTemplates([]*v1alpha1.AnalysisTemplate{
 			{
 				Spec: v1alpha1.AnalysisTemplateSpec{
@@ -633,7 +633,7 @@ func TestNewAnalysisRunFromTemplates(t *testing.T) {
 
 	arg := v1alpha1.Argument{
 		Name:  "my-arg",
-		Value: pointer.StringPtr("my-val"),
+		Value: ptr.To[string]("my-val"),
 	}
 	secretArg := v1alpha1.Argument{
 		Name: "my-secret",
@@ -725,7 +725,7 @@ func TestMergeArgs(t *testing.T) {
 			nil, []v1alpha1.Argument{
 				{
 					Name:  "foo",
-					Value: pointer.StringPtr("bar"),
+					Value: ptr.To[string]("bar"),
 				},
 				{
 					Name: "my-secret",
@@ -750,12 +750,12 @@ func TestMergeArgs(t *testing.T) {
 			[]v1alpha1.Argument{
 				{
 					Name:  "foo",
-					Value: pointer.StringPtr("overwrite"),
+					Value: ptr.To[string]("overwrite"),
 				},
 			}, []v1alpha1.Argument{
 				{
 					Name:  "foo",
-					Value: pointer.StringPtr("bar"),
+					Value: ptr.To[string]("bar"),
 				},
 			})
 		assert.NoError(t, err)
@@ -784,11 +784,11 @@ func TestMergeArgs(t *testing.T) {
 			[]v1alpha1.Argument{
 				{
 					Name:  "foo",
-					Value: pointer.StringPtr("my-value"),
+					Value: ptr.To[string]("my-value"),
 				},
 				{
 					Name:  "extra-arg",
-					Value: pointer.StringPtr("extra-value"),
+					Value: ptr.To[string]("extra-value"),
 				},
 			}, []v1alpha1.Argument{
 				{
@@ -828,11 +828,11 @@ func TestNewAnalysisRunFromUnstructured(t *testing.T) {
 	args := []v1alpha1.Argument{
 		{
 			Name:  "my-arg-1",
-			Value: pointer.StringPtr("my-val-1"),
+			Value: ptr.To[string]("my-val-1"),
 		},
 		{
 			Name:  "my-arg-2",
-			Value: pointer.StringPtr("my-val-2"),
+			Value: ptr.To[string]("my-val-2"),
 		},
 	}
 
@@ -878,7 +878,7 @@ func TestCompatibilityNewAnalysisRunFromTemplate(t *testing.T) {
 	args := []v1alpha1.Argument{
 		{
 			Name:  "my-arg",
-			Value: pointer.StringPtr("my-val"),
+			Value: ptr.To[string]("my-val"),
 		},
 	}
 	labels := make(map[string]string)
@@ -915,7 +915,7 @@ func TestCompatibilityNewAnalysisRunFromClusterTemplate(t *testing.T) {
 	args := []v1alpha1.Argument{
 		{
 			Name:  "my-arg",
-			Value: pointer.StringPtr("my-val"),
+			Value: ptr.To[string]("my-val"),
 		},
 	}
 	labels := make(map[string]string)

--- a/utils/aws/aws_test.go
+++ b/utils/aws/aws_test.go
@@ -12,7 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	testutil "github.com/argoproj/argo-rollouts/test/util"
 	"github.com/argoproj/argo-rollouts/utils/aws/mocks"
@@ -41,8 +41,8 @@ func TestFindLoadBalancerByDNSName(t *testing.T) {
 		fakeELB, c := newFakeClient()
 		// Mock output
 		expectedLB := elbv2types.LoadBalancer{
-			LoadBalancerArn: pointer.StringPtr("lb-abc123"),
-			DNSName:         pointer.StringPtr("find-loadbalancer-test-abc-123.us-west-2.elb.amazonaws.com"),
+			LoadBalancerArn: ptr.To[string]("lb-abc123"),
+			DNSName:         ptr.To[string]("find-loadbalancer-test-abc-123.us-west-2.elb.amazonaws.com"),
 		}
 		lbOut := elbv2.DescribeLoadBalancersOutput{
 			LoadBalancers: []elbv2types.LoadBalancer{
@@ -103,13 +103,13 @@ func TestGetTargetGroupMetadata(t *testing.T) {
 	tgOut := elbv2.DescribeTargetGroupsOutput{
 		TargetGroups: []elbv2types.TargetGroup{
 			{
-				TargetGroupArn: pointer.StringPtr("tg-abc123"),
+				TargetGroupArn: ptr.To[string]("tg-abc123"),
 			},
 			{
-				TargetGroupArn: pointer.StringPtr("tg-def456"),
+				TargetGroupArn: ptr.To[string]("tg-def456"),
 			},
 			{
-				TargetGroupArn: pointer.StringPtr("tg-ghi789"),
+				TargetGroupArn: ptr.To[string]("tg-ghi789"),
 			},
 		},
 	}
@@ -125,11 +125,11 @@ func TestGetTargetGroupMetadata(t *testing.T) {
 		}
 		for _, arn := range tagsIn.ResourceArns {
 			tagsOut.TagDescriptions = append(tagsOut.TagDescriptions, elbv2types.TagDescription{
-				ResourceArn: pointer.StringPtr(arn),
+				ResourceArn: ptr.To[string](arn),
 				Tags: []elbv2types.Tag{
 					{
-						Key:   pointer.StringPtr("foo"),
-						Value: pointer.StringPtr("bar"),
+						Key:   ptr.To[string]("foo"),
+						Value: ptr.To[string]("bar"),
 					},
 				},
 			})
@@ -141,8 +141,8 @@ func TestGetTargetGroupMetadata(t *testing.T) {
 	listenersOut := elbv2.DescribeListenersOutput{
 		Listeners: []elbv2types.Listener{
 			{
-				ListenerArn:     pointer.StringPtr("lst-abc123"),
-				LoadBalancerArn: pointer.StringPtr("lb-abc123"),
+				ListenerArn:     ptr.To[string]("lst-abc123"),
+				LoadBalancerArn: ptr.To[string]("lb-abc123"),
 			},
 		},
 	}
@@ -156,8 +156,8 @@ func TestGetTargetGroupMetadata(t *testing.T) {
 						ForwardConfig: &elbv2types.ForwardActionConfig{
 							TargetGroups: []elbv2types.TargetGroupTuple{
 								{
-									TargetGroupArn: pointer.StringPtr("tg-abc123"),
-									Weight:         pointer.Int32Ptr(10),
+									TargetGroupArn: ptr.To[string]("tg-abc123"),
+									Weight:         ptr.To[int32](10),
 								},
 							},
 						},
@@ -194,7 +194,7 @@ func TestGetTargetGroupHealth(t *testing.T) {
 	expectedHealth := elbv2.DescribeTargetHealthOutput{
 		TargetHealthDescriptions: []elbv2types.TargetHealthDescription{
 			{
-				HealthCheckPort: pointer.StringPtr("80"),
+				HealthCheckPort: ptr.To[string]("80"),
 				Target:          &elbv2types.TargetDescription{},
 				TargetHealth: &elbv2types.TargetHealth{
 					State: elbv2types.TargetHealthStateEnumHealthy,
@@ -290,7 +290,7 @@ func TestVerifyTargetGroupBindingIgnoreInstanceMode(t *testing.T) {
 	_, awsClnt := newFakeClient()
 	tgb := TargetGroupBinding{
 		Spec: TargetGroupBindingSpec{
-			TargetType: (*TargetType)(pointer.StringPtr("instance")),
+			TargetType: (*TargetType)(ptr.To[string]("instance")),
 		},
 	}
 	res, err := VerifyTargetGroupBinding(context.TODO(), logCtx, awsClnt, tgb, nil, nil)
@@ -306,7 +306,7 @@ func TestVerifyTargetGroupBinding(t *testing.T) {
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: TargetGroupBindingSpec{
-			TargetType:     (*TargetType)(pointer.StringPtr("ip")),
+			TargetType:     (*TargetType)(ptr.To[string]("ip")),
 			TargetGroupARN: "arn::1234",
 			ServiceRef: ServiceReference{
 				Name: "active",
@@ -360,26 +360,26 @@ func TestVerifyTargetGroupBinding(t *testing.T) {
 		TargetHealthDescriptions: []elbv2types.TargetHealthDescription{
 			{
 				Target: &elbv2types.TargetDescription{
-					Id:   pointer.StringPtr("1.2.3.4"),
-					Port: pointer.Int32Ptr(8080),
+					Id:   ptr.To[string]("1.2.3.4"),
+					Port: ptr.To[int32](8080),
 				},
 			},
 			{
 				Target: &elbv2types.TargetDescription{
-					Id:   pointer.StringPtr("5.6.7.8"),
-					Port: pointer.Int32Ptr(8080),
+					Id:   ptr.To[string]("5.6.7.8"),
+					Port: ptr.To[int32](8080),
 				},
 			},
 			{
 				Target: &elbv2types.TargetDescription{
-					Id:   pointer.StringPtr("2.4.6.8"), // irrelevant
-					Port: pointer.Int32Ptr(8081),       // wrong port
+					Id:   ptr.To[string]("2.4.6.8"), // irrelevant
+					Port: ptr.To[int32](8081),       // wrong port
 				},
 			},
 			{
 				Target: &elbv2types.TargetDescription{
-					Id:   pointer.StringPtr("9.8.7.6"), // irrelevant ip
-					Port: pointer.Int32Ptr(8080),
+					Id:   ptr.To[string]("9.8.7.6"), // irrelevant ip
+					Port: ptr.To[int32](8080),
 				},
 			},
 		},

--- a/utils/conditions/rollouts_test.go
+++ b/utils/conditions/rollouts_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/hash"
@@ -388,7 +388,7 @@ func TestRolloutHealthy(t *testing.T) {
 		r := rollout(desired, current, updated, available, correctObservedGeneration)
 		steps := []v1alpha1.CanaryStep{}
 		if hasSteps {
-			steps = append(steps, v1alpha1.CanaryStep{SetWeight: pointer.Int32Ptr(30)})
+			steps = append(steps, v1alpha1.CanaryStep{SetWeight: ptr.To[int32](30)})
 		}
 		r.Spec.Strategy = v1alpha1.RolloutStrategy{
 			Canary: &v1alpha1.CanaryStrategy{
@@ -433,12 +433,12 @@ func TestRolloutHealthy(t *testing.T) {
 		},
 		{
 			name:     "CanaryWithSteps Completed",
-			r:        canaryRollout(1, 1, 1, 1, true, "active", true, pointer.Int32Ptr(1)),
+			r:        canaryRollout(1, 1, 1, 1, true, "active", true, ptr.To[int32](1)),
 			expected: false,
 		},
 		{
 			name:     "CanaryWithSteps Not Completed: Steps left",
-			r:        canaryRollout(1, 1, 1, 1, true, "active", true, pointer.Int32Ptr(0)),
+			r:        canaryRollout(1, 1, 1, 1, true, "active", true, ptr.To[int32](0)),
 			expected: false,
 		},
 		{
@@ -617,7 +617,7 @@ func TestComputeStepHash(t *testing.T) {
 
 	roWithSameSteps := ro.DeepCopy()
 	roWithSameSteps.Status.CurrentPodHash = "Test"
-	roWithSameSteps.Spec.Replicas = pointer.Int32Ptr(1)
+	roWithSameSteps.Spec.Replicas = ptr.To[int32](1)
 	roWithSameStepsHash := ComputeStepHash(roWithSameSteps)
 	assert.Equal(t, "6b9b86fbd5", roWithSameStepsHash)
 

--- a/utils/defaults/defaults_test.go
+++ b/utils/defaults/defaults_test.go
@@ -4,10 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/utils/pointer"
-
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 )
@@ -26,7 +25,7 @@ func TestGetReplicasOrDefault(t *testing.T) {
 func TestGetExperimentScaleDownDelaySecondsOrDefault(t *testing.T) {
 	exp := v1alpha1.Experiment{
 		Spec: v1alpha1.ExperimentSpec{
-			ScaleDownDelaySeconds: pointer.Int32Ptr(0),
+			ScaleDownDelaySeconds: ptr.To[int32](0),
 		},
 	}
 	// Custom value

--- a/utils/diff/diff_test.go
+++ b/utils/diff/diff_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 )
@@ -37,7 +37,7 @@ func TestCreateTwoWayMergeInvalidDataStruct(t *testing.T) {
 			Name: "test",
 		},
 		Spec: v1alpha1.RolloutSpec{
-			Replicas: pointer.Int32Ptr(1),
+			Replicas: ptr.To[int32](1),
 		},
 	}
 	_, _, err := CreateTwoWayMergePatch(rollout, rollout2, nil)
@@ -55,7 +55,7 @@ func TestCreateTwoWayMergeCreatePatch(t *testing.T) {
 			Name: "test",
 		},
 		Spec: v1alpha1.RolloutSpec{
-			Replicas: pointer.Int32Ptr(1),
+			Replicas: ptr.To[int32](1),
 		},
 	}
 	patch, isPatched, err := CreateTwoWayMergePatch(rollout, rollout2, v1alpha1.Rollout{})

--- a/utils/experiment/experiment_test.go
+++ b/utils/experiment/experiment_test.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubetesting "k8s.io/client-go/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
@@ -163,7 +163,7 @@ func TestReplicaSetNameFromExperiment(t *testing.T) {
 
 	newTemplateStatus := v1alpha1.TemplateStatus{
 		Name:           templateName,
-		CollisionCount: pointer.Int32Ptr(1),
+		CollisionCount: ptr.To[int32](1),
 	}
 	e.Status.TemplateStatuses = append(e.Status.TemplateStatuses, newTemplateStatus)
 	assert.Equal(t, "foo-template-688c48b575", ReplicasetNameFromExperiment(e, template))
@@ -423,7 +423,7 @@ func TestIsSemanticallyEqual(t *testing.T) {
 	right := left.DeepCopy()
 	right.Terminate = true
 	assert.True(t, IsSemanticallyEqual(*left, *right))
-	right.Templates[0].Replicas = pointer.Int32Ptr(1)
+	right.Templates[0].Replicas = ptr.To[int32](1)
 	assert.False(t, IsSemanticallyEqual(*left, *right))
 }
 

--- a/utils/experiment/filter_test.go
+++ b/utils/experiment/filter_test.go
@@ -7,7 +7,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 )
@@ -60,9 +60,9 @@ func TestSortExperimentsByPodHash(t *testing.T) {
 	}
 	exs := []*v1alpha1.Experiment{
 		ex(nil),
-		ex(pointer.StringPtr("ab")),
-		ex(pointer.StringPtr("abc")),
-		ex(pointer.StringPtr("abc")),
+		ex(ptr.To[string]("ab")),
+		ex(ptr.To[string]("abc")),
+		ex(ptr.To[string]("abc")),
 	}
 	exMap := SortExperimentsByPodHash(exs)
 	assert.Len(t, exMap, 2)

--- a/utils/hash/hash_test.go
+++ b/utils/hash/hash_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestHashUtils(t *testing.T) {
@@ -19,7 +19,7 @@ func TestHashUtils(t *testing.T) {
 		assert.Equal(t, hashRed, podHash)
 	})
 	t.Run("HashForDifferentTemplates", func(t *testing.T) {
-		podHash := ComputePodTemplateHash(&template, pointer.Int32(1))
+		podHash := ComputePodTemplateHash(&template, ptr.To[int32](1))
 		assert.NotEqual(t, hashRed, podHash)
 	})
 }

--- a/utils/ingress/wrapper_test.go
+++ b/utils/ingress/wrapper_test.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	kubeinformers "k8s.io/client-go/informers"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/ingress"
@@ -976,7 +976,7 @@ func networkingIngress() *ingress.Ingress {
 	pathType := v1.PathTypeImplementationSpecific
 	res := v1.Ingress{
 		Spec: v1.IngressSpec{
-			IngressClassName: pointer.String("v1ingress"),
+			IngressClassName: ptr.To[string]("v1ingress"),
 			Rules: []v1.IngressRule{
 				{
 					Host: "v1host",
@@ -1010,7 +1010,7 @@ func networkingIngressWithPath(paths ...string) *ingress.Ingress {
 	}
 	res := v1.Ingress{
 		Spec: v1.IngressSpec{
-			IngressClassName: pointer.String("v1ingress"),
+			IngressClassName: ptr.To[string]("v1ingress"),
 			Rules: []v1.IngressRule{
 				{
 					Host: "v1host",
@@ -1044,7 +1044,7 @@ func extensionsIngress() *ingress.Ingress {
 	pathType := v1beta1.PathTypeImplementationSpecific
 	res := v1beta1.Ingress{
 		Spec: v1beta1.IngressSpec{
-			IngressClassName: pointer.String("v1beta1ingress"),
+			IngressClassName: ptr.To[string]("v1beta1ingress"),
 			Rules: []v1beta1.IngressRule{
 				{
 					Host: "v1beta1host",
@@ -1076,7 +1076,7 @@ func extensionsIngressWithPath(paths ...string) *ingress.Ingress {
 	}
 	res := v1beta1.Ingress{
 		Spec: v1beta1.IngressSpec{
-			IngressClassName: pointer.String("v1beta1ingress"),
+			IngressClassName: ptr.To[string]("v1beta1ingress"),
 			Rules: []v1beta1.IngressRule{
 				{
 					Host: "v1beta1host",

--- a/utils/replicaset/bluegreen_test.go
+++ b/utils/replicaset/bluegreen_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 )
@@ -49,7 +49,7 @@ func TestReadyForPause(t *testing.T) {
 			Labels: map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: "abcd"},
 		},
 		Spec: appsv1.ReplicaSetSpec{
-			Replicas: pointer.Int32Ptr(1),
+			Replicas: ptr.To[int32](1),
 		},
 		Status: appsv1.ReplicaSetStatus{
 			AvailableReplicas: 1,
@@ -61,7 +61,7 @@ func TestReadyForPause(t *testing.T) {
 			Labels: map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: "abcd"},
 		},
 		Spec: appsv1.ReplicaSetSpec{
-			Replicas: pointer.Int32Ptr(1),
+			Replicas: ptr.To[int32](1),
 		},
 		Status: appsv1.ReplicaSetStatus{
 			AvailableReplicas: 0,

--- a/utils/replicaset/canary_test.go
+++ b/utils/replicaset/canary_test.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 )
@@ -1030,19 +1030,19 @@ func TestBeforeStartingStep(t *testing.T) {
 	}
 	assert.False(t, BeforeStartingStep(ro))
 
-	ro.Spec.Strategy.Canary.Analysis.StartingStep = pointer.Int32Ptr(1)
+	ro.Spec.Strategy.Canary.Analysis.StartingStep = ptr.To[int32](1)
 	assert.False(t, BeforeStartingStep(ro))
 	ro.Spec.Strategy.Canary.Steps = []v1alpha1.CanaryStep{
 		{
-			SetWeight: pointer.Int32Ptr(1),
+			SetWeight: ptr.To[int32](1),
 		},
 		{
 			Pause: &v1alpha1.RolloutPause{},
 		},
 	}
-	ro.Status.CurrentStepIndex = pointer.Int32Ptr(0)
+	ro.Status.CurrentStepIndex = ptr.To[int32](0)
 	assert.True(t, BeforeStartingStep(ro))
-	ro.Status.CurrentStepIndex = pointer.Int32Ptr(1)
+	ro.Status.CurrentStepIndex = ptr.To[int32](1)
 	assert.False(t, BeforeStartingStep(ro))
 
 }
@@ -1089,8 +1089,8 @@ func TestAtDesiredReplicaCountsForCanary(t *testing.T) {
 
 	t.Run("we are at desired replica counts and availability", func(t *testing.T) {
 		rollout := newRollout(4, 50, intstr.FromInt(1), intstr.FromInt(1), "current", "stable", &v1alpha1.SetCanaryScale{
-			Weight:             pointer.Int32Ptr(2),
-			Replicas:           pointer.Int32Ptr(2),
+			Weight:             ptr.To[int32](2),
+			Replicas:           ptr.To[int32](2),
 			MatchTrafficWeight: false,
 		}, nil)
 
@@ -1115,8 +1115,8 @@ func TestAtDesiredReplicaCountsForCanary(t *testing.T) {
 
 	t.Run("new replicaset is not at desired counts or availability", func(t *testing.T) {
 		rollout := newRollout(4, 50, intstr.FromInt(1), intstr.FromInt(1), "current", "stable", &v1alpha1.SetCanaryScale{
-			Weight:             pointer.Int32Ptr(2),
-			Replicas:           pointer.Int32Ptr(2),
+			Weight:             ptr.To[int32](2),
+			Replicas:           ptr.To[int32](2),
 			MatchTrafficWeight: false,
 		}, nil)
 
@@ -1184,8 +1184,8 @@ func TestAtDesiredReplicaCountsForCanary(t *testing.T) {
 
 	t.Run("test that when status field lags behind spec.replicas we fail", func(t *testing.T) {
 		rollout := newRollout(4, 50, intstr.FromInt(1), intstr.FromInt(1), "current", "stable", &v1alpha1.SetCanaryScale{
-			Weight:             pointer.Int32Ptr(2),
-			Replicas:           pointer.Int32Ptr(2),
+			Weight:             ptr.To[int32](2),
+			Replicas:           ptr.To[int32](2),
 			MatchTrafficWeight: false,
 		}, nil)
 
@@ -1227,22 +1227,22 @@ func TestGetCurrentExperiment(t *testing.T) {
 			},
 		},
 	}
-	rollout.Status.CurrentStepIndex = pointer.Int32Ptr(0)
+	rollout.Status.CurrentStepIndex = ptr.To[int32](0)
 
 	e := GetCurrentExperimentStep(rollout)
 	assert.Equal(t, v1alpha1.DurationString("1s"), e.Duration)
 
-	rollout.Status.CurrentStepIndex = pointer.Int32Ptr(1)
+	rollout.Status.CurrentStepIndex = ptr.To[int32](1)
 
 	e = GetCurrentExperimentStep(rollout)
 	assert.Equal(t, v1alpha1.DurationString("1s"), e.Duration)
 
-	rollout.Status.CurrentStepIndex = pointer.Int32Ptr(2)
+	rollout.Status.CurrentStepIndex = ptr.To[int32](2)
 
 	assert.Nil(t, GetCurrentExperimentStep(rollout))
 
-	rollout.Spec.Strategy.Canary.Steps[0] = v1alpha1.CanaryStep{SetWeight: pointer.Int32Ptr(10)}
-	rollout.Status.CurrentStepIndex = pointer.Int32Ptr(1)
+	rollout.Spec.Strategy.Canary.Steps[0] = v1alpha1.CanaryStep{SetWeight: ptr.To[int32](10)}
+	rollout.Status.CurrentStepIndex = ptr.To[int32](1)
 
 	assert.Nil(t, GetCurrentExperimentStep(rollout))
 
@@ -1391,7 +1391,7 @@ func TestGetReplicasForScaleDown(t *testing.T) {
 			name: "test expected replicas is less than actual replicas",
 			rs: &appsv1.ReplicaSet{
 				Spec: appsv1.ReplicaSetSpec{
-					Replicas: pointer.Int32Ptr(3),
+					Replicas: ptr.To[int32](3),
 				},
 				Status: appsv1.ReplicaSetStatus{
 					AvailableReplicas: 5,
@@ -1403,7 +1403,7 @@ func TestGetReplicasForScaleDown(t *testing.T) {
 			name: "test ignore availability",
 			rs: &appsv1.ReplicaSet{
 				Spec: appsv1.ReplicaSetSpec{
-					Replicas: pointer.Int32Ptr(3),
+					Replicas: ptr.To[int32](3),
 				},
 				Status: appsv1.ReplicaSetStatus{
 					AvailableReplicas: 2,
@@ -1416,7 +1416,7 @@ func TestGetReplicasForScaleDown(t *testing.T) {
 			name: "test not ignore availability",
 			rs: &appsv1.ReplicaSet{
 				Spec: appsv1.ReplicaSetSpec{
-					Replicas: pointer.Int32Ptr(3),
+					Replicas: ptr.To[int32](3),
 				},
 				Status: appsv1.ReplicaSetStatus{
 					AvailableReplicas: 2,
@@ -1458,11 +1458,11 @@ func TestGetCanaryReplicasOrWeight(t *testing.T) {
 						Canary: &v1alpha1.CanaryStrategy{
 							Steps: []v1alpha1.CanaryStep{
 								{
-									SetWeight: pointer.Int32Ptr(10),
+									SetWeight: ptr.To[int32](10),
 								},
 								{
 									SetCanaryScale: &v1alpha1.SetCanaryScale{
-										Weight: pointer.Int32Ptr(20),
+										Weight: ptr.To[int32](20),
 									},
 								},
 							},
@@ -1471,7 +1471,7 @@ func TestGetCanaryReplicasOrWeight(t *testing.T) {
 					},
 				},
 				Status: v1alpha1.RolloutStatus{
-					CurrentStepIndex: pointer.Int32Ptr(1),
+					CurrentStepIndex: ptr.To[int32](1),
 					StableRS:         "stable-rs",
 				},
 			},
@@ -1486,11 +1486,11 @@ func TestGetCanaryReplicasOrWeight(t *testing.T) {
 						Canary: &v1alpha1.CanaryStrategy{
 							Steps: []v1alpha1.CanaryStep{
 								{
-									SetWeight: pointer.Int32Ptr(10),
+									SetWeight: ptr.To[int32](10),
 								},
 								{
 									SetCanaryScale: &v1alpha1.SetCanaryScale{
-										Replicas: pointer.Int32Ptr(5),
+										Replicas: ptr.To[int32](5),
 									},
 								},
 							},
@@ -1499,11 +1499,11 @@ func TestGetCanaryReplicasOrWeight(t *testing.T) {
 					},
 				},
 				Status: v1alpha1.RolloutStatus{
-					CurrentStepIndex: pointer.Int32Ptr(1),
+					CurrentStepIndex: ptr.To[int32](1),
 					StableRS:         "stable-rs",
 				},
 			},
-			replicas: pointer.Int32(5),
+			replicas: ptr.To[int32](5),
 			weight:   0,
 		},
 		{

--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	corev1defaults "k8s.io/kubernetes/pkg/apis/core/v1"
 	"k8s.io/kubernetes/pkg/controller"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/annotations"
@@ -506,7 +506,7 @@ func PodTemplateOrStepsChanged(rollout *v1alpha1.Rollout, newRS *appsv1.ReplicaS
 // ResetCurrentStepIndex resets the index back to zero unless there are no steps
 func ResetCurrentStepIndex(rollout *v1alpha1.Rollout) *int32 {
 	if rollout.Spec.Strategy.Canary != nil && len(rollout.Spec.Strategy.Canary.Steps) > 0 {
-		return pointer.Int32Ptr(0)
+		return ptr.To[int32](0)
 	}
 	return nil
 }

--- a/utils/replicaset/replicaset_test.go
+++ b/utils/replicaset/replicaset_test.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/kubernetes/pkg/controller"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
@@ -37,7 +37,7 @@ func generateRollout(image string) v1alpha1.Rollout {
 			Annotations: make(map[string]string),
 		},
 		Spec: v1alpha1.RolloutSpec{
-			Replicas: pointer.Int32Ptr(1),
+			Replicas: ptr.To[int32](1),
 			Selector: &metav1.LabelSelector{MatchLabels: podLabels},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -693,12 +693,12 @@ func TestResetCurrentStepIndex(t *testing.T) {
 	ro.Spec.Strategy.Canary = &v1alpha1.CanaryStrategy{
 		Steps: []v1alpha1.CanaryStep{
 			{
-				SetWeight: pointer.Int32Ptr(1),
+				SetWeight: ptr.To[int32](1),
 			},
 		},
 	}
 	newStepIndex := ResetCurrentStepIndex(&ro)
-	assert.Equal(t, pointer.Int32Ptr(0), newStepIndex)
+	assert.Equal(t, ptr.To[int32](0), newStepIndex)
 
 	ro.Spec.Strategy.Canary.Steps = nil
 	newStepIndex = ResetCurrentStepIndex(&ro)
@@ -1247,7 +1247,7 @@ func TestIsReplicaSetAvailable(t *testing.T) {
 	{
 		rs := appsv1.ReplicaSet{
 			Spec: appsv1.ReplicaSetSpec{
-				Replicas: pointer.Int32Ptr(1),
+				Replicas: ptr.To[int32](1),
 			},
 			Status: appsv1.ReplicaSetStatus{
 				ReadyReplicas:     0,
@@ -1259,7 +1259,7 @@ func TestIsReplicaSetAvailable(t *testing.T) {
 	{
 		rs := appsv1.ReplicaSet{
 			Spec: appsv1.ReplicaSetSpec{
-				Replicas: pointer.Int32Ptr(1),
+				Replicas: ptr.To[int32](1),
 			},
 			Status: appsv1.ReplicaSetStatus{
 				ReadyReplicas:     1,
@@ -1271,7 +1271,7 @@ func TestIsReplicaSetAvailable(t *testing.T) {
 	{
 		rs := appsv1.ReplicaSet{
 			Spec: appsv1.ReplicaSetSpec{
-				Replicas: pointer.Int32Ptr(1),
+				Replicas: ptr.To[int32](1),
 			},
 			Status: appsv1.ReplicaSetStatus{
 				ReadyReplicas:     2,
@@ -1283,7 +1283,7 @@ func TestIsReplicaSetAvailable(t *testing.T) {
 	{
 		rs := appsv1.ReplicaSet{
 			Spec: appsv1.ReplicaSetSpec{
-				Replicas: pointer.Int32Ptr(0),
+				Replicas: ptr.To[int32](0),
 			},
 			Status: appsv1.ReplicaSetStatus{
 				ReadyReplicas:     0,
@@ -1296,7 +1296,7 @@ func TestIsReplicaSetAvailable(t *testing.T) {
 	{
 		rs := appsv1.ReplicaSet{
 			Spec: appsv1.ReplicaSetSpec{
-				Replicas: pointer.Int32Ptr(0),
+				Replicas: ptr.To[int32](0),
 			},
 			Status: appsv1.ReplicaSetStatus{
 				ReadyReplicas:     1,
@@ -1311,7 +1311,7 @@ func TestIsReplicaSetPartiallyAvailable(t *testing.T) {
 	t.Run("No Availability", func(t *testing.T) {
 		rs := appsv1.ReplicaSet{
 			Spec: appsv1.ReplicaSetSpec{
-				Replicas: pointer.Int32Ptr(2),
+				Replicas: ptr.To[int32](2),
 			},
 			Status: appsv1.ReplicaSetStatus{
 				ReadyReplicas:     0,
@@ -1323,7 +1323,7 @@ func TestIsReplicaSetPartiallyAvailable(t *testing.T) {
 	t.Run("Partial Availability", func(t *testing.T) {
 		rs := appsv1.ReplicaSet{
 			Spec: appsv1.ReplicaSetSpec{
-				Replicas: pointer.Int32Ptr(2),
+				Replicas: ptr.To[int32](2),
 			},
 			Status: appsv1.ReplicaSetStatus{
 				ReadyReplicas:     2,
@@ -1335,7 +1335,7 @@ func TestIsReplicaSetPartiallyAvailable(t *testing.T) {
 	t.Run("Full Availability", func(t *testing.T) {
 		rs := appsv1.ReplicaSet{
 			Spec: appsv1.ReplicaSetSpec{
-				Replicas: pointer.Int32Ptr(2),
+				Replicas: ptr.To[int32](2),
 			},
 			Status: appsv1.ReplicaSetStatus{
 				ReadyReplicas:     2,

--- a/utils/rollout/rolloututil_test.go
+++ b/utils/rollout/rolloututil_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/tj/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/annotations"
@@ -21,12 +21,12 @@ func newCanaryRollout() *v1alpha1.Rollout {
 			Namespace: "test",
 		},
 		Spec: v1alpha1.RolloutSpec{
-			Replicas: pointer.Int32Ptr(5),
+			Replicas: ptr.To[int32](5),
 			Strategy: v1alpha1.RolloutStrategy{
 				Canary: &v1alpha1.CanaryStrategy{
 					Steps: []v1alpha1.CanaryStep{
 						{
-							SetWeight: pointer.Int32Ptr(10),
+							SetWeight: ptr.To[int32](10),
 						},
 						{
 							Pause: &v1alpha1.RolloutPause{
@@ -34,14 +34,14 @@ func newCanaryRollout() *v1alpha1.Rollout {
 							},
 						},
 						{
-							SetWeight: pointer.Int32Ptr(20),
+							SetWeight: ptr.To[int32](20),
 						},
 					},
 				},
 			},
 		},
 		Status: v1alpha1.RolloutStatus{
-			CurrentStepIndex:  pointer.Int32Ptr(1),
+			CurrentStepIndex:  ptr.To[int32](1),
 			Replicas:          4,
 			ReadyReplicas:     1,
 			UpdatedReplicas:   3,
@@ -57,13 +57,13 @@ func newBlueGreenRollout() *v1alpha1.Rollout {
 			Namespace: "test",
 		},
 		Spec: v1alpha1.RolloutSpec{
-			Replicas: pointer.Int32Ptr(5),
+			Replicas: ptr.To[int32](5),
 			Strategy: v1alpha1.RolloutStrategy{
 				BlueGreen: &v1alpha1.BlueGreenStrategy{},
 			},
 		},
 		Status: v1alpha1.RolloutStatus{
-			CurrentStepIndex:  pointer.Int32Ptr(1),
+			CurrentStepIndex:  ptr.To[int32](1),
 			Replicas:          4,
 			ReadyReplicas:     1,
 			UpdatedReplicas:   3,
@@ -116,7 +116,7 @@ func TestRolloutStatusPaused(t *testing.T) {
 func TestRolloutStatusProgressing(t *testing.T) {
 	{
 		ro := newCanaryRollout()
-		ro.Spec.Replicas = pointer.Int32Ptr(5)
+		ro.Spec.Replicas = ptr.To[int32](5)
 		ro.Status.UpdatedReplicas = 4
 		ro.Status.AvailableReplicas = 4
 		ro.Status.Replicas = 5
@@ -126,7 +126,7 @@ func TestRolloutStatusProgressing(t *testing.T) {
 	}
 	{
 		ro := newCanaryRollout()
-		ro.Spec.Replicas = pointer.Int32Ptr(5)
+		ro.Spec.Replicas = ptr.To[int32](5)
 		ro.Status.UpdatedReplicas = 5
 		ro.Status.AvailableReplicas = 4
 		ro.Status.Replicas = 5
@@ -136,7 +136,7 @@ func TestRolloutStatusProgressing(t *testing.T) {
 	}
 	{
 		ro := newCanaryRollout()
-		ro.Spec.Replicas = pointer.Int32Ptr(5)
+		ro.Spec.Replicas = ptr.To[int32](5)
 		ro.Status.UpdatedReplicas = 5
 		ro.Status.AvailableReplicas = 5
 		ro.Status.Replicas = 7
@@ -149,7 +149,7 @@ func TestRolloutStatusProgressing(t *testing.T) {
 		ro.Status.BlueGreen.ActiveSelector = "abc1234"
 		ro.Status.StableRS = "abc1234"
 		ro.Status.CurrentPodHash = "def5678"
-		ro.Spec.Replicas = pointer.Int32Ptr(5)
+		ro.Spec.Replicas = ptr.To[int32](5)
 		ro.Status.Replicas = 5
 		ro.Status.UpdatedReplicas = 5
 		ro.Status.AvailableReplicas = 5
@@ -163,7 +163,7 @@ func TestRolloutStatusProgressing(t *testing.T) {
 		ro.Status.BlueGreen.ActiveSelector = "def5678"
 		ro.Status.StableRS = "abc1234"
 		ro.Status.CurrentPodHash = "def5678"
-		ro.Spec.Replicas = pointer.Int32Ptr(5)
+		ro.Spec.Replicas = ptr.To[int32](5)
 		ro.Status.Replicas = 5
 		ro.Status.UpdatedReplicas = 5
 		ro.Status.AvailableReplicas = 5
@@ -176,7 +176,7 @@ func TestRolloutStatusProgressing(t *testing.T) {
 		ro.Status.BlueGreen.ActiveSelector = "def5678"
 		ro.Status.StableRS = "abc1234"
 		ro.Status.CurrentPodHash = "def5678"
-		ro.Spec.Replicas = pointer.Int32Ptr(5)
+		ro.Spec.Replicas = ptr.To[int32](5)
 		ro.Status.Replicas = 5
 		ro.Status.UpdatedReplicas = 5
 		ro.Status.AvailableReplicas = 5
@@ -355,7 +355,7 @@ func TestCanaryStepString(t *testing.T) {
 		expectedString string
 	}{
 		{
-			step:           v1alpha1.CanaryStep{SetWeight: pointer.Int32Ptr(20)},
+			step:           v1alpha1.CanaryStep{SetWeight: ptr.To[int32](20)},
 			expectedString: "setWeight: 20",
 		},
 		{
@@ -379,7 +379,7 @@ func TestCanaryStepString(t *testing.T) {
 			expectedString: "analysis",
 		},
 		{
-			step:           v1alpha1.CanaryStep{SetCanaryScale: &v1alpha1.SetCanaryScale{Weight: pointer.Int32Ptr(20)}},
+			step:           v1alpha1.CanaryStep{SetCanaryScale: &v1alpha1.SetCanaryScale{Weight: ptr.To[int32](20)}},
 			expectedString: "setCanaryScale{weight: 20}",
 		},
 		{
@@ -387,7 +387,7 @@ func TestCanaryStepString(t *testing.T) {
 			expectedString: "setCanaryScale{matchTrafficWeight: true}",
 		},
 		{
-			step:           v1alpha1.CanaryStep{SetCanaryScale: &v1alpha1.SetCanaryScale{Replicas: pointer.Int32Ptr(5)}},
+			step:           v1alpha1.CanaryStep{SetCanaryScale: &v1alpha1.SetCanaryScale{Replicas: ptr.To[int32](5)}},
 			expectedString: "setCanaryScale{replicas: 5}",
 		},
 		{
@@ -423,9 +423,9 @@ func TestIsUnpausing(t *testing.T) {
 func TestShouldVerifyWeight(t *testing.T) {
 	ro := newCanaryRollout()
 	ro.Status.StableRS = "34feab23f"
-	ro.Status.CurrentStepIndex = pointer.Int32Ptr(0)
+	ro.Status.CurrentStepIndex = ptr.To[int32](0)
 	ro.Spec.Strategy.Canary.Steps = []v1alpha1.CanaryStep{{
-		SetWeight: pointer.Int32Ptr(20),
+		SetWeight: ptr.To[int32](20),
 	}}
 	assert.Equal(t, true, ShouldVerifyWeight(ro, 20))
 

--- a/utils/template/template_test.go
+++ b/utils/template/template_test.go
@@ -7,7 +7,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 
@@ -75,7 +75,7 @@ func TestResolveArgsWithNoSubstitution(t *testing.T) {
 func TestResolveArgsRemoveWhiteSpace(t *testing.T) {
 	args := []v1alpha1.Argument{{
 		Name:  "var",
-		Value: pointer.StringPtr("foo"),
+		Value: ptr.To[string]("foo"),
 	}}
 	query, err := ResolveArgs("test-{{ args.var }}", args)
 	assert.Nil(t, err)
@@ -85,7 +85,7 @@ func TestResolveArgsRemoveWhiteSpace(t *testing.T) {
 func TestResolveArgsWithSubstitution(t *testing.T) {
 	args := []v1alpha1.Argument{{
 		Name:  "var",
-		Value: pointer.StringPtr("foo"),
+		Value: ptr.To[string]("foo"),
 	}}
 	query, err := ResolveArgs("test-{{args.var}}", args)
 	assert.Nil(t, err)
@@ -113,7 +113,7 @@ func TestResolveQuotedArgs(t *testing.T) {
 	args := []v1alpha1.Argument{
 		{
 			Name:  "var",
-			Value: pointer.StringPtr("double quotes\"newline\nand tab\t"),
+			Value: ptr.To[string]("double quotes\"newline\nand tab\t"),
 		},
 	}
 	{


### PR DESCRIPTION
Background
=====
`pointer` (https://pkg.go.dev/k8s.io/utils/pointer) package is deprecated and the recommended fix is to change all functions to the new package `ptr` (https://pkg.go.dev/k8s.io/utils/ptr)

Modifications
=====
- convert all `pointer` calls to `ptr` calls via this modification pattern
  - `pointer.Type(...)`  -> `ptr.To[type](...)`

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
