### PR TITLE
fix(trafficrouting): Fix skipping setHeaderRoute if the Stable ReplicaSet is not ready

### DIFF
--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -268,11 +268,6 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			}
 		}
 
-		// check if the stable RS has enough pods before recalculating the new
-		// weight status.
-		if !c.checkReplicasAvailable(c.stableRS, weightutil.MaxTrafficWeight(c.rollout)-desiredWeight) {
-			return nil
-		}
 		// We need to check for revision > 1 because when we first install the rollout we run step 0 this prevents that.
 		// There is a bigger fix needed for the reasons on why we run step 0 on rollout install, that needs to be explored.
 		revision, revisionFound := annotations.GetRevisionAnnotation(c.rollout)
@@ -287,6 +282,12 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 					return err
 				}
 			}
+		}
+
+		// check if the stable RS has enough pods before recalculating the new
+		// weight status.
+		if !c.checkReplicasAvailable(c.stableRS, weightutil.MaxTrafficWeight(c.rollout)-desiredWeight) {
+			return nil
 		}
 
 		err = reconciler.UpdateHash(canaryHash, stableHash, weightDestinations...)

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -1783,17 +1783,10 @@ func TestReconcileTrafficRoutingSetHeaderRouteShouldBeCalledEvenIfStableUnavaila
 	f.expectPatchRolloutAction(r2)
 
 	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
-	f.fakeTrafficRouting.On("RemoveManagedRoutes", mock.Anything, mock.Anything).Return(nil)
-	f.fakeTrafficRouting.On("SetHeaderRoute", &v1alpha1.SetHeaderRoute{
-		Name: "test-header",
-		Match: []v1alpha1.HeaderRoutingMatch{
-			{
-				HeaderName: "test",
-				HeaderValue: &v1alpha1.StringMatch{
-					Prefix: "test",
-				},
-			},
-		},
-	}).Once().Return(nil)
+	f.fakeTrafficRouting.On("RemoveManagedRoutes").Return(nil)
+	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything).Return(nil)
 	f.run(getKey(r1, t))
+
+	// Make sure that SetHeaderRoute was called.
+	f.fakeTrafficRouting.AssertCalled(t, "SetHeaderRoute", mock.Anything)
 }

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -1688,3 +1688,112 @@ func TestDynamicScalingAbortWithZeroReplicas(t *testing.T) {
 	// This should not panic or cause division by zero
 	f.run(getKey(r1, t))
 }
+
+func TestReconcileTrafficRoutingSetHeaderRouteShouldBeCalledEvenIfStableUnavailable(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{
+		{
+			SetHeaderRoute: &v1alpha1.SetHeaderRoute{
+				Name: "test-header",
+				Match: []v1alpha1.HeaderRoutingMatch{
+					{
+						HeaderName: "test",
+						HeaderValue: &v1alpha1.StringMatch{
+							Prefix: "test",
+						},
+					},
+				},
+			},
+		},
+		{
+			Pause: &v1alpha1.RolloutPause{},
+		},
+	}
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(1))
+	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
+		Istio: &v1alpha1.IstioTrafficRouting{
+			VirtualService: &v1alpha1.IstioVirtualService{
+				Name: "test",
+				Routes: []string{
+					"primary",
+				},
+			},
+		},
+		ManagedRoutes: []v1alpha1.MangedRoutes{
+			{
+				Name: "test-header",
+			},
+		},
+	}
+	r1.Spec.Strategy.Canary.CanaryService = "canary"
+	r1.Spec.Strategy.Canary.StableService = "stable"
+	r2 := bumpVersion(r1)
+
+	// Stable ReplicaSet is not redy (desired: 10, available: 5)
+	rs1 := newReplicaSetWithStatus(r1, 10, 5)
+	rs2 := newReplicaSetWithStatus(r2, 0, 0)
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	canarySelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}
+	stableSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}
+	canarySvc := newService("canary", 80, canarySelector, r1)
+	stableSvc := newService("stable", 80, stableSelector, r1)
+	r2.Status.StableRS = rs1PodHash
+
+	vs := istio.VirtualService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: r1.Namespace,
+		},
+		Spec: istio.VirtualServiceSpec{
+			HTTP: []istio.VirtualServiceHTTPRoute{{
+				Name: "primary",
+				Route: []istio.VirtualServiceRouteDestination{{
+					Destination: istio.VirtualServiceDestination{
+						Host: "stable",
+					},
+					Weight: 100,
+				}, {
+					Destination: istio.VirtualServiceDestination{
+						Host: "canary",
+					},
+					Weight: 0,
+				}},
+			}},
+		},
+	}
+	mapObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&vs)
+	assert.Nil(t, err)
+
+	unstructuredObj := &unstructured.Unstructured{Object: mapObj}
+	unstructuredObj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   istioutil.GetIstioVirtualServiceGVR().Group,
+		Version: istioutil.GetIstioVirtualServiceGVR().Version,
+		Kind:    "VirtualService",
+	})
+
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2, canarySvc, stableSvc)
+	f.serviceLister = append(f.serviceLister, canarySvc, stableSvc)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2, unstructuredObj)
+
+	f.expectPatchRolloutAction(r2)
+
+	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+	f.fakeTrafficRouting.On("RemoveManagedRoutes", mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("SetHeaderRoute", &v1alpha1.SetHeaderRoute{
+		Name: "test-header",
+		Match: []v1alpha1.HeaderRoutingMatch{
+			{
+				HeaderName: "test",
+				HeaderValue: &v1alpha1.StringMatch{
+					Prefix: "test",
+				},
+			},
+		},
+	}).Once().Return(nil)
+	f.run(getKey(r1, t))
+}


### PR DESCRIPTION
Fixes: https://github.com/argoproj/argo-rollouts/issues/4561

Details: Changes the guardrail (`checkReplicasAvailable`) to be called after `SetHeaderRoute` (and `SetMirrorRoute`) are executed so that `setHeaderRoute` step is not skipped when the Stable ReplicaSet is not ready.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
