### PR TITLE
fix(controller): set version annotation via server-side apply to better handle concurrent writes

### DIFF
--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -927,6 +927,16 @@ func (f *fixture) expectPatchRolloutActionWithPatch(rollout *v1alpha1.Rollout, p
 	return len
 }
 
+func (f *fixture) expectPatchMainRolloutAction(rollout *v1alpha1.Rollout) int {
+	rolloutSchema := schema.GroupVersionResource{
+		Resource: "rollouts",
+		Version:  "v1alpha1",
+	}
+	len := len(f.actions)
+	f.actions = append(f.actions, core.NewPatchAction(rolloutSchema, rollout.Namespace, rollout.Name, types.ApplyPatchType, nil))
+	return len
+}
+
 func (f *fixture) expectGetEndpointsAction(ep *corev1.Endpoints) int {
 	len := len(f.kubeactions)
 	f.kubeactions = append(f.kubeactions, core.NewGetAction(schema.GroupVersionResource{Resource: "endpoints"}, ep.Namespace, ep.Name))

--- a/rollout/experiment_test.go
+++ b/rollout/experiment_test.go
@@ -510,7 +510,7 @@ func TestRolloutDoNotCreateExperimentWithoutStableRS(t *testing.T) {
 	f.objects = append(f.objects, r2)
 
 	f.expectCreateReplicaSetAction(rs2)
-	f.expectUpdateRolloutAction(r2)       // update revision
+	f.expectPatchMainRolloutAction(r2)    // update revision
 	f.expectUpdateRolloutStatusAction(r2) // update progressing condition
 	f.expectUpdateReplicaSetAction(rs2)   // scale replicaset
 	f.expectPatchRolloutAction(r1)

--- a/rollout/sync_serverside_test.go
+++ b/rollout/sync_serverside_test.go
@@ -93,6 +93,7 @@ func TestSetRolloutRevisionServerSideApply(t *testing.T) {
 	assert.Equal(t, "2", patchedRollout.Annotations[annotations.RevisionAnnotation])
 
 	retrievedRollout, err := fakeArgoprojClientset.ArgoprojV1alpha1().Rollouts("default").Get(context.TODO(), "test-rollout", metav1.GetOptions{})
+	require.NoError(t, err)
 	assert.Equal(
 		t,
 		map[string]string{

--- a/rollout/sync_serverside_test.go
+++ b/rollout/sync_serverside_test.go
@@ -1,0 +1,104 @@
+package rollout
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	patchtypes "k8s.io/apimachinery/pkg/types"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	argofake "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
+	"github.com/argoproj/argo-rollouts/utils/annotations"
+	logutil "github.com/argoproj/argo-rollouts/utils/log"
+	"github.com/argoproj/argo-rollouts/utils/record"
+)
+
+type fakeRefResolver struct{}
+
+func (f *fakeRefResolver) Resolve(_ *v1alpha1.Rollout) error {
+	return nil
+}
+
+func TestSetRolloutRevisionServerSideApply(t *testing.T) {
+	rollout := &v1alpha1.Rollout{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rollout",
+			Namespace: "default",
+			Annotations: map[string]string{
+				// To ensure we don't void existing annotations.
+				"existing-annotation":          "true",
+				annotations.RevisionAnnotation: "1",
+			},
+		},
+		Spec: v1alpha1.RolloutSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "test",
+							Image: "nginx:1.0",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeArgoprojClientset := argofake.NewSimpleClientset(rollout)
+	fakeKubeClientset := kubefake.NewSimpleClientset()
+	recorder := record.NewFakeEventRecorder()
+
+	ctx := &rolloutContext{
+		reconcilerBase: reconcilerBase{
+			argoprojclientset: fakeArgoprojClientset,
+			kubeclientset:     fakeKubeClientset,
+			recorder:          recorder,
+			refResolver:       &fakeRefResolver{},
+		},
+		rollout: rollout,
+		log:     logutil.WithRollout(rollout),
+	}
+
+	err := ctx.setRolloutRevision("2")
+	require.NoError(t, err)
+
+	actions := fakeArgoprojClientset.Actions()
+	require.Len(t, actions, 1)
+
+	action := actions[0]
+	assert.Equal(t, "patch", action.GetVerb())
+	assert.Equal(t, "rollouts", action.GetResource().Resource)
+	assert.Equal(t, "default", action.GetNamespace())
+
+	patchAction, ok := action.(ktesting.PatchAction)
+	require.True(t, ok, "Expected PatchAction but got %T", patchAction)
+	assert.Equal(t, patchtypes.ApplyPatchType, patchAction.GetPatchType())
+
+	patchData := patchAction.GetPatch()
+	var patchedRollout v1alpha1.Rollout
+	err = json.Unmarshal(patchData, &patchedRollout)
+	require.NoError(t, err)
+
+	assert.Equal(t, "argoproj.io/v1alpha1", patchedRollout.APIVersion)
+	assert.Equal(t, "Rollout", patchedRollout.Kind)
+	assert.Equal(t, "test-rollout", patchedRollout.Name)
+	assert.Equal(t, "default", patchedRollout.Namespace)
+	assert.Equal(t, "2", patchedRollout.Annotations[annotations.RevisionAnnotation])
+
+	retrievedRollout, err := fakeArgoprojClientset.ArgoprojV1alpha1().Rollouts("default").Get(context.TODO(), "test-rollout", metav1.GetOptions{})
+	assert.Equal(
+		t,
+		map[string]string{
+			"existing-annotation":          "true",
+			annotations.RevisionAnnotation: "2",
+		},
+		retrievedRollout.Annotations,
+	)
+}

--- a/rollout/sync_test.go
+++ b/rollout/sync_test.go
@@ -335,7 +335,7 @@ func TestCanaryPromoteFull(t *testing.T) {
 	f.replicaSetLister = append(f.replicaSetLister, rs1)
 
 	createdRS2Index := f.expectCreateReplicaSetAction(rs2) // create new ReplicaSet (size 0)
-	f.expectUpdateRolloutAction(r2)                        // update rollout revision
+	f.expectPatchMainRolloutAction(r2)                     // update rollout revision
 	f.expectUpdateRolloutStatusAction(r2)                  // update rollout conditions
 	updatedRS2Index := f.expectUpdateReplicaSetAction(rs2) // scale new ReplicaSet to 10
 	patchedRolloutIndex := f.expectPatchRolloutAction(r2)
@@ -679,7 +679,7 @@ func TestIsScalingEventMissMatchedDesiredOldReplicas(t *testing.T) {
 	f.kubeobjects = append(f.kubeobjects, oldRs, stableRs)
 	f.replicaSetLister = append(f.replicaSetLister, oldRs, stableRs)
 
-	f.expectUpdateRolloutAction(r2) // update rollout revision
+	f.expectPatchMainRolloutAction(r2) // update rollout revision
 	f.expectUpdateRolloutStatusAction(r2)
 	updatedROIndex := f.expectPatchRolloutAction(r2)
 	createdRS2Index := f.expectCreateReplicaSetAction(stableRs)

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -1240,7 +1240,7 @@ func TestRolloutReplicaIsAvailableAndGenerationNotBeModifiedShouldModifyVirtualS
 	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
 	f.rolloutLister = append(f.rolloutLister, r2)
 	f.objects = append(f.objects, r2, unstructuredObj)
-	f.expectUpdateRolloutAction(r2)
+	f.expectPatchMainRolloutAction(r2)
 	f.expectUpdateRolloutStatusAction(r2)
 	f.expectPatchRolloutAction(r2)
 	f.expectCreateReplicaSetAction(rs2)
@@ -1317,7 +1317,7 @@ func TestDontWeightToZeroWhenDynamicallyRollingBackToStable(t *testing.T) {
 	f.objects = append(f.objects, r2)
 
 	f.expectUpdateReplicaSetAction(rs1)                 // Updates the revision annotation from 1 to 3 from func isScalingEvent
-	f.expectUpdateRolloutAction(r2)                     // Update the rollout revision from 1 to 3
+	f.expectPatchMainRolloutAction(r2)                  // Update the rollout revision from 1 to 3
 	scaleUpIndex := f.expectUpdateReplicaSetAction(rs1) // Scale The replicaset from 1 to 10 from func scaleReplicaSet
 	f.expectPatchRolloutAction(r2)                      // Updates the rollout status from the scaling to 10 action
 
@@ -1495,7 +1495,7 @@ func TestCheckReplicaSetAvailable(t *testing.T) {
 	fix.objects = append(fix.objects, rollout2)
 
 	fix.expectUpdateReplicaSetAction(replicaSet1)
-	fix.expectUpdateRolloutAction(rollout2)
+	fix.expectPatchMainRolloutAction(rollout2)
 	fix.expectUpdateReplicaSetAction(replicaSet1)
 	fix.expectPatchRolloutAction(rollout2)
 	fix.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()

--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -633,7 +633,7 @@ func (s *CanarySuite) TestCanaryDynamicStableScale() {
 		ApplyManifests().
 		MarkPodsReady("1", 4). // mark all 4 pods ready
 		WaitForRolloutStatus("Healthy").
-		UpdateSpec(). // update to revision 2
+		UpdateSpec().          // update to revision 2
 		MarkPodsReady("2", 1). // mark 1 of 1 canary pods ready
 		WaitForRolloutStatus("Paused").
 		Sleep(2*time.Second).
@@ -709,7 +709,7 @@ func (s *CanarySuite) TestCanaryDynamicStableScaleRollbackToStable() {
 			assert.Equal(s.T(), int32(75), ro.Status.Canary.Weights.Stable.Weight)
 		}).
 		When().
-		MarkPodsReady("3", 1). // marks the 4th pod of stableRS/newRS (revision 3) ready
+		MarkPodsReady("3", 1).           // marks the 4th pod of stableRS/newRS (revision 3) ready
 		WaitForRevisionPodCount("2", 0). // make sure we scale down the previous desired (revision 2)
 		Then().
 		Assert(func(t *fixtures.Then) {


### PR DESCRIPTION
Addresses an issue where a higher-level CRD might issue writes that cause argo's reconciliations to hit "object modified" errors. By leveraging server-side applies, these minimal modifications can be persisted without issue.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not.
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
