### PR TITLE
docs(example): Update argo-rollouts docs url

### DIFF
--- a/docs/features/kustomize.md
+++ b/docs/features/kustomize.md
@@ -25,14 +25,14 @@ An example kustomize app demonstrating the ability to use transformers with Roll
 
 ```yaml
 configurations:
-  - https://argoproj.github.io/argo-rollouts/features/kustomize/rollout-transform.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-rollouts/master/docs/features/kustomize/rollout-transform.yaml
 ```
 
 - With Kustomize 5 it is possible to reference the configuration directly from a remote resource:
 
 ```yaml
 configurations:
-  - https://argoproj.github.io/argo-rollouts/features/kustomize/rollout-transform-kustomize-v5.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-rollouts/master/docs/features/kustomize/rollout-transform-kustomize-v5.yaml
 ```
 
 - With Kustomize 4.5.5 kustomize can use kubernetes OpenAPI data to get merge key and patch strategy information about [resource types](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/openapi). For example, given the following rollout:


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).


Since `1:30 PM (13:30) UTC`, all kustomize configs referencing `https://argoproj.github.io` are failing with 
```
err='accumulating resources from 'xxx': 'xxx' must resolve to a file': recursed accumulation of path 'xxx': URL is a git repository
```

As `https://argoproj.github.io` started to return a redirect to `https://argo-rollouts.readthedocs.io`
```
> GET /argo-rollouts/features/kustomize/rollout-transform.yaml HTTP/2
> Host: argoproj.github.io
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/2 404
< server: GitHub.com
< content-type: text/html; charset=utf-8
< access-control-allow-origin: *
< strict-transport-security: max-age=31556952
< etag: "6970d6c8-184"
< x-proxy-cache: MISS
< x-github-request-id: 8322:23EAD0:4DA2F:54FF0:6970DF4A
< accept-ranges: bytes
< age: 2944
< date: Wed, 21 Jan 2026 15:03:38 GMT
< via: 1.1 varnish
< x-served-by: cache-bma-essb1270078-BMA
< x-cache: HIT
< x-cache-hits: 0
< x-timer: S1769007819.647810,VS0,VE1
< vary: Accept-Encoding
< x-fastly-request-id: 8e308ea749d3034e384dfe3bc069f6c452d4cae3
< content-length: 388
<
<body>
  <p>If you are not redirected, <a href="https://argo-rollouts.readthedocs.io">click here</a>.</p>
  <script>
    var path = window.location.pathname;
    if (path.startsWith('/argo-rollouts')) {
      path = path.substr('/argo-rollouts'.length);
    }
    window.location.replace('https://argo-rollouts.readthedocs.io/en/stable' + path + window.location.hash);
  </script>
* Connection #0 to host argoproj.github.io left intact
</body>
```
