### PR TITLE
fix(cli): expose AWS API versions in controller CLI. Fixes #4334

### DIFF
--- a/cmd/rollouts-controller/main.go
+++ b/cmd/rollouts-controller/main.go
@@ -70,6 +70,8 @@ func newCommand() *cobra.Command {
 		serviceThreads                 int
 		ingressThreads                 int
 		ephemeralMetadataThreads       int
+		targetGroupBindingVersion      string
+		albTagKeyResourceID            string
 		istioVersion                   string
 		trafficSplitVersion            string
 		traefikAPIGroup                string
@@ -108,6 +110,8 @@ func newCommand() *cobra.Command {
 			ctx := signals.SetupSignalHandlerContext()
 
 			defaults.SetVerifyTargetGroup(awsVerifyTargetGroup)
+			defaults.SetTargetGroupBindingAPIVersion(targetGroupBindingVersion)
+			defaults.SetalbTagKeyResourceID(albTagKeyResourceID)
 			defaults.SetIstioAPIVersion(istioVersion)
 			defaults.SetAmbassadorAPIVersion(ambassadorVersion)
 			defaults.SetSMIAPIVersion(trafficSplitVersion)
@@ -309,6 +313,8 @@ func newCommand() *cobra.Command {
 	command.Flags().IntVar(&serviceThreads, "service-threads", controller.DefaultServiceThreads, "Set the number of worker threads for the Service controller")
 	command.Flags().IntVar(&ingressThreads, "ingress-threads", controller.DefaultIngressThreads, "Set the number of worker threads for the Ingress controller")
 	command.Flags().IntVar(&ephemeralMetadataThreads, "ephemeral-metadata-threads", rollout.DefaultEphemeralMetadataThreads, "Set the number of worker threads for the Ephemeral Metadata reconciler")
+	command.Flags().StringVar(&targetGroupBindingVersion, "aws-target-group-binding-api-version", defaults.DefaultTargetGroupBindingAPIVersion, "Set the default AWS TargetGroupBinding apiVersion that controller uses when verifying target group weights.")
+	command.Flags().StringVar(&albTagKeyResourceID, "alb-tag-key-resource-id", defaults.DefaultAlbTagKeyResourceID, "Set the default AWS LoadBalancer tag key for resource ID that controller uses when verifying target group weights.")
 	command.Flags().StringVar(&istioVersion, "istio-api-version", defaults.DefaultIstioVersion, "Set the default Istio apiVersion that controller should look when manipulating VirtualServices.")
 	command.Flags().StringVar(&ambassadorVersion, "ambassador-api-version", defaults.DefaultAmbassadorVersion, "Set the Ambassador apiVersion that controller should look when manipulating Ambassador Mappings.")
 	command.Flags().StringVar(&trafficSplitVersion, "traffic-split-api-version", defaults.DefaultSMITrafficSplitVersion, "Set the default TrafficSplit apiVersion that controller uses when creating TrafficSplits.")

--- a/cmd/rollouts-controller/main.go
+++ b/cmd/rollouts-controller/main.go
@@ -298,7 +298,7 @@ func newCommand() *cobra.Command {
 	command.Flags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")
 	command.Flags().StringVar(&logFormat, "logformat", "", "Set the logging format. One of: text|json")
 	command.Flags().IntVar(&klogLevel, "kloglevel", 0, "Set the klog logging level")
-	command.Flags().IntVar(&metricsPort, "metricsport", controller.DefaultMetricsPort, "Set the port the metrics endpoint should be exposed over")
+	command.Flags().IntVar(&metricsPort, "metricsPort", controller.DefaultMetricsPort, "Set the port the metrics endpoint should be exposed over")
 	command.Flags().IntVar(&healthzPort, "healthzPort", controller.DefaultHealthzPort, "Set the port the healthz endpoint should be exposed over")
 	command.Flags().StringVar(&instanceID, "instance-id", "", "Indicates which argo rollout objects the controller should operate on")
 	command.Flags().Float32Var(&qps, "qps", defaults.DefaultQPS, "Maximum QPS (queries per second) to the K8s API server")

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -16671,6 +16671,7 @@ rules:
   - get
 - apiGroups:
   - elbv2.k8s.aws
+  - eks.amazonaws.com
   resources:
   - targetgroupbindings
   verbs:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -192,6 +192,7 @@ rules:
   - get
 - apiGroups:
   - elbv2.k8s.aws
+  - eks.amazonaws.com
   resources:
   - targetgroupbindings
   verbs:

--- a/manifests/role/argo-rollouts-clusterrole.yaml
+++ b/manifests/role/argo-rollouts-clusterrole.yaml
@@ -197,6 +197,7 @@ rules:
   - get
 - apiGroups:
   - elbv2.k8s.aws
+  - eks.amazonaws.com
   resources:
   - targetgroupbindings
   verbs:

--- a/rollout/trafficrouting/alb/alb.go
+++ b/rollout/trafficrouting/alb/alb.go
@@ -286,7 +286,7 @@ func (r *Reconciler) VerifyWeightPerIngress(desiredWeight int32, ingresses []str
 				updateTargetGroupStatus(&r.cfg.Status.ALBs[i], &tg, canaryResourceID, stableResourceID, r.log)
 				updateTargetGroupStatus(r.cfg.Status.ALB, &tg, canaryResourceID, stableResourceID, r.log)
 				if tg.Weight != nil {
-					if tg.Tags[aws.AWSLoadBalancerV2TagKeyResourceID] == canaryResourceID {
+					if tg.Tags[defaults.GetalbTagKeyResourceID()] == canaryResourceID {
 						logCtx := logCtx.WithField("tg", *tg.TargetGroupArn)
 						logCtx.Infof("canary weight of %s (desired: %d, current: %d)", canaryResourceID, desiredWeight, *tg.Weight)
 						verified := *tg.Weight == desiredWeight
@@ -296,9 +296,9 @@ func (r *Reconciler) VerifyWeightPerIngress(desiredWeight int32, ingresses []str
 						} else {
 							r.cfg.Recorder.Warnf(rollout, record.EventOptions{EventReason: conditions.TargetGroupUnverifiedReason}, conditions.TargetGroupUnverifiedWeightsMessage, canaryService, *tg.TargetGroupArn, desiredWeight, *tg.Weight)
 						}
-					} else if dest, ok := resourceIDToDest[tg.Tags[aws.AWSLoadBalancerV2TagKeyResourceID]]; ok {
+					} else if dest, ok := resourceIDToDest[tg.Tags[defaults.GetalbTagKeyResourceID()]]; ok {
 						logCtx := logCtx.WithField("tg", *tg.TargetGroupArn)
-						logCtx.Infof("%s weight of %s (desired: %d, current: %d)", dest.ServiceName, tg.Tags[aws.AWSLoadBalancerV2TagKeyResourceID], dest.Weight, *tg.Weight)
+						logCtx.Infof("%s weight of %s (desired: %d, current: %d)", dest.ServiceName, tg.Tags[defaults.GetalbTagKeyResourceID()], dest.Weight, *tg.Weight)
 						verified := *tg.Weight == dest.Weight
 						if verified {
 							numVerifiedWeights += 1
@@ -326,7 +326,7 @@ func updateLoadBalancerStatus(status *v1alpha1.ALBStatus, lb *elbv2types.LoadBal
 }
 
 func updateTargetGroupStatus(status *v1alpha1.ALBStatus, tg *aws.TargetGroupMeta, canaryResourceID string, stableResourceID string, log *logrus.Entry) {
-	if tg.Tags[aws.AWSLoadBalancerV2TagKeyResourceID] == canaryResourceID {
+	if tg.Tags[defaults.GetalbTagKeyResourceID()] == canaryResourceID {
 		status.CanaryTargetGroup.Name = *tg.TargetGroupName
 		status.CanaryTargetGroup.ARN = *tg.TargetGroupArn
 		if tgArnParts := strings.Split(*tg.TargetGroupArn, "/"); len(tgArnParts) > 1 {
@@ -335,7 +335,7 @@ func updateTargetGroupStatus(status *v1alpha1.ALBStatus, tg *aws.TargetGroupMeta
 			status.CanaryTargetGroup.FullName = ""
 			log.Errorf("error parsing canary target group arn: '%s'", *tg.TargetGroupArn)
 		}
-	} else if tg.Tags[aws.AWSLoadBalancerV2TagKeyResourceID] == stableResourceID {
+	} else if tg.Tags[defaults.GetalbTagKeyResourceID()] == stableResourceID {
 		status.StableTargetGroup.Name = *tg.TargetGroupName
 		status.StableTargetGroup.ARN = *tg.TargetGroupArn
 		if tgArnParts := strings.Split(*tg.TargetGroupArn, "/"); len(tgArnParts) > 1 {

--- a/rollout/trafficrouting/alb/alb_test.go
+++ b/rollout/trafficrouting/alb/alb_test.go
@@ -33,6 +33,7 @@ const STABLE_SVC = "stable-svc"
 const CANARY_SVC = "canary-svc"
 const PING_SVC = "ping-service"
 const PONG_SVC = "pong-service"
+const ALB_TAG_KEY_RESOURCE_ID = "ingress.k8s.aws/resource"
 
 func fakeRollout(stableSvc, canarySvc string, pingPong *v1alpha1.PingPongSpec, stableIng string, port int32) *v1alpha1.Rollout {
 	return &v1alpha1.Rollout{
@@ -893,7 +894,7 @@ func TestVerifyWeight(t *testing.T) {
 				},
 				Weight: ptr.To[int32](11),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
@@ -903,7 +904,7 @@ func TestVerifyWeight(t *testing.T) {
 				},
 				Weight: ptr.To[int32](89),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-stable-svc:443",
 				},
 			},
 		}
@@ -935,7 +936,7 @@ func TestVerifyWeight(t *testing.T) {
 				},
 				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
@@ -945,7 +946,7 @@ func TestVerifyWeight(t *testing.T) {
 				},
 				Weight: ptr.To[int32](11),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-stable-svc:443",
 				},
 			},
 		}
@@ -977,7 +978,7 @@ func TestVerifyWeight(t *testing.T) {
 				},
 				Weight: ptr.To[int32](100),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
@@ -987,7 +988,7 @@ func TestVerifyWeight(t *testing.T) {
 				},
 				Weight: ptr.To[int32](0),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-stable-svc:443",
 				},
 			},
 		}
@@ -1018,7 +1019,7 @@ func TestVerifyWeight(t *testing.T) {
 				},
 				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
@@ -1028,7 +1029,7 @@ func TestVerifyWeight(t *testing.T) {
 				},
 				Weight: ptr.To[int32](11),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-stable-svc:443",
 				},
 			},
 		}
@@ -1161,7 +1162,7 @@ func TestVerifyWeightMultiIngress(t *testing.T) {
 				},
 				Weight: ptr.To[int32](11),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
@@ -1171,7 +1172,7 @@ func TestVerifyWeightMultiIngress(t *testing.T) {
 				},
 				Weight: ptr.To[int32](89),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-stable-svc:443",
 				},
 			},
 			{
@@ -1181,7 +1182,7 @@ func TestVerifyWeightMultiIngress(t *testing.T) {
 				},
 				Weight: ptr.To[int32](11),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/multi-ingress-canary-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/multi-ingress-canary-svc:443",
 				},
 			},
 			{
@@ -1191,7 +1192,7 @@ func TestVerifyWeightMultiIngress(t *testing.T) {
 				},
 				Weight: ptr.To[int32](89),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/multi-ingress-stable-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/multi-ingress-stable-svc:443",
 				},
 			},
 		}
