### PR TITLE
fix(trafficrouting): ensure early SetWeight runs after checkReplicasAvailable

### DIFF
--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -227,15 +227,6 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			// During the V2 rollout, managed routes could have been setup and would continue
 			// to direct traffic to the canary service which is now in front of 0 available replicas.
 			// We want to remove these managed routes alongside the safety here of never weighting to the canary.
-			// Additionally, if there was previous canary weight > 0, we must reset the weight
-			// BEFORE updating the hash (done later) to avoid routing traffic to non-existent pods.
-			// Note: SetWeight is idempotent, so calling it twice is harmless.
-			if c.rollout.Status.Canary.Weights != nil && c.rollout.Status.Canary.Weights.Canary.Weight > 0 {
-				if err := reconciler.SetWeight(desiredWeight, weightDestinations...); err != nil {
-					c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: "TrafficRoutingError"}, err.Error())
-					return err
-				}
-			}
 			err := reconciler.RemoveManagedRoutes()
 			if err != nil {
 				return err
@@ -295,6 +286,20 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 				if err = reconciler.SetMirrorRoute(currentStep.SetMirrorRoute); err != nil {
 					return err
 				}
+			}
+		}
+
+		// If there was a previous canary weight > 0 and the new canary has no available
+		// replicas, we must reset the weight to 0 BEFORE updating the hash. Otherwise,
+		// UpdateHash will point the destination rule to the new (empty) canary while the
+		// old weight is still in effect, routing traffic to non-existent pods.
+		// This runs after checkReplicasAvailable so we only reset when stable can handle
+		// the full traffic load.
+		if (c.newRS == nil || c.newRS.Status.AvailableReplicas == 0) &&
+			c.rollout.Status.Canary.Weights != nil && c.rollout.Status.Canary.Weights.Canary.Weight > 0 {
+			if err := reconciler.SetWeight(desiredWeight, weightDestinations...); err != nil {
+				c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: "TrafficRoutingError"}, err.Error())
+				return err
 			}
 		}
 

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -1919,3 +1919,114 @@ func TestTrafficRoutingErrorsWhenNewCanaryHasNoReplicas(t *testing.T) {
 		})
 	}
 }
+
+// TestDynamicStableScaleNewCanarySupersedeShouldNotOverloadStable verifies that superseding an
+// in-progress rollout with dynamicStableScale enabled does NOT route 100% of traffic to a
+// stable RS that only has a fraction of its pods available.
+//
+// Scenario from https://github.com/argoproj/argo-rollouts/pull/4564#issuecomment-4015022647:
+//   - dynamicStableScale: true
+//   - Rolling A→B: stable (A) dynamically scaled to 1/10 pods, canary (B) at 9/10 pods, 90% traffic weight
+//   - New canary C triggered (superseding B): C has 0 replicas, 0% traffic
+//
+// The fix moves the early SetWeight(0) (needed to reset traffic before UpdateHash points the
+// destination rule to the new empty canary) so that it runs AFTER the checkReplicasAvailable
+// guard. This ensures:
+//  1. When stable lacks capacity (this test): checkReplicasAvailable returns early, and neither
+//     SetWeight(0) nor UpdateHash is called. Traffic stays on the old canary until stable scales up.
+//  2. When stable has capacity: SetWeight(0) runs before UpdateHash, preserving the ordering
+//     fix from PR #4564 that prevents Istio 503s.
+func TestDynamicStableScaleNewCanarySupersedeShouldNotOverloadStable(t *testing.T) {
+	const (
+		canaryService = "myservice-canary"
+		stableService = "myservice-stable"
+	)
+
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{
+		{SetWeight: ptr.To[int32](90)},
+		{Pause: &v1alpha1.RolloutPause{}},
+	}
+
+	// r1 is the stable version (A)
+	r1 := newCanaryRollout("myservice", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
+	r1.Spec.Strategy.Canary.DynamicStableScale = true
+	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
+		SMI: &v1alpha1.SMITrafficRouting{},
+	}
+	r1.Spec.Strategy.Canary.CanaryService = canaryService
+	r1.Spec.Strategy.Canary.StableService = stableService
+
+	// r2 is the "previous canary" (B) — rollout in progress at 90% weight
+	r2 := bumpVersion(r1)
+
+	// r3 is the "new canary" (C) — superseding B, just triggered, 0 replicas
+	r3 := bumpVersion(r2)
+
+	// Stable (A): 1 of 10 replicas available — dynamically scaled down because
+	// 90% of traffic was being served by the canary (B).
+	rs1 := newReplicaSetWithStatus(r1, 1, 1)
+	// Old canary (B): 9 of 10 replicas — was carrying 90% of traffic.
+	rs2 := newReplicaSetWithStatus(r2, 9, 9)
+	// New canary (C): 0 replicas — just triggered, not yet scaled up.
+	rs3 := newReplicaSetWithStatus(r3, 0, 0)
+
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs3PodHash := rs3.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+
+	canarySelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs3PodHash}
+	stableSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}
+	canarySvc := newService(canaryService, 80, canarySelector, r3)
+	stableSvc := newService(stableService, 80, stableSelector, r3)
+
+	// Status: C is the new active canary, A is stable.
+	// Weights still reflect the previous rollout state: 90% to B, 10% to A.
+	r3.Status.StableRS = rs1PodHash
+	r3.Status.CurrentPodHash = rs3PodHash
+	r3.Status.CurrentStepIndex = ptr.To[int32](0)
+	r3.Status.Canary.Weights = &v1alpha1.TrafficWeights{
+		Canary: v1alpha1.WeightDestination{
+			Weight:          90,
+			ServiceName:     canaryService,
+			PodTemplateHash: rs2PodHash, // Still pointing to old canary B
+		},
+		Stable: v1alpha1.WeightDestination{
+			Weight:          10,
+			ServiceName:     stableService,
+			PodTemplateHash: rs1PodHash,
+		},
+	}
+
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2, rs3, canarySvc, stableSvc)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2, rs3)
+	f.rolloutLister = append(f.rolloutLister, r3)
+	f.objects = append(f.objects, r3)
+
+	var setWeightCalls []int32
+	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, additionalDestinations ...v1alpha1.WeightDestination) error {
+		setWeightCalls = append(setWeightCalls, desiredWeight)
+		t.Logf("SetWeight called with weight=%d", desiredWeight)
+		return nil
+	})
+	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("RemoveManagedRoutes", mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](true), nil)
+
+	f.expectPatchRolloutAction(r3)
+	f.expectUpdateReplicaSetAction(rs3) // Scale up new canary C
+	f.run(getKey(r3, t))
+
+	// With dynamicStableScale=true, stable (A) only has 1/10 pods available.
+	// checkReplicasAvailable should return early, preventing both SetWeight and
+	// UpdateHash from being called. If SetWeight(0) were called, it would route
+	// 100% of traffic to a stable RS with only 10% of its pods.
+	assert.Empty(t, setWeightCalls,
+		"SetWeight should not be called when stable lacks capacity with dynamicStableScale; "+
+			"checkReplicasAvailable should return early. Calls observed: %v", setWeightCalls)
+	f.fakeTrafficRouting.AssertNotCalled(t, "UpdateHash", mock.Anything, mock.Anything, mock.Anything)
+}


### PR DESCRIPTION
https://github.com/argoproj/argo-rollouts/pull/4564 introduced a bug when `DynamicStableScale` is enabled - it could cause a "scaled down" stable replicaset to receive full traffic prior to it being scaled back up.

This PR adds a test case to show that this is in fact an issue, and a refactoring of the fix from 4564 to address both cases.

cc @ssantichaivekin-plaid

---

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green. Try syncing with master if they are not. 
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).