### PR TITLE
feat(deploy): support setting Canary and Stable weights without traffic routing

### DIFF
--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -997,7 +997,8 @@ type CanaryStatus struct {
 	CurrentBackgroundAnalysisRunStatus *RolloutAnalysisRunStatus `json:"currentBackgroundAnalysisRunStatus,omitempty" protobuf:"bytes,2,opt,name=currentBackgroundAnalysisRunStatus"`
 	// CurrentExperiment indicates the running experiment
 	CurrentExperiment string `json:"currentExperiment,omitempty" protobuf:"bytes,3,opt,name=currentExperiment"`
-	// Weights records the weights which have been set on traffic provider. Only valid when using traffic routing
+	// Weights records the weights which have been set for the canary and stable ReplicaSets.
+	// This field is now always set for canary rollouts, regardless of whether traffic routing is enabled.
 	Weights *TrafficWeights `json:"weights,omitempty" protobuf:"bytes,4,opt,name=weights"`
 	// StablePingPong For the ping-pong feature holds the current stable service, ping or pong
 	StablePingPong PingPongType `json:"stablePingPong,omitempty" protobuf:"bytes,5,opt,name=stablePingPong"`


### PR DESCRIPTION
### Description

This PR enables the specification of separate weights for Canary and Stable replicas even when traffic routing is disabled. This enhancement allows teams to simulate canary rollout behavior more flexibly, supporting internal testing and rollout strategies without requiring traffic routing.

We originally opened an issue to discuss this feature:
https://github.com/argoproj/argo-rollouts/issues/4241

As there has been no response, we're submitting this PR as a proposed improvement to the upstream project. It enhances usability by allowing calculated weight distribution in non-traffic-routed canary deployments, aligning with real-world deployment needs.

### Tests

We have intentionally kept the tests unchanged at this stage simply for the fact that there is many of them that are affectd by the change,  and it appears that rollout.Status.Canary.Weights is currently used internally as an indicator for traffic routing. Given this, we wanted to open the discussion before making broader test updates.

If the maintainers consider this change to break intended invariants or internal assumptions, we’re happy to close the PR and revisit our approach.


Checklist:

* [ X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
