### PR TITLE
chore: add Code owners similar to Argo CD

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,16 @@
+# All
+** @argoproj/argo-rollouts-approvers
+
+# Docs
+/docs/**     @argoproj/argo-rollouts-approvers @argoproj/argo-rollouts-approvers-docs
+/USERS.md    @argoproj/argo-rollouts-approvers @argoproj/argo-rollouts-approvers-docs
+/README.md   @argoproj/argo-rollouts-approvers @argoproj/argo-rollouts-approvers-docs
+/mkdocs.yml  @argoproj/argo-rollouts-approvers @argoproj/argo-rollouts-approvers-docs
+
+# CI
+/.codecov.yml             @argoproj/argo-rollouts-approvers @argoproj/argo-rollouts-approvers-ci
+/.github/**               @argoproj/argo-rollouts-approvers @argoproj/argo-rollouts-approvers-ci
+/.golangci.yml            @argoproj/argo-rollouts-approvers @argoproj/argo-rollouts-approvers-ci
+/sonar-project.properties @argoproj/argo-rollouts-approvers @argoproj/argo-rollouts-approvers-ci
+
+


### PR DESCRIPTION
Add Codeowers similar to Argo CD to allow different levels of approvers (only for docs, only for CI)

You can see the existing teams at https://github.com/orgs/argoproj/teams

At the time of writing only `argo-rollouts-approvers` exist, so a project maintainer needs to also create `argo-rollouts-approvers-docs` and `argo-rollouts-approvers-ci`


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
