### PR TITLE
docs(example): Fix broken links in docs. Fixes #4382

### DIFF
--- a/docs/features/canary/index.md
+++ b/docs/features/canary/index.md
@@ -10,7 +10,7 @@ There are multiple steps available, the most basic ones are `setWeight` and `pau
 
 !!! important
 
-    If the canary Rollout does not use [traffic management](traffic-management/index.md), the Rollout makes a best effort attempt to achieve the percentage listed in the last `setWeight` step between the new and old version. For example, if a Rollout has 10 Replicas and 10% for the first `setWeight` step, the controller will scale the new desired ReplicaSet to 1 replicas and the old stable ReplicaSet to 9. In the case where the setWeight is 41%, the Rollout attempts to get there by finding the whole number with the smallest delta, rounding up the calculation if the deltas are equals (i.e. the new ReplicaSet has 4 pods since 41% of 10 is closer to 4/10 than 5/10, and the old ReplicaSet has 6 pods). If a user wants to have more fine-grained control of the percentages without a large number of Replicas, that user should use the [traffic management](#trafficrouting) functionality.
+    If the canary Rollout does not use [traffic management](../traffic-management/index.md), the Rollout makes a best effort attempt to achieve the percentage listed in the last `setWeight` step between the new and old version. For example, if a Rollout has 10 Replicas and 10% for the first `setWeight` step, the controller will scale the new desired ReplicaSet to 1 replicas and the old stable ReplicaSet to 9. In the case where the setWeight is 41%, the Rollout attempts to get there by finding the whole number with the smallest delta, rounding up the calculation if the deltas are equals (i.e. the new ReplicaSet has 4 pods since 41% of 10 is closer to 4/10 than 5/10, and the old ReplicaSet has 6 pods). If a user wants to have more fine-grained control of the percentages without a large number of Replicas, that user should use the [traffic management](#trafficrouting) functionality.
 
 ## Example
 
@@ -64,7 +64,7 @@ spec:
         - pause: {} # pause indefinitely
 ```
 
-If no `duration` is specified for a pause step, the rollout will be paused indefinitely. To unpause, use the [argo kubectl plugin](kubectl-plugin.md) `promote` command.
+If no `duration` is specified for a pause step, the rollout will be paused indefinitely. To unpause, use the [argo kubectl plugin](../kubectl-plugin.md) `promote` command.
 
 ```shell
 # promote to the next step

--- a/docs/generated/notification-services/email.md
+++ b/docs/generated/notification-services/email.md
@@ -46,7 +46,7 @@ data:
 
 ## Template
 
-[Notification templates](../templates.md) support specifying subject for email notifications:
+[Notification templates](../../features/notifications.md#templates) support specifying subject for email notifications:
 
 ```yaml
 apiVersion: v1

--- a/docs/generated/notification-services/pagerduty.md
+++ b/docs/generated/notification-services/pagerduty.md
@@ -35,7 +35,7 @@ data:
 
 ## Template
 
