### PR TITLE
fix(experiments): Update replicaset on experiment retry. Fixes #4578

### DIFF
--- a/experiments/experiment.go
+++ b/experiments/experiment.go
@@ -137,6 +137,7 @@ func (ec *experimentContext) reconcileTemplate(template v1alpha1.TemplateSpec) {
 			if err := ec.deleteReplicaSet(rs); err != nil {
 				templateStatus.Status = v1alpha1.TemplateStatusError
 				templateStatus.Message = fmt.Sprintf("Failed to delete ReplicaSet '%s' for template '%s': %v", rs.Name, template.Name, err)
+				experimentutil.SetTemplateStatus(ec.newStatus, *templateStatus)
 			} else {
 				ec.templateRSs[template.Name] = nil
 				ec.enqueueExperimentAfter(ec.ex, time.Second)

--- a/experiments/experiment_test.go
+++ b/experiments/experiment_test.go
@@ -436,6 +436,49 @@ func TestFailReplicaSetCreation(t *testing.T) {
 	assert.Equal(t, newStatus.Phase, v1alpha1.AnalysisPhaseError)
 }
 
+func TestRetryRecreatesReplicaSetOnTemplateDiff(t *testing.T) {
+	templates := generateTemplates("bar")
+	oldTemplate := templates[0]
+	newTemplate := oldTemplate.DeepCopy()
+	newTemplate.Template.Spec.Containers[0].Image = "bar-v2"
+
+	ex := newExperiment("foo", []v1alpha1.TemplateSpec{*newTemplate}, "")
+	ex.Status = v1alpha1.ExperimentStatus{}
+
+	oldRS := templateToRS(ex, oldTemplate, 1)
+	exCtx := newTestContext(ex, oldRS)
+	exCtx.templateRSs[oldTemplate.Name] = oldRS
+
+	fakeClient := exCtx.kubeclientset.(*k8sfake.Clientset)
+	exCtx.reconcile()
+
+	deleted := false
+	for _, action := range fakeClient.Actions() {
+		if action.Matches("delete", "replicasets") {
+			deleted = true
+			break
+		}
+	}
+	assert.True(t, deleted)
+
+	exCtx.reconcile()
+	var createdRS *appsv1.ReplicaSet
+	for _, action := range fakeClient.Actions() {
+		if action.Matches("create", "replicasets") {
+			createAction, ok := action.(kubetesting.CreateAction)
+			assert.True(t, ok)
+			obj := createAction.GetObject()
+			rs, ok := obj.(*appsv1.ReplicaSet)
+			assert.True(t, ok)
+			createdRS = rs
+			break
+		}
+	}
+	if assert.NotNil(t, createdRS) {
+		assert.Equal(t, "bar-v2", createdRS.Spec.Template.Spec.Containers[0].Image)
+	}
+}
+
 func TestFailServiceCreation(t *testing.T) {
 	templates := generateTemplates("bad")
 	setExperimentService(&templates[0])

--- a/experiments/replicaset.go
+++ b/experiments/replicaset.go
@@ -303,6 +303,15 @@ func (ec *experimentContext) scaleReplicaSet(rs *appsv1.ReplicaSet, newScale int
 	return scaled, rs, err
 }
 
+func (ec *experimentContext) deleteReplicaSet(rs *appsv1.ReplicaSet) error {
+	ctx := context.TODO()
+	err := ec.kubeclientset.AppsV1().ReplicaSets(rs.Namespace).Delete(ctx, rs.Name, metav1.DeleteOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
 func newReplicaSetAnnotations(experimentName, templateName string) map[string]string {
 	return map[string]string{
 		v1alpha1.ExperimentNameAnnotationKey:         experimentName,


### PR DESCRIPTION
Update experiment template reconciler that If experiment is being retried, check if template RS pod template has changed and delete RS to recreate new RS with new spec.

Fixes: #4578

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
