### PR TITLE
docs: Fix typos and linguistic errors in documentation / hacktoberfest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -839,9 +839,9 @@
 
 ### Fix
 
-* make new alb fullName field  optional for backward compatability ([#2806](https://github.com/argoproj/argo-rollouts/issues/2806))
+* make new alb fullName field  optional for backward compatibility ([#2806](https://github.com/argoproj/argo-rollouts/issues/2806))
 * cloudwatch metrics provider multiple dimensions ([#2932](https://github.com/argoproj/argo-rollouts/issues/2932))
-*  rollout not modify the VirtualService whit setHeaderRoute step with workloadRef ([#2797](https://github.com/argoproj/argo-rollouts/issues/2797))
+*  rollout not modify the VirtualService with setHeaderRoute step with workloadRef ([#2797](https://github.com/argoproj/argo-rollouts/issues/2797))
 * get new httpRoutesI after removeRoute() to avoid duplicates. Fixes [#2769](https://github.com/argoproj/argo-rollouts/issues/2769) ([#2887](https://github.com/argoproj/argo-rollouts/issues/2887))
 * change logic of analysis run to better handle errors ([#2695](https://github.com/argoproj/argo-rollouts/issues/2695))
 * istio dropping fields during removing of managed routes ([#2692](https://github.com/argoproj/argo-rollouts/issues/2692))
@@ -883,7 +883,7 @@ types.
 
 ### Fix
 
-* make new alb fullName field  optional for backward compatability ([#2806](https://github.com/argoproj/argo-rollouts/issues/2806))
+* make new alb fullName field  optional for backward compatibility ([#2806](https://github.com/argoproj/argo-rollouts/issues/2806))
 * properly wrap Datadog API v2 request body ([#2771](https://github.com/argoproj/argo-rollouts/issues/2771)) ([#2775](https://github.com/argoproj/argo-rollouts/issues/2775))
 
 
@@ -1083,7 +1083,7 @@ There was an unintentional change in behavior related to service creation with e
 
 ### Build
 
-* use fixed docker repository because we can't reach accross jobs ([#2474](https://github.com/argoproj/argo-rollouts/issues/2474))
+* use fixed docker repository because we can't reach across jobs ([#2474](https://github.com/argoproj/argo-rollouts/issues/2474))
 * copy proto files from GOPATH so we can clone outside of GOPATH ([#2360](https://github.com/argoproj/argo-rollouts/issues/2360))
 * add sha256 checksums for all released bins ([#2332](https://github.com/argoproj/argo-rollouts/issues/2332))
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Argo Rollouts is a Kubernetes controller and set of CRDs which provide advanced 
 
 Argo Rollouts (optionally) integrates with ingress controllers and service meshes, leveraging their traffic shaping abilities to gradually shift traffic to the new version during an update. Additionally, Rollouts can query and interpret metrics from various providers to verify key KPIs and drive automated promotion or rollback during an update.
 
-[![Argo Rollotus Demo](https://img.youtube.com/vi/hIL0E2gLkf8/0.jpg)](https://youtu.be/hIL0E2gLkf8)
+[![Argo Rollouts Demo](https://img.youtube.com/vi/hIL0E2gLkf8/0.jpg)](https://youtu.be/hIL0E2gLkf8)
 
 ## Quick Start
 

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -176,7 +176,7 @@ Each time a change occurs in the ConfigMap, its name will change in the Deployme
 
 However, it's not enough to perform correctly progressive rollouts, as the old ConfigMap might get deleted as soon as the new one is created. This would prevent Experiments and rollbacks in case of rollout failure to work correctly.
 
-While no magical solution exist to work aroud that, you can tweak your deployment tool to remove the ConfigMap only when the Rollout is completed successfully.
+While no magical solution exists to work around that, you can tweak your deployment tool to remove the ConfigMap only when the Rollout is completed successfully.
 
 Example with Argo CD:
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -33,7 +33,7 @@ While the industry has used a consistent terminology to describe various deploym
 A `RollingUpdate` slowly replaces the old version with the new version. As the new version comes up, the old version is scaled down in order to maintain the overall count of the application. This is the default strategy of the Deployment object.
 
 ### Recreate
-A Recreate deployment deletes the old version of the application before bring up the new version. As a result, this ensures that two versions of the application never run at the same time, but there is downtime during the deployment.
+A Recreate deployment deletes the old version of the application before bringing up the new version. As a result, this ensures that two versions of the application never run at the same time, but there is downtime during the deployment.
 
 ### Blue-Green
 A Blue-Green deployment (sometimes referred to as a Red-Black) has both the new and old version of the application deployed at the same time.  During this time, only the old version of the application will receive production traffic. This allows the developers to run tests against the new version before switching the live traffic to the new version.

--- a/docs/features/canary/index.md
+++ b/docs/features/canary/index.md
@@ -132,7 +132,7 @@ spec:
         - pause: {}
 ```
 
-The above situation is caused by the changed behvaior of `setWeight` after `setCanaryScale`. To reset, set `matchTrafficWeight: true` and the `setWeight` behavior will be restored, i.e., subsequent `setWeight` will create canary replicas matching the traffic weight.
+The above situation is caused by the changed behavior of `setWeight` after `setCanaryScale`. To reset, set `matchTrafficWeight: true` and the `setWeight` behavior will be restored, i.e., subsequent `setWeight` will create canary replicas matching the traffic weight.
 
 ## Dynamic Stable Scale (with Traffic Routing)
 

--- a/docs/features/kubectl-plugin.md
+++ b/docs/features/kubectl-plugin.md
@@ -8,7 +8,7 @@ Argo Rollouts offers a Kubectl plugin to enrich the experience with Rollouts, Ex
 See the [installation guide](../installation.md) for instructions on installing the plugin.
 
 ## Usage
-The best way to get information on the available Argo Rollouts kubectl plugin commands is by run `kubectl argo rollouts`. The plugin lists all the available commands that the tool can execute along with a description of each commend. All the plugin's commands interact with the Kubernetes API server and use KubeConfig credentials for authentication. Since the plugin leverages the KubeConfig of the user running the command, the plugin has the permissions of those configs. 
+The best way to get information on the available Argo Rollouts kubectl plugin commands is by running `kubectl argo rollouts`. The plugin lists all the available commands that the tool can execute along with a description of each command. All the plugin's commands interact with the Kubernetes API server and use KubeConfig credentials for authentication. Since the plugin leverages the KubeConfig of the user running the command, the plugin has the permissions of those configs. 
 
 Similar to kubectl, the plugin uses many of the same flags as the kubectl. For example, the `kubectl argo rollouts get rollout canary-demo -w` command starts a watch on the `canary-demo` rollout object similar to how the `kubectl get deployment canary-demo -w` command starts a watch on a deployment.
 

--- a/docs/features/traffic-management/alb.md
+++ b/docs/features/traffic-management/alb.md
@@ -51,7 +51,7 @@ spec:
           # the AWS Load Balancer Controller to split traffic between the canary and stable
           # Service, according to the desired traffic weight (required).
           ingress: ingress
-          # If you want to controll multiple ingress resources you can use the ingresses field, if ingresses is specified
+          # If you want to control multiple ingress resources you can use the ingresses field, if ingresses is specified
           # the ingress field will need to be omitted.
           ingresses:
            - ingress-1

--- a/docs/proposals/step-plugin.md
+++ b/docs/proposals/step-plugin.md
@@ -293,7 +293,7 @@ A utility function such as `PluginHelper.GetStatuses(rollout, pluginName)` can b
 A parameter such as `abortOnFailure` can be added to the Rollout plugin step configuration object.
 When specified, the controller can use the value to modify the default logic.
 
-##### I dont want my plugin execution time to count towards the progress deadline
+##### I don't want my plugin execution time to count towards the progress deadline
 
 A parameter such as `ignoreProgressDeadline` can be added to the Rollout plugin step configuration object.
 When specified, the controller can use the value to modify the default logic.


### PR DESCRIPTION

Fix typos and linguistic errors in documentation.  It's not much, but I'm happy to help


Checklist:

* [ X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [X ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ X] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
