### PR TITLE
fix: bluegreen analysis prematurely succeeds if new ReplicaSet becomes unsaturated

### DIFF
--- a/rollout/analysis.go
+++ b/rollout/analysis.go
@@ -246,7 +246,7 @@ func (c *rolloutContext) reconcilePrePromotionAnalysisRun() (*v1alpha1.AnalysisR
 	}
 	c.log.Info("Reconciling Pre Promotion Analysis")
 
-	if skipPrePromotionAnalysisRun(c.rollout, c.newRS) {
+	if skipPrePromotionAnalysisRun(c.rollout, c.newRS, currentAr) {
 		err := c.cancelAnalysisRuns([]*v1alpha1.AnalysisRun{currentAr})
 		return currentAr, err
 	}
@@ -271,12 +271,19 @@ func (c *rolloutContext) reconcilePrePromotionAnalysisRun() (*v1alpha1.AnalysisR
 // skipPrePromotionAnalysisRun checks if the controller should skip creating a pre promotion
 // analysis run by checking if the rollout active promotion happened, the rollout was just created,
 // the newRS is not saturated
-func skipPrePromotionAnalysisRun(rollout *v1alpha1.Rollout, newRS *appsv1.ReplicaSet) bool {
+func skipPrePromotionAnalysisRun(rollout *v1alpha1.Rollout, newRS *appsv1.ReplicaSet, currentAr *v1alpha1.AnalysisRun) bool {
 	currentPodHash := replicasetutil.GetPodTemplateHash(newRS)
 	activeSelector := rollout.Status.BlueGreen.ActiveSelector
 	if rollout.Status.StableRS == currentPodHash || activeSelector == "" || activeSelector == currentPodHash || currentPodHash == "" {
 		return true
 	}
+	// If we already started pre-promotion analysis, then we should not skip it.
+	// Otherwise, performing the saturation check below might cancel the analysis run
+	// prematurely if the newRS becomes unsaturated (e.g. due to natural pod churn)
+	if currentAr != nil {
+		return false
+	}
+	// Don't start pre-promotion analysis if the newRS is not saturated.
 	// Checking saturation is different if the previewReplicaCount feature is being used because
 	// annotations.IsSaturated() also looks at the desired annotation on the ReplicaSet, and the
 	// check using previewReplicaCount does not.
@@ -290,10 +297,20 @@ func skipPrePromotionAnalysisRun(rollout *v1alpha1.Rollout, newRS *appsv1.Replic
 // skipPrePromotionAnalysisRun checks if the controller should skip creating a post promotion
 // analysis run by checking that the desired ReplicaSet is the stable ReplicaSet, the active
 // service promotion has not happened, the rollout was just created, or the newRS is not saturated
-func skipPostPromotionAnalysisRun(rollout *v1alpha1.Rollout, newRS *appsv1.ReplicaSet) bool {
+func skipPostPromotionAnalysisRun(rollout *v1alpha1.Rollout, newRS *appsv1.ReplicaSet, currentAr *v1alpha1.AnalysisRun) bool {
 	currentPodHash := replicasetutil.GetPodTemplateHash(newRS)
 	activeSelector := rollout.Status.BlueGreen.ActiveSelector
-	return rollout.Status.StableRS == currentPodHash || activeSelector != currentPodHash || currentPodHash == "" || !annotations.IsSaturated(rollout, newRS)
+	if rollout.Status.StableRS == currentPodHash || activeSelector != currentPodHash || currentPodHash == "" {
+		return true
+	}
+	// If we already started post-promotion analysis, then we should not skip it.
+	// Otherwise, performing the saturation check below might cancel the analysis run
+	// prematurely if the newRS becomes unsaturated (e.g. due to natural pod churn)
+	if currentAr != nil {
+		return false
+	}
+	// Don't start post-promotion analysis if the newRS is not saturated.
+	return !annotations.IsSaturated(rollout, newRS)
 }
 
 func (c *rolloutContext) reconcilePostPromotionAnalysisRun() (*v1alpha1.AnalysisRun, error) {
@@ -305,7 +322,7 @@ func (c *rolloutContext) reconcilePostPromotionAnalysisRun() (*v1alpha1.Analysis
 
 	c.log.Info("Reconciling Post Promotion Analysis")
 	// don't start post-promotion if we are not ready to, or we are still waiting for target verification
-	if skipPostPromotionAnalysisRun(c.rollout, c.newRS) || !c.areTargetsVerified() {
+	if skipPostPromotionAnalysisRun(c.rollout, c.newRS, currentAr) || !c.areTargetsVerified() {
 		err := c.cancelAnalysisRuns([]*v1alpha1.AnalysisRun{currentAr})
 		return currentAr, err
 	}

--- a/rollout/analysis.go
+++ b/rollout/analysis.go
@@ -294,7 +294,7 @@ func skipPrePromotionAnalysisRun(rollout *v1alpha1.Rollout, newRS *appsv1.Replic
 	return !annotations.IsSaturated(rollout, newRS)
 }
 
-// skipPrePromotionAnalysisRun checks if the controller should skip creating a post promotion
+// skipPostPromotionAnalysisRun checks if the controller should skip creating a post promotion
 // analysis run by checking that the desired ReplicaSet is the stable ReplicaSet, the active
 // service promotion has not happened, the rollout was just created, or the newRS is not saturated
 func skipPostPromotionAnalysisRun(rollout *v1alpha1.Rollout, newRS *appsv1.ReplicaSet, currentAr *v1alpha1.AnalysisRun) bool {

--- a/rollout/analysis_test.go
+++ b/rollout/analysis_test.go
@@ -19,7 +19,9 @@ import (
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	analysisutil "github.com/argoproj/argo-rollouts/utils/analysis"
+	"github.com/argoproj/argo-rollouts/utils/annotations"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
+	replicasetutil "github.com/argoproj/argo-rollouts/utils/replicaset"
 	rolloututil "github.com/argoproj/argo-rollouts/utils/rollout"
 )
 
@@ -2935,4 +2937,228 @@ func concatMultipleSlices[T any](slices [][]T) []T {
 	}
 
 	return result
+}
+
+// TestSkipPrePromotionAnalysisRun tests the skipPrePromotionAnalysisRun function
+func TestSkipPrePromotionAnalysisRun(t *testing.T) {
+	t.Run("should skip when StableRS equals currentPodHash", func(t *testing.T) {
+		rollout := newBlueGreenRollout("test", 2, nil, "active", "preview")
+		newRS := newReplicaSetWithStatus(rollout, 2, 2)
+		podHash := replicasetutil.GetPodTemplateHash(newRS)
+		rollout.Status.StableRS = podHash
+		rollout.Status.BlueGreen.ActiveSelector = "different-hash"
+
+		result := skipPrePromotionAnalysisRun(rollout, newRS, nil)
+		assert.True(t, result, "Should skip when StableRS equals currentPodHash")
+	})
+
+	t.Run("should skip when activeSelector is empty", func(t *testing.T) {
+		rollout := newBlueGreenRollout("test", 2, nil, "active", "preview")
+		newRS := newReplicaSetWithStatus(rollout, 2, 2)
+		rollout.Status.BlueGreen.ActiveSelector = ""
+		rollout.Status.StableRS = "different-hash"
+
+		result := skipPrePromotionAnalysisRun(rollout, newRS, nil)
+		assert.True(t, result, "Should skip when activeSelector is empty")
+	})
+
+	t.Run("should skip when activeSelector equals currentPodHash", func(t *testing.T) {
+		rollout := newBlueGreenRollout("test", 2, nil, "active", "preview")
+		newRS := newReplicaSetWithStatus(rollout, 2, 2)
+		podHash := replicasetutil.GetPodTemplateHash(newRS)
+		rollout.Status.BlueGreen.ActiveSelector = podHash
+		rollout.Status.StableRS = "different-hash"
+
+		result := skipPrePromotionAnalysisRun(rollout, newRS, nil)
+		assert.True(t, result, "Should skip when activeSelector equals currentPodHash")
+	})
+
+	t.Run("should skip when currentPodHash is empty", func(t *testing.T) {
+		rollout := newBlueGreenRollout("test", 2, nil, "active", "preview")
+		newRS := newReplicaSetWithStatus(rollout, 2, 2)
+		newRS.Labels = nil // Remove labels to make podHash empty
+		rollout.Status.BlueGreen.ActiveSelector = "some-hash"
+		rollout.Status.StableRS = "different-hash"
+
+		result := skipPrePromotionAnalysisRun(rollout, newRS, nil)
+		assert.True(t, result, "Should skip when currentPodHash is empty")
+	})
+
+	t.Run("should not skip when currentAr is not nil", func(t *testing.T) {
+		rollout := newBlueGreenRollout("test", 2, nil, "active", "preview")
+		newRS := newReplicaSetWithStatus(rollout, 2, 1) // Unsaturated
+		rollout.Status.BlueGreen.ActiveSelector = "different-hash"
+		rollout.Status.StableRS = "different-hash"
+		currentAr := &v1alpha1.AnalysisRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-ar",
+			},
+		}
+
+		result := skipPrePromotionAnalysisRun(rollout, newRS, currentAr)
+		assert.False(t, result, "Should not skip when currentAr is not nil, even if ReplicaSet is unsaturated")
+	})
+
+	t.Run("should skip when currentAr is nil and ReplicaSet is not saturated", func(t *testing.T) {
+		rollout := newBlueGreenRollout("test", 2, nil, "active", "preview")
+		newRS := newReplicaSetWithStatus(rollout, 2, 1) // Unsaturated: 2 desired, 1 available
+		rollout.Status.BlueGreen.ActiveSelector = "different-hash"
+		rollout.Status.StableRS = "different-hash"
+		// Set up annotations for IsSaturated check
+		if newRS.Annotations == nil {
+			newRS.Annotations = make(map[string]string)
+		}
+		newRS.Annotations[annotations.DesiredReplicasAnnotation] = "2"
+
+		result := skipPrePromotionAnalysisRun(rollout, newRS, nil)
+		assert.True(t, result, "Should skip when currentAr is nil and ReplicaSet is not saturated")
+	})
+
+	t.Run("should not skip when currentAr is nil and ReplicaSet is saturated", func(t *testing.T) {
+		rollout := newBlueGreenRollout("test", 2, nil, "active", "preview")
+		newRS := newReplicaSetWithStatus(rollout, 2, 2) // Saturated: 2 desired, 2 available
+		rollout.Status.BlueGreen.ActiveSelector = "different-hash"
+		rollout.Status.StableRS = "different-hash"
+		// Set up annotations for IsSaturated check
+		if newRS.Annotations == nil {
+			newRS.Annotations = make(map[string]string)
+		}
+		newRS.Annotations[annotations.DesiredReplicasAnnotation] = "2"
+
+		result := skipPrePromotionAnalysisRun(rollout, newRS, nil)
+		assert.False(t, result, "Should not skip when currentAr is nil and ReplicaSet is saturated")
+	})
+
+	t.Run("should handle PreviewReplicaCount when currentAr is nil", func(t *testing.T) {
+		rollout := newBlueGreenRollout("test", 2, nil, "active", "preview")
+		previewCount := int32(3)
+		rollout.Spec.Strategy.BlueGreen.PreviewReplicaCount = &previewCount
+		newRS := newReplicaSetWithStatus(rollout, 3, 3) // Matches preview count
+		rollout.Status.BlueGreen.ActiveSelector = "different-hash"
+		rollout.Status.StableRS = "different-hash"
+
+		result := skipPrePromotionAnalysisRun(rollout, newRS, nil)
+		assert.False(t, result, "Should not skip when PreviewReplicaCount matches and ReplicaSet is saturated")
+
+		// Test with unsaturated ReplicaSet
+		newRS2 := newReplicaSetWithStatus(rollout, 3, 2) // Doesn't match preview count
+		result2 := skipPrePromotionAnalysisRun(rollout, newRS2, nil)
+		assert.True(t, result2, "Should skip when PreviewReplicaCount doesn't match")
+	})
+
+	t.Run("should not skip when currentAr is not nil even with PreviewReplicaCount mismatch", func(t *testing.T) {
+		rollout := newBlueGreenRollout("test", 2, nil, "active", "preview")
+		previewCount := int32(3)
+		rollout.Spec.Strategy.BlueGreen.PreviewReplicaCount = &previewCount
+		newRS := newReplicaSetWithStatus(rollout, 3, 2) // Doesn't match preview count
+		rollout.Status.BlueGreen.ActiveSelector = "different-hash"
+		rollout.Status.StableRS = "different-hash"
+		currentAr := &v1alpha1.AnalysisRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-ar",
+			},
+		}
+
+		result := skipPrePromotionAnalysisRun(rollout, newRS, currentAr)
+		assert.False(t, result, "Should not skip when currentAr is not nil, even with PreviewReplicaCount mismatch")
+	})
+}
+
+// TestSkipPostPromotionAnalysisRun tests the skipPostPromotionAnalysisRun function
+func TestSkipPostPromotionAnalysisRun(t *testing.T) {
+	t.Run("should skip when StableRS equals currentPodHash", func(t *testing.T) {
+		rollout := newBlueGreenRollout("test", 2, nil, "active", "")
+		newRS := newReplicaSetWithStatus(rollout, 2, 2)
+		podHash := replicasetutil.GetPodTemplateHash(newRS)
+		rollout.Status.StableRS = podHash
+		rollout.Status.BlueGreen.ActiveSelector = podHash
+
+		result := skipPostPromotionAnalysisRun(rollout, newRS, nil)
+		assert.True(t, result, "Should skip when StableRS equals currentPodHash")
+	})
+
+	t.Run("should skip when activeSelector does not equal currentPodHash", func(t *testing.T) {
+		rollout := newBlueGreenRollout("test", 2, nil, "active", "")
+		newRS := newReplicaSetWithStatus(rollout, 2, 2)
+		rollout.Status.BlueGreen.ActiveSelector = "different-hash"
+		rollout.Status.StableRS = "different-hash"
+
+		result := skipPostPromotionAnalysisRun(rollout, newRS, nil)
+		assert.True(t, result, "Should skip when activeSelector does not equal currentPodHash")
+	})
+
+	t.Run("should skip when currentPodHash is empty", func(t *testing.T) {
+		rollout := newBlueGreenRollout("test", 2, nil, "active", "")
+		newRS := newReplicaSetWithStatus(rollout, 2, 2)
+		newRS.Labels = nil // Remove labels to make podHash empty
+		rollout.Status.BlueGreen.ActiveSelector = "some-hash"
+		rollout.Status.StableRS = "some-hash"
+
+		result := skipPostPromotionAnalysisRun(rollout, newRS, nil)
+		assert.True(t, result, "Should skip when currentPodHash is empty")
+	})
+
+	t.Run("should not skip when currentAr is not nil", func(t *testing.T) {
+		rollout := newBlueGreenRollout("test", 2, nil, "active", "")
+		newRS := newReplicaSetWithStatus(rollout, 2, 1) // Unsaturated
+		podHash := replicasetutil.GetPodTemplateHash(newRS)
+		rollout.Status.BlueGreen.ActiveSelector = podHash
+		rollout.Status.StableRS = "different-hash"
+		currentAr := &v1alpha1.AnalysisRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-ar",
+			},
+		}
+
+		result := skipPostPromotionAnalysisRun(rollout, newRS, currentAr)
+		assert.False(t, result, "Should not skip when currentAr is not nil, even if ReplicaSet is unsaturated")
+	})
+
+	t.Run("should skip when currentAr is nil and ReplicaSet is not saturated", func(t *testing.T) {
+		rollout := newBlueGreenRollout("test", 2, nil, "active", "")
+		newRS := newReplicaSetWithStatus(rollout, 2, 1) // Unsaturated: 2 desired, 1 available
+		podHash := replicasetutil.GetPodTemplateHash(newRS)
+		rollout.Status.BlueGreen.ActiveSelector = podHash
+		rollout.Status.StableRS = "different-hash"
+		// Set up annotations for IsSaturated check
+		if newRS.Annotations == nil {
+			newRS.Annotations = make(map[string]string)
+		}
+		newRS.Annotations[annotations.DesiredReplicasAnnotation] = "2"
+
+		result := skipPostPromotionAnalysisRun(rollout, newRS, nil)
+		assert.True(t, result, "Should skip when currentAr is nil and ReplicaSet is not saturated")
+	})
+
+	t.Run("should not skip when currentAr is nil and ReplicaSet is saturated", func(t *testing.T) {
+		rollout := newBlueGreenRollout("test", 2, nil, "active", "")
+		newRS := newReplicaSetWithStatus(rollout, 2, 2) // Saturated: 2 desired, 2 available
+		podHash := replicasetutil.GetPodTemplateHash(newRS)
+		rollout.Status.BlueGreen.ActiveSelector = podHash
+		rollout.Status.StableRS = "different-hash"
+		// Set up annotations for IsSaturated check
+		if newRS.Annotations == nil {
+			newRS.Annotations = make(map[string]string)
+		}
+		newRS.Annotations[annotations.DesiredReplicasAnnotation] = "2"
+
+		result := skipPostPromotionAnalysisRun(rollout, newRS, nil)
+		assert.False(t, result, "Should not skip when currentAr is nil and ReplicaSet is saturated")
+	})
+
+	t.Run("should not skip when currentAr is not nil even if ReplicaSet becomes unsaturated", func(t *testing.T) {
+		rollout := newBlueGreenRollout("test", 2, nil, "active", "")
+		newRS := newReplicaSetWithStatus(rollout, 2, 1) // Unsaturated
+		podHash := replicasetutil.GetPodTemplateHash(newRS)
+		rollout.Status.BlueGreen.ActiveSelector = podHash
+		rollout.Status.StableRS = "different-hash"
+		currentAr := &v1alpha1.AnalysisRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-ar",
+			},
+		}
+
+		result := skipPostPromotionAnalysisRun(rollout, newRS, currentAr)
+		assert.False(t, result, "Should not skip when currentAr is not nil, even if ReplicaSet becomes unsaturated")
+	})
 }

--- a/rollout/bluegreen.go
+++ b/rollout/bluegreen.go
@@ -207,8 +207,8 @@ func (c *rolloutContext) scaleDownOldReplicaSetsForBlueGreen(oldRSs []*appsv1.Re
 		c.log.Infof("Cannot scale down old ReplicaSets while paused with inconclusive Analysis ")
 		return false, nil
 	}
-	if c.rollout.Spec.Strategy.BlueGreen != nil && c.rollout.Spec.Strategy.BlueGreen.PostPromotionAnalysis != nil && c.rollout.Spec.Strategy.BlueGreen.ScaleDownDelaySeconds == nil && !skipPostPromotionAnalysisRun(c.rollout, c.newRS) {
-		currentPostAr := c.currentArs.BlueGreenPostPromotion
+	currentPostAr := c.currentArs.BlueGreenPostPromotion
+	if c.rollout.Spec.Strategy.BlueGreen != nil && c.rollout.Spec.Strategy.BlueGreen.PostPromotionAnalysis != nil && c.rollout.Spec.Strategy.BlueGreen.ScaleDownDelaySeconds == nil && !skipPostPromotionAnalysisRun(c.rollout, c.newRS, currentPostAr) {
 		if currentPostAr == nil || currentPostAr.Status.Phase != v1alpha1.AnalysisPhaseSuccessful {
 			c.log.Infof("Cannot scale down old ReplicaSets while Analysis is running and no ScaleDownDelaySeconds")
 			return false, nil


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-rollouts/issues/3724.

During blue-green rollout reconciliation, we have two methods that determine whether to skip and cancel the pre- and post-promotion analysis (`skipPrePromotionAnalysisRun`, `skipPostPromotionAnalysisRun`).

One of the checks in those methods is to see whether the new ReplicaSet is fully saturated. If not, we return true that analysis should be skipped/cancelled. The intended purpose of this check is to prevent analysis from starting unless the newRS is fully up and saturated. In the happy path, where Pods never come down after becoming saturated, this is not a problem.

However, if the new ReplicaSets ever become **_unsaturated_** after pre/post promotion had already started, and while the analysis is running, then these methods return true, causing:
1. In-flight pre/post analysis to become cancelled
2. The rollout progresses to the next stage, which is often completing the update prematurely

The checks are performed during every Rollout reconciliation. If by chance, the new ReplicaSet becomes unsaturated (e.g., due to normal node/pod churn), we will prematurely cause rollouts to promote.

To reproduce this:
1. Create a blue-green rollout with either pre/post analysis. e.g., a Job analysis that sleeps for 5m and exits 1
2. Perform an update of the rollout and wait until analysis runs
3. Before analysis completes, delete a pod of the newRS
4. The newRS becomes unsaturated, the analysis is terminated, and the rollout update completes without the analysis actually successfully completing.

This change fixes the issue by not considering pod saturation of the new ReplicaSet if we had already started analysis.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
