### PR TITLE
fix(controller): Always reconcile pod metadata

### DIFF
--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -799,7 +799,8 @@ func filterInformerActions(actions []core.Action) []core.Action {
 			action.Matches("list", "services") ||
 			action.Matches("watch", "services") ||
 			action.Matches("list", "ingresses") ||
-			action.Matches("watch", "ingresses") {
+			action.Matches("watch", "ingresses") ||
+			action.Matches("list", "pods") {
 			continue
 		}
 		ret = append(ret, action)
@@ -846,18 +847,6 @@ func (f *fixture) expectPatchReplicaSetAction(rs *appsv1.ReplicaSet) int {
 func (f *fixture) expectUpdatePodAction(p *corev1.Pod) int {
 	len := len(f.kubeactions)
 	f.kubeactions = append(f.kubeactions, core.NewUpdateAction(schema.GroupVersionResource{Resource: "pods"}, p.Namespace, p))
-	return len
-}
-
-func (f *fixture) expectListPodAction(namespace string) int {
-	len := len(f.kubeactions)
-	f.kubeactions = append(f.kubeactions, core.NewListAction(schema.GroupVersionResource{Resource: "pods"}, schema.GroupVersionKind{Kind: "Pod", Version: "v1"}, namespace, metav1.ListOptions{}))
-	return len
-}
-
-func (f *fixture) expectGetRolloutAction(rollout *v1alpha1.Rollout) int { //nolint:unused
-	len := len(f.actions)
-	f.kubeactions = append(f.actions, core.NewGetAction(schema.GroupVersionResource{Resource: "rollouts"}, rollout.Namespace, rollout.Name))
 	return len
 }
 

--- a/rollout/ephemeralmetadata_test.go
+++ b/rollout/ephemeralmetadata_test.go
@@ -46,7 +46,6 @@ func TestSyncCanaryEphemeralMetadataInitialRevision(t *testing.T) {
 
 	f.expectUpdateRolloutStatusAction(r1)
 	idx := f.expectCreateReplicaSetAction(rs1)
-	f.expectListPodAction(r1.Namespace)
 	f.expectUpdateReplicaSetAction(rs1)
 	_ = f.expectPatchRolloutAction(r1)
 	f.run(getKey(r1, t))
@@ -89,7 +88,6 @@ func TestSyncBlueGreenEphemeralMetadataInitialRevision(t *testing.T) {
 	f.expectPatchRolloutAction(r1)
 	f.expectPatchServiceAction(previewSvc, rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey])
 	f.expectUpdateReplicaSetAction(rs1) // scale replicaset
-	f.expectListPodAction(r1.Namespace)
 	f.run(getKey(r1, t))
 	createdRS1 := f.getCreatedReplicaSet(idx)
 	expectedLabels := map[string]string{
@@ -145,9 +143,7 @@ func TestSyncCanaryEphemeralMetadataSecondRevision(t *testing.T) {
 
 	f.expectUpdateRolloutStatusAction(r2)         // Update Rollout conditions
 	rs2idx := f.expectCreateReplicaSetAction(rs2) // Create revision 2 ReplicaSet
-	f.expectListPodAction(r1.Namespace)
 	rs1idx := f.expectUpdateReplicaSetAction(rs1) // update stable replicaset with stable metadata
-	f.expectListPodAction(r1.Namespace)           // list pods to patch ephemeral data on revision 1 ReplicaSets pods
 	pod1Idx := f.expectUpdatePodAction(&pod1)     // Update pod1 with ephemeral data
 	pod2Idx := f.expectUpdatePodAction(pod2)      // Update pod2 with ephemeral data
 	f.expectUpdateReplicaSetAction(rs1)           // scale revision 1 ReplicaSet down
@@ -231,12 +227,10 @@ func TestSyncBlueGreenEphemeralMetadataSecondRevision(t *testing.T) {
 	rs2idx := f.expectCreateReplicaSetAction(rs2)      // Create revision 2 ReplicaSet
 	f.expectPatchServiceAction(previewSvc, rs2PodHash) // Update preview service to point at revision 2 replicaset
 	f.expectUpdateReplicaSetAction(rs2)                // scale revision 2 ReplicaSet up
-	f.expectListPodAction(r1.Namespace)
-	rs1idx := f.expectUpdateReplicaSetAction(rs1) // update stable replicaset with stable metadata
-	f.expectListPodAction(r1.Namespace)           // list pods to patch ephemeral data on revision 1 ReplicaSets pods`
-	pod1Idx := f.expectUpdatePodAction(&pod1)     // Update pod1 with ephemeral data
-	pod2Idx := f.expectUpdatePodAction(pod2)      // Update pod2 with ephemeral data
-	f.expectPatchRolloutAction(r2)                // Patch Rollout status
+	rs1idx := f.expectUpdateReplicaSetAction(rs1)      // update stable replicaset with stable metadata
+	pod1Idx := f.expectUpdatePodAction(&pod1)          // Update pod1 with ephemeral data
+	pod2Idx := f.expectUpdatePodAction(pod2)           // Update pod2 with ephemeral data
+	f.expectPatchRolloutAction(r2)                     // Patch Rollout status
 
 	f.run(getKey(r2, t))
 	// revision 2 replicaset should been updated to use canary metadata
@@ -365,7 +359,6 @@ func TestSyncCanaryEphemeralMetadataReplicaSetAlreadyPatched(t *testing.T) {
 
 	f.expectPatchRolloutAction(r1)
 	// ReplicaSet should not be updated since it already has the stable metadata
-	f.expectListPodAction(r1.Namespace)
 	// pod1 should not be updated since it already has the stable metadata
 	pod2Idx := f.expectUpdatePodAction(pod2) // Update pod2 with ephemeral data
 
@@ -444,7 +437,6 @@ func TestSyncBlueGreenEphemeralMetadataReplicaSetAlreadyPatched(t *testing.T) {
 	// ReplicaSet should not be updated since it already has the active metadata
 	f.expectPatchServiceAction(previewSvc, rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey])
 	f.expectPatchServiceAction(activeSvc, rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey])
-	f.expectListPodAction(r1.Namespace)
 	// pod1 should not be updated since it already has the active metadata
 	pod2Idx := f.expectUpdatePodAction(pod2) // Update pod2 with ephemeral data
 

--- a/rollout/ephemeralmetadata_test.go
+++ b/rollout/ephemeralmetadata_test.go
@@ -46,6 +46,7 @@ func TestSyncCanaryEphemeralMetadataInitialRevision(t *testing.T) {
 
 	f.expectUpdateRolloutStatusAction(r1)
 	idx := f.expectCreateReplicaSetAction(rs1)
+	f.expectListPodAction(r1.Namespace)
 	f.expectUpdateReplicaSetAction(rs1)
 	_ = f.expectPatchRolloutAction(r1)
 	f.run(getKey(r1, t))
@@ -88,6 +89,7 @@ func TestSyncBlueGreenEphemeralMetadataInitialRevision(t *testing.T) {
 	f.expectPatchRolloutAction(r1)
 	f.expectPatchServiceAction(previewSvc, rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey])
 	f.expectUpdateReplicaSetAction(rs1) // scale replicaset
+	f.expectListPodAction(r1.Namespace)
 	f.run(getKey(r1, t))
 	createdRS1 := f.getCreatedReplicaSet(idx)
 	expectedLabels := map[string]string{
@@ -143,6 +145,7 @@ func TestSyncCanaryEphemeralMetadataSecondRevision(t *testing.T) {
 
 	f.expectUpdateRolloutStatusAction(r2)         // Update Rollout conditions
 	rs2idx := f.expectCreateReplicaSetAction(rs2) // Create revision 2 ReplicaSet
+	f.expectListPodAction(r1.Namespace)
 	rs1idx := f.expectUpdateReplicaSetAction(rs1) // update stable replicaset with stable metadata
 	f.expectListPodAction(r1.Namespace)           // list pods to patch ephemeral data on revision 1 ReplicaSets pods
 	pod1Idx := f.expectUpdatePodAction(&pod1)     // Update pod1 with ephemeral data
@@ -228,11 +231,12 @@ func TestSyncBlueGreenEphemeralMetadataSecondRevision(t *testing.T) {
 	rs2idx := f.expectCreateReplicaSetAction(rs2)      // Create revision 2 ReplicaSet
 	f.expectPatchServiceAction(previewSvc, rs2PodHash) // Update preview service to point at revision 2 replicaset
 	f.expectUpdateReplicaSetAction(rs2)                // scale revision 2 ReplicaSet up
-	rs1idx := f.expectUpdateReplicaSetAction(rs1)      // update stable replicaset with stable metadata
-	f.expectListPodAction(r1.Namespace)                // list pods to patch ephemeral data on revision 1 ReplicaSets pods`
-	pod1Idx := f.expectUpdatePodAction(&pod1)          // Update pod1 with ephemeral data
-	pod2Idx := f.expectUpdatePodAction(pod2)           // Update pod2 with ephemeral data
-	f.expectPatchRolloutAction(r2)                     // Patch Rollout status
+	f.expectListPodAction(r1.Namespace)
+	rs1idx := f.expectUpdateReplicaSetAction(rs1) // update stable replicaset with stable metadata
+	f.expectListPodAction(r1.Namespace)           // list pods to patch ephemeral data on revision 1 ReplicaSets pods`
+	pod1Idx := f.expectUpdatePodAction(&pod1)     // Update pod1 with ephemeral data
+	pod2Idx := f.expectUpdatePodAction(pod2)      // Update pod2 with ephemeral data
+	f.expectPatchRolloutAction(r2)                // Patch Rollout status
 
 	f.run(getKey(r2, t))
 	// revision 2 replicaset should been updated to use canary metadata
@@ -260,10 +264,18 @@ func TestSyncBlueGreenEphemeralMetadataSecondRevision(t *testing.T) {
 }
 
 func TestReconcileEphemeralMetadata(t *testing.T) {
-	newRS := &v1.ReplicaSet{}
-	stableRS := &v1.ReplicaSet{}
+	selector := &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}
+	newRS := &v1.ReplicaSet{
+		Spec: v1.ReplicaSetSpec{Selector: selector},
+	}
+	stableRS := &v1.ReplicaSet{
+		Spec: v1.ReplicaSetSpec{Selector: selector},
+	}
 
 	mockContext := &rolloutContext{
+		reconcilerBase: reconcilerBase{
+			kubeclientset: k8sfake.NewSimpleClientset(),
+		},
 		rollout: &v1alpha1.Rollout{
 			Spec: v1alpha1.RolloutSpec{
 				Strategy: v1alpha1.RolloutStrategy{
@@ -279,7 +291,11 @@ func TestReconcileEphemeralMetadata(t *testing.T) {
 		},
 		newRS:    newRS,
 		stableRS: stableRS,
-		otherRSs: []*v1.ReplicaSet{new(v1.ReplicaSet), new(v1.ReplicaSet)},
+		otherRSs: []*v1.ReplicaSet{{
+			Spec: v1.ReplicaSetSpec{Selector: selector},
+		}, {
+			Spec: v1.ReplicaSetSpec{Selector: selector},
+		}},
 	}
 
 	// Scenario 1: upgrading state when the new ReplicaSet is a canary
@@ -290,6 +306,158 @@ func TestReconcileEphemeralMetadata(t *testing.T) {
 	mockContext.rollout.Status.StableRS = "" // Set stable ReplicaSet to empty to simulate an upgrading state
 	err = mockContext.reconcileEphemeralMetadata()
 	assert.NoError(t, err)
+}
+
+// TestSyncCanaryEphemeralMetadataReplicaSetAlreadyPatched verifies that even if the ephemeral metadata of a ReplicaSet
+// already has been patched, then it still patches the pods of the ReplicaSet that do not have the metadata yet.
+func TestSyncCanaryEphemeralMetadataReplicaSetAlreadyPatched(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	r1 := newCanaryRollout("foo", 3, nil, nil, ptr.To[int32](1), intstr.FromInt32(1), intstr.FromInt32(1))
+	r1.Annotations[annotations.RevisionAnnotation] = "1"
+	r1.Spec.Strategy.Canary.CanaryMetadata = &v1alpha1.PodTemplateMetadata{
+		Labels: map[string]string{
+			"role": "canary",
+		},
+	}
+	r1.Spec.Strategy.Canary.StableMetadata = &v1alpha1.PodTemplateMetadata{
+		Labels: map[string]string{
+			"role": "stable",
+		},
+	}
+
+	// Create a ReplicaSet that already has the stable metadata label
+	rs1 := newReplicaSetWithStatus(r1, 3, 3)
+	rs1.Spec.Template.Labels = map[string]string{
+		"role": "stable",
+	}
+
+	rsGVK := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"}
+
+	// pod1 already has the stable metadata label and should not be updated
+	pod1 := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo-abc123",
+			Namespace: r1.Namespace,
+			Labels: map[string]string{
+				"foo":                        "bar",
+				"role":                       "stable",
+				"rollouts-pod-template-hash": r1.Status.CurrentPodHash,
+			},
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(rs1, rsGVK)},
+		},
+	}
+
+	// pod2 does not have the stable metadata label and must be updated
+	pod2 := pod1.DeepCopy()
+	pod2.Name = "foo-abc456"
+	pod2.Labels = map[string]string{
+		"foo":                        "bar",
+		"role":                       "canary",
+		"rollouts-pod-template-hash": r1.Status.CurrentPodHash,
+	}
+
+	f.rolloutLister = append(f.rolloutLister, r1)
+	f.objects = append(f.objects, r1)
+	f.kubeobjects = append(f.kubeobjects, rs1, &pod1, pod2)
+	f.replicaSetLister = append(f.replicaSetLister, rs1)
+
+	f.expectPatchRolloutAction(r1)
+	// ReplicaSet should not be updated since it already has the stable metadata
+	f.expectListPodAction(r1.Namespace)
+	// pod1 should not be updated since it already has the stable metadata
+	pod2Idx := f.expectUpdatePodAction(pod2) // Update pod2 with ephemeral data
+
+	f.run(getKey(r1, t))
+
+	// pod2 should have been updated to have the stable metadata
+	expectedPodLabels := map[string]string{
+		"foo":                        "bar",
+		"role":                       "stable",
+		"rollouts-pod-template-hash": r1.Status.CurrentPodHash,
+	}
+	updatedPod2 := f.getUpdatedPod(pod2Idx)
+	assert.Equal(t, expectedPodLabels, updatedPod2.Labels)
+}
+
+// TestSyncBlueGreenEphemeralMetadataReplicaSetAlreadyPatched verifies that even if the ephemeral metadata of a ReplicaSet
+// already has been patched, then it still patches the pods of the ReplicaSet that do not have the metadata yet.
+func TestSyncBlueGreenEphemeralMetadataReplicaSetAlreadyPatched(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	r1 := newBlueGreenRollout("foo", 3, nil, "active", "preview")
+	r1.Annotations[annotations.RevisionAnnotation] = "1"
+	r1.Spec.Strategy.BlueGreen.PreviewMetadata = &v1alpha1.PodTemplateMetadata{
+		Labels: map[string]string{
+			"role": "preview",
+		},
+	}
+	r1.Spec.Strategy.BlueGreen.ActiveMetadata = &v1alpha1.PodTemplateMetadata{
+		Labels: map[string]string{
+			"role": "active",
+		},
+	}
+
+	// Create a ReplicaSet that already has the active metadata label
+	rs1 := newReplicaSetWithStatus(r1, 3, 3)
+	rs1.Spec.Template.Labels = map[string]string{
+		"role": "active",
+	}
+
+	rsGVK := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"}
+
+	// pod1 already has the active metadata label and should not be updated
+	pod1 := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo-abc123",
+			Namespace: r1.Namespace,
+			Labels: map[string]string{
+				"foo":                        "bar",
+				"role":                       "active",
+				"rollouts-pod-template-hash": r1.Status.CurrentPodHash,
+			},
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(rs1, rsGVK)},
+		},
+	}
+
+	// pod2 does not have the active metadata label and must be updated
+	pod2 := pod1.DeepCopy()
+	pod2.Name = "foo-abc456"
+	pod2.Labels = map[string]string{
+		"foo":                        "bar",
+		"role":                       "preview",
+		"rollouts-pod-template-hash": r1.Status.CurrentPodHash,
+	}
+
+	previewSvc := newService("preview", 80, nil, r1)
+	activeSvc := newService("active", 80, nil, r1)
+
+	f.rolloutLister = append(f.rolloutLister, r1)
+	f.objects = append(f.objects, r1)
+	f.kubeobjects = append(f.kubeobjects, rs1, &pod1, pod2, previewSvc, activeSvc)
+	f.replicaSetLister = append(f.replicaSetLister, rs1)
+	f.serviceLister = append(f.serviceLister, activeSvc, previewSvc)
+
+	f.expectPatchRolloutAction(r1)
+	// ReplicaSet should not be updated since it already has the active metadata
+	f.expectPatchServiceAction(previewSvc, rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey])
+	f.expectPatchServiceAction(activeSvc, rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey])
+	f.expectListPodAction(r1.Namespace)
+	// pod1 should not be updated since it already has the active metadata
+	pod2Idx := f.expectUpdatePodAction(pod2) // Update pod2 with ephemeral data
+
+	f.run(getKey(r1, t))
+
+	// pod2 should have been updated to have the active metadata
+	expectedPodLabels := map[string]string{
+		"foo":                        "bar",
+		"role":                       "active",
+		"rollouts-pod-template-hash": r1.Status.CurrentPodHash,
+	}
+	updatedPod2 := f.getUpdatedPod(pod2Idx)
+	assert.Equal(t, expectedPodLabels, updatedPod2.Labels)
 }
 
 // TestSyncEphemeralMetadata verifies that syncEphemeralMetadata correctly applies metadata to pods


### PR DESCRIPTION
Fixes #4256 

This addresses an issue we observe often: pod metadata is not consistent.

## Example

Rollout is done.

```
kubectl argo rollouts list rollouts -A
NAMESPACE      NAME                                         STRATEGY   STATUS        STEP   SET-WEIGHT  READY  DESIRED  UP-TO-DATE  AVAILABLE
platform       portal-app-rollout                           Canary     Healthy       10/10  100         2/2    2        2           2
```

A single ReplicaSet has replicas:
```
kubectl get replicaset -n platform | grep portal
...
portal-app-rollout-58ff85fcb                                          2         2         2       17h
```

With the correct spec:
```
spec:
  replicas: 2
  template:
    metadata:
      labels:
        ...
        role: stable
```

Yet, some pods don't have the expected labels:
```
kubectl get pods -n platform -l app=portal --show-labels         
NAME                                 READY   STATUS    RESTARTS   AGE   LABELS
portal-app-rollout-58ff85fcb-bk7kr   2/2     Running   0          17h   ...role=canary...
portal-app-rollout-58ff85fcb-tqd98   2/2     Running   0          17h   ...role=stable...
```

Reconciliation happens and does nothing to fix this:
```
time="2025-10-01T18:41:16Z" level=info msg="Started syncing rollout" generation=314 namespace=platform resourceVersion=398118957 rollout=portal-app-rollout
time="2025-10-01T18:41:16Z" level=info msg="Found 1 TrafficRouting Reconcilers" namespace=platform rollout=portal-app-rollout
time="2025-10-01T18:41:16Z" level=info msg="Reconciling TrafficRouting with type 'Istio'" namespace=platform rollout=portal-app-rollout
time="2025-10-01T18:41:16Z" level=info msg="No StableRS exists to reconcile or matches newRS" namespace=platform rollout=portal-app-rollout
time="2025-10-01T18:41:16Z" level=info msg="No Steps remain in the canary steps" namespace=platform rollout=portal-app-rollout
time="2025-10-01T18:41:16Z" level=info msg="No status changes. Skipping patch" generation=314 namespace=platform resourceVersion=398118957 rollout=portal-app-rollout
time="2025-10-01T18:41:16Z" level=info msg="Reconciliation completed" generation=314 namespace=platform resourceVersion=398118957 rollout=portal-app-rollout time_ms=61.302378
```

## Why does it matter?
We have PDBs on `role=stable` and the mismtach between the RS replica count and the Pods actually matching the label leads to PDB preventing any change. 

## Root Cause

This is because the code bails if the ReplicaSet metadata matches what it should be. So if for any reason: pod update failure, crash, OOM, etc... one of the pod is not updated after the ReplicaSet is updated the first time, the controller will never try to rectify this and the inconsistent state will stay.

Also, the race condition is still present. Between the ReplicaSet update and the Pod listing. It is entirely possible that the ReplicaSet controller is reconciling on the old spec and creates a Pod with the old spec, after the Pod listing.

This ensure the logic to update pod metadata always runs, which is mostly fine efficiency-wise because the current code already doesn't patch pod in the correct state, so it would be a Pod list call at most in the standard case.

## Testing
Asserting on reads doesn't seem to be a pattern and has little value. It would require 80 tests to be updated, makes more sense to ignore it.

The increased reconciliation time reveals a racy behavior in the e2e tests, especially around `promote`.
I added logic to make sure the controller has done its job before promote is applied.

---
Checklist:
* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [X] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [X] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [X] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
  * https://github.com/argoproj/argo-rollouts/pull/4476
