### PR TITLE
fix: region mapping in Kayenta metric provider

### DIFF
--- a/metricproviders/kayenta/kayenta.go
+++ b/metricproviders/kayenta/kayenta.go
@@ -50,13 +50,21 @@ type AnalysisRequest struct {
 }
 
 type ScopeRequest struct {
-	ControlScope    v1alpha1.ScopeDetail `json:"controlScope"`
-	ExperimentScope v1alpha1.ScopeDetail `json:"experimentScope"`
+	ControlScope    ScopeDetailRequest `json:"controlScope"`
+	ExperimentScope ScopeDetailRequest `json:"experimentScope"`
 }
 
 type ThresholdsRequest struct {
 	Pass     int64 `json:"pass"`
 	Marginal int64 `json:"marginal"`
+}
+
+type ScopeDetailRequest struct {
+	Scope    string `json:"scope"`
+	Location string `json:"location"`
+	Step     int64  `json:"step"`
+	Start    string `json:"start,omitempty"`
+	End      string `json:"end,omitempty"`
 }
 
 // Type indicates provider is a kayenta provider
@@ -282,8 +290,20 @@ func getEndTime(currentTime metav1.Time) string {
 
 func scopeToScopeRequest(scope v1alpha1.KayentaScope) (ScopeRequest, error) {
 	return ScopeRequest{
-		ControlScope:    scope.ControlScope,
-		ExperimentScope: scope.ExperimentScope,
+		ControlScope: ScopeDetailRequest{
+			Scope:    scope.ControlScope.Scope,
+			Location: scope.ControlScope.Region,
+			Step:     scope.ControlScope.Step,
+			Start:    scope.ControlScope.Start,
+			End:      scope.ControlScope.End,
+		},
+		ExperimentScope: ScopeDetailRequest{
+			Scope:    scope.ExperimentScope.Scope,
+			Location: scope.ExperimentScope.Region,
+			Step:     scope.ExperimentScope.Step,
+			Start:    scope.ExperimentScope.Start,
+			End:      scope.ExperimentScope.End,
+		},
 	}, nil
 }
 

--- a/metricproviders/kayenta/kayenta_test.go
+++ b/metricproviders/kayenta/kayenta_test.go
@@ -142,8 +142,8 @@ const expectedBody = `{
 		"default":{
 			"controlScope": {
 				"scope":"app=guestbook and rollouts-pod-template-hash=xxxx",
-				"region":"us-=west-2",
-				"step":60,"start":"2019-03-29T01:08:34Z","end":"2019-03-29T01:38:34Z"}, "experimentScope": {"scope":"app=guestbook and rollouts-pod-template-hash=yyyy","region":"us-=west-2","step":60,"start":"2019-03-29T01:08:34Z","end":"2019-03-29T01:38:34Z"}}	
+				"location":"us-=west-2",
+				"step":60,"start":"2019-03-29T01:08:34Z","end":"2019-03-29T01:38:34Z"}, "experimentScope": {"scope":"app=guestbook and rollouts-pod-template-hash=yyyy","location":"us-=west-2","step":60,"start":"2019-03-29T01:08:34Z","end":"2019-03-29T01:38:34Z"}}	
 	},	
 	"thresholds" : {	
 		"pass": 90,	
@@ -294,7 +294,7 @@ func TestRunBadLookupResponse(t *testing.T) {
 			assert.Equal(t, string(body), `
 							{
 								"scopes": {
-										"default":{"controlScope": {"scope":"app=guestbook and rollouts-pod-template-hash=xxxx","region":"us-=west-2","step":60,"start":"2019-03-29T01:08:34Z","end":"2019-03-29T01:38:34Z"}, "experimentScope": {"scope":"app=guestbook and rollouts-pod-template-hash=yyyy","region":"us-=west-2","step":60,"start":"2019-03-29T01:08:34Z","end":"2019-03-29T01:38:34Z"}}
+										"default":{"controlScope": {"scope":"app=guestbook and rollouts-pod-template-hash=xxxx","location":"us-=west-2","step":60,"start":"2019-03-29T01:08:34Z","end":"2019-03-29T01:38:34Z"}, "experimentScope": {"scope":"app=guestbook and rollouts-pod-template-hash=yyyy","location":"us-=west-2","step":60,"start":"2019-03-29T01:08:34Z","end":"2019-03-29T01:38:34Z"}}
 								},
                                 "thresholds" : {
                                     "pass": 90,
@@ -359,7 +359,7 @@ func TestRunInvalidLookupResponse(t *testing.T) {
 			assert.Equal(t, string(body), `
 							{
 								"scopes": {
-										"default":{"controlScope": {"scope":"app=guestbook and rollouts-pod-template-hash=xxxx","region":"us-=west-2","step":60,"start":"2019-03-29T01:08:34Z","end":"2019-03-29T01:38:34Z"}, "experimentScope": {"scope":"app=guestbook and rollouts-pod-template-hash=yyyy","region":"us-=west-2","step":60,"start":"2019-03-29T01:08:34Z","end":"2019-03-29T01:38:34Z"}}
+										"default":{"controlScope": {"scope":"app=guestbook and rollouts-pod-template-hash=xxxx","location":"us-=west-2","step":60,"start":"2019-03-29T01:08:34Z","end":"2019-03-29T01:38:34Z"}, "experimentScope": {"scope":"app=guestbook and rollouts-pod-template-hash=yyyy","location":"us-=west-2","step":60,"start":"2019-03-29T01:08:34Z","end":"2019-03-29T01:38:34Z"}}
 								},
                                 "thresholds" : {
                                     "pass": 90,


### PR DESCRIPTION
Fix mapping of `region` field, in Kayenta API it's [location](https://github.com/armory-io/spinnaker/blob/de171bc4477bc00d11f416965281da669a3367b8/kayenta/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryScope.java#L36).

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
