### PR TITLE
fix: allows plugins to implement traffic mirroring (and not just Istio)

### DIFF
--- a/pkg/apis/rollouts/validation/validation.go
+++ b/pkg/apis/rollouts/validation/validation.go
@@ -36,8 +36,8 @@ const (
 	InvalidSetCanaryScaleTrafficPolicy = "SetCanaryScale requires TrafficRouting to be set"
 	// InvalidSetHeaderRouteTrafficPolicy indicates that TrafficRouting required for SetHeaderRoute is missing
 	InvalidSetHeaderRouteTrafficPolicy = "SetHeaderRoute requires TrafficRouting, supports Istio and ALB and Apisix"
-	// InvalidSetMirrorRouteTrafficPolicy indicates that TrafficRouting, required for SetCanaryScale, is missing
-	InvalidSetMirrorRouteTrafficPolicy = "SetMirrorRoute requires TrafficRouting, supports Istio only"
+	// InvalidSetMirrorRouteTrafficPolicy indicates that TrafficRouting, required for SetMirrorRoute, is missing
+	InvalidSetMirrorRouteTrafficPolicy = "SetMirrorRoute requires TrafficRouting, supports Istio and Plugins"
 	// InvalidStringMatchMultipleValuePolicy indicates that SetCanaryScale, has multiple values set
 	InvalidStringMatchMultipleValuePolicy = "StringMatch match value must have exactly one of the following: exact, regex, prefix"
 	// InvalidStringMatchMissedValuePolicy indicates that SetCanaryScale, has multiple values set
@@ -350,8 +350,8 @@ func ValidateRolloutStrategyCanary(rollout *v1alpha1.Rollout, fldPath *field.Pat
 
 		if step.SetMirrorRoute != nil {
 			trafficRouting := rollout.Spec.Strategy.Canary.TrafficRouting
-			if trafficRouting == nil || trafficRouting.Istio == nil {
-				allErrs = append(allErrs, field.Invalid(stepFldPath.Child("setMirrorRoute"), step.SetMirrorRoute, "SetMirrorRoute requires TrafficRouting, supports Istio only"))
+			if trafficRouting == nil || (trafficRouting.Istio == nil && len(trafficRouting.Plugins) == 0) {
+				allErrs = append(allErrs, field.Invalid(stepFldPath.Child("setMirrorRoute"), step.SetMirrorRoute, InvalidSetMirrorRouteTrafficPolicy))
 			}
 			if step.SetMirrorRoute.Match != nil && len(step.SetMirrorRoute.Match) > 0 {
 				for j, match := range step.SetMirrorRoute.Match {

--- a/pkg/apis/rollouts/validation/validation_test.go
+++ b/pkg/apis/rollouts/validation/validation_test.go
@@ -539,9 +539,9 @@ func TestValidateRolloutStrategyCanarySetHeaderRoutePlugins(t *testing.T) {
 	}
 
 	t.Run("using SetHeaderRoute step with plugins", func(t *testing.T) {
-		invalidRo := ro.DeepCopy()
+		validRo := ro.DeepCopy()
 		routeName := "test"
-		invalidRo.Spec.Strategy.Canary.Steps = []v1alpha1.CanaryStep{{
+		validRo.Spec.Strategy.Canary.Steps = []v1alpha1.CanaryStep{{
 			SetHeaderRoute: &v1alpha1.SetHeaderRoute{
 				Name: routeName,
 				Match: []v1alpha1.HeaderRoutingMatch{
@@ -552,7 +552,7 @@ func TestValidateRolloutStrategyCanarySetHeaderRoutePlugins(t *testing.T) {
 				},
 			},
 		}}
-		invalidRo.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
+		validRo.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
 			ManagedRoutes: []v1alpha1.MangedRoutes{
 				{
 					Name: routeName,
@@ -562,7 +562,67 @@ func TestValidateRolloutStrategyCanarySetHeaderRoutePlugins(t *testing.T) {
 				"anyplugin": []byte(`{"key": "value"}`),
 			},
 		}
+		allErrs := ValidateRolloutStrategyCanary(validRo, field.NewPath(""))
+		assert.Equal(t, 0, len(allErrs))
+	})
+}
+
+func TestValidateRolloutStrategyCanarySetMirrorRoute(t *testing.T) {
+	ro := &v1alpha1.Rollout{}
+	ro.Spec.Strategy.Canary = &v1alpha1.CanaryStrategy{
+		CanaryService: "canary",
+		StableService: "stable",
+	}
+
+	t.Run("using SetMirrorRoute step without the traffic routing", func(t *testing.T) {
+		invalidRo := ro.DeepCopy()
+		invalidRo.Spec.Strategy.Canary.Steps = []v1alpha1.CanaryStep{{
+			SetMirrorRoute: &v1alpha1.SetMirrorRoute{
+				Name:       "test-mirror-1",
+				Match:      nil,
+				Percentage: nil,
+			},
+		}}
 		allErrs := ValidateRolloutStrategyCanary(invalidRo, field.NewPath(""))
+		assert.Equal(t, InvalidSetMirrorRouteTrafficPolicy, allErrs[0].Detail)
+	})
+}
+
+func TestValidateRolloutStrategyCanarySetMirrorRoutePlugins(t *testing.T) {
+	ro := &v1alpha1.Rollout{}
+	ro.Spec.Strategy.Canary = &v1alpha1.CanaryStrategy{
+		CanaryService: "canary",
+		StableService: "stable",
+	}
+
+	t.Run("using SetMirrorRoute step with plugins", func(t *testing.T) {
+		validRo := ro.DeepCopy()
+		routeName := "test-mirror-1"
+		validRo.Spec.Strategy.Canary.Steps = []v1alpha1.CanaryStep{{
+			SetMirrorRoute: &v1alpha1.SetMirrorRoute{
+				Name: routeName,
+				Match: []v1alpha1.RouteMatch{{
+					Method: &v1alpha1.StringMatch{
+						Exact: "GET",
+					},
+					Path: &v1alpha1.StringMatch{
+						Prefix: "/api",
+					},
+				}},
+				Percentage: ptr.To[int32](50),
+			},
+		}}
+		validRo.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
+			ManagedRoutes: []v1alpha1.MangedRoutes{
+				{
+					Name: routeName,
+				},
+			},
+			Plugins: map[string]json.RawMessage{
+				"anyplugin": []byte(`{"key": "value"}`),
+			},
+		}
+		allErrs := ValidateRolloutStrategyCanary(validRo, field.NewPath(""))
 		assert.Equal(t, 0, len(allErrs))
 	})
 }


### PR DESCRIPTION
I want to implement [traffic mirroring](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/issues/32) with the Gateway API Plugin. But I can't because currently Argo Rollouts allows mirroring only with Istio and nothing else.

This PR relaxes the validation and allows plugins as well to implement Traffir mirroring (same way as traffic routing)

I also found a header based route test that was confusing to me, since it used "invalidRO" as a variable name, even though it tested a valid scenario.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green. Try syncing with master if they are not. 
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).