### PR TITLE
docs: update rollout spec for incorrect attribute YAML

### DIFF
--- a/docs/features/specification.md
+++ b/docs/features/specification.md
@@ -386,11 +386,11 @@ spec:
               - name: mann-whitney
                 templateName: mann-whitney
                 # Metadata which will be attached to the AnalysisRun.
-                analysisRunMetadata:
-                  labels:
-                    app.service.io/analysisType: smoke-test
-                  annotations:
-                    link.argocd.argoproj.io/external-link: http://my-loggin-platform.com/pre-generated-link
+            analysisRunMetadata:
+              labels:
+                app.service.io/analysisType: smoke-test
+              annotations:
+                link.argocd.argoproj.io/external-link: http://my-loggin-platform.com/pre-generated-link
 
       # Anti-affinity configuration between desired and previous ReplicaSet.
       # Only one must be specified.


### PR DESCRIPTION
The Rollout spec has the `analysisRunMetadata` stanza at the wrong level. This should be at the same indent as `templates` and `analyses`.

This is described correctly in "docs/features/analysis.md", and also verified against the CRD spec.

```
yq '.properties.spec.properties.strategy.properties.canary.properties.steps.items.properties.experiment.properties | keys' rollout_v1alpha1.json
[
  "analyses",
  "analysisRunMetadata",
  "dryRun",
  "duration",
  "templates"
]
```


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
