### PR TITLE
fix(controller): Cap minPodsPerReplicaSet to rollout spec replicas. Fixes #4566

### DIFF
--- a/docs/features/specification.md
+++ b/docs/features/specification.md
@@ -230,7 +230,9 @@ spec:
 
       # The minimum number of pods that will be requested for each ReplicaSet
       # when using traffic routed canary. This is to ensure high availability
-      # of each ReplicaSet. Defaults to 1. +optional
+      # of each ReplicaSet. spec.replicas should be >= minPodsPerReplicaSet
+      # for it to take full effect; otherwise it is capped at the rollout
+      # replica count. Defaults to 1. +optional
       minPodsPerReplicaSet: 2
 
       # Limits the number of old RS that can run at one time before getting

--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -361,7 +361,7 @@ func CheckMinPodsPerReplicaSet(rollout *v1alpha1.Rollout, count int32) int32 {
 	if rollout.Spec.Strategy.Canary == nil || rollout.Spec.Strategy.Canary.MinPodsPerReplicaSet == nil || rollout.Spec.Strategy.Canary.TrafficRouting == nil {
 		return count
 	}
-	// Cap the minPodsPerReplicaSet to the total number of replicas in the rollout spec to prevent reconciliation loop
+	// Cap MinPodsPerReplicaSet to rollout spec replicas to prevent reconciliation loop
 	minPodsPerReplicaSet := *rollout.Spec.Strategy.Canary.MinPodsPerReplicaSet
 	rolloutSpecReplicaSet := defaults.GetReplicasOrDefault(rollout.Spec.Replicas)
 	if minPodsPerReplicaSet > rolloutSpecReplicaSet {

--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -361,7 +361,13 @@ func CheckMinPodsPerReplicaSet(rollout *v1alpha1.Rollout, count int32) int32 {
 	if rollout.Spec.Strategy.Canary == nil || rollout.Spec.Strategy.Canary.MinPodsPerReplicaSet == nil || rollout.Spec.Strategy.Canary.TrafficRouting == nil {
 		return count
 	}
-	return max(count, *rollout.Spec.Strategy.Canary.MinPodsPerReplicaSet)
+	// Cap the minPodsPerReplicaSet to the total number of replicas in the rollout spec to prevent reconciliation loop
+	minPodsPerReplicaSet := *rollout.Spec.Strategy.Canary.MinPodsPerReplicaSet
+	rolloutSpecReplicaSet := defaults.GetReplicasOrDefault(rollout.Spec.Replicas)
+	if minPodsPerReplicaSet > rolloutSpecReplicaSet {
+		minPodsPerReplicaSet = rolloutSpecReplicaSet
+	}
+	return max(count, minPodsPerReplicaSet)
 }
 
 // CalculateReplicaCountsForTrafficRoutedCanary calculates the canary and stable replica counts

--- a/utils/replicaset/canary_test.go
+++ b/utils/replicaset/canary_test.go
@@ -741,6 +741,24 @@ func TestCalculateReplicaCountsForCanary(t *testing.T) {
 			expectedStableReplicaCount: 10,
 			expectedCanaryReplicaCount: 2,
 		},
+		{
+			name:                "Cap MinPodsPerReplicaSet when it exceeds rollout replicas with trafficRouting",
+			rolloutSpecReplicas: 1,
+			setWeight:           100,
+			promoteFull:         true,
+
+			stableSpecReplica:      1,
+			stableAvailableReplica: 1,
+
+			canarySpecReplica:      0,
+			canaryAvailableReplica: 0,
+
+			trafficRouting:       &v1alpha1.RolloutTrafficRouting{},
+			minPodsPerReplicaSet: intPnt(2),
+
+			expectedStableReplicaCount: 1,
+			expectedCanaryReplicaCount: 1,
+		},
 	}
 	for i := range tests {
 		test := tests[i]


### PR DESCRIPTION
Cap `minPodsPerReplicaSet` to `rollout.Spec.Replicas` to prevent reconciliation loop where desired RS count never met the actual RS count which was over-provisioned by `minPodsPerReplicaSet`.
 
Fixes: https://github.com/argoproj/argo-rollouts/issues/4566

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x]  I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