@@ -1227,7 +1228,7 @@ func TestVerifyWeightMultiIngress(t *testing.T) {
 				},
 				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
@@ -1237,7 +1238,7 @@ func TestVerifyWeightMultiIngress(t *testing.T) {
 				},
 				Weight: ptr.To[int32](90),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-stable-svc:443",
 				},
 			},
 			{
@@ -1247,7 +1248,7 @@ func TestVerifyWeightMultiIngress(t *testing.T) {
 				},
 				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/multi-ingress-canary-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/multi-ingress-canary-svc:443",
 				},
 			},
 			{
@@ -1257,7 +1258,7 @@ func TestVerifyWeightMultiIngress(t *testing.T) {
 				},
 				Weight: ptr.To[int32](90),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/multi-ingress-stable-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/multi-ingress-stable-svc:443",
 				},
 			},
 		}
@@ -1437,7 +1438,7 @@ func TestVerifyWeightWithAdditionalDestinations(t *testing.T) {
 				},
 				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
@@ -1447,7 +1448,7 @@ func TestVerifyWeightWithAdditionalDestinations(t *testing.T) {
 				},
 				Weight: ptr.To[int32](90),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-stable-svc:443",
 				},
 			},
 		}
@@ -1477,7 +1478,7 @@ func TestVerifyWeightWithAdditionalDestinations(t *testing.T) {
 				},
 				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
