### PR TITLE
revert: PR #4074

### DIFF
--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -371,15 +371,6 @@ func (c *rolloutContext) syncRolloutStatusCanary() error {
 	newStatus.HPAReplicas = replicasetutil.GetActualReplicaCountForReplicaSets(c.allRSs)
 	newStatus.Selector = metav1.FormatLabelSelector(c.rollout.Spec.Selector)
 
-	if c.rollout.Spec.Strategy.Canary != nil && c.rollout.Spec.Strategy.Canary.TrafficRouting != nil && !c.rollout.Spec.Strategy.Canary.DynamicStableScale && c.stableRS != nil {
-		// When using traffic routed canary without scaling down the stable replicaset, the number of pods
-		// selected by the rollout selector will be up to twice the amount of desired spec.replicas.
-		// We update the selector to select the stable pods since the Scale subresource expects a
-		// label that queries over pods that should match the replicas count, because that is the number
-		// of pods that will be receiving traffic.
-		newStatus.Selector = metav1.FormatLabelSelector(c.stableRS.Spec.Selector)
-	}
-
 	newStatus.Canary.StablePingPong = c.rollout.Status.Canary.StablePingPong
 	newStatus.Canary.StepPluginStatuses = c.rollout.Status.Canary.StepPluginStatuses
 	c.stepPluginContext.updateStatus(&newStatus)

--- a/rollout/service_test.go
+++ b/rollout/service_test.go
@@ -495,15 +495,10 @@ func TestCanaryAWSVerifyTargetGroupsNotYetReady(t *testing.T) {
 	f.ingressLister = append(f.ingressLister, ingressutil.NewLegacyIngress(ing))
 
 	f.expectGetEndpointsAction(ep)
-	rolloutPatchIndex := f.expectPatchRolloutAction(r2)
 	f.run(getKey(r2, t))
 	f.assertEvents([]string{
 		conditions.TargetGroupUnverifiedReason,
 	})
-	patch := f.getPatchedRollout(rolloutPatchIndex)
-	// NOTE: Similar to other tests, the hash must be updated for every k8s library upgrade
-	expectedPatch := `{"status":{"selector":"foo=bar,rollouts-pod-template-hash=5cb4fd98cf"}}`
-	assert.JSONEq(t, expectedPatch, patch)
 }
 
 // TestCanaryAWSVerifyTargetGroupsReady verifies we proceed with scale down of old
@@ -601,16 +596,11 @@ func TestCanaryAWSVerifyTargetGroupsReady(t *testing.T) {
 	f.expectGetEndpointsAction(ep)
 	scaleDownRSIndex := f.expectPatchReplicaSetAction(rs1)
 
-	rolloutPatchIndex := f.expectPatchRolloutAction(r2)
 	f.run(getKey(r2, t))
 	f.verifyPatchedReplicaSet(scaleDownRSIndex, 30)
 	f.assertEvents([]string{
 		conditions.TargetGroupVerifiedReason,
 	})
-	patch := f.getPatchedRollout(rolloutPatchIndex)
-	// NOTE: Similar to other tests, the hash must be updated for every k8s library upgrade
-	expectedPatch := `{"status":{"selector":"foo=bar,rollouts-pod-template-hash=5cb4fd98cf"}}`
-	assert.JSONEq(t, expectedPatch, patch)
 }
 
 // TestCanaryAWSVerifyTargetGroupsSkip verifies we skip unnecessary verification if scaledown
@@ -668,14 +658,8 @@ func TestCanaryAWSVerifyTargetGroupsSkip(t *testing.T) {
 	f.serviceLister = append(f.serviceLister, rootSvc, canarySvc, stableSvc)
 	f.ingressLister = append(f.ingressLister, ingressutil.NewLegacyIngress(ing))
 
-	patchIndex := f.expectPatchRolloutAction(r2)
 	f.run(getKey(r2, t)) // there should be no api calls
 	f.assertEvents(nil)
-
-	patch := f.getPatchedRollout(patchIndex)
-	// NOTE: Similar to other tests, the hash must be updated for every k8s library upgrade
-	expectedPatch := `{"status":{"selector":"foo=bar,rollouts-pod-template-hash=5cb4fd98cf"}}`
-	assert.Equal(t, expectedPatch, patch)
 }
 
 // TestShouldVerifyTargetGroups returns whether or not we should verify the target group

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -840,15 +840,10 @@ func TestCanaryWithTrafficRoutingAddScaleDownDelay(t *testing.T) {
 	f.rolloutLister = append(f.rolloutLister, r2)
 	f.objects = append(f.objects, r2)
 
-	rs1Patch := f.expectPatchReplicaSetAction(rs1)      // set scale-down-deadline annotation
-	rolloutPatchIndex := f.expectPatchRolloutAction(r2) // patch to update rollout status, hpa selector
+	rs1Patch := f.expectPatchReplicaSetAction(rs1) // set scale-down-deadline annotation
 	f.run(getKey(r2, t))
 
 	f.verifyPatchedReplicaSet(rs1Patch, 30)
-	updatedRollout := f.getPatchedRollout(rolloutPatchIndex)
-	// NOTE: The hash must be updated for every k8s library upgrade
-	expectedRolloutPatch := `{"status":{"selector":"foo=bar,rollouts-pod-template-hash=5cb4fd98cf"}}`
-	assert.JSONEq(t, expectedRolloutPatch, updatedRollout)
 }
 
 // Verifies with a canary using traffic routing, we scale down old ReplicaSets which exceed our limit


### PR DESCRIPTION
While PR #4074 attempted to fix the issues with value type metrics as seen [here](https://cloud-native.slack.com/archives/C01U781DW2E/p1764033025944389) we did cause some un-intended breaking changes with other metric types like utilization. There was also a bug in the PR to not update the `.status.HPAReplicas` to stable.

Therefore, we will revert this PR for the 1.9 release and look into providing some configuration options possibly to address the issue of there not being a method of metric/HPA calculation that works for both Utilization metrics and Value/Object metrics at the same time.

#### Note

That even with this revert Utilization metrics have a not perfect interaction with metrics because the metric gets diluted by pods not taking traffic which can cause improper scaling this would only take place during an active rollout. This however is the status quo so sticking with that for the time being.


## The Problem

When doing a canary rollout with traffic routing (without `dynamicStableScale`), you temporarily have **two sets of pods**:
- **Stable pods** (old version)
- **Canary pods** (new version)

The HPA needs to know two things:
1. **How many pods exist?** (from `.status.HPAReplicas`)
2. **Which pods to check metrics for?** (from `.status.selector`)

## The Conflict

Different HPA metric types need different things:

### Value Metrics (e.g., "handle 1000 total requests")
- **Needs:** `HPAReplicas` = 10 (your configured spec.replicas)
- **Problem:** During rollout, `HPAReplicas` = 15 (10 stable + 5 canary)
- **Result:** HPA thinks you need 15 pods instead of 10

### Utilization Metrics (e.g., "keep pods at 50% CPU")
- **Needs:** Selector to query metrics from pods actually receiving traffic
- **Problem:** If selector points to stable pods while canary has all traffic, HPA sees 0% CPU
- **Result:** HPA scales down to minimum while your app is busy

## What PR #4074 Did

Changed selector to only point to stable pods to fix Value metrics.

**Broke:** Utilization metrics (more common, maybe?) - caused scale-down to minimum at high canary traffic percentages.

## What the Revert Does

Changes selector back to pointing to all pods.

**Fixes:** Utilization metrics work again (no catastrophic scale-downs)
**Breaks:** Value metrics see inflated pod count during rollouts

**Note:** Even with the revert, Utilization metrics still have issues with traffic routing:
- Pods receive different amounts of traffic based on weights
- At `setWeight: 50`, stable pods get 50% traffic (lower CPU), canary gets 50% traffic (higher CPU per pod)
- HPA averages across all pods, which dilutes the metric
- Not catastrophic like PR #4074, but not perfect either