### PR TITLE
fix fix abort scenario where canary/stable service is not provided

### DIFF
--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -939,10 +939,6 @@ func (c *rolloutContext) isRollbackWithinWindow() bool {
 func (c *rolloutContext) shouldFullPromote(newStatus v1alpha1.RolloutStatus) string {
 	// NOTE: the order of these checks are significant
 	if c.stableRS == nil {
-		// For initial deployments, only promote if the new ReplicaSet is actually healthy
-		if c.newRS == nil || c.newRS.Status.AvailableReplicas != defaults.GetReplicasOrDefault(c.rollout.Spec.Replicas) {
-			return ""
-		}
 		return "Initial deploy"
 	} else if c.rollout.Spec.Strategy.Canary != nil {
 		if c.pauseContext.IsAborted() {

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -939,6 +939,10 @@ func (c *rolloutContext) isRollbackWithinWindow() bool {
 func (c *rolloutContext) shouldFullPromote(newStatus v1alpha1.RolloutStatus) string {
 	// NOTE: the order of these checks are significant
 	if c.stableRS == nil {
+		// For initial deployments, only promote if the new ReplicaSet is actually healthy
+		if c.newRS == nil || c.newRS.Status.AvailableReplicas != defaults.GetReplicasOrDefault(c.rollout.Spec.Replicas) {
+			return ""
+		}
 		return "Initial deploy"
 	} else if c.rollout.Spec.Strategy.Canary != nil {
 		if c.pauseContext.IsAborted() {

--- a/rollout/trafficrouting/istio/istio.go
+++ b/rollout/trafficrouting/istio/istio.go
@@ -323,7 +323,8 @@ func (r *Reconciler) reconcileVirtualService(obj *unstructured.Unstructured, vsv
 func (r *Reconciler) UpdateHash(canaryHash, stableHash string, additionalDestinations ...v1alpha1.WeightDestination) error {
 	// We need to check if the replicasets are ready here as well if we didn't define any services in the rollout
 	// See: https://github.com/argoproj/argo-rollouts/issues/2507
-	if r.rollout.Spec.Strategy.Canary.CanaryService == "" && r.rollout.Spec.Strategy.Canary.StableService == "" {
+	// During abort scenarios, we should skip this check to allow traffic routing cleanup
+	if r.rollout.Spec.Strategy.Canary.CanaryService == "" && r.rollout.Spec.Strategy.Canary.StableService == "" && !r.rollout.Status.Abort {
 
 		for _, rs := range r.replicaSets {
 			if *rs.Spec.Replicas > 0 && !replicasetutil.IsReplicaSetAvailable(rs) {


### PR DESCRIPTION
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