@@ -1487,7 +1488,7 @@ func TestVerifyWeightWithAdditionalDestinations(t *testing.T) {
 				},
 				Weight: ptr.To[int32](100),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-ex-svc-1:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-ex-svc-1:443",
 				},
 			},
 			{
@@ -1497,7 +1498,7 @@ func TestVerifyWeightWithAdditionalDestinations(t *testing.T) {
 				},
 				Weight: ptr.To[int32](100),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-ex-svc-2:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-ex-svc-2:443",
 				},
 			},
 			{
@@ -1507,7 +1508,7 @@ func TestVerifyWeightWithAdditionalDestinations(t *testing.T) {
 				},
 				Weight: ptr.To[int32](85),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-stable-svc:443",
 				},
 			},
 		}
@@ -1537,7 +1538,7 @@ func TestVerifyWeightWithAdditionalDestinations(t *testing.T) {
 				},
 				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
@@ -1547,7 +1548,7 @@ func TestVerifyWeightWithAdditionalDestinations(t *testing.T) {
 				},
 				Weight: &weightDestinations[0].Weight,
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-ex-svc-1:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-ex-svc-1:443",
 				},
 			},
 			{
@@ -1557,7 +1558,7 @@ func TestVerifyWeightWithAdditionalDestinations(t *testing.T) {
 				},
 				Weight: &weightDestinations[1].Weight,
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-ex-svc-2:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-ex-svc-2:443",
 				},
 			},
 			{
@@ -1567,7 +1568,7 @@ func TestVerifyWeightWithAdditionalDestinations(t *testing.T) {
 				},
 				Weight: ptr.To[int32](85),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-stable-svc:443",
 				},
 			},
 		}
@@ -1665,7 +1666,7 @@ func TestVerifyWeightWithAdditionalDestinationsMultiIngress(t *testing.T) {
 				},
 				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
@@ -1675,7 +1676,7 @@ func TestVerifyWeightWithAdditionalDestinationsMultiIngress(t *testing.T) {
 				},
 				Weight: ptr.To[int32](90),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-stable-svc:443",
 				},
 			},
 			{
@@ -1685,7 +1686,7 @@ func TestVerifyWeightWithAdditionalDestinationsMultiIngress(t *testing.T) {
 				},
 				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/multi-ingress-canary-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/multi-ingress-canary-svc:443",
 				},
 			},
 			{
@@ -1695,7 +1696,7 @@ func TestVerifyWeightWithAdditionalDestinationsMultiIngress(t *testing.T) {
 				},
 				Weight: ptr.To[int32](90),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/multi-ingress-stable-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/multi-ingress-stable-svc:443",
 				},
 			},
 		}
@@ -1730,7 +1731,7 @@ func TestVerifyWeightWithAdditionalDestinationsMultiIngress(t *testing.T) {
 				},
 				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
@@ -1740,7 +1741,7 @@ func TestVerifyWeightWithAdditionalDestinationsMultiIngress(t *testing.T) {
 				},
 				Weight: ptr.To[int32](85),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-stable-svc:443",
 				},
 			},
 			{
@@ -1750,7 +1751,7 @@ func TestVerifyWeightWithAdditionalDestinationsMultiIngress(t *testing.T) {
 				},
 				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/multi-ingress-canary-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/multi-ingress-canary-svc:443",
 				},
 			},
 			{
@@ -1760,7 +1761,7 @@ func TestVerifyWeightWithAdditionalDestinationsMultiIngress(t *testing.T) {
 				},
 				Weight: ptr.To[int32](85),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/multi-ingress-stable-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/multi-ingress-stable-svc:443",
 				},
 			},
 			{
@@ -1770,7 +1771,7 @@ func TestVerifyWeightWithAdditionalDestinationsMultiIngress(t *testing.T) {
 				},
 				Weight: ptr.To[int32](100),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-ex-svc-1:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-ex-svc-1:443",
 				},
 			},
 			{
@@ -1780,7 +1781,7 @@ func TestVerifyWeightWithAdditionalDestinationsMultiIngress(t *testing.T) {
 				},
 				Weight: ptr.To[int32](100),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-ex-svc-2:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-ex-svc-2:443",
 				},
 			},
 		}
@@ -1816,7 +1817,7 @@ func TestVerifyWeightWithAdditionalDestinationsMultiIngress(t *testing.T) {
 				},
 				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-canary-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-canary-svc:443",
 				},
 			},
 			{
@@ -1826,7 +1827,7 @@ func TestVerifyWeightWithAdditionalDestinationsMultiIngress(t *testing.T) {
 				},
 				Weight: ptr.To[int32](85),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-stable-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-stable-svc:443",
 				},
 			},
 			{
@@ -1836,7 +1837,7 @@ func TestVerifyWeightWithAdditionalDestinationsMultiIngress(t *testing.T) {
 				},
 				Weight: ptr.To[int32](10),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/multi-ingress-canary-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/multi-ingress-canary-svc:443",
 				},
 			},
 			{
@@ -1846,7 +1847,7 @@ func TestVerifyWeightWithAdditionalDestinationsMultiIngress(t *testing.T) {
 				},
 				Weight: ptr.To[int32](85),
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/multi-ingress-stable-svc:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/multi-ingress-stable-svc:443",
 				},
 			},
 			{
@@ -1856,7 +1857,7 @@ func TestVerifyWeightWithAdditionalDestinationsMultiIngress(t *testing.T) {
 				},
 				Weight: &weightDestinations[0].Weight,
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-ex-svc-1:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-ex-svc-1:443",
 				},
 			},
 			{
@@ -1866,7 +1867,7 @@ func TestVerifyWeightWithAdditionalDestinationsMultiIngress(t *testing.T) {
 				},
 				Weight: &weightDestinations[1].Weight,
 				Tags: map[string]string{
-					aws.AWSLoadBalancerV2TagKeyResourceID: "default/ingress-ex-svc-2:443",
+					ALB_TAG_KEY_RESOURCE_ID: "default/ingress-ex-svc-2:443",
 				},
 			},
 		}

--- a/utils/aws/aws.go
+++ b/utils/aws/aws.go
@@ -21,15 +21,6 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/defaults"
 )
 
-// AWSLoadBalancerV2TagKeyResourceID is the tag applied to an AWS resource by the AWS Load Balancer
-// controller, to associate it to the corresponding kubernetes resource. This is used by the rollout
-// controller to identify the correct TargetGroups associated with the LoadBalancer. For AWS
-// target group service references, the format is: <namespace>/<ingress-name>-<service-name>:<port>
-// Example: ingress.k8s.aws/resource: default/alb-rollout-ingress-alb-rollout-stable:80
-// See: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/annotations/#resource-tags
-// https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/da8951f80521651e0a1ffe1361c011d6baad7706/pkg/deploy/tracking/provider.go#L19
-const AWSLoadBalancerV2TagKeyResourceID = "ingress.k8s.aws/resource"
-
 // TargetType is the targetType of your ELBV2 TargetGroup.
 //
 // * with `instance` TargetType, nodes with nodePort for your service will be registered as targets

--- a/utils/aws/aws_test.go
+++ b/utils/aws/aws_test.go
@@ -26,6 +26,16 @@ func newFakeClient() (*mocks.ELBv2APIClient, Client) {
 	return &fakeELB, awsClient
 }
 
+func TestGetTargetGroupBindingsGVR(t *testing.T) {
+	defaults.SetTargetGroupBindingAPIVersion("eks.amazonaws.com/v1")
+	gvr, err := GetTargetGroupBindingsGVR()
+	assert.NoError(t, err)
+	assert.Equal(t, "eks.amazonaws.com", gvr.Group)
+	assert.Equal(t, "v1", gvr.Version)
+	assert.Equal(t, "targetgroupbindings", gvr.Resource)
+	defaults.SetTargetGroupBindingAPIVersion("elbv2.k8s.aws/v1beta1")
+}
+
 func TestFindLoadBalancerByDNSName(t *testing.T) {
 	// LoadBalancer not found
 	{

--- a/utils/defaults/defaults.go
+++ b/utils/defaults/defaults.go
@@ -60,6 +60,7 @@ const (
 	DefaultIstioVersion                 = "v1alpha3"
 	DefaultSMITrafficSplitVersion       = "v1alpha1"
 	DefaultTargetGroupBindingAPIVersion = "elbv2.k8s.aws/v1beta1"
+	DefaultAlbTagKeyResourceID          = "ingress.k8s.aws/resource"
 	DefaultAppMeshCRDVersion            = "v1beta2"
 	DefaultTraefikAPIGroup              = "traefik.containo.us"
 	DefaultTraefikVersion               = "traefik.containo.us/v1alpha1"
@@ -75,6 +76,7 @@ var (
 	ambassadorAPIVersion         = DefaultAmbassadorVersion
 	smiAPIVersion                = DefaultSMITrafficSplitVersion
 	targetGroupBindingAPIVersion = DefaultTargetGroupBindingAPIVersion
+	albTagKeyResourceID          = DefaultAlbTagKeyResourceID
 	appmeshCRDVersion            = DefaultAppMeshCRDVersion
 	defaultMetricCleanupDelay    = DefaultMetricCleanupDelay
 	defaultDescribeTagsLimit     = DefaultDescribeTagsLimit
@@ -323,6 +325,14 @@ func SetTraefikAPIGroup(apiGroup string) {
 
 func GetTraefikAPIGroup() string {
 	return traefikAPIGroup
+}
+
+func SetalbTagKeyResourceID(tagKey string) {
+	albTagKeyResourceID = tagKey
+}
+
+func GetalbTagKeyResourceID() string {
+	return albTagKeyResourceID
 }
 
 func SetTargetGroupBindingAPIVersion(apiVersion string) {

--- a/utils/defaults/defaults_test.go
+++ b/utils/defaults/defaults_test.go
@@ -412,6 +412,11 @@ func TestSetDefaults(t *testing.T) {
 	SetTargetGroupBindingAPIVersion(DefaultTargetGroupBindingAPIVersion)
 	assert.Equal(t, DefaultTargetGroupBindingAPIVersion, GetTargetGroupBindingAPIVersion())
 
+	SetalbTagKeyResourceID("ingress.amazonaws.com/resource")
+	assert.Equal(t, "ingress.amazonaws.com/resource", GetalbTagKeyResourceID())
+	SetalbTagKeyResourceID(DefaultAlbTagKeyResourceID)
+	assert.Equal(t, DefaultAlbTagKeyResourceID, GetalbTagKeyResourceID())
+
 	assert.Equal(t, DefaultAppMeshCRDVersion, GetAppMeshCRDVersion())
 	SetAppMeshCRDVersion("v1beta3")
 	assert.Equal(t, "v1beta3", GetAppMeshCRDVersion())


### PR DESCRIPTION
The Argo Rollouts controller fails to perform target weight verification and, as a result, cannot scale down the old ReplicaSet during canary rollouts when the target group verification option `--aws-verify-target-group` is enabled on AWS EKS Auto Mode. This issue is caused by a [change in the AWS API version used by EKS Auto Mode](https://docs.aws.amazon.com/eks/latest/userguide/auto-configure-alb.html#_considerations) — from `elbv2.k8s.aws/v1beta1` to `eks.amazonaws.com/v1` — which prevents the controller from retrieving the target group resources.

This PR exposes the following CLI flags to allow users to dynamically configure the AWS API versions, similar to other flags that expose provider-specific API versions (e.g., for Ambassador, Istio, Traefik):

* `aws-target-group-binding-api-version`: Specifies the AWS API version for the `TargetGroupBinding` resource. Use `elbv2.k8s.aws/v1beta1` for the standard AWS Load Balancer Controller on EKS, and `eks.amazonaws.com/v1` for the AWS Load Balancer Controller used in EKS Auto Mode.
* `alb-tag-key-resource-id`: Specifies the [ALB resource tag](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.13/guide/ingress/annotations/#resource-tags) key used to fetch tag values. This is typically `ingress.k8s.aws/resource` for the standard controller, and `ingress.eks.amazonaws.com` for EKS Auto Mode.

This PR also includes a minor fix for a camelCase typo in the `metricsPort` CLI flag.

It addresses and resolves https://github.com/argoproj/argo-rollouts/issues/4334

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).