### PR TITLE
fix(trafficrouting): ReplicaSetReferenced does not check istio DestinationRules

### DIFF
--- a/rollout/replicaset.go
+++ b/rollout/replicaset.go
@@ -6,21 +6,20 @@ import (
 	"sort"
 	"time"
 
-	logutil "github.com/argoproj/argo-rollouts/utils/log"
-
 	appsv1 "k8s.io/api/apps/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	patchtypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/controller"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
+	logutil "github.com/argoproj/argo-rollouts/utils/log"
 	replicasetutil "github.com/argoproj/argo-rollouts/utils/replicaset"
 	serviceutil "github.com/argoproj/argo-rollouts/utils/service"
 	timeutil "github.com/argoproj/argo-rollouts/utils/time"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 var controllerKind = v1alpha1.SchemeGroupVersion.WithKind("Rollout")

--- a/rollout/replicaset_test.go
+++ b/rollout/replicaset_test.go
@@ -661,12 +661,12 @@ spec:
 	}
 
 	testCases := []struct {
-		name               string
-		rollout            *v1alpha1.Rollout
-		destinationRule    string
-		rsHash             string
-		expectedResult     bool
-		noIstioController  bool
+		name              string
+		rollout           *v1alpha1.Rollout
+		destinationRule   string
+		rsHash            string
+		expectedResult    bool
+		noIstioController bool
 	}{
 		{
 			name:           "no istio traffic routing configured",
@@ -780,9 +780,9 @@ spec:
 
 				istioController = &istio.IstioController{
 					IstioControllerConfig: istio.IstioControllerConfig{
-						DynamicClientSet:           dynamicClient,
-						DestinationRuleInformer:    destinationRuleInformer,
-						VirtualServiceInformer:     virtualServiceInformer,
+						DynamicClientSet:        dynamicClient,
+						DestinationRuleInformer: destinationRuleInformer,
+						VirtualServiceInformer:  virtualServiceInformer,
 					},
 				}
 				istioController.DestinationRuleLister = druleLister

--- a/rollout/replicaset_test.go
+++ b/rollout/replicaset_test.go
@@ -590,6 +590,8 @@ func TestIsReplicaSetReferenced(t *testing.T) {
 }
 
 func TestIsReplicaSetReferencedByIstioDestinationRule(t *testing.T) {
+	const testDestRuleName = "test-destrule"
+
 	newRSWithPodTemplateHash := func(hash string) *appsv1.ReplicaSet {
 		return &appsv1.ReplicaSet{
 			ObjectMeta: metav1.ObjectMeta{
@@ -686,47 +688,47 @@ spec:
 		},
 		{
 			name:            "destination rule references hash - should return true",
-			rollout:         newRolloutWithIstioDestinationRule("test-destrule"),
-			destinationRule: newDestinationRuleYAML("test-destrule", "abc123", "def456"),
+			rollout:         newRolloutWithIstioDestinationRule(testDestRuleName),
+			destinationRule: newDestinationRuleYAML(testDestRuleName, "abc123", "def456"),
 			rsHash:          "abc123",
 			expectedResult:  true,
 		},
 		{
 			name:            "destination rule does not reference hash - should return false",
-			rollout:         newRolloutWithIstioDestinationRule("test-destrule"),
-			destinationRule: newDestinationRuleYAML("test-destrule", "abc123", "def456"),
+			rollout:         newRolloutWithIstioDestinationRule(testDestRuleName),
+			destinationRule: newDestinationRuleYAML(testDestRuleName, "abc123", "def456"),
 			rsHash:          "xyz789",
 			expectedResult:  false,
 		},
 		{
 			name:            "destination rule not found - should return false",
 			rollout:         newRolloutWithIstioDestinationRule("non-existent-destrule"),
-			destinationRule: newDestinationRuleYAML("test-destrule", "abc123", "def456"),
+			destinationRule: newDestinationRuleYAML(testDestRuleName, "abc123", "def456"),
 			rsHash:          "abc123",
 			expectedResult:  false,
 		},
 		{
 			name:              "no istio controller - should return false",
-			rollout:           newRolloutWithIstioDestinationRule("test-destrule"),
+			rollout:           newRolloutWithIstioDestinationRule(testDestRuleName),
 			noIstioController: true,
 			rsHash:            "abc123",
 			expectedResult:    false,
 		},
 		{
 			name:            "canary subset references hash - should return true",
-			rollout:         newRolloutWithIstioDestinationRule("test-destrule"),
-			destinationRule: newDestinationRuleYAML("test-destrule", "stable-hash", "canary-hash"),
+			rollout:         newRolloutWithIstioDestinationRule(testDestRuleName),
+			destinationRule: newDestinationRuleYAML(testDestRuleName, "stable-hash", "canary-hash"),
 			rsHash:          "canary-hash",
 			expectedResult:  true,
 		},
 		{
 			name:    "destination rule with no subsets - should return false",
-			rollout: newRolloutWithIstioDestinationRule("test-destrule"),
+			rollout: newRolloutWithIstioDestinationRule(testDestRuleName),
 			destinationRule: `
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
-  name: test-destrule
+  name: ` + testDestRuleName + `
   namespace: default
 spec:
   host: test-service
@@ -736,12 +738,12 @@ spec:
 		},
 		{
 			name:    "destination rule with subset missing labels - should return false",
-			rollout: newRolloutWithIstioDestinationRule("test-destrule"),
+			rollout: newRolloutWithIstioDestinationRule(testDestRuleName),
 			destinationRule: `
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
-  name: test-destrule
+  name: ` + testDestRuleName + `
   namespace: default
 spec:
   host: test-service


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-rollouts/issues/4390 and https://github.com/argoproj/argo-rollouts/issues/4534

The `isReplicaSetReferenced` function checks:
- Static references in rollout status (StableRS, CurrentPodHash, Weights.Canary.PodTemplateHash, Weights.Stable.PodTemplateHash)
- Service selectors for Canary/BlueGreen services

However, when using Istio with subset-level traffic splitting (DestinationRules), the function doesn't check if the ReplicaSet's pod template hash is still referenced in the Istio DestinationRule subsets.
This means a ReplicaSet can be scaled down even though Istio is still routing traffic to that subset.

We see these logs:
```
Skip scale down of older RS 'service-5f68597bd5': still referenced
Patched: {"status":{"availableReplicas":367,"canary":{"weights":{"canary":{"podTemplateHash":"fb447bcd9"}}},"readyReplicas":367}}
delaying destination rule switch: ReplicaSet service-88dd777fc not fully available
scaling down intermediate RS 'service-5f68597bd5'
Scaled down ReplicaSet service-5f68597bd5 (revision 1823) from 139 to 0
```
At which point Istio starts attempting to send to the scaled-down replica and starts returning HTTP 503 with a `UH` (no healthy upstreams) error.

The issue is that the metadata is being updated, but since we do not use services (only istio subsets), trafficrouting cannot detect that the "intermediate RS" is still in use.

---

When using Istio with DestinationRule subsets (without explicit canary/stable services), the isReplicaSetReferenced function doesn't check the DestinationRule to see if the pod template hash is still referenced in a subset.

The problem is:
- The rollout status (e.g., Weights.Canary.PodTemplateHash) gets updated to the new hash
- But the Istio DestinationRule subsets still have the old hash because UpdateHash hasn't been called yet (or returns early due to checkReplicasAvailable)
- The ReplicaSet with the old hash gets scaled down because isReplicaSetReferenced returns false
- Traffic is still being routed to that subset, causing 503s

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
