### PR TITLE
docs(analysis): Update analysis docs on valueFrom arg support

### DIFF
--- a/docs/features/analysis.md
+++ b/docs/features/analysis.md
@@ -646,7 +646,8 @@ spec:
 
 !!! important
     Available since v1.2
-Analysis arguments also support valueFrom for reading any field from Rollout status and passing them as arguments to AnalysisTemplate.
+Analysis arguments also support valueFrom for reading any field from Rollout status or Rollout pod template and passing them as arguments to AnalysisTemplate.
+
 Following example references Rollout status field like aws canaryTargetGroup name and passing them along to AnalysisTemplate
 
 from the Rollout status
@@ -674,6 +675,39 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.alb.canaryTargetGroup.name
+```
+
+Following example references Rollout pod template metadata field like version and passing them along to AnalysisTemplate
+
+from the Rollout pod template
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: guestbook
+  ...
+spec:
+...
+  strategy:
+    canary:
+      analysis:
+        templates:
+        - templateName: args-example
+        args:
+        ...
+        - name: rollout-version
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.template.metadata.labels.version
+  ...
+  template:
+    metadata:
+      labels:
+        version: "1"
+    spec:
+      containers:
+      - name: rollouts-demo
+        image: argoproj/rollouts-demo:blue
 ```
 
 ## BlueGreen Pre Promotion Analysis

--- a/utils/analysis/factory_test.go
+++ b/utils/analysis/factory_test.go
@@ -497,6 +497,15 @@ func Test_extractValueFromRollout(t *testing.T) {
 				},
 			},
 		},
+		Spec: v1alpha1.RolloutSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"version": "v1",
+					},
+				},
+			},
+		},
 	}
 	tests := map[string]struct {
 		path    string
@@ -538,6 +547,10 @@ func Test_extractValueFromRollout(t *testing.T) {
 		"should fail when path references a non-primitive value": {
 			path:    "status.pauseConditions[0]",
 			wantErr: "path status.pauseConditions[0] in rollout must terminate in a primitive value",
+		},
+		"should return a pod template label using dot notation": {
+			path: "spec.template.metadata.labels.version",
+			want: "v1",
 		},
 	}
 	for name, tt := range tests {


### PR DESCRIPTION
Update [Analysis Template Arguments](https://argo-rollouts.readthedocs.io/en/stable/features/analysis/#analysis-template-arguments) documentation to mention that `valueFrom` with dot notation works for any field in the Rollout pod template, along with the new test case demonstrating this behavior.

For more information, please follow this issue: https://github.com/argoproj/argo-rollouts/issues/4504

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
