### PR TITLE
fix(trafficrouting): Verify ALB TG health before final canary step. Fixes #4433

### DIFF
--- a/rollout/bluegreen.go
+++ b/rollout/bluegreen.go
@@ -53,7 +53,7 @@ func (c *rolloutContext) rolloutBlueGreen() error {
 		return err
 	}
 
-	err = c.awsVerifyTargetGroups(activeSvc)
+	err = c.awsVerifyTargetGroups(activeSvc, false)
 	if err != nil {
 		return err
 	}

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -316,7 +316,7 @@ func (c *rolloutContext) canProceedWithScaleDownAnnotation(oldRSs []*appsv1.Repl
 	if err != nil {
 		return false, err
 	}
-	err = c.awsVerifyTargetGroups(stableSvc)
+	err = c.awsVerifyTargetGroups(stableSvc, false)
 	if err != nil {
 		return false, err
 	}

--- a/rollout/service.go
+++ b/rollout/service.go
@@ -130,7 +130,7 @@ func (c *rolloutContext) areTargetsVerified() bool {
 // of the Service's Endpoint IPs and ports registered. Only valid for services which are reachable
 // by an ALB Ingress, which can be determined if there exists a TargetGroupBinding object in the
 // namespace that references the given service
-func (c *rolloutContext) awsVerifyTargetGroups(svc *corev1.Service) error {
+func (c *rolloutContext) awsVerifyTargetGroups(svc *corev1.Service, checkHealth bool) error {
 	if !shouldVerifyTargetGroup(c.rollout, c.newRS, svc) {
 		return nil
 	}
@@ -162,7 +162,7 @@ func (c *rolloutContext) awsVerifyTargetGroups(svc *corev1.Service) error {
 	}
 
 	for _, tgb := range tgBindings {
-		verifyRes, err := aws.VerifyTargetGroupBinding(ctx, c.log, awsClnt, tgb, endpoints, svc)
+		verifyRes, err := aws.VerifyTargetGroupBinding(ctx, c.log, awsClnt, tgb, endpoints, svc, checkHealth)
 		if err != nil {
 			c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: conditions.TargetGroupVerifyErrorReason}, conditions.TargetGroupVerifyErrorMessage, svc.Name, tgb.Spec.TargetGroupARN, err)
 			return err

--- a/utils/aws/aws_test.go
+++ b/utils/aws/aws_test.go
@@ -303,7 +303,7 @@ func TestVerifyTargetGroupBindingIgnoreInstanceMode(t *testing.T) {
 			TargetType: (*TargetType)(ptr.To[string]("instance")),
 		},
 	}
-	res, err := VerifyTargetGroupBinding(context.TODO(), logCtx, awsClnt, tgb, nil, nil)
+	res, err := VerifyTargetGroupBinding(context.TODO(), logCtx, awsClnt, tgb, nil, nil, false)
 	assert.Nil(t, res)
 	assert.NoError(t, err)
 }
@@ -395,7 +395,7 @@ func TestVerifyTargetGroupBinding(t *testing.T) {
 		},
 	}
 	fakeELB.On("DescribeTargetHealth", mock.Anything, mock.Anything).Return(&thOut, nil)
-	res, err := VerifyTargetGroupBinding(context.TODO(), logCtx, awsClnt, tgb, &ep, &svc)
+	res, err := VerifyTargetGroupBinding(context.TODO(), logCtx, awsClnt, tgb, &ep, &svc, false)
 	expectedRes := TargetGroupVerifyResult{
 		Service:             "active",
 		Verified:            false,


### PR DESCRIPTION
Verify ALB target group health before applying the final weight patch to prevent a race condition where new pods are not yet healthy after a selector change, which can cause the ALB to return 503 errors when routing 100% of traffic.

Fixes: https://github.com/argoproj/argo-rollouts/issues/4433

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
