### PR TITLE
docs: fix traffic manager note

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -75,4 +75,4 @@ Here is a summary table for the possible approaches.
 | Advanced routing scenarios |         No               |       No                   |         Yes                    |
 |      Failure Blast Radius | Massive impact            |  Low impact                       | Low impact              |
 
-Note that that traffic manager can be any compatible Service Mesh or Ingress Controller or Gateway API implementation (via a plugin).
+Note that the traffic manager can be any compatible Service Mesh or Ingress Controller or Gateway API implementation (via a plugin).


### PR DESCRIPTION
docs(concepts): fix traffic manager wording

## Summary
- Fixed a duplicated word in the traffic manager note in docs/concepts.md.
  The sentence now reads: "Note that the traffic manager can be any compatible
  Service Mesh or Ingress Controller or Gateway API implementation (via a plugin)."

## Checklist
* [x] This is a bug fix (documentation typo).
* [x] Title follows conventional commit format.
* [ ] Signed commit with DCO.
* [ ] Unit/e2e tests not applicable (docs only).
* [ ] Build is green.
* [ ] No organization update needed in USERS.md.
