### PR TITLE
ci: pin k3s version to avoid breakage of e2e tests

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -75,13 +75,13 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes:
-          - version: '1.32'
+          - version: 'v1.32.12+k3s1'
             latest: false
-          - version: '1.33'
+          - version: 'v1.33.8+k3s1'
             latest: false
-          - version: '1.34'
+          - version: 'v1.34.4+k3s1'
             latest: false
-          - version: '1.35'
+          - version: 'v1.35.1+k3s1'
             latest: true
     name: Run end-to-end tests
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -75,15 +75,19 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes:
-          - version: '1.32.12+k3s1'
+          - version: '1.32'
+            k3s_version: '1.32.12+k3s1'
             latest: false
-          - version: '1.33.8+k3s1'
+          - version: '1.33'
+            k3s_version: '1.33.8+k3s1'
             latest: false
-          - version: '1.34.4+k3s1'
+          - version: '1.34'
+            k3s_version: '1.34.4+k3s1'
             latest: false
-          - version: '1.35.1+k3s1'
+          - version: '1.35'
+            k3s_version: '1.35.1+k3s1'
             latest: true
-    name: Run end-to-end tests
+    name: Run end-to-end tests (${{ matrix.kubernetes.version }}, ${{ matrix.kubernetes.latest }})
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
@@ -93,7 +97,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup k3s
         env:
-          INSTALL_K3S_CHANNEL: v${{ matrix.kubernetes.version }}
+          INSTALL_K3S_VERSION: v${{ matrix.kubernetes.k3s_version }}
         run: |
           curl -sfL https://get.k3s.io | sh -
           sudo mkdir ~/.kube

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -75,13 +75,13 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes:
-          - version: 'v1.32.12+k3s1'
+          - version: '1.32.12+k3s1'
             latest: false
-          - version: 'v1.33.8+k3s1'
+          - version: '1.33.8+k3s1'
             latest: false
-          - version: 'v1.34.4+k3s1'
+          - version: '1.34.4+k3s1'
             latest: false
-          - version: 'v1.35.1+k3s1'
+          - version: '1.35.1+k3s1'
             latest: true
     name: Run end-to-end tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
The last k3s patch version broke all our e2e tests. Even minor documentation PRs such as https://github.com/argoproj/argo-rollouts/pull/4640 have failed ALL their tests

This PR pins k3s versions to their last known version that worked. The real issue should be fixed in k3s upstream.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green. Try syncing with master if they are not. 
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).