### PR TITLE
chore: don't use httpbin.org it's flaky

### DIFF
--- a/test/e2e/functional/analysistemplate-web-background-inconclusive.yaml
+++ b/test/e2e/functional/analysistemplate-web-background-inconclusive.yaml
@@ -1,4 +1,4 @@
-# A web metric which uses Google Books API (returns JSON)
+# A web metric which uses Google Public DNS-over-HTTPS API (returns JSON)
 # The conditions check for values that won't match the actual response,
 # causing measurements to be inconclusive (neither success nor failure)
 apiVersion: argoproj.io/v1alpha1
@@ -8,13 +8,13 @@ metadata:
 spec:
   args:
     - name: url-val
-      value: "https://www.googleapis.com/books/v1/volumes?q=isbn:0747532699"
+      value: "https://dns.google/resolve?name=google.com"
   metrics:
     - name: web
       interval: 5s
       inconclusiveLimit: 3
-      successCondition: result.kind == "will-never-match"
-      failureCondition: result.kind == "also-will-never-match"
+      successCondition: result.Status == 999
+      failureCondition: result.Status == -1
       provider:
         web:
           url: "{{args.url-val}}"

--- a/test/e2e/functional/analysistemplate-web-background-inconclusive.yaml
+++ b/test/e2e/functional/analysistemplate-web-background-inconclusive.yaml
@@ -1,4 +1,6 @@
-# A web metric which uses the httpbin service as a metric provider
+# A web metric which uses google.com as a metric provider
+# The conditions are designed to always be inconclusive (neither success nor failure)
+# Google returns HTML, which won't match either string condition
 apiVersion: argoproj.io/v1alpha1
 kind: AnalysisTemplate
 metadata:
@@ -6,17 +8,13 @@ metadata:
 spec:
   args:
     - name: url-val
-      value: "https://httpbin.io/anything"
+      value: "https://www.google.com"
   metrics:
     - name: web
-      interval: 7s
+      interval: 5s
       inconclusiveLimit: 3
-      successCondition: result.json.status == "success"
-      failureCondition: result.json.status == "failure"
+      successCondition: result == "success"
+      failureCondition: result == "failure"
       provider:
         web:
           url: "{{args.url-val}}"
-          method: POST
-          jsonBody:
-            status: "inconclusive"
-          jsonPath: "{$}"

--- a/test/e2e/functional/analysistemplate-web-background-inconclusive.yaml
+++ b/test/e2e/functional/analysistemplate-web-background-inconclusive.yaml
@@ -11,7 +11,7 @@ spec:
   metrics:
     - name: web
       interval: 5s
-      inconclusiveLimit: 1
+      inconclusiveLimit: 3
       # These conditions will never match the /version response, causing inconclusive results
       successCondition: result.major == 'never-match-success'
       failureCondition: result.major == 'never-match-failure'

--- a/test/e2e/functional/analysistemplate-web-background-inconclusive.yaml
+++ b/test/e2e/functional/analysistemplate-web-background-inconclusive.yaml
@@ -1,5 +1,4 @@
-# A web metric which uses the kubernetes API server as a metric provider
-# The conditions are designed to always be inconclusive (neither success nor failure)
+# A web metric which uses the httpbin service as a metric provider
 apiVersion: argoproj.io/v1alpha1
 kind: AnalysisTemplate
 metadata:
@@ -7,15 +6,17 @@ metadata:
 spec:
   args:
     - name: url-val
-      value: "https://kubernetes.default.svc/version"
+      value: "https://httpbin.io/anything"
   metrics:
     - name: web
-      interval: 3s
-      inconclusiveLimit: 2
-      # These conditions will never match the /version response, causing inconclusive results
-      successCondition: result.major == 'never-match-success'
-      failureCondition: result.major == 'never-match-failure'
+      interval: 7s
+      inconclusiveLimit: 3
+      successCondition: result.json.status == "success"
+      failureCondition: result.json.status == "failure"
       provider:
         web:
           url: "{{args.url-val}}"
-          insecure: true
+          method: POST
+          jsonBody:
+            status: "inconclusive"
+          jsonPath: "{$}"

--- a/test/e2e/functional/analysistemplate-web-background-inconclusive.yaml
+++ b/test/e2e/functional/analysistemplate-web-background-inconclusive.yaml
@@ -10,8 +10,8 @@ spec:
       value: "https://kubernetes.default.svc/version"
   metrics:
     - name: web
-      interval: 5s
-      inconclusiveLimit: 3
+      interval: 3s
+      inconclusiveLimit: 2
       # These conditions will never match the /version response, causing inconclusive results
       successCondition: result.major == 'never-match-success'
       failureCondition: result.major == 'never-match-failure'

--- a/test/e2e/functional/analysistemplate-web-background-inconclusive.yaml
+++ b/test/e2e/functional/analysistemplate-web-background-inconclusive.yaml
@@ -1,22 +1,18 @@
-# A web metric which uses the httpbin service as a metric provider
+# A web metric which uses the kubernetes API server as a metric provider
+# The conditions are designed to always be inconclusive (neither success nor failure)
 apiVersion: argoproj.io/v1alpha1
 kind: AnalysisTemplate
 metadata:
   name: web-background-inconclusive
 spec:
-  args:
-    - name: url-val
-      value: "https://httpbin.org/anything"
   metrics:
     - name: web
-      interval: 7s
-      inconclusiveLimit: 3
-      successCondition: result.json.status == "success"
-      failureCondition: result.json.status == "failure"
+      interval: 5s
+      inconclusiveLimit: 1
+      # These conditions will never match the /version response, causing inconclusive results
+      successCondition: result.major == 'never-match-success'
+      failureCondition: result.major == 'never-match-failure'
       provider:
         web:
-          url: "{{args.url-val}}"
-          method: POST
-          jsonBody:
-            status: "inconclusive"
-          jsonPath: "{$}"
+          url: "https://kubernetes.default.svc/version"
+          insecure: true

--- a/test/e2e/functional/analysistemplate-web-background-inconclusive.yaml
+++ b/test/e2e/functional/analysistemplate-web-background-inconclusive.yaml
@@ -1,6 +1,6 @@
-# A web metric which uses google.com as a metric provider
-# The conditions are designed to always be inconclusive (neither success nor failure)
-# Google returns HTML, which won't match either string condition
+# A web metric which uses Google Books API (returns JSON)
+# The conditions check for values that won't match the actual response,
+# causing measurements to be inconclusive (neither success nor failure)
 apiVersion: argoproj.io/v1alpha1
 kind: AnalysisTemplate
 metadata:
@@ -8,13 +8,13 @@ metadata:
 spec:
   args:
     - name: url-val
-      value: "https://www.google.com"
+      value: "https://www.googleapis.com/books/v1/volumes?q=isbn:0747532699"
   metrics:
     - name: web
       interval: 5s
       inconclusiveLimit: 3
-      successCondition: result == "success"
-      failureCondition: result == "failure"
+      successCondition: result.kind == "will-never-match"
+      failureCondition: result.kind == "also-will-never-match"
       provider:
         web:
           url: "{{args.url-val}}"

--- a/test/e2e/functional/analysistemplate-web-background-inconclusive.yaml
+++ b/test/e2e/functional/analysistemplate-web-background-inconclusive.yaml
@@ -5,6 +5,9 @@ kind: AnalysisTemplate
 metadata:
   name: web-background-inconclusive
 spec:
+  args:
+    - name: url-val
+      value: "https://kubernetes.default.svc/version"
   metrics:
     - name: web
       interval: 5s
@@ -14,5 +17,5 @@ spec:
       failureCondition: result.major == 'never-match-failure'
       provider:
         web:
-          url: "https://kubernetes.default.svc/version"
+          url: "{{args.url-val}}"
           insecure: true


### PR DESCRIPTION
httpbin.org is not stable and when its down it cause test failures


Tried really hard to use a non dependent url, it was a much bigger challenge or required changing rbac permsion to list k8s /version when using the k8s api. So switched to google.com for now.