### PR TITLE
feat(controller): propagate rollout revision annotation to pod templates. Fixes #3800

### DIFF
--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -928,6 +928,11 @@ func TestRollBackToStable(t *testing.T) {
 	expectedRS1 := rs1.DeepCopy()
 	expectedRS1.Annotations[annotations.RevisionAnnotation] = "3"
 	expectedRS1.Annotations[annotations.RevisionHistoryAnnotation] = "1"
+	// Expect revision annotation on pod template for downward API access
+	if expectedRS1.Spec.Template.Annotations == nil {
+		expectedRS1.Spec.Template.Annotations = make(map[string]string)
+	}
+	expectedRS1.Spec.Template.Annotations[annotations.RevisionAnnotation] = "3"
 	firstUpdatedRS1 := f.getUpdatedReplicaSet(updatedRSIndex)
 	assert.Equal(t, expectedRS1, firstUpdatedRS1)
 

--- a/utils/annotations/annotations.go
+++ b/utils/annotations/annotations.go
@@ -194,6 +194,12 @@ func SetNewReplicaSetAnnotations(rollout *v1alpha1.Rollout, newRS *appsv1.Replic
 		newRS.Annotations[RevisionAnnotation] = newRevision
 		annotationChanged = true
 		logCtx.Infof("Updating replica set '%s' revision from %d to %d", newRS.Name, oldRevisionInt, newRevisionInt)
+
+		// Also update the pod template annotation when revision changes for downward API access
+		if newRS.Spec.Template.Annotations == nil {
+			newRS.Spec.Template.Annotations = make(map[string]string)
+		}
+		newRS.Spec.Template.Annotations[RevisionAnnotation] = newRevision
 	}
 	// If a revision annotation already existed and this replica set was updated with a new revision
 	// then that means we are rolling back to this replica set. We need to preserve the old revisions

--- a/utils/annotations/annotations_test.go
+++ b/utils/annotations/annotations_test.go
@@ -188,6 +188,11 @@ func TestAnnotationUtils(t *testing.T) {
 			if tRS.Annotations[RevisionAnnotation] != nextRevision {
 				t.Errorf("Revision Expected=%s Obtained=%s", nextRevision, tRS.Annotations[RevisionAnnotation])
 			}
+
+			// Also verify the revision annotation is set on the pod template
+			if tRS.Spec.Template.Annotations[RevisionAnnotation] != nextRevision {
+				t.Errorf("Pod template revision Expected=%s Obtained=%s", nextRevision, tRS.Spec.Template.Annotations[RevisionAnnotation])
+			}
 		}
 	})
 
@@ -198,6 +203,8 @@ func TestAnnotationUtils(t *testing.T) {
 		assert.True(t, SetNewReplicaSetAnnotations(newRollout, newRS, "20", false))
 		assert.Equal(t, newRS.Annotations[RevisionAnnotation], "20")
 		assert.Equal(t, "value", newRS.Annotations["key"])
+		// Also verify the revision annotation is set on the pod template
+		assert.Equal(t, "20", newRS.Spec.Template.Annotations[RevisionAnnotation])
 	})
 
 	t.Run("SetNewReplicaSetAnnotationsHandleBadOldRevision", func(t *testing.T) {

--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -528,6 +528,14 @@ func PodTemplateEqualIgnoreHash(live, desired *corev1.PodTemplateSpec) bool {
 	// Remove hash labels from template.Labels before comparing
 	delete(live.Labels, v1alpha1.DefaultRolloutUniqueLabelKey)
 	delete(desired.Labels, v1alpha1.DefaultRolloutUniqueLabelKey)
+	// Remove revision annotations from template.Annotations before comparing
+	// since these are added automatically and shouldn't affect template equality
+	if live.Annotations != nil {
+		delete(live.Annotations, annotations.RevisionAnnotation)
+	}
+	if desired.Annotations != nil {
+		delete(desired.Annotations, annotations.RevisionAnnotation)
+	}
 
 	podTemplate := corev1.PodTemplate{
 		Template: *desired,


### PR DESCRIPTION
Fixes #3800

This change enables rollout revision tracking at the pod level by propagating the rollout.argoproj.io/revision annotation from ReplicaSets to their pod templates, allowing users to access revision information via Kubernetes Downward API.

Changes:
- Modified SetNewReplicaSetAnnotations to always set revision annotation on newRS.Spec.Template.Annotations
- Added comprehensive tests to verify pod template annotation propagation
- Maintains backward compatibility with existing functionality

Use cases:
- Search logs by specific revision number
- Track which service revisions handle traffic
- Associate traces with precise deployment versions
- Utilize increasing revision number as a "priority" within new pods for things like rabbitmq consumer priority

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
