### PR TITLE
fix(cli): update incorrect boolean flag syntax example in cli help output. Fixes #4112

### DIFF
--- a/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_status.md
+++ b/docs/generated/kubectl-argo-rollouts/kubectl-argo-rollouts_status.md
@@ -18,7 +18,7 @@ kubectl argo rollouts status ROLLOUT_NAME [flags]
 kubectl argo rollouts status guestbook
 
 # Show the rollout status
-kubectl argo rollouts status guestbook --watch false
+kubectl argo rollouts status guestbook --watch=false
 
 # Watch the rollout until it succeeds, fail if it takes more than 60 seconds
 kubectl argo rollouts status --timeout 60s guestbook

--- a/pkg/kubectl-argo-rollouts/cmd/status/status.go
+++ b/pkg/kubectl-argo-rollouts/cmd/status/status.go
@@ -22,7 +22,7 @@ the rollout is healthy upon completion and an error otherwise.`
 	%[1]s status guestbook
 
 	# Show the rollout status
-    %[1]s status guestbook --watch false
+    %[1]s status guestbook --watch=false
 
 	# Watch the rollout until it succeeds, fail if it takes more than 60 seconds
 	%[1]s status --timeout 60s guestbook


### PR DESCRIPTION
The [`spf13/pflag`](https://github.com/spf13/pflag/blob/master/README.md#command-line-flag-syntax) module used by the Argo Rollouts CLI states that the boolean flag syntax should be `--watch=false`.

However, the `kubectl argo rollouts status --help` currently shows the following example, which may confuse users into using `--watch false` instead of the correct syntax `--watch=false`:

https://github.com/argoproj/argo-rollouts/blob/468cfdf3d4a8bfd849a0cd8c559aef1b983d0221/pkg/kubectl-argo-rollouts/cmd/status/status.go#L25

This updates the CLI example for boolean flags to prevent further misuse of the command.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [c] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).