### PR TITLE
chore: Use current Kubernetes version for testing

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -75,13 +75,13 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes:
-          - version: '1.28'
-            latest: false
-          - version: '1.29'
-            latest: false
-          - version: '1.30'
-            latest: false
           - version: '1.31'
+            latest: false
+          - version: '1.32'
+            latest: false
+          - version: '1.33'
+            latest: false
+          - version: '1.34'
             latest: true
     name: Run end-to-end tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Not sure why it is still using versions that are way past EOL.

This will require an admin to change the required checks in GitHub.