### PR TITLE
fix(controller): sanitize k8s_request_total name label to prevent unbounded cardinality. Fixes #4571

### DIFF
--- a/controller/metrics/client.go
+++ b/controller/metrics/client.go
@@ -12,6 +12,13 @@ const (
 	clientsetMetricsNamespace = "controller_clientset"
 )
 
+var ephemeralKinds = map[string]bool{
+	"events":       true,
+	"replicasets":  true,
+	"analysisruns": true,
+	"experiments":  true,
+}
+
 type K8sRequestsCountProvider struct {
 	k8sRequestsCount *prometheus.CounterVec
 }
@@ -27,7 +34,7 @@ func (m *K8sRequestsCountProvider) IncKubernetesRequest(resourceInfo kubeclientm
 	namespace := resourceInfo.Namespace
 	kind := resourceInfo.Kind
 	statusCode := strconv.Itoa(resourceInfo.StatusCode)
-	if resourceInfo.Verb == kubeclientmetrics.List || kind == "events" || kind == "replicasets" {
+	if resourceInfo.Verb == kubeclientmetrics.List || ephemeralKinds[kind] {
 		name = "N/A"
 	}
 	if resourceInfo.Verb == kubeclientmetrics.Unknown {

--- a/controller/metrics/client_test.go
+++ b/controller/metrics/client_test.go
@@ -28,3 +28,45 @@ func TestIncKubernetesRequest(t *testing.T) {
 	})
 	testHttpResponse(t, metricsServ.Handler, expectedKubernetesRequest, assert.Contains)
 }
+
+func incRequest(provider *K8sRequestsCountProvider, kind, namespace, name string, verb kubeclientmetrics.K8sRequestVerb) {
+	provider.IncKubernetesRequest(kubeclientmetrics.ResourceInfo{
+		Kind:       kind,
+		Namespace:  namespace,
+		Name:       name,
+		Verb:       verb,
+		StatusCode: 200,
+	})
+}
+
+func TestIncKubernetesRequestEphemeralResourcesSanitized(t *testing.T) {
+	config := newFakeServerConfig()
+	metricsServ := NewMetricsServer(config)
+
+	// AnalysisRuns with unique names should all be sanitized to N/A
+	incRequest(config.K8SRequestProvider, "analysisruns", "default", "my-rollout-abc123-1", kubeclientmetrics.Get)
+	incRequest(config.K8SRequestProvider, "analysisruns", "default", "my-rollout-def456-2", kubeclientmetrics.Get)
+
+	// Experiments with unique names should also be sanitized to N/A
+	incRequest(config.K8SRequestProvider, "experiments", "default", "my-experiment-abc123-1", kubeclientmetrics.Get)
+
+	// Rollouts have stable names and should NOT be sanitized
+	incRequest(config.K8SRequestProvider, "rollouts", "default", "my-rollout", kubeclientmetrics.Get)
+
+	// Both analysisrun requests should be collapsed into a single metric with name="N/A" and count=2
+	expectedAnalysisRuns := `controller_clientset_k8s_request_total{kind="analysisruns",name="N/A",namespace="default",status_code="200",verb="Get"} 2`
+	testHttpResponse(t, metricsServ.Handler, expectedAnalysisRuns, assert.Contains)
+
+	// Experiment request should be sanitized to N/A
+	expectedExperiments := `controller_clientset_k8s_request_total{kind="experiments",name="N/A",namespace="default",status_code="200",verb="Get"} 1`
+	testHttpResponse(t, metricsServ.Handler, expectedExperiments, assert.Contains)
+
+	// Rollout name should be preserved (not sanitized)
+	expectedRollout := `controller_clientset_k8s_request_total{kind="rollouts",name="my-rollout",namespace="default",status_code="200",verb="Get"} 1`
+	testHttpResponse(t, metricsServ.Handler, expectedRollout, assert.Contains)
+
+	// The unique ephemeral names should NOT appear in the metrics output
+	for _, unexpectedName := range []string{`name="my-rollout-abc123-1"`, `name="my-rollout-def456-2"`, `name="my-experiment-abc123-1"`} {
+		testHttpResponse(t, metricsServ.Handler, unexpectedName, assert.NotContains)
+	}
+}


### PR DESCRIPTION
Addresses https://github.com/argoproj/argo-rollouts/issues/4571

## Motivation

The `controller_clientset_k8s_request_total` Prometheus CounterVec uses a `name` label containing actual Kubernetes resource names. Since AnalysisRun and Experiment names are unique per deployment (`{rollout}-{podHash}-{revision}`), every deployment permanently creates new metric time series that are never cleaned up. This causes the leader controller pod to grow from ~140Mi to 8.8GB over ~127 days.

PR #2851 deliberately kept the `name` label for resources with **stable** names (e.g. `rollouts`) — the maintainer explicitly wanted per-rollout observability. Only `events` and `replicasets` were sanitized because they were the top cardinality offenders at the time. The leak from `analysisruns` and `experiments` was not addressed.

## Changes

- **Extend `name` sanitization to `analysisruns` and `experiments`** in `IncKubernetesRequest` — these resources have ephemeral hash-based names and are the primary leak vectors. Resources with stable names (e.g. `rollouts`, `services`, `configmaps`) continue to preserve the actual `name` for per-rollout observability, matching the original intent from PR #2851.
- **Add unit tests** verifying that ephemeral resource names (`analysisruns`, `experiments`) are sanitized to `"N/A"`, while stable resource names (`rollouts`) are preserved.

## Verification

```
$ go test ./controller/metrics/... -v -count=1
--- PASS: TestIncKubernetesRequest (0.10s)
--- PASS: TestIncKubernetesRequestEphemeralResourcesSanitized (0.11s)
--- PASS: TestRemove (2.11s)
... (all 14 tests pass)
PASS
ok  	github.com/argoproj/argo-rollouts/controller/metrics	4.211s
```

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).