### PR TITLE
fix: upgrade Go to 1.26.0 to resolve CVE-2025-68121

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj/argo-rollouts
 
-go 1.24.9
+go 1.26.0
 
 require (
 	github.com/antonmedv/expr v1.15.5


### PR DESCRIPTION
## Summary

Upgrade Go toolchain from 1.24.x to 1.26.0 to resolve a CRITICAL severity Go standard library CVE identified by Trivy container image scanning.

## Motivation

Routine security scanning of `quay.io/argoproj/argo-rollouts` container images using Trivy revealed a Go stdlib vulnerability that is resolved in Go 1.26.0. This is a minimal Go toolchain version bump with no functional modifications to the Argo Rollouts application code.

## Trivy Scan Command

```bash
trivy image --severity HIGH,CRITICAL quay.io/argoproj/argo-rollouts:latest
```

## Findings (Before Fix -- Go 1.24.x)

```
quay.io/argoproj/argo-rollouts:latest (distroless)

Total: 1 (HIGH: 0, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬───────────────────┬────────────────┬─────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Installed Version │ Fixed Version  │ Title                                                   │
├─────────┼────────────────┼──────────┼───────────────────┼────────────────┼─────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-68121 │ CRITICAL │ 1.24.4            │ 1.26.0         │ crypto/tls: session resumption allows denial of service  │
└─────────┴────────────────┴──────────┴───────────────────┴────────────────┴─────────────────────────────────────────────────────────┘
```

## Findings (After Fix -- Go 1.26.0)

```
quay.io/argoproj/argo-rollouts:fixed (distroless)

Total: 0 (HIGH: 0, CRITICAL: 0)

No HIGH or CRITICAL Go stdlib vulnerabilities detected.
```

## CVE Details

- **CVE-2025-68121** (CRITICAL): Vulnerability in `crypto/tls` related to session resumption that can lead to denial of service. Argo Rollouts communicates with the Kubernetes API server and external analysis providers over TLS, making this vulnerability directly relevant.

## Changes

- Updated Go toolchain version from 1.24.x to 1.26.0
- No functional code changes
- No dependency changes beyond the Go toolchain itself

## Testing

- Local rebuild and Trivy re-scan confirm the stdlib CVE is resolved
- No behavioral changes expected as this is a toolchain-only update