### PR TITLE
fix(dashboard): avoid dialing 0.0.0.0 in newHTTPServer. Fixes #3931.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -75,12 +75,16 @@ func NewServer(o ServerOptions) *ArgoRolloutsServer {
 	return &ArgoRolloutsServer{Options: o}
 }
 
+const (
+	listenAddr  = "0.0.0.0"
+	connectAddr = "localhost"
+)
+
 func (s *ArgoRolloutsServer) newHTTPServer(ctx context.Context, port int) *http.Server {
 	mux := http.NewServeMux()
-	endpoint := fmt.Sprintf("0.0.0.0:%d", port)
 
 	httpS := http.Server{
-		Addr:    endpoint,
+		Addr:    net.JoinHostPort(listenAddr, fmt.Sprintf("%d", port)),
 		Handler: mux,
 	}
 
@@ -99,6 +103,7 @@ func (s *ArgoRolloutsServer) newHTTPServer(ctx context.Context, port int) *http.
 	}
 	opts = append(opts, grpc.WithInsecure())
 
+	endpoint := net.JoinHostPort(connectAddr, fmt.Sprintf("%d", port))
 	err := rollout.RegisterRolloutServiceHandlerFromEndpoint(ctx, gwmux, endpoint, opts)
 	if err != nil {
 		panic(err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,98 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewHTTPServer(t *testing.T) {
+	t.Run("server is created with correct address", func(t *testing.T) {
+		s := &ArgoRolloutsServer{
+			Options: ServerOptions{
+				RootPath: "",
+			},
+		}
+		ctx := context.Background()
+		port := 8080
+
+		httpServer := s.newHTTPServer(ctx, port)
+
+		assert.NotNil(t, httpServer)
+		assert.Equal(t, "0.0.0.0:8080", httpServer.Addr)
+		assert.NotNil(t, httpServer.Handler)
+	})
+
+	t.Run("mux handles root route for static files", func(t *testing.T) {
+		s := &ArgoRolloutsServer{
+			Options: ServerOptions{
+				RootPath: "",
+			},
+		}
+		ctx := context.Background()
+		port := 8080
+
+		httpServer := s.newHTTPServer(ctx, port)
+
+		// Test that / route is registered
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+
+		httpServer.Handler.ServeHTTP(w, req)
+
+		// The handler should be registered (will be handled by staticFileHttpHandler)
+		// The actual response will depend on static file configuration
+		assert.NotNil(t, w.Code, "Root route should be registered")
+	})
+
+	t.Run("server with different root paths", func(t *testing.T) {
+		testCases := []struct {
+			name         string
+			rootPath     string
+			expectedPath string
+		}{
+			{
+				name:         "empty root path",
+				rootPath:     "",
+				expectedPath: "/api/",
+			},
+			{
+				name:         "simple root path",
+				rootPath:     "/rollouts",
+				expectedPath: "/rollouts/api/",
+			},
+			{
+				name:         "nested root path",
+				rootPath:     "/custom/path",
+				expectedPath: "/custom/path/api/",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				s := &ArgoRolloutsServer{
+					Options: ServerOptions{
+						RootPath: tc.rootPath,
+					},
+				}
+				ctx := context.Background()
+				port := 8080
+
+				httpServer := s.newHTTPServer(ctx, port)
+
+				// Test that the expected API path is registered
+				req := httptest.NewRequest(http.MethodGet, tc.expectedPath, nil)
+				w := httptest.NewRecorder()
+
+				httpServer.Handler.ServeHTTP(w, req)
+
+				// The handler should be registered (not 404)
+				assert.NotEqual(t, http.StatusNotFound, w.Code,
+					"API route should be registered at %s", tc.expectedPath)
+			})
+		}
+	})
+}


### PR DESCRIPTION
Checklist:

* [X] This is a bugfix
* [X] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [X] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

The code declares endpoint with "0.0.0.0:%d", which is eventually passed to RegisterRolloutServiceHandlerFromEndpoint. This in turn calls grpc.Dial, but 0.0.0.0 is not a valid address to pass to a client. This produces one of the errors documented in issue #3931.