### PR TITLE
feat(trafficrouting): add CanScaleDown hook for traffic router plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -178,6 +178,14 @@ type TrafficRouterPlugin interface {
   RemoveManagedRoutes(ro *v1alpha1.Rollout) RpcError
   // Type returns the type of the traffic routing reconciler
   Type() string
+  // CanScaleDown checks if it is safe to scale down the ReplicaSet identified by the given pod template hash.
+  // This allows traffic routing plugins to delay scale-down until external systems (e.g., long-running
+  // connections, worker versioning, message queue consumers) have completed draining.
+  // Returns:
+  // - ScaleDownVerified: scale-down is safe
+  // - ScaleDownNotVerified: scale-down is NOT safe yet, controller should retry later
+  // - ScaleDownNotImplemented: plugin does not implement this check, default behavior applies
+  CanScaleDown(rollout *v1alpha1.Rollout, podTemplateHash string) (RpcScaleDownVerified, RpcError)
 }
 
 type StepPlugin interface {

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -242,10 +242,7 @@ func (c *rolloutContext) scaleDownOldReplicaSetsForCanary(oldRSs []*appsv1.Repli
 				// While no new traffic is directed to this RS, external systems may still
 				// have work running on it that needs to complete.
 				podTemplateHash := replicasetutil.GetPodTemplateHash(targetRS)
-				canScaleDown, err := c.canScaleDownRS(podTemplateHash)
-				if err != nil {
-					c.log.Warnf("Error checking CanScaleDown for intermediate RS '%s': %v", targetRS.Name, err)
-				}
+				canScaleDown, _ := c.canScaleDownRS(podTemplateHash)
 				if canScaleDown != nil && !*canScaleDown {
 					c.log.Infof("Intermediate RS '%s' scale-down blocked by traffic router plugin", targetRS.Name)
 					desiredReplicaCount = *targetRS.Spec.Replicas

--- a/rollout/mocks/TrafficRoutingReconciler.go
+++ b/rollout/mocks/TrafficRoutingReconciler.go
@@ -13,6 +13,36 @@ type TrafficRoutingReconciler struct {
 	mock.Mock
 }
 
+// CanScaleDown provides a mock function with given fields: podTemplateHash
+func (_m *TrafficRoutingReconciler) CanScaleDown(podTemplateHash string) (*bool, error) {
+	ret := _m.Called(podTemplateHash)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CanScaleDown")
+	}
+
+	var r0 *bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (*bool, error)); ok {
+		return rf(podTemplateHash)
+	}
+	if rf, ok := ret.Get(0).(func(string) *bool); ok {
+		r0 = rf(podTemplateHash)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*bool)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(podTemplateHash)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // RemoveManagedRoutes provides a mock function with no fields
 func (_m *TrafficRoutingReconciler) RemoveManagedRoutes() error {
 	ret := _m.Called()
@@ -108,36 +138,6 @@ func (_m *TrafficRoutingReconciler) Type() string {
 	}
 
 	return r0
-}
-
-// CanScaleDown provides a mock function with given fields: podTemplateHash
-func (_m *TrafficRoutingReconciler) CanScaleDown(podTemplateHash string) (*bool, error) {
-	ret := _m.Called(podTemplateHash)
-
-	if len(ret) == 0 {
-		panic("no return value specified for CanScaleDown")
-	}
-
-	var r0 *bool
-	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (*bool, error)); ok {
-		return rf(podTemplateHash)
-	}
-	if rf, ok := ret.Get(0).(func(string) *bool); ok {
-		r0 = rf(podTemplateHash)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*bool)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(podTemplateHash)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
 }
 
 // UpdateHash provides a mock function with given fields: canaryHash, stableHash, additionalDestinations

--- a/rollout/mocks/TrafficRoutingReconciler.go
+++ b/rollout/mocks/TrafficRoutingReconciler.go
@@ -110,6 +110,36 @@ func (_m *TrafficRoutingReconciler) Type() string {
 	return r0
 }
 
+// CanScaleDown provides a mock function with given fields: podTemplateHash
+func (_m *TrafficRoutingReconciler) CanScaleDown(podTemplateHash string) (*bool, error) {
+	ret := _m.Called(podTemplateHash)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CanScaleDown")
+	}
+
+	var r0 *bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (*bool, error)); ok {
+		return rf(podTemplateHash)
+	}
+	if rf, ok := ret.Get(0).(func(string) *bool); ok {
+		r0 = rf(podTemplateHash)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*bool)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(podTemplateHash)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // UpdateHash provides a mock function with given fields: canaryHash, stableHash, additionalDestinations
 func (_m *TrafficRoutingReconciler) UpdateHash(canaryHash string, stableHash string, additionalDestinations ...v1alpha1.WeightDestination) error {
 	_va := make([]interface{}, len(additionalDestinations))

--- a/rollout/trafficrouting/alb/alb.go
+++ b/rollout/trafficrouting/alb/alb.go
@@ -75,6 +75,11 @@ func (r *Reconciler) Type() string {
 	return Type
 }
 
+// CanScaleDown returns nil (not implemented) as ALB does not support scale-down checks
+func (r *Reconciler) CanScaleDown(podTemplateHash string) (*bool, error) {
+	return nil, nil
+}
+
 // SetWeight modifies ALB Ingress resources to reach desired state
 func (r *Reconciler) SetWeight(desiredWeight int32, additionalDestinations ...v1alpha1.WeightDestination) error {
 	if ingresses := r.cfg.Rollout.Spec.Strategy.Canary.TrafficRouting.ALB.Ingresses; ingresses != nil {

--- a/rollout/trafficrouting/ambassador/ambassador.go
+++ b/rollout/trafficrouting/ambassador/ambassador.go
@@ -252,6 +252,11 @@ func (r *Reconciler) Type() string {
 	return Type
 }
 
+// CanScaleDown returns nil (not implemented) as Ambassador does not support scale-down checks
+func (r *Reconciler) CanScaleDown(podTemplateHash string) (*bool, error) {
+	return nil, nil
+}
+
 func setMappingWeight(obj *unstructured.Unstructured, weight int32) {
 	unstructured.SetNestedField(obj.Object, int64(weight), "spec", "weight")
 }

--- a/rollout/trafficrouting/apisix/apisix.go
+++ b/rollout/trafficrouting/apisix/apisix.go
@@ -417,6 +417,11 @@ func (r *Reconciler) Type() string {
 	return Type
 }
 
+// CanScaleDown returns nil (not implemented) as Apisix does not support scale-down checks
+func (r *Reconciler) CanScaleDown(podTemplateHash string) (*bool, error) {
+	return nil, nil
+}
+
 func (r *Reconciler) SetMirrorRoute(setMirrorRoute *v1alpha1.SetMirrorRoute) error {
 	return nil
 }

--- a/rollout/trafficrouting/appmesh/appmesh.go
+++ b/rollout/trafficrouting/appmesh/appmesh.go
@@ -324,6 +324,11 @@ func (r *Reconciler) Type() string {
 	return Type
 }
 
+// CanScaleDown returns nil (not implemented) as AppMesh does not support scale-down checks
+func (r *Reconciler) CanScaleDown(podTemplateHash string) (*bool, error) {
+	return nil, nil
+}
+
 func getPodSelectorMatchLabels(vnode *unstructured.Unstructured) (map[string]any, error) {
 	m, found, err := unstructured.NestedMap(vnode.Object, "spec", "podSelector", "matchLabels")
 	if err != nil {

--- a/rollout/trafficrouting/istio/istio.go
+++ b/rollout/trafficrouting/istio/istio.go
@@ -701,6 +701,11 @@ func (r *Reconciler) Type() string {
 	return Type
 }
 
+// CanScaleDown returns nil (not implemented) as Istio does not support scale-down checks
+func (r *Reconciler) CanScaleDown(podTemplateHash string) (*bool, error) {
+	return nil, nil
+}
+
 // SetWeight modifies Istio resources to reach desired state
 func (r *Reconciler) SetWeight(desiredWeight int32, additionalDestinations ...v1alpha1.WeightDestination) error {
 	ctx := context.TODO()

--- a/rollout/trafficrouting/nginx/nginx.go
+++ b/rollout/trafficrouting/nginx/nginx.go
@@ -60,6 +60,11 @@ func (r *Reconciler) Type() string {
 	return Type
 }
 
+// CanScaleDown returns nil (not implemented) as Nginx does not support scale-down checks
+func (r *Reconciler) CanScaleDown(podTemplateHash string) (*bool, error) {
+	return nil, nil
+}
+
 func (r *Reconciler) buildCanaryIngress(stableIngress *networkingv1.Ingress, name string, desiredWeight int32) (*ingressutil.Ingress, error) {
 	stableIngressName := r.cfg.Rollout.Spec.Strategy.Canary.TrafficRouting.Nginx.StableIngress
 	stableServiceName := r.cfg.Rollout.Spec.Strategy.Canary.StableService

--- a/rollout/trafficrouting/plugin/plugin.go
+++ b/rollout/trafficrouting/plugin/plugin.go
@@ -96,3 +96,12 @@ func (r *Reconciler) RemoveManagedRoutes() error {
 	}
 	return nil
 }
+
+// CanScaleDown checks if it is safe to scale down the ReplicaSet identified by the given pod template hash
+func (r *Reconciler) CanScaleDown(podTemplateHash string) (*bool, error) {
+	canScaleDown, errResp := r.TrafficRouterPlugin.CanScaleDown(r.Rollout, podTemplateHash)
+	if errResp.HasError() {
+		return canScaleDown.CanScaleDown(), fmt.Errorf("failed to check can scale down via plugin: %w", errResp)
+	}
+	return canScaleDown.CanScaleDown(), nil
+}

--- a/rollout/trafficrouting/plugin/rpc/rpc_test_implementation.go
+++ b/rollout/trafficrouting/plugin/rpc/rpc_test_implementation.go
@@ -40,3 +40,7 @@ func (r *testRpcPlugin) RemoveManagedRoutes(ro *v1alpha1.Rollout) types.RpcError
 func (r *testRpcPlugin) Type() string {
 	return "TestRPCPlugin"
 }
+
+func (r *testRpcPlugin) CanScaleDown(ro *v1alpha1.Rollout, podTemplateHash string) (types.RpcScaleDownVerified, types.RpcError) {
+	return types.ScaleDownNotImplemented, types.RpcError{}
+}

--- a/rollout/trafficrouting/smi/smi.go
+++ b/rollout/trafficrouting/smi/smi.go
@@ -183,6 +183,11 @@ func (r *Reconciler) Type() string {
 	return Type
 }
 
+// CanScaleDown returns nil (not implemented) as SMI does not support scale-down checks
+func (r *Reconciler) CanScaleDown(podTemplateHash string) (*bool, error) {
+	return nil, nil
+}
+
 // SetWeight creates and modifies traffic splits based on the desired weight
 func (r *Reconciler) SetWeight(desiredWeight int32, additionalDestinations ...v1alpha1.WeightDestination) error {
 	// If TrafficSplitName not set, then set to Rollout name

--- a/rollout/trafficrouting/traefik/traefik.go
+++ b/rollout/trafficrouting/traefik/traefik.go
@@ -170,6 +170,11 @@ func (r *Reconciler) Type() string {
 	return Type
 }
 
+// CanScaleDown returns nil (not implemented) as Traefik does not support scale-down checks
+func (r *Reconciler) CanScaleDown(podTemplateHash string) (*bool, error) {
+	return nil, nil
+}
+
 func (r *Reconciler) SetMirrorRoute(setMirrorRoute *v1alpha1.SetMirrorRoute) error {
 	return nil
 }

--- a/rollout/trafficrouting/trafficroutingutil.go
+++ b/rollout/trafficrouting/trafficroutingutil.go
@@ -21,4 +21,11 @@ type TrafficRoutingReconciler interface {
 	RemoveManagedRoutes() error
 	// Type returns the type of the traffic routing reconciler
 	Type() string
+	// CanScaleDown checks if it is safe to scale down the ReplicaSet identified by the given pod template hash.
+	// This allows traffic routing plugins to delay scale-down until external systems have completed draining.
+	// Returns:
+	// - *true: scale-down is safe
+	// - *false: scale-down is NOT safe yet
+	// - nil: not implemented, default behavior applies
+	CanScaleDown(podTemplateHash string) (*bool, error)
 }

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -7,9 +7,11 @@ import (
 	"testing"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/argoproj/argo-rollouts/rollout/trafficrouting/apisix"
 
@@ -24,6 +26,7 @@ import (
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/rollout/mocks"
+	"github.com/argoproj/argo-rollouts/rollout/trafficrouting"
 	"github.com/argoproj/argo-rollouts/rollout/trafficrouting/alb"
 	apisixMocks "github.com/argoproj/argo-rollouts/rollout/trafficrouting/apisix/mocks"
 	"github.com/argoproj/argo-rollouts/rollout/trafficrouting/appmesh"
@@ -51,6 +54,7 @@ func newFakeSingleTrafficRoutingReconciler() *mocks.TrafficRoutingReconciler {
 	trafficRoutingReconciler.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](true), nil)
 	trafficRoutingReconciler.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	trafficRoutingReconciler.On("RemoveManagedRoutes", mock.Anything, mock.Anything).Return(nil)
+	trafficRoutingReconciler.On("CanScaleDown", mock.Anything).Return((*bool)(nil), nil)
 	return &trafficRoutingReconciler
 }
 
@@ -1917,5 +1921,414 @@ func TestTrafficRoutingErrorsWhenNewCanaryHasNoReplicas(t *testing.T) {
 
 			f.fakeTrafficRouting.AssertCalled(t, tc.expectedCall, mock.Anything, mock.Anything)
 		})
+	}
+}
+
+// TestCanScaleDownRS tests the canScaleDownRS function which checks if traffic routers
+// allow scale-down of a ReplicaSet
+func TestCanScaleDownRS(t *testing.T) {
+	tests := []struct {
+		name                string
+		hasTrafficRouting   bool
+		canScaleDownReturn  *bool
+		canScaleDownErr     error
+		expectedResult      *bool
+		expectedErrContains string
+	}{
+		{
+			name:               "No traffic routing configured",
+			hasTrafficRouting:  false,
+			canScaleDownReturn: nil,
+			canScaleDownErr:    nil,
+			expectedResult:     nil,
+		},
+		{
+			name:               "Traffic router returns not implemented (nil)",
+			hasTrafficRouting:  true,
+			canScaleDownReturn: nil,
+			canScaleDownErr:    nil,
+			expectedResult:     nil,
+		},
+		{
+			name:               "Traffic router allows scale-down",
+			hasTrafficRouting:  true,
+			canScaleDownReturn: ptr.To[bool](true),
+			canScaleDownErr:    nil,
+			expectedResult:     ptr.To[bool](true),
+		},
+		{
+			name:               "Traffic router blocks scale-down",
+			hasTrafficRouting:  true,
+			canScaleDownReturn: ptr.To[bool](false),
+			canScaleDownErr:    nil,
+			expectedResult:     ptr.To[bool](false),
+		},
+		{
+			name:                "Traffic router returns error",
+			hasTrafficRouting:   true,
+			canScaleDownReturn:  nil,
+			canScaleDownErr:     errors.New("connection error"),
+			expectedResult:      nil,
+			expectedErrContains: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFixture(t)
+			defer f.Close()
+
+			steps := []v1alpha1.CanaryStep{
+				{SetWeight: ptr.To[int32](10)},
+			}
+			r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(0))
+
+			if tc.hasTrafficRouting {
+				r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
+					SMI: &v1alpha1.SMITrafficRouting{},
+				}
+				r1.Spec.Strategy.Canary.CanaryService = "canary-svc"
+				r1.Spec.Strategy.Canary.StableService = "stable-svc"
+			}
+
+			rs1 := newReplicaSetWithStatus(r1, 10, 10)
+			rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+
+			r1.Status.StableRS = rs1PodHash
+
+			f.kubeobjects = append(f.kubeobjects, rs1)
+			f.replicaSetLister = append(f.replicaSetLister, rs1)
+			f.rolloutLister = append(f.rolloutLister, r1)
+			f.objects = append(f.objects, r1)
+
+			c, i, k8sI := f.newController(noResyncPeriodFunc)
+			f.runController(getKey(r1, t), true, false, c, i, k8sI)
+
+			// Create the rollout context
+			roCtx, err := c.newRolloutContext(r1)
+			assert.NoError(t, err)
+
+			if tc.hasTrafficRouting {
+				f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+				f.fakeTrafficRouting.On("CanScaleDown", mock.Anything).Return(tc.canScaleDownReturn, tc.canScaleDownErr)
+
+				roCtx.newTrafficRoutingReconciler = func(roCtx *rolloutContext) ([]trafficrouting.TrafficRoutingReconciler, error) {
+					return []trafficrouting.TrafficRoutingReconciler{f.fakeTrafficRouting}, nil
+				}
+			}
+
+			result, err := roCtx.canScaleDownRS(rs1PodHash)
+
+			if tc.expectedErrContains != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedErrContains)
+			} else {
+				// Note: errors from CanScaleDown are logged as warnings but don't fail the operation
+				if tc.canScaleDownErr != nil {
+					// When there's an error but we continue, result should be nil
+					assert.Nil(t, result)
+				} else if tc.expectedResult == nil {
+					assert.Nil(t, result)
+				} else {
+					assert.NotNil(t, result)
+					assert.Equal(t, *tc.expectedResult, *result)
+				}
+			}
+		})
+	}
+}
+
+// TestCanScaleDownRSMultipleReconcilers tests canScaleDownRS with multiple traffic reconcilers
+func TestCanScaleDownRSMultipleReconcilers(t *testing.T) {
+	tests := []struct {
+		name            string
+		reconciler1Resp *bool
+		reconciler2Resp *bool
+		expectedResult  *bool
+	}{
+		{
+			name:            "Both return not implemented",
+			reconciler1Resp: nil,
+			reconciler2Resp: nil,
+			expectedResult:  nil,
+		},
+		{
+			name:            "First allows, second not implemented",
+			reconciler1Resp: ptr.To[bool](true),
+			reconciler2Resp: nil,
+			expectedResult:  ptr.To[bool](true),
+		},
+		{
+			name:            "First not implemented, second allows",
+			reconciler1Resp: nil,
+			reconciler2Resp: ptr.To[bool](true),
+			expectedResult:  ptr.To[bool](true),
+		},
+		{
+			name:            "Both allow",
+			reconciler1Resp: ptr.To[bool](true),
+			reconciler2Resp: ptr.To[bool](true),
+			expectedResult:  ptr.To[bool](true),
+		},
+		{
+			name:            "First allows, second blocks",
+			reconciler1Resp: ptr.To[bool](true),
+			reconciler2Resp: ptr.To[bool](false),
+			expectedResult:  ptr.To[bool](false),
+		},
+		{
+			name:            "First blocks, second allows",
+			reconciler1Resp: ptr.To[bool](false),
+			reconciler2Resp: ptr.To[bool](true),
+			expectedResult:  ptr.To[bool](false),
+		},
+		{
+			name:            "First not implemented, second blocks",
+			reconciler1Resp: nil,
+			reconciler2Resp: ptr.To[bool](false),
+			expectedResult:  ptr.To[bool](false),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFixture(t)
+			defer f.Close()
+
+			steps := []v1alpha1.CanaryStep{
+				{SetWeight: ptr.To[int32](10)},
+			}
+			r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(0))
+			r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
+				SMI: &v1alpha1.SMITrafficRouting{},
+			}
+			r1.Spec.Strategy.Canary.CanaryService = "canary-svc"
+			r1.Spec.Strategy.Canary.StableService = "stable-svc"
+
+			rs1 := newReplicaSetWithStatus(r1, 10, 10)
+			rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+			r1.Status.StableRS = rs1PodHash
+
+			f.kubeobjects = append(f.kubeobjects, rs1)
+			f.replicaSetLister = append(f.replicaSetLister, rs1)
+			f.rolloutLister = append(f.rolloutLister, r1)
+			f.objects = append(f.objects, r1)
+
+			c, i, k8sI := f.newController(noResyncPeriodFunc)
+			f.runController(getKey(r1, t), true, false, c, i, k8sI)
+
+			roCtx, err := c.newRolloutContext(r1)
+			assert.NoError(t, err)
+
+			// Create two mock reconcilers
+			reconciler1 := &mocks.TrafficRoutingReconciler{}
+			reconciler1.On("Type").Return("reconciler1")
+			reconciler1.On("CanScaleDown", mock.Anything).Return(tc.reconciler1Resp, nil)
+
+			reconciler2 := &mocks.TrafficRoutingReconciler{}
+			reconciler2.On("Type").Return("reconciler2")
+			reconciler2.On("CanScaleDown", mock.Anything).Return(tc.reconciler2Resp, nil)
+
+			roCtx.newTrafficRoutingReconciler = func(roCtx *rolloutContext) ([]trafficrouting.TrafficRoutingReconciler, error) {
+				return []trafficrouting.TrafficRoutingReconciler{reconciler1, reconciler2}, nil
+			}
+
+			result, err := roCtx.canScaleDownRS(rs1PodHash)
+			assert.NoError(t, err)
+
+			if tc.expectedResult == nil {
+				assert.Nil(t, result)
+			} else {
+				assert.NotNil(t, result)
+				assert.Equal(t, *tc.expectedResult, *result)
+			}
+		})
+	}
+}
+
+// TestCanScaleDownBlocksIntermediateRSScaleDown tests that when a traffic router blocks scale-down
+// via CanScaleDown, the intermediate RS is not scaled down during an interrupted update (rainbow deployment)
+func TestCanScaleDownBlocksIntermediateRSScaleDown(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{
+		{
+			SetWeight: ptr.To[int32](100),
+		},
+		{
+			Pause: &v1alpha1.RolloutPause{},
+		},
+	}
+	r1 := newCanaryRollout("foo", 5, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
+	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
+		SMI: &v1alpha1.SMITrafficRouting{},
+	}
+	r1.Spec.Strategy.Canary.StableService = "stable-svc"
+	r1.Spec.Strategy.Canary.CanaryService = "canary-svc"
+	r2 := bumpVersion(r1)
+	r3 := bumpVersion(r2)
+
+	stableSvc := newService("stable-svc", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: r1.Status.CurrentPodHash}, r1)
+	canarySvc := newService("canary-svc", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: r3.Status.CurrentPodHash}, r3)
+	r3.Status.StableRS = r1.Status.CurrentPodHash
+
+	rs1 := newReplicaSetWithStatus(r1, 5, 5)
+	rs2 := newReplicaSetWithStatus(r2, 5, 5) // This is the intermediate RS that should be blocked
+	rs3 := newReplicaSetWithStatus(r3, 5, 5)
+
+	f.objects = append(f.objects, r3)
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2, rs3, canarySvc, stableSvc)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2, rs3)
+	f.serviceLister = append(f.serviceLister, canarySvc, stableSvc)
+
+	// Mock traffic router to block scale-down
+	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](true), nil)
+	f.fakeTrafficRouting.On("RemoveManagedRoutes", mock.Anything).Return(nil)
+	// Block scale-down for the intermediate RS
+	f.fakeTrafficRouting.On("CanScaleDown", mock.Anything).Return(ptr.To[bool](false), nil)
+
+	f.expectPatchRolloutAction(r3)
+	// We should NOT see an update to rs2 because CanScaleDown blocks it
+	f.run(getKey(r3, t))
+
+	// Verify rs2 was NOT scaled down (no ReplicaSet update action)
+	for _, action := range f.kubeclient.Actions() {
+		if action.GetVerb() == "update" && action.GetResource().Resource == "replicasets" {
+			updateAction := action.(k8stesting.UpdateAction)
+			rs := updateAction.GetObject().(*appsv1.ReplicaSet)
+			// If rs2 was updated, it should still have 5 replicas (not 0)
+			if rs.Name == rs2.Name {
+				assert.Equal(t, int32(5), *rs.Spec.Replicas, "rs2 should not be scaled down when CanScaleDown returns false")
+			}
+		}
+	}
+}
+
+// TestCanScaleDownAllowsIntermediateRSScaleDown tests that when a traffic router allows scale-down
+// via CanScaleDown, the intermediate RS is scaled down during an interrupted update
+func TestCanScaleDownAllowsIntermediateRSScaleDown(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{
+		{
+			SetWeight: ptr.To[int32](100),
+		},
+		{
+			Pause: &v1alpha1.RolloutPause{},
+		},
+	}
+	r1 := newCanaryRollout("foo", 5, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
+	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
+		SMI: &v1alpha1.SMITrafficRouting{},
+	}
+	r1.Spec.Strategy.Canary.StableService = "stable-svc"
+	r1.Spec.Strategy.Canary.CanaryService = "canary-svc"
+	r2 := bumpVersion(r1)
+	r3 := bumpVersion(r2)
+
+	stableSvc := newService("stable-svc", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: r1.Status.CurrentPodHash}, r1)
+	canarySvc := newService("canary-svc", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: r3.Status.CurrentPodHash}, r3)
+	r3.Status.StableRS = r1.Status.CurrentPodHash
+
+	rs1 := newReplicaSetWithStatus(r1, 5, 5)
+	rs2 := newReplicaSetWithStatus(r2, 5, 5) // This is the intermediate RS that should be scaled down
+	rs3 := newReplicaSetWithStatus(r3, 5, 5)
+
+	f.objects = append(f.objects, r3)
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2, rs3, canarySvc, stableSvc)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2, rs3)
+	f.serviceLister = append(f.serviceLister, canarySvc, stableSvc)
+
+	// Mock traffic router to allow scale-down
+	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](true), nil)
+	f.fakeTrafficRouting.On("RemoveManagedRoutes", mock.Anything).Return(nil)
+	// Allow scale-down
+	f.fakeTrafficRouting.On("CanScaleDown", mock.Anything).Return(ptr.To[bool](true), nil)
+
+	f.expectPatchRolloutAction(r3)
+	updatedRSIndex := f.expectUpdateReplicaSetAction(rs2)
+	f.run(getKey(r3, t))
+
+	// Verify rs2 WAS scaled down to 0
+	updatedRs2 := f.getUpdatedReplicaSet(updatedRSIndex)
+	assert.Equal(t, int32(0), *updatedRs2.Spec.Replicas)
+}
+
+// TestCanScaleDownBlocksScaleDownAtRevisionLimit tests that when exceeding scaleDownDelayRevisionLimit,
+// the traffic router's CanScaleDown is still respected
+func TestCanScaleDownBlocksScaleDownAtRevisionLimit(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{
+		{SetWeight: ptr.To[int32](100)},
+	}
+	r1 := newCanaryRollout("foo", 5, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(0))
+	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
+		SMI: &v1alpha1.SMITrafficRouting{},
+	}
+	r1.Spec.Strategy.Canary.StableService = "stable-svc"
+	r1.Spec.Strategy.Canary.CanaryService = "canary-svc"
+	// Set revision limit to 1, so the second RS exceeds the limit
+	r1.Spec.Strategy.Canary.ScaleDownDelayRevisionLimit = ptr.To[int32](1)
+
+	r2 := bumpVersion(r1)
+	r3 := bumpVersion(r2)
+
+	stableSvc := newService("stable-svc", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: r3.Status.CurrentPodHash}, r3)
+	canarySvc := newService("canary-svc", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: r3.Status.CurrentPodHash}, r3)
+
+	rs1 := newReplicaSetWithStatus(r1, 5, 5)
+	rs2 := newReplicaSetWithStatus(r2, 5, 5)
+	rs3 := newReplicaSetWithStatus(r3, 5, 5)
+
+	// Add scale-down deadline to both old RSs (they're waiting to be scaled down)
+	now := timeutil.MetaNow()
+	pastDeadline := now.Add(-1 * time.Minute).UTC().Format(time.RFC3339)
+	rs1.Annotations = map[string]string{v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey: pastDeadline}
+	rs2.Annotations = map[string]string{v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey: pastDeadline}
+
+	// Mark rollout as fully promoted (stable = canary = rs3)
+	r3.Status.StableRS = replicasetutil.GetPodTemplateHash(rs3)
+	r3.Status.CurrentPodHash = replicasetutil.GetPodTemplateHash(rs3)
+
+	f.objects = append(f.objects, r3)
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2, rs3, canarySvc, stableSvc)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2, rs3)
+	f.serviceLister = append(f.serviceLister, canarySvc, stableSvc)
+
+	// Mock traffic router to block scale-down
+	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](true), nil)
+	f.fakeTrafficRouting.On("RemoveManagedRoutes", mock.Anything).Return(nil)
+	// Block scale-down
+	f.fakeTrafficRouting.On("CanScaleDown", mock.Anything).Return(ptr.To[bool](false), nil)
+
+	f.expectPatchRolloutAction(r3)
+	// We should NOT see any RS scaled down because CanScaleDown blocks it
+	f.run(getKey(r3, t))
+
+	// Verify neither rs1 nor rs2 was scaled down
+	for _, action := range f.kubeclient.Actions() {
+		if action.GetVerb() == "update" && action.GetResource().Resource == "replicasets" {
+			updateAction := action.(k8stesting.UpdateAction)
+			rs := updateAction.GetObject().(*appsv1.ReplicaSet)
+			if rs.Name == rs1.Name || rs.Name == rs2.Name {
+				assert.Equal(t, int32(5), *rs.Spec.Replicas, "RS should not be scaled down when CanScaleDown returns false")
+			}
+		}
 	}
 }

--- a/test/cmd/trafficrouter-plugin-sample/internal/plugin/plugin.go
+++ b/test/cmd/trafficrouter-plugin-sample/internal/plugin/plugin.go
@@ -334,6 +334,19 @@ func (r *RpcPlugin) Type() string {
 	return "plugin-nginx"
 }
 
+// CanScaleDown checks if it is safe to scale down the ReplicaSet identified by the given pod template hash.
+// This sample implementation returns ScaleDownNotImplemented, meaning the default behavior will be used.
+// Plugins can implement custom logic here to delay scale-down until external systems have completed draining.
+func (r *RpcPlugin) CanScaleDown(ro *v1alpha1.Rollout, podTemplateHash string) (pluginTypes.RpcScaleDownVerified, pluginTypes.RpcError) {
+	r.LogCtx.Infof("CanScaleDown called for pod template hash: %s", podTemplateHash)
+	// Return ScaleDownNotImplemented to use default scale-down behavior.
+	// Plugins can return:
+	// - ScaleDownVerified: scale-down is safe
+	// - ScaleDownNotVerified: scale-down is NOT safe, controller should retry later
+	// - ScaleDownNotImplemented: plugin does not implement this check, default behavior applies
+	return pluginTypes.ScaleDownNotImplemented, pluginTypes.RpcError{}
+}
+
 func getCanaryIngressName(rollout *v1alpha1.Rollout, stableIngress string) string {
 	// names limited to 253 characters
 	if rollout.Spec.Strategy.Canary != nil &&

--- a/utils/conditions/conditions.go
+++ b/utils/conditions/conditions.go
@@ -182,6 +182,9 @@ const (
 	// WeightVerifyErrorReason is emitted when there is an error verifying the set weight
 	WeightVerifyErrorReason  = "WeightVerifyError"
 	WeightVerifyErrorMessage = "Failed to verify weight: %s"
+	// ScaleDownCheckErrorReason is emitted when there is an error checking if scale-down is allowed
+	ScaleDownCheckErrorReason  = "ScaleDownCheckError"
+	ScaleDownCheckErrorMessage = "Failed to check scale-down: %s"
 	// LoadBalancerNotFoundReason is emitted when load balancer can not be found
 	LoadBalancerNotFoundReason  = "LoadBalancerNotFound"
 	LoadBalancerNotFoundMessage = "Failed to find load balancer: %s"


### PR DESCRIPTION
Allow traffic router plugins to delay ReplicaSet scale-down until external systems have completed draining (e.g., long-running connections, worker versioning, message queue consumers).

The hook is checked before scaling down:
- Intermediate ReplicaSets during interrupted updates (rainbow deployments)
- ReplicaSets after scale-down deadline has passed
- ReplicaSets when exceeding scaleDownDelayRevisionLimit

... am leaving this ready if the enhancement issue is approved, I already had it coded up so thought I would open the PR now just in case :) 

Closes https://github.com/argoproj/argo-rollouts/issues/4597

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