-[Notification templates](../templates.md) support specifying subject for PagerDuty notifications:
+[Notification templates](../../features/notifications.md#templates) support specifying subject for PagerDuty notifications:
 
 ```yaml
 apiVersion: v1

--- a/docs/generated/notification-services/pagerduty_v2.md
+++ b/docs/generated/notification-services/pagerduty_v2.md
@@ -37,7 +37,7 @@ data:
 
 ## Template
 
-[Notification templates](../templates.md) support specifying subject for PagerDuty notifications:
+[Notification templates](../../features/notifications.md#templates) support specifying subject for PagerDuty notifications:
 
 ```yaml
 apiVersion: v1

--- a/docs/generated/notification-services/rocketchat.md
+++ b/docs/generated/notification-services/rocketchat.md
@@ -64,7 +64,7 @@ metadata:
 
 ## Templates
 
-[Notification templates](../templates.md) can be customized with RocketChat [attachments](https://developer.rocket.chat/api/rest-api/methods/chat/postmessage#attachments-detail).
+[Notification templates](../../features/notifications.md#templates) can be customized with RocketChat [attachments](https://developer.rocket.chat/api/rest-api/methods/chat/postmessage#attachments-detail).
 
 *Note: Attachments structure in Rocketchat is same with Slack attachments [feature](https://api.slack.com/messaging/composing/layouts).*
 

--- a/docs/generated/notification-services/slack.md
+++ b/docs/generated/notification-services/slack.md
@@ -55,7 +55,7 @@ The Slack notification service configuration includes following settings:
           token: $slack-token
     ```
 
-1. Add annotation in application yaml file to enable notifications for specific argocd app.  The following example uses the [on-sync-succeeded trigger](../catalog.md#triggers):
+1. Add annotation in application yaml file to enable notifications for specific argocd app.  The following example uses the [on-sync-succeeded trigger](../../features/notifications.md#custom-triggers):
 
     ```yaml
       apiVersion: argoproj.io/v1alpha1
@@ -65,7 +65,7 @@ The Slack notification service configuration includes following settings:
           notifications.argoproj.io/subscribe.on-sync-succeeded.slack: my_channel
     ```
 
-1. Annotation with more than one [trigger](../catalog.md#triggers), with multiple destinations and recipients
+1. Annotation with more than one [trigger](../../features/notifications.md#custom-triggers), with multiple destinations and recipients
 
     ```yaml
       apiVersion: argoproj.io/v1alpha1
@@ -87,7 +87,7 @@ The Slack notification service configuration includes following settings:
 
 ## Templates
 
-[Notification templates](../templates.md) can be customized to leverage slack message blocks and attachments
+[Notification templates](../../features/notifications.md#templates) can be customized to leverage slack message blocks and attachments
 [feature](https://api.slack.com/messaging/composing/layouts).
 
 ![](https://user-images.githubusercontent.com/426437/72776856-6dcef880-3bc8-11ea-8e3b-c72df16ee8e6.png)

--- a/docs/generated/notification-services/teams.md
+++ b/docs/generated/notification-services/teams.md
@@ -48,7 +48,7 @@ metadata:
 
 ![](https://user-images.githubusercontent.com/18019529/114271500-9d2b8880-9a4c-11eb-85c1-f6935f0431d5.png)
 
-[Notification templates](../templates.md) can be customized to leverage teams message sections, facts, themeColor, summary and potentialAction [feature](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using).
+[Notification templates](../../features/notifications.md#templates) can be customized to leverage teams message sections, facts, themeColor, summary and potentialAction [feature](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using).
 
 ```yaml
 template.app-sync-succeeded: |

--- a/docs/getting-started/mixed/index.md
+++ b/docs/getting-started/mixed/index.md
@@ -9,7 +9,7 @@ This guide covers how Argo Rollouts integrates with multiple TrafficRoutings, us
 should be able to produce any other combination between the existing trafficRouting options.
 
 This guide builds upon the concepts of the [basic getting started guide](../../getting-started.md),
-[NGINX Guide](getting-started/nginx/index.md), and [SMI Guide](getting-started/smi/index.md).
+[NGINX Guide](../nginx/index.md), and [SMI Guide](../smi/index.md).
 
 ## Requirements
 - Kubernetes cluster with Linkerd installed

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -11,7 +11,7 @@ When converting a Deployment to a Rollout, it involves changing three fields:
 
 1. Replacing the `apiVersion` from `apps/v1` to `argoproj.io/v1alpha1`
 1. Replacing the `kind` from `Deployment` to `Rollout`
-1. Replacing the deployment strategy with a [blue-green](features/bluegreen.md) or [canary](features/canary.md) strategy
+2. Replacing the deployment strategy with a [blue-green](features/bluegreen.md) or [canary](features/canary/index.md) strategy
 
 Below is an example of a Rollout resource using the canary strategy.
 

--- a/hack/gen-docs/main.go
+++ b/hack/gen-docs/main.go
@@ -42,6 +42,12 @@ func generateNotificationsDocs() {
 		if e := strReplaceDocFiles("argocd-notifications-secret", "argo-rollouts-notification-secret", files); e != nil {
 			log.Fatal(e)
 		}
+		if e := strReplaceDocFiles("../templates.md", "../../features/notifications.md#templates", files); e != nil {
+			log.Fatal(e)
+		}
+		if e := strReplaceDocFiles("../catalog.md#triggers", "../../features/notifications.md#custom-triggers", files); e != nil {
+			log.Fatal(e)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes broken links in the docs that were flagged by the `go run -mod=mod ./hack/gen-docs/main.go` gen-docs command.
Below `WARNINGS` logs can also be found in the `Deploy-Docs` GitHub Actions, for example:

https://github.com/argoproj/argo-rollouts/actions/runs/16835236045/job/47692973101

```
go run -mod=mod ./hack/gen-docs/main.go
...
WARNING -  Doc file 'migrating.md' contains a link 'features/canary.md', but the target is not found among documentation files.
...
WARNING -  Doc file 'features/canary/index.md' contains a link 'traffic-management/index.md', but the target 'features/canary/traffic-management/index.md' is not found among documentation files.
WARNING -  Doc file 'features/canary/index.md' contains a link 'kubectl-plugin.md', but the target 'features/canary/kubectl-plugin.md' is not found among documentation files.
...
WARNING -  Doc file 'generated/notification-services/email.md' contains a link '../templates.md', but the target 'generated/templates.md' is not found among documentation files.
WARNING -  Doc file 'generated/notification-services/pagerduty.md' contains a link '../templates.md', but the target 'generated/templates.md' is not found among documentation files.
WARNING -  Doc file 'generated/notification-services/pagerduty_v2.md' contains a link '../templates.md', but the target 'generated/templates.md' is not found among documentation files.
WARNING -  Doc file 'generated/notification-services/rocketchat.md' contains a link '../templates.md', but the target 'generated/templates.md' is not found among documentation files.
WARNING -  Doc file 'generated/notification-services/slack.md' contains a link '../catalog.md#triggers', but the target 'generated/catalog.md' is not found among documentation files.
WARNING -  Doc file 'generated/notification-services/slack.md' contains a link '../catalog.md#triggers', but the target 'generated/catalog.md' is not found among documentation files.
WARNING -  Doc file 'generated/notification-services/slack.md' contains a link '../templates.md', but the target 'generated/templates.md' is not found among documentation files.
WARNING -  Doc file 'generated/notification-services/teams.md' contains a link '../templates.md', but the target 'generated/templates.md' is not found among documentation files.
WARNING -  Doc file 'getting-started/mixed/index.md' contains a link 'getting-started/nginx/index.md', but the target 'getting-started/mixed/getting-started/nginx/index.md' is not found among documentation files.
WARNING -  Doc file 'getting-started/mixed/index.md' contains a link 'getting-started/smi/index.md', but the target 'getting-started/mixed/getting-started/smi/index.md' is not found among documentation files.
INFO    -  Documentation built in 2.30 seconds
```

Fixes https://github.com/argoproj/argo-rollouts/issues/4382

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
