### PR TITLE
chore: support team workflows and Nats.io for notifications

### DIFF
--- a/docs/generated/notification-services/alertmanager.md
+++ b/docs/generated/notification-services/alertmanager.md
@@ -11,6 +11,10 @@ The notification service is used to push events to [Alertmanager](https://github
 * `basicAuth` - optional, server auth
 * `bearerToken` - optional, server auth
 * `timeout` - optional, the timeout in seconds used when sending alerts, default is "3 seconds"
+* `maxIdleConns` - optional, maximum number of idle (keep-alive) connections across all hosts.
+* `maxIdleConnsPerHost` - optional, maximum number of idle (keep-alive) connections per host.
+* `maxConnsPerHost` - optional, maximum total connections per host.
+* `idleConnTimeout` - optional, maximum amount of time an idle (keep-alive) connection will remain open before closing.
 
 `basicAuth` or `bearerToken` is used for authentication, you can choose one. If the two are set at the same time, `basicAuth` takes precedence over `bearerToken`.
 

--- a/docs/generated/notification-services/email.md
+++ b/docs/generated/notification-services/email.md
@@ -12,6 +12,19 @@ The Email notification service sends email notifications using SMTP protocol and
 * `html` - optional bool, true or false
 * `insecure_skip_verify` - optional bool, true or false
 
+### Using Gmail
+
+When configuring Gmail as the SMTP service:
+
+* `username` - Must be your Gmail address.
+* `password` - Use an App Password, not your regular Gmail password.
+
+To Generate an app password, follow this link https://myaccount.google.com/apppasswords
+
+!!! note
+    This applies to personal Gmail accounts (non-Google Workspace). For Google Workspace users, SMTP settings 
+    and authentication methods may differ.
+
 ## Example
 
 The following snippet contains sample Gmail service configuration:
@@ -23,11 +36,11 @@ metadata:
   name: argo-rollouts-notification-configmap
 data:
   service.email.gmail: |
-    username: $email-username
-    password: $email-password
+    username: $username
+    password: $password
     host: smtp.gmail.com
     port: 465
-    from: $email-username
+    from: $email-address
 ```
 
 Without authentication:
@@ -41,7 +54,7 @@ data:
   service.email.example: |
     host: smtp.example.com
     port: 587
-    from: $email-username
+    from: $email-address
 ```
 
 ## Template

--- a/docs/generated/notification-services/github.md
+++ b/docs/generated/notification-services/github.md
@@ -8,6 +8,10 @@ The GitHub notification service changes commit status using [GitHub Apps](https:
 - `installationID` - the app installation id
 - `privateKey` - the app private key
 - `enterpriseBaseURL` - optional URL, e.g. https://git.example.com/api/v3
+- `maxIdleConns` - optional, maximum number of idle (keep-alive) connections across all hosts.
+- `maxIdleConnsPerHost` - optional, maximum number of idle (keep-alive) connections per host.
+- `maxConnsPerHost` - optional, maximum total connections per host.
+- `idleConnTimeout` - optional, maximum amount of time an idle (keep-alive) connection will remain open before closing.
 
 > ⚠️ _NOTE:_ Specifying `/api/v3` in the `enterpriseBaseURL` is required until [argoproj/notifications-engine#205](https://github.com/argoproj/notifications-engine/issues/205) is resolved.
 
@@ -111,3 +115,6 @@ template.app-deployed: |
 - The `github.pullRequestComment.commentTag` parameter is used to identify the comment. If a comment with the specified tag is found, it will be updated (upserted). If no comment with the tag is found, a new comment will be created.
 - Reference is optional. When set, it will be used as the ref to deploy. If not set, the revision will be used as the ref to deploy.
 
+## Commit Statuses
+
+The [method for generating commit statuses](https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status) allows a maximum of 1000 attempts using the same commit SHA and context. Once this limit is reached, the API returns validation errors (HTTP 422). The notification engine ignores these errors and marks the notification attempts as completed.

--- a/docs/generated/notification-services/grafana.md
+++ b/docs/generated/notification-services/grafana.md
@@ -9,6 +9,10 @@ Available parameters :
 * `apiURL` - the server url, e.g. https://grafana.example.com
 * `apiKey` - the API key for the serviceaccount
 * `insecureSkipVerify` - optional bool, true or false
+* `maxIdleConns` - optional, maximum number of idle (keep-alive) connections across all hosts.
+* `maxIdleConnsPerHost` - optional, maximum number of idle (keep-alive) connections per host.
+* `maxConnsPerHost` - optional, maximum total connections per host.
+* `idleConnTimeout` - optional, maximum amount of time an idle (keep-alive) connection will remain open before closing.
 
 1. Login to your Grafana instance as `admin`
 2. On the left menu, go to Configuration / API Keys

--- a/docs/generated/notification-services/mattermost.md
+++ b/docs/generated/notification-services/mattermost.md
@@ -5,6 +5,10 @@
 * `apiURL` - the server url, e.g. https://mattermost.example.com
 * `token` - the bot token
 * `insecureSkipVerify` - optional bool, true or false
+* `maxIdleConns` - optional, maximum number of idle (keep-alive) connections across all hosts.
+* `maxIdleConnsPerHost` - optional, maximum number of idle (keep-alive) connections per host.
+* `maxConnsPerHost` - optional, maximum total connections per host.
+* `idleConnTimeout` - optional, maximum amount of time an idle (keep-alive) connection will remain open before closing, e.g. '90s'.
 
 ## Configuration
 

--- a/docs/generated/notification-services/nats.md
+++ b/docs/generated/notification-services/nats.md
@@ -1,0 +1,49 @@
+# Nats
+
+## Parameters
+
+This notification service is capable of sending simple messages via Nats.
+
+* Url - Nats server URL, e.g. `nats://nats:4222`
+* Headers - optional, additional headers to be sent with the message
+* User - optional, Nats user for authentication used in combination with password
+* Password - optional, Nats password for authentication used in combination with user
+* Nkey - optional, Nats key for authentication 
+
+## Example
+
+Resource Annotation:
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  annotations:
+    notifications.argoproj.io/subscribe.on-deployment-ready.nats: "mytopic"
+```
+
+* ConfigMap
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argo-rollouts-notification-configmap
+data:
+  service.nats: |
+    url: "nats://nats:4222"
+    headers:
+      my-header: "my-value"
+
+template.deployment-ready: |
+    message: |
+      Deployment {{.obj.metadata.name}} is ready!
+
+  trigger.on-deployment-ready: |
+    - when: any(obj.status.conditions, {.type == 'Available' && .status == 'True'})
+      send: [deployment-ready]
+    - oncePer: obj.metadata.annotations["generation"]
+
+```
+
+
+

--- a/docs/generated/notification-services/newrelic.md
+++ b/docs/generated/notification-services/newrelic.md
@@ -4,6 +4,10 @@
 
 * `apiURL` - the api server url, e.g. https://api.newrelic.com
 * `apiKey` - a [NewRelic ApiKey](https://docs.newrelic.com/docs/apis/rest-api-v2/get-started/introduction-new-relic-rest-api-v2/#api_key)
+* `maxIdleConns` - optional, maximum number of idle (keep-alive) connections across all hosts.
+* `maxIdleConnsPerHost` - optional, maximum number of idle (keep-alive) connections per host.
+* `maxConnsPerHost` - optional, maximum total connections per host.
+* `idleConnTimeout` - optional, maximum amount of time an idle (keep-alive) connection will remain open before closing, e.g. '90s'.
 
 ## Configuration
 
@@ -43,12 +47,14 @@ metadata:
 
 ## Templates
 
-* `description` - __optional__, high-level description of this deployment, visible in the [Summary](https://docs.newrelic.com/docs/apm/applications-menu/monitoring/apm-overview-page) page and on the [Deployments](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page) page when you select an individual deployment.
-  * Defaults to `message`
-* `changelog` - __optional__, A summary of what changed in this deployment, visible in the [Deployments](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page) page when you select (selected deployment) > Change log.
-  * Defaults to `{{(call .repo.GetCommitMetadata .app.status.sync.revision).Message}}`
-* `user` - __optional__, A username to associate with the deployment, visible in the [Summary](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page) and on the [Deployments](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page).
-  * Defaults to `{{(call .repo.GetCommitMetadata .app.status.sync.revision).Author}}`
+- `revision` - **optional**, The revision being deployed. Can contain a custom template to extract the revision from your specific application status structure.
+  - Defaults to `{{.app.status.operationState.syncResult.revision}}`
+- `description` - **optional**, high-level description of this deployment, visible in the [Summary](https://docs.newrelic.com/docs/apm/applications-menu/monitoring/apm-overview-page) page and on the [Deployments](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page) page when you select an individual deployment.
+  - Defaults to `message`
+- `changelog` - **optional**, A summary of what changed in this deployment, visible in the [Deployments](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page) page when you select (selected deployment) > Change log.
+  - Defaults to `{{(call .repo.GetCommitMetadata .app.status.sync.revision).Message}}`
+- `user` - **optional**, A username to associate with the deployment, visible in the [Summary](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page) and on the [Deployments](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page).
+  - Defaults to `{{(call .repo.GetCommitMetadata .app.status.sync.revision).Author}}`
 
 ```yaml
 context: |

--- a/docs/generated/notification-services/overview.md
+++ b/docs/generated/notification-services/overview.md
@@ -47,7 +47,8 @@ metadata:
 * [Grafana](./grafana.md)
 * [Webhook](./webhook.md)
 * [Telegram](./telegram.md)
-* [Teams](./teams.md)
+* [Teams (Office 365 Connectors)](./teams.md) - Legacy service (deprecated, retires March 31, 2026)
+* [Teams Workflows](./teams-workflows.md) - Recommended replacement for Office 365 Connectors
 * [Google Chat](./googlechat.md)
 * [Rocket.Chat](./rocketchat.md)
 * [Pushover](./pushover.md)

--- a/docs/generated/notification-services/pagerduty_v2.md
+++ b/docs/generated/notification-services/pagerduty_v2.md
@@ -62,6 +62,8 @@ The parameters for the PagerDuty configuration in the template generally match w
 * `group` - Logical grouping of components of a service.
 * `class` - The class/type of the event.
 * `url` - The URL that should be used for the link "View in ArgoCD" in PagerDuty.
+* `dedupKey` - A string used by PagerDuty to deduplicate and correlate events. Events with the same `dedupKey` will be grouped into the same incident. If omitted, PagerDuty will create a new incident for each event.
+
 
 The `timestamp` and `custom_details` parameters are not currently supported.
 

--- a/docs/generated/notification-services/slack.md
+++ b/docs/generated/notification-services/slack.md
@@ -16,6 +16,11 @@ The Slack notification service configuration includes following settings:
 | `token`              | **True**     | `string`       | The app's OAuth access token. | `xoxb-1234567890-1234567890123-5n38u5ed63fgzqlvuyxvxcx6` |
 | `username`           | False        | `string`       | The app username. | `argocd` |
 | `disableUnfurl`      | False        | `bool`         | Disable slack unfurling links in messages | `true` |
+| `maxIdleConns`        | False        | `int`          | Maximum number of idle (keep-alive) connections across all hosts.                               | —                      |
+| `maxIdleConnsPerHost` | False        | `int`          | Maximum number of idle (keep-alive) connections per host.                                       | —                      |
+| `maxConnsPerHost`     | False        | `int`          | Maximum total connections per host.                                                             | —                      |
+| `idleConnTimeout`     | False        | `string`       | Maximum amount of time an idle (keep-alive) connection will remain open before closing (e.g., `90s`). | —              |
+
 
 ## Configuration
 

--- a/docs/generated/notification-services/teams-workflows.md
+++ b/docs/generated/notification-services/teams-workflows.md
@@ -1,0 +1,370 @@
+# Teams Workflows
+
+## Overview
+
+The Teams Workflows notification service sends message notifications using Microsoft Teams Workflows (Power Automate). This is the recommended replacement for the legacy Office 365 Connectors service, which will be retired on March 31, 2026.
+
+## Parameters
+
+The Teams Workflows notification service requires specifying the following settings:
+
+* `recipientUrls` - the webhook url map, e.g. `channelName: https://api.powerautomate.com/webhook/...`
+
+## Supported Webhook URL Formats
+
+The service supports the following Microsoft Teams Workflows webhook URL patterns:
+
+- `https://api.powerautomate.com/...`
+- `https://api.powerplatform.com/...`
+- `https://flow.microsoft.com/...`
+- URLs containing `/powerautomate/` in the path
+
+## Configuration
+
+1. Open `Teams` and go to the channel you wish to set notifications for
+2. Click on the 3 dots next to the channel name
+3. Select`Workflows`
+4. Click on `Manage`
+5. Click `New flow`
+6. Write `Send webhook alerts to a channel` in the search bar or select it from the template list 
+7. Choose your team and channel
+8. Configure the webhook name and settings
+9. Copy the webhook URL (it will be from `api.powerautomate.com`, `api.powerplatform.com`, or `flow.microsoft.com`)
+10. Store it in `argo-rollouts-notification-secret` and define it in `argo-rollouts-notification-configmap`
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argo-rollouts-notification-configmap
+data:
+  service.teams-workflows: |
+    recipientUrls:
+      channelName: $channel-workflows-url
+```
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <secret-name>
+stringData:
+  channel-workflows-url: https://api.powerautomate.com/webhook/your-webhook-id
+```
+
+11. Create subscription for your Teams Workflows integration:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-succeeded.teams-workflows: channelName
+```
+
+## Channel Support
+
+- ✅ Standard Teams channels
+- ✅ Shared channels (as of December 2025)
+- ✅ Private channels (as of December 2025)
+
+Teams Workflows provides enhanced channel support compared to Office 365 Connectors, allowing you to post to shared and private channels in addition to standard channels.
+
+## Adaptive Card Format
+
+The Teams Workflows service uses **Adaptive Cards** exclusively, which is the modern, flexible card format for Microsoft Teams. All notifications are automatically converted to Adaptive Card format and wrapped in the required message envelope.
+
+### Option 1: Using Template Fields (Recommended)
+
+The service automatically converts template fields to Adaptive Card format. This is the simplest and most maintainable approach:
+
+```yaml
+template.app-sync-succeeded: |
+  teams-workflows:
+    # ThemeColor supports Adaptive Card semantic colors: "Good", "Warning", "Attention", "Accent"
+    # or hex colors like "#000080"
+    themeColor: "Good"
+    title: Application {{.app.metadata.name}} has been successfully synced
+    text: Application {{.app.metadata.name}} has been successfully synced at {{.app.status.operationState.finishedAt}}.
+    summary: "{{.app.metadata.name}} sync succeeded"
+    facts: |
+      [{
+        "name": "Sync Status",
+        "value": "{{.app.status.sync.status}}"
+      }, {
+        "name": "Repository",
+        "value": "{{.app.spec.source.repoURL}}"
+      }]
+    sections: |
+      [{
+        "facts": [
+          {
+            "name": "Namespace",
+            "value": "{{.app.metadata.namespace}}"
+          },
+          {
+            "name": "Cluster",
+            "value": "{{.app.spec.destination.server}}"
+          }
+        ]
+      }]
+    potentialAction: |-
+      [{
+        "@type": "OpenUri",
+        "name": "View in Argo CD",
+        "targets": [{
+          "os": "default",
+          "uri": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}"
+        }]
+      }]
+```
+
+**How it works:**
+- `title` → Converted to a large, bold TextBlock
+- `text` → Converted to a regular TextBlock
+- `facts` → Converted to a FactSet element
+- `sections` → Facts within sections are extracted and converted to FactSet elements
+- `potentialAction` → OpenUri actions are converted to Action.OpenUrl
+- `themeColor` → Applied to the title TextBlock (supports semantic colors like "Good", "Warning", "Attention", "Accent" or hex colors)
+
+### Option 2: Custom Adaptive Card JSON
+
+For full control and advanced features, you can provide a complete Adaptive Card JSON template:
+
+```yaml
+template.app-sync-succeeded: |
+  teams-workflows:
+    adaptiveCard: |
+      {
+        "type": "AdaptiveCard",
+        "version": "1.4",
+        "body": [
+          {
+            "type": "TextBlock",
+            "text": "Application {{.app.metadata.name}} synced successfully",
+            "size": "Large",
+            "weight": "Bolder",
+            "color": "Good"
+          },
+          {
+            "type": "TextBlock",
+            "text": "Application {{.app.metadata.name}} has been successfully synced at {{.app.status.operationState.finishedAt}}.",
+            "wrap": true
+          },
+          {
+            "type": "FactSet",
+            "facts": [
+              {
+                "title": "Sync Status",
+                "value": "{{.app.status.sync.status}}"
+              },
+              {
+                "title": "Repository",
+                "value": "{{.app.spec.source.repoURL}}"
+              }
+            ]
+          }
+        ],
+        "actions": [
+          {
+            "type": "Action.OpenUrl",
+            "title": "View in Argo CD",
+            "url": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}"
+          }
+        ]
+      }
+```
+
+**Note:** When using `adaptiveCard`, you only need to provide the AdaptiveCard JSON structure (not the full message envelope). The service automatically wraps it in the required `message` + `attachments` format for Teams Workflows.
+
+**Important:** If you provide `adaptiveCard`, it takes precedence over all other template fields (`title`, `text`, `facts`, etc.).
+
+## Template Fields
+
+The Teams Workflows service supports the following template fields, which are automatically converted to Adaptive Card format:
+
+### Standard Fields
+
+- `title` - Message title (converted to large, bold TextBlock)
+- `text` - Message text content (converted to TextBlock)
+- `summary` - Summary text (currently not used in Adaptive Cards, but preserved for compatibility)
+- `themeColor` - Color for the title. Supports:
+  - Semantic colors: `"Good"` (green), `"Warning"` (yellow), `"Attention"` (red), `"Accent"` (blue)
+  - Hex colors: `"#000080"`, `"#FF0000"`, etc.
+- `facts` - JSON array of fact key-value pairs (converted to FactSet)
+  ```yaml
+  facts: |
+    [{
+      "name": "Status",
+      "value": "{{.app.status.sync.status}}"
+    }]
+  ```
+- `sections` - JSON array of sections containing facts (facts are extracted and converted to FactSet)
+  ```yaml
+  sections: |
+    [{
+      "facts": [{
+        "name": "Namespace",
+        "value": "{{.app.metadata.namespace}}"
+      }]
+    }]
+  ```
+- `potentialAction` - JSON array of action buttons (OpenUri actions converted to Action.OpenUrl)
+  ```yaml
+  potentialAction: |-
+    [{
+      "@type": "OpenUri",
+      "name": "View Details",
+      "targets": [{
+        "os": "default",
+        "uri": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}"
+      }]
+    }]
+  ```
+
+### Advanced Fields
+
+- `adaptiveCard` - Complete Adaptive Card JSON template (takes precedence over all other fields)
+  - Only provide the AdaptiveCard structure, not the message envelope
+  - Supports full Adaptive Card 1.4 specification
+  - Allows access to all Adaptive Card features (containers, columns, images, etc.)
+
+- `template` - Raw JSON template (legacy, use `adaptiveCard` instead)
+
+### Field Conversion Details
+
+| Template Field | Adaptive Card Element | Notes |
+|---------------|----------------------|-------|
+| `title` | `TextBlock` with `size: "Large"`, `weight: "Bolder"` | ThemeColor applied to this element |
+| `text` | `TextBlock` with `wrap: true` | Uses `n.Message` if `text` is empty |
+| `facts` | `FactSet` | Each fact becomes a `title`/`value` pair |
+| `sections[].facts` | `FactSet` | Facts extracted from sections |
+| `potentialAction[OpenUri]` | `Action.OpenUrl` | Only OpenUri actions are converted |
+| `themeColor` | Applied to title `TextBlock.color` | Supports semantic and hex colors |
+
+## Migration from Office 365 Connectors
+
+If you're currently using the `teams` service with Office 365 Connectors, follow these steps to migrate:
+
+1. **Create a new Workflows webhook** using the configuration steps above
+
+2. **Update your service configuration:**
+   - Change from `service.teams` to `service.teams-workflows`
+   - Update the webhook URL to your new Workflows webhook URL
+
+3. **Update your templates:**
+   - Change `teams:` to `teams-workflows:` in your templates
+   - Your existing template fields (`title`, `text`, `facts`, `sections`, `potentialAction`) will automatically be converted to Adaptive Card format
+   - No changes needed to your template structure - the conversion is automatic
+
+4. **Update your subscriptions:**
+   ```yaml
+   # Old
+   notifications.argoproj.io/subscribe.on-sync-succeeded.teams: channelName
+   
+   # New
+   notifications.argoproj.io/subscribe.on-sync-succeeded.teams-workflows: channelName
+   ```
+
+5. **Test and verify:**
+   - Send a test notification to verify it works correctly
+   - Once verified, you can remove the old Office 365 Connector configuration
+
+**Note:** Your existing templates will work without modification. The service automatically converts your template fields to Adaptive Card format, so you get the benefits of modern cards without changing your templates.
+
+## Differences from Office 365 Connectors
+
+| Feature | Office 365 Connectors | Teams Workflows |
+|---------|----------------------|-----------------|
+| Service Name | `teams` | `teams-workflows` |
+| Standard Channels | ✅ | ✅ |
+| Shared Channels | ❌ | ✅ (Dec 2025+) |
+| Private Channels | ❌ | ✅ (Dec 2025+) |
+| Card Format | messageCard (legacy) | Adaptive Cards (modern) |
+| Template Conversion | N/A | Automatic conversion from template fields |
+| Retirement Date | March 31, 2026 | Active |
+
+## Adaptive Card Features
+
+The Teams Workflows service leverages Adaptive Cards, which provide:
+
+- **Rich Content**: Support for text, images, fact sets, and more
+- **Flexible Layout**: Containers, columns, and adaptive layouts
+- **Interactive Elements**: Action buttons, input fields, and more
+- **Semantic Colors**: Built-in color schemes (Good, Warning, Attention, Accent)
+- **Cross-Platform**: Works across Teams, Outlook, and other Microsoft 365 apps
+
+### Example: Advanced Adaptive Card Template
+
+For complex notifications, you can use the full Adaptive Card specification:
+
+```yaml
+template.app-sync-succeeded-advanced: |
+  teams-workflows:
+    adaptiveCard: |
+      {
+        "type": "AdaptiveCard",
+        "version": "1.4",
+        "body": [
+          {
+            "type": "Container",
+            "items": [
+              {
+                "type": "ColumnSet",
+                "columns": [
+                  {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                      {
+                        "type": "Image",
+                        "url": "https://example.com/success-icon.png",
+                        "size": "Small"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                      {
+                        "type": "TextBlock",
+                        "text": "Application {{.app.metadata.name}}",
+                        "weight": "Bolder",
+                        "size": "Large"
+                      },
+                      {
+                        "type": "TextBlock",
+                        "text": "Successfully synced",
+                        "spacing": "None",
+                        "isSubtle": true
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "FactSet",
+                "facts": [
+                  {
+                    "title": "Status",
+                    "value": "{{.app.status.sync.status}}"
+                  },
+                  {
+                    "title": "Repository",
+                    "value": "{{.app.spec.source.repoURL}}"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "actions": [
+          {
+            "type": "Action.OpenUrl",
+            "title": "View in Argo CD",
+            "url": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}"
+          }
+        ]
+      }
+```

--- a/docs/generated/notification-services/teams.md
+++ b/docs/generated/notification-services/teams.md
@@ -1,18 +1,46 @@
-# Teams
+# Teams (Office 365 Connectors)
+
+## ⚠️ Deprecation Notice
+
+**Office 365 Connectors are being retired by Microsoft.**
+
+Microsoft is retiring the Office 365 Connectors service in Teams. The service will be fully retired by **March 31, 2026** (extended from the original timeline of December 2025). 
+
+### What this means:
+- **Old Office 365 Connectors** (webhook URLs from `webhook.office.com`) will stop working after the retirement date
+- **New Power Automate Workflows** (webhook URLs from `api.powerautomate.com`, `api.powerplatform.com`, or `flow.microsoft.com`) are the recommended replacement
+
+### Migration Required:
+If you are currently using Office 365 Connectors (Incoming Webhook), you should migrate to Power Automate Workflows before the retirement date. The notifications-engine automatically detects the webhook type and handles both formats, but you should plan your migration.
+
+**Migration Resources:**
+- [Microsoft Deprecation Notice](https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/)
+- [Create incoming webhooks with Workflows for Microsoft Teams](https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-4b3b0b0e-0b5a-4b5a-9b5a-0b5a-4b5a-9b5a)
+
+---
 
 ## Parameters
 
-The Teams notification service send message notifications using Teams bot and requires specifying the following settings:
+The Teams notification service sends message notifications using Office 365 Connectors and requires specifying the following settings:
 
-* `recipientUrls` - the webhook url map, e.g. `channelName: https://example.com`
+* `recipientUrls` - the webhook url map, e.g. `channelName: https://outlook.office.com/webhook/...`
+
+> **⚠️ Deprecation Notice:** Office 365 Connectors will be retired by Microsoft on **March 31, 2026**. We recommend migrating to the [Teams Workflows service](./teams-workflows.md) for continued support and enhanced features.
 
 ## Configuration
+
+> **💡 For Power Automate Workflows (Recommended):** See the [Teams Workflows documentation](./teams-workflows.md) for detailed configuration instructions.
+
+### Office 365 Connectors (Deprecated - Retiring March 31, 2026)
+
+> **⚠️ Warning:** This method is deprecated and will stop working after March 31, 2026. Please migrate to Power Automate Workflows.
 
 1. Open `Teams` and goto `Apps`
 2. Find `Incoming Webhook` microsoft app and click on it
 3. Press `Add to a team` -> select team and channel -> press `Set up a connector`
 4. Enter webhook name and upload image (optional)
-5. Press `Create` then copy webhook url and store it in `argo-rollouts-notification-secret` and define it in `argo-rollouts-notification-configmap`
+5. Press `Create` then copy webhook url (it will be from `webhook.office.com`)
+6. Store it in `argo-rollouts-notification-secret` and define it in `argo-rollouts-notification-configmap`
 
 ```yaml
 apiVersion: v1
@@ -31,10 +59,20 @@ kind: Secret
 metadata:
   name: <secret-name>
 stringData:
-  channel-teams-url: https://example.com
+  channel-teams-url: https://webhook.office.com/webhook/your-webhook-id  # Office 365 Connector (deprecated)
 ```
 
-6. Create subscription for your Teams integration:
+> **Note:** For Power Automate Workflows webhooks, use the [Teams Workflows service](./teams-workflows.md) instead.
+
+### Webhook Type Detection
+
+The `teams` service supports Office 365 Connectors (deprecated):
+
+- **Office 365 Connectors**: URLs from `webhook.office.com` (deprecated)
+  - Requires response body to be exactly `"1"` for success
+  - Will stop working after March 31, 2026
+
+7. Create subscription for your Teams integration:
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -44,11 +82,19 @@ metadata:
     notifications.argoproj.io/subscribe.on-sync-succeeded.teams: channelName
 ```
 
+## Channel Support
+
+- ✅ Standard Teams channels only
+
+> **Note:** Office 365 Connectors only support standard Teams channels. For shared channels or private channels, use the [Teams Workflows service](./teams-workflows.md).
+
 ## Templates
 
 ![](https://user-images.githubusercontent.com/18019529/114271500-9d2b8880-9a4c-11eb-85c1-f6935f0431d5.png)
 
 [Notification templates](../../features/notifications.md#templates) can be customized to leverage teams message sections, facts, themeColor, summary and potentialAction [feature](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using).
+
+The Teams service uses the **messageCard** format (MessageCard schema) which is compatible with Office 365 Connectors.
 
 ```yaml
 template.app-sync-succeeded: |
@@ -124,3 +170,7 @@ template.app-sync-succeeded: |
   teams:
     summary: "Sync Succeeded"
 ```
+
+## Migration to Teams Workflows
+
+If you're currently using Office 365 Connectors, see the [Teams Workflows documentation](./teams-workflows.md) for migration instructions and enhanced features.

--- a/docs/generated/notification-services/webhook.md
+++ b/docs/generated/notification-services/webhook.md
@@ -14,6 +14,10 @@ The Webhook notification service configuration includes following settings:
 - `retryWaitMin` - Optional, the minimum wait time between retries. Default value: 1s.
 - `retryWaitMax` - Optional, the maximum wait time between retries. Default value: 5s.
 - `retryMax` - Optional, the maximum number of retries. Default value: 3.
+- `maxIdleConns` - optional, maximum number of idle (keep-alive) connections across all hosts.
+- `maxIdleConnsPerHost` - optional, maximum number of idle (keep-alive) connections per host.
+- `maxConnsPerHost` - optional, maximum total connections per host.
+- `idleConnTimeout` - optional, maximum amount of time an idle (keep-alive) connection will remain open before closing, e.g. '90s'.
 
 ## Retry Behavior
 
@@ -73,6 +77,29 @@ metadata:
   annotations:
     notifications.argoproj.io/subscribe.<trigger-name>.<webhook-name>: ""
 ```
+
+4. TLS configuration (optional)
+
+If your webhook server uses a custom TLS certificate, you can configure the notification service to trust it by adding the certificate to the `argocd-tls-certs-cm` ConfigMap as shown below:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-tls-certs-cm
+data:
+  <hostname>: |
+    -----BEGIN CERTIFICATE-----
+    <TLS DATA>
+    -----END CERTIFICATE-----
+```
+
+*NOTE:*
+*If the custom certificate is not trusted, you may encounter errors such as:*
+```
+Put \"https://...\": x509: certificate signed by unknown authority
+```
+*Adding the server's certificate to `argocd-tls-certs-cm` resolves this issue.*
 
 ## Examples
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.9
 
 require (
 	github.com/antonmedv/expr v1.15.5
-	github.com/argoproj/notifications-engine v0.5.0
+	github.com/argoproj/notifications-engine v0.5.1-0.20260213231747-1dbe3de712f8
 	github.com/argoproj/pkg v0.13.6
 	github.com/aws/aws-sdk-go-v2 v1.36.6
 	github.com/aws/aws-sdk-go-v2/config v1.29.14
@@ -136,6 +136,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/lunixbochs/vtclean v1.0.0 // indirect
@@ -153,6 +154,9 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
+	github.com/nats-io/nats.go v1.43.0 // indirect
+	github.com/nats-io/nkeys v0.4.11 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/oapi-codegen/runtime v1.0.0 // indirect
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
@@ -184,7 +188,7 @@ require (
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/term v0.34.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
-	golang.org/x/time v0.10.0 // indirect
+	golang.org/x/time v0.11.0 // indirect
 	golang.org/x/tools v0.36.0 // indirect
 	gomodules.xyz/envconfig v1.3.1-0.20190308184047-426f31af0d45 // indirect
 	gomodules.xyz/notify v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/antonmedv/expr v1.15.5/go.mod h1:0E/6TxnOlRNp81GMzX9QfDPAmHo2Phg00y4J
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/appscode/go v0.0.0-20191119085241-0887d8ec2ecc/go.mod h1:OawnOmAL4ZX3YaPdN+8HTNwBveT1jMsqP74moa9XUbE=
-github.com/argoproj/notifications-engine v0.5.0 h1:ZSIY4wwWvudYhryUclPnvajzz+KvEgHI5J6sDwBLByU=
-github.com/argoproj/notifications-engine v0.5.0/go.mod h1:d1RazGXWvKRFv9//rg4MRRR7rbvbE7XLgTSMT5fITTE=
+github.com/argoproj/notifications-engine v0.5.1-0.20260213231747-1dbe3de712f8 h1:OGoe2RFv1wuhxHrFcdAC/VW+5HUkRI+1/zf3RGR5LnY=
+github.com/argoproj/notifications-engine v0.5.1-0.20260213231747-1dbe3de712f8/go.mod h1:zz+4OVgqmyD0T5whLAPO6k5BGLSop4j32BKHSAe80tM=
 github.com/argoproj/pkg v0.13.6 h1:36WPD9MNYECHcO1/R1pj6teYspiK7uMQLCgLGft2abM=
 github.com/argoproj/pkg v0.13.6/go.mod h1:I698DoJBKuvNFaixh4vFl2C88cNIT1WS7KCbz5ewyF8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -311,6 +311,8 @@ github.com/google/go-github/v69 v69.2.0/go.mod h1:xne4jymxLR6Uj9b7J7PyTpkMYstEMM
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+github.com/google/go-tpm v0.9.5 h1:ocUmnDebX54dnW+MQWGQRbdaAcJELsa6PqZhJ48KwVU=
+github.com/google/go-tpm v0.9.5/go.mod h1:h9jEsEECg7gtLis0upRBQU+GhYVH6jMjrFxI8u6bVUY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -457,6 +459,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/minio/highwayhash v1.0.3 h1:kbnuUMoHYyVl7szWjSxJnxw11k2U709jqFPPmIUyD6Q=
+github.com/minio/highwayhash v1.0.3/go.mod h1:GGYsuwP/fPD6Y9hMiXuapVvlIUEhFhMTh0rxU3ik1LQ=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=
 github.com/minio/minio-go/v7 v7.0.29/go.mod h1:x81+AX5gHSfCSqw7jxRKHvxUXMlE5uKX0Vb75Xk5yYg=
 github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
@@ -491,6 +495,16 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/nats-io/jwt/v2 v2.7.4 h1:jXFuDDxs/GQjGDZGhNgH4tXzSUK6WQi2rsj4xmsNOtI=
+github.com/nats-io/jwt/v2 v2.7.4/go.mod h1:me11pOkwObtcBNR8AiMrUbtVOUGkqYjMQZ6jnSdVUIA=
+github.com/nats-io/nats-server/v2 v2.11.4 h1:oQhvy6He6ER926sGqIKBKuYHH4BGnUQCNb0Y5Qa+M54=
+github.com/nats-io/nats-server/v2 v2.11.4/go.mod h1:jFnKKwbNeq6IfLHq+OMnl7vrFRihQ/MkhRbiWfjLdjU=
+github.com/nats-io/nats.go v1.43.0 h1:uRFZ2FEoRvP64+UUhaTokyS18XBCR/xM2vQZKO4i8ug=
+github.com/nats-io/nats.go v1.43.0/go.mod h1:iRWIPokVIFbVijxuMQq4y9ttaBTMe0SFdlZfMDd+33g=
+github.com/nats-io/nkeys v0.4.11 h1:q44qGV008kYd9W1b1nEBkNzvnWxtRSQ7A8BoqRrcfa0=
+github.com/nats-io/nkeys v0.4.11/go.mod h1:szDimtgmfOi9n25JpfIdGw12tZFYXqhGxjhVxsatHVE=
+github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
+github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/newrelic/newrelic-client-go/v2 v2.54.0 h1:d4rKYO/souvIMmsA58DfL17TR8clCt6ZNUoPfzjIKng=
 github.com/newrelic/newrelic-client-go/v2 v2.54.0/go.mod h1:+RRjI3nDGWT3kLm9Oi3QxpBm70uu8q1upEHBVWCZFpo=
 github.com/nlopes/slack v0.5.0/go.mod h1:jVI4BBK3lSktibKahxBF74txcK2vyvkza1z/+rRnVAM=
@@ -1030,8 +1044,8 @@ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
-golang.org/x/time v0.10.0 h1:3usCWA8tQn0L8+hFJQNgzpWbd89begxN66o1Ojdn5L4=
-golang.org/x/time v0.10.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
+golang.org/x/time v0.11.0 h1:/bpjEDfN9tkoN/ryeYHnv5hcMlc8ncjMcM4XBk5NWV0=
+golang.org/x/time v0.11.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
     - generated/notification-services/googlechat.md
     - generated/notification-services/grafana.md
     - generated/notification-services/mattermost.md
+    - generated/notification-services/nats.md
     - generated/notification-services/newrelic.md
     - generated/notification-services/opsgenie.md
     - generated/notification-services/overview.md
@@ -90,6 +91,7 @@ nav:
     - generated/notification-services/pushover.md
     - generated/notification-services/rocketchat.md
     - generated/notification-services/slack.md
+    - generated/notification-services/teams-workflows.md
     - generated/notification-services/teams.md
     - generated/notification-services/telegram.md
     - generated/notification-services/webex.md


### PR DESCRIPTION
Upgraded to latest version of the notification engine to get support for [Team workflows](https://github.com/argoproj/notifications-engine/pull/414) and [Nats.io](https://github.com/argoproj/notifications-engine/pull/380)

Same [change for Argo CD](https://github.com/argoproj/argo-cd/pull/25785/files)

Closes https://github.com/argoproj/argo-rollouts/issues/4621

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
