### PR TITLE
fix: preserve header routes during canary deployment. Fixes #4486

### DIFF
--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -228,17 +228,16 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			// to direct traffic to the canary service which is now in front of 0 available replicas.
 			// We want to remove these managed routes alongside the safety here of never weighting to the canary.
 
-			// Check if any step uses managed routes
-			usesManagedRoutes := false
-			for _, step := range c.rollout.Spec.Strategy.Canary.Steps {
-				if step.SetHeaderRoute != nil || step.SetMirrorRoute != nil {
-					usesManagedRoutes = true
-					break
+			// Check if current step uses managed routes (setHeaderRoute or setMirrorRoute)
+			currentStepUsesManagedRoutes := false
+			if currentStep != nil {
+				if currentStep.SetHeaderRoute != nil || currentStep.SetMirrorRoute != nil {
+					currentStepUsesManagedRoutes = true
 				}
 			}
 
 			// Only remove managed routes if current step doesn't use them
-			if !usesManagedRoutes {
+			if !currentStepUsesManagedRoutes {
 				err := reconciler.RemoveManagedRoutes()
 				if err != nil {
 					return err

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -228,16 +228,17 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			// to direct traffic to the canary service which is now in front of 0 available replicas.
 			// We want to remove these managed routes alongside the safety here of never weighting to the canary.
 
-			// Check if current step uses managed routes (setHeaderRoute or setMirrorRoute)
-			currentStepUsesManagedRoutes := false
-			if currentStep != nil {
-				if currentStep.SetHeaderRoute != nil || currentStep.SetMirrorRoute != nil {
-					currentStepUsesManagedRoutes = true
+			// Check if any step uses managed routes
+			usesManagedRoutes := false
+			for _, step := range c.rollout.Spec.Strategy.Canary.Steps {
+				if step.SetHeaderRoute != nil || step.SetMirrorRoute != nil {
+					usesManagedRoutes = true
+					break
 				}
 			}
 
 			// Only remove managed routes if current step doesn't use them
-			if !currentStepUsesManagedRoutes {
+			if !usesManagedRoutes {
 				err := reconciler.RemoveManagedRoutes()
 				if err != nil {
 					return err

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -1688,3 +1688,82 @@ func TestDynamicScalingAbortWithZeroReplicas(t *testing.T) {
 	// This should not panic or cause division by zero
 	f.run(getKey(r1, t))
 }
+
+func TestPreserveHeaderRouteDuringNormalCanaryDeployment(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{
+		{
+			SetHeaderRoute: &v1alpha1.SetHeaderRoute{
+				Name: "test-header",
+				Match: []v1alpha1.HeaderRoutingMatch{
+					{
+						HeaderName:  "x-test",
+						HeaderValue: &v1alpha1.StringMatch{Exact: "canary"},
+					},
+				},
+			},
+		},
+		{
+			SetCanaryScale: &v1alpha1.SetCanaryScale{Replicas: pointer.Int32(1)},
+		},
+		{
+			SetWeight: pointer.Int32(10),
+		},
+		{
+			Pause: &v1alpha1.RolloutPause{},
+		},
+	}
+
+	r1 := newCanaryRollout("foo", 5, nil, steps, pointer.Int32Ptr(0), intstr.FromInt(1), intstr.FromInt(0))
+	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
+		ALB: &v1alpha1.ALBTrafficRouting{Ingress: "test-ingress"},
+		ManagedRoutes: []v1alpha1.MangedRoutes{
+			{Name: "test-header"},
+		},
+	}
+	r1.Spec.Strategy.Canary.StableService = "stable-svc"
+	r1.Spec.Strategy.Canary.CanaryService = "canary-svc"
+
+	r2 := bumpVersion(r1)
+
+	rs1 := newReplicaSetWithStatus(r1, 5, 5)
+	rs2 := newReplicaSetWithStatus(r2, 0, 0)
+
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+
+	stableSvc := newService("stable-svc", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}, r1)
+	canarySvc := newService("canary-svc", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}, r2)
+
+	ingress := newIngress("test-ingress", canarySvc, stableSvc)
+	ingress.Spec.Rules[0].HTTP.Paths[0].Backend.ServiceName = stableSvc.Name
+
+	r2.Status.StableRS = rs1PodHash
+	r2.Status.CurrentPodHash = rs2PodHash
+
+	f.objects = append(f.objects, r2)
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2, canarySvc, stableSvc, ingress)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+	f.serviceLister = append(f.serviceLister, canarySvc, stableSvc)
+	f.ingressLister = append(f.ingressLister, ingressutil.NewLegacyIngress(ingress))
+
+	f.expectPatchRolloutAction(r2)
+
+	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("SetHeaderRoute", &v1alpha1.SetHeaderRoute{
+		Name: "test-header",
+		Match: []v1alpha1.HeaderRoutingMatch{
+			{
+				HeaderName:  "x-test",
+				HeaderValue: &v1alpha1.StringMatch{Exact: "canary"},
+			},
+		},
+	}).Once().Return(nil)
+	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(pointer.BoolPtr(true), nil)
+
+	f.run(getKey(r2, t))
+}

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -1746,15 +1746,9 @@ func TestRemoveManagedRoute(t *testing.T) {
 	f.ingressLister = append(f.ingressLister, ingressutil.NewLegacyIngress(ingress))
 
 	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
-	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything).Return(nil)
-	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(nil)
-	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(pointer.BoolPtr(true), nil)
-	f.fakeTrafficRouting.On("RemoveManagedRoutes").Return(nil)
+	f.fakeTrafficRouting.On("RemoveManagedRoutes").Return(errors.New("remove managed routes error"))
 
 	f.expectPatchServiceAction(stableSvc, rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey])
-	f.expectUpdateReplicaSetAction(rs2)
-	f.expectPatchRolloutAction(r2)
-
-	f.run(getKey(r2, t))
+	f.runExpectError(getKey(r2, t), true)
 	f.fakeTrafficRouting.AssertCalled(t, "RemoveManagedRoutes")
 }


### PR DESCRIPTION
Implemented managed route preservation logic to ensure Header Routes are not removed even when the new ReplicaSet is unavailable.

Fixes: #4486 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
