### PR TITLE
docs: correct name of command based on file name in installation guidelines

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -105,7 +105,7 @@ sudo mv ./kubectl_complete-argo-rollouts /usr/local/bin/
 
 To enable auto completion for the CLI run as a standalone binary, the CLI can export shell completion code for several shells.
 
-For bash, ensure you have bash completions installed and enabled. To access completions in your current shell, run $ `source <(kubectl-argo-rollouts completion bash)`. Alternatively, write it to a file and source in `.bash_profile`.
+For bash, ensure you have bash completions installed and enabled. To access completions in your current shell, run $ `source <(kubectl_complete-argo-rollouts completion bash)`. Alternatively, write it to a file and source in `.bash_profile`.
 
 The completion command supports bash, zsh, fish and powershell.
 


### PR DESCRIPTION
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
