### PR TITLE
feat: The `/api` mux server should respect the `--root-path` arg.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"path"
 	"strings"
 	"time"
 
@@ -104,7 +105,15 @@ func (s *ArgoRolloutsServer) newHTTPServer(ctx context.Context, port int) *http.
 	}
 
 	var apiHandler http.Handler = gwmux
-	mux.Handle("/api/", apiHandler)
+
+	// Mount API at rootPath/api/ when rootPath is configured
+	apiPath := "/api/"
+	if s.Options.RootPath != "" {
+		apiPath = path.Join("/", s.Options.RootPath, "api") + "/"
+		stripPrefix := path.Join("/", s.Options.RootPath)
+		apiHandler = http.StripPrefix(stripPrefix, gwmux)
+	}
+	mux.Handle(apiPath, apiHandler)
 	mux.HandleFunc("/", s.staticFileHttpHandler)
 
 	return &httpS

--- a/ui/src/app/components/rollout-actions/rollout-actions.tsx
+++ b/ui/src/app/components/rollout-actions/rollout-actions.tsx
@@ -39,7 +39,7 @@ export const RolloutActionButton = (props: {action: RolloutAction; rollout: Roll
             {
                 label: 'RESTART',
                 icon: faSync,
-                action: api.rolloutServiceRestartRollout,
+                action: api.rolloutServiceRestartRollout.bind(api),
                 tooltip: restartedAt === 'Never' ? 'Never restarted' : `Last restarted ${restartedAt}`,
                 shouldConfirm: true,
             },
@@ -49,7 +49,7 @@ export const RolloutActionButton = (props: {action: RolloutAction; rollout: Roll
             {
                 label: 'RETRY',
                 icon: faRedoAlt,
-                action: api.rolloutServiceRetryRollout,
+                action: api.rolloutServiceRetryRollout.bind(api),
                 disabled: props.rollout.status !== RolloutStatus.Degraded,
                 shouldConfirm: true,
             },
@@ -59,7 +59,7 @@ export const RolloutActionButton = (props: {action: RolloutAction; rollout: Roll
             {
                 label: 'ABORT',
                 icon: faExclamationCircle,
-                action: api.rolloutServiceAbortRollout,
+                action: api.rolloutServiceAbortRollout.bind(api),
                 disabled: !isDeploying,
                 shouldConfirm: true,
             },
@@ -69,7 +69,7 @@ export const RolloutActionButton = (props: {action: RolloutAction; rollout: Roll
             {
                 label: 'PROMOTE',
                 icon: faChevronCircleUp,
-                action: api.rolloutServicePromoteRollout,
+                action: api.rolloutServicePromoteRollout.bind(api),
                 body: {full: false},
                 disabled: !isDeploying,
                 shouldConfirm: true,
@@ -80,7 +80,7 @@ export const RolloutActionButton = (props: {action: RolloutAction; rollout: Roll
             {
                 label: 'PROMOTE-FULL',
                 icon: faArrowCircleUp,
-                action: api.rolloutServicePromoteRollout,
+                action: api.rolloutServicePromoteRollout.bind(api),
                 body: {full: true},
                 disabled: !isDeploying,
                 shouldConfirm: true,

--- a/ui/src/app/shared/context/api.tsx
+++ b/ui/src/app/shared/context/api.tsx
@@ -1,7 +1,24 @@
 import * as React from 'react';
-import {RolloutNamespaceInfo, RolloutServiceApi} from '../../../models/rollout/generated';
+import {RolloutNamespaceInfo, RolloutServiceApi, Configuration} from '../../../models/rollout/generated';
 
-export const RolloutAPI = new RolloutServiceApi();
+// Get the base path from document.baseURI
+// The generated API client already includes /api in its paths, so we just need the base
+let cachedBasePath: string | null = null;
+
+const getApiBasePath = (): string => {
+    if (cachedBasePath === null) {
+        const baseURI = new URL(document.baseURI);
+        cachedBasePath = baseURI.pathname.replace(/\/$/, '');
+    }
+    return cachedBasePath;
+};
+
+// Export the base path function for use in other modules
+export { getApiBasePath };
+
+
+const basePath = getApiBasePath();
+export const RolloutAPI = new RolloutServiceApi(new Configuration({ basePath }));
 export const RolloutAPIContext = React.createContext(RolloutAPI);
 
 export const APIProvider = (props: {children: React.ReactNode}) => {

--- a/ui/src/app/shared/services/rollout.ts
+++ b/ui/src/app/shared/services/rollout.ts
@@ -2,7 +2,7 @@ import {RolloutRolloutWatchEvent, RolloutServiceApiFetchParamCreator} from '../.
 import {ListState, useLoading, useWatch, useWatchList} from '../utils/watch';
 import {RolloutInfo} from '../../../models/rollout/rollout';
 import * as React from 'react';
-import {NamespaceContext, RolloutAPIContext} from '../context/api';
+import {NamespaceContext, RolloutAPIContext, getApiBasePath} from '../context/api';
 
 export const useRollouts = (): RolloutInfo[] => {
     const api = React.useContext(RolloutAPIContext);
@@ -24,7 +24,7 @@ export const useWatchRollouts = (): ListState<RolloutInfo> => {
     const findRollout = React.useCallback((ri: RolloutInfo, change: RolloutRolloutWatchEvent) => ri.objectMeta.name === change.rolloutInfo?.objectMeta?.name, []);
     const getRollout = React.useCallback((c) => c.rolloutInfo as RolloutInfo, []);
     const namespaceCtx = React.useContext(NamespaceContext);
-    const streamUrl = RolloutServiceApiFetchParamCreator().rolloutServiceWatchRolloutInfos(namespaceCtx.namespace).url;
+    const streamUrl = getApiBasePath() + RolloutServiceApiFetchParamCreator().rolloutServiceWatchRolloutInfos(namespaceCtx.namespace).url;
 
     const init = useRollouts();
     const loading = useLoading(init);
@@ -52,7 +52,7 @@ export const useWatchRollout = (name: string, subscribe: boolean, timeoutAfter?:
 
         return JSON.parse(a.objectMeta.resourceVersion) === JSON.parse(b.objectMeta.resourceVersion);
     }, []);
-    const streamUrl = RolloutServiceApiFetchParamCreator().rolloutServiceWatchRolloutInfo(namespaceCtx.namespace, name).url;
+    const streamUrl = getApiBasePath() + RolloutServiceApiFetchParamCreator().rolloutServiceWatchRolloutInfo(namespaceCtx.namespace, name).url;
     const ri = useWatch<RolloutInfo>(streamUrl, subscribe, isEqual, timeoutAfter);
     if (callback && ri.objectMeta) {
         callback(ri);


### PR DESCRIPTION
Fixes: #2434 

Updating the server to mount the API handler at the rootPath-prefixed path

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
