### PR TITLE
fix(traffigrouting): avoiding a desired weight bigger than 100% during a full promotion when "dynamicStableScale" is enabled

### DIFF
--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -233,7 +233,7 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			// But we can only increase canary weight according to available replica counts of the canary.
 			// we will need to set the desiredWeight to 0 when the newRS is not available.
 			if c.rollout.Spec.Strategy.Canary.DynamicStableScale {
-				desiredWeight = (weightutil.MaxTrafficWeight(c.rollout) * c.newRS.Status.AvailableReplicas) / *c.rollout.Spec.Replicas
+				desiredWeight = minInt(100, (weightutil.MaxTrafficWeight(c.rollout)*c.newRS.Status.AvailableReplicas) / *c.rollout.Spec.Replicas)
 			} else if c.rollout.Status.Canary.Weights != nil {
 				desiredWeight = c.rollout.Status.Canary.Weights.Canary.Weight
 			}


### PR DESCRIPTION
I found a bug during a full promotion when `dynamicStableScale` is enabled and uses Istio traffic routing. The bug can be reproduced by following the steps below:

1. The `spec.replicas` param set to `1` in the `Rollout` object;
2. A step with `setCanaryScale` setting `replicas` to `2` or more;
3. Canary step using the step described above;
4. Perform the full promotion action.

The result will be `trafficroutingerror` events on the Argo Rollouts controller, because this behaviour will try to set the weight as `-100` on Istio's `VirtualService`. There is a Math os Istio management using this value and subtracts by `100`, resulting in negative values, like `-100`, when the math changed on this pull request results in `200`.

This pull request fixes the math related to the desired weight during a full promotion, avoiding results bigger than `100`.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
