### PR TITLE
fix(controller): Use maxTrafficWeight instead of hardcoded 100 in checkReplicasAvailable.

### DIFF
--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -146,7 +146,7 @@ func (c *rolloutContext) checkReplicasAvailable(rs *appsv1.ReplicaSet, desiredWe
 	availableReplicas := rs.Status.AvailableReplicas
 	totalReplicas := *c.rollout.Spec.Replicas
 
-	desiredReplicas := (desiredWeight * totalReplicas) / 100
+	desiredReplicas := (desiredWeight * totalReplicas) / weightutil.MaxTrafficWeight(c.rollout)
 	if availableReplicas < desiredReplicas &&
 		!replicasetutil.ReplicaProgressThresholdMet(c.rollout.Spec.Strategy.Canary.ReplicaProgressThreshold, rs, desiredReplicas) {
 		c.log.Infof("ReplicaSet '%s' has %d available replicas, waiting for %d", rs.Name, availableReplicas, desiredReplicas)

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -1631,6 +1631,87 @@ func TestCheckReplicasAvailableWithReplicaProgressThreshold(t *testing.T) {
 	}
 }
 
+func TestCheckReplicasAvailableWithCustomMaxTrafficWeight(t *testing.T) {
+	tests := []struct {
+		name              string
+		totalReplicas     int32
+		availableReplicas int
+		desiredWeight     int32
+		maxTrafficWeight  int32
+		expectedResult    bool
+		description       string
+	}{
+		{
+			name:              "custom maxTrafficWeight - replicas available",
+			totalReplicas:     2,
+			availableReplicas: 1,
+			desiredWeight:     50000000,
+			maxTrafficWeight:  100000000,
+			expectedResult:    true,
+			description:       "With maxTrafficWeight=100000000, 50% weight on 2 replicas needs 1 replica (2*50000000/100000000=1)",
+		},
+		{
+			name:              "custom maxTrafficWeight - replicas not available",
+			totalReplicas:     2,
+			availableReplicas: 0,
+			desiredWeight:     50000000,
+			maxTrafficWeight:  100000000,
+			expectedResult:    false,
+			description:       "With maxTrafficWeight=100000000, 50% weight on 2 replicas needs 1 replica but 0 available",
+		},
+		{
+			name:              "custom maxTrafficWeight - high weight needs all replicas",
+			totalReplicas:     2,
+			availableReplicas: 2,
+			desiredWeight:     100000000,
+			maxTrafficWeight:  100000000,
+			expectedResult:    true,
+			description:       "With maxTrafficWeight=100000000, 100% weight on 2 replicas needs 2 replicas",
+		},
+		{
+			name:              "custom maxTrafficWeight - low weight needs zero replicas",
+			totalReplicas:     2,
+			availableReplicas: 0,
+			desiredWeight:     0,
+			maxTrafficWeight:  100000000,
+			expectedResult:    true,
+			description:       "With maxTrafficWeight=100000000, 0% weight needs 0 replicas",
+		},
+		{
+			name:              "default maxTrafficWeight - same behavior as before",
+			totalReplicas:     10,
+			availableReplicas: 5,
+			desiredWeight:     50,
+			maxTrafficWeight:  0, // 0 means use default (100)
+			expectedResult:    true,
+			description:       "With default maxTrafficWeight (100), 50% weight on 10 replicas needs 5 replicas",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newCanaryRollout("foo", int(tt.totalReplicas), nil, nil, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(0))
+			r.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
+				SMI: &v1alpha1.SMITrafficRouting{},
+			}
+			if tt.maxTrafficWeight > 0 {
+				r.Spec.Strategy.Canary.TrafficRouting.MaxTrafficWeight = ptr.To[int32](tt.maxTrafficWeight)
+			}
+
+			roCtx := &rolloutContext{
+				rollout: r,
+				log:     logutil.WithRollout(r),
+			}
+
+			rs := newReplicaSetWithStatus(r, int(tt.totalReplicas), tt.availableReplicas)
+
+			result := roCtx.checkReplicasAvailable(rs, tt.desiredWeight)
+
+			assert.Equal(t, tt.expectedResult, result, tt.description)
+		})
+	}
+}
+
 // TestDynamicScalingAbortWithZeroReplicas verifies we handle zero replicas gracefully during abort
 func TestDynamicScalingAbortWithZeroReplicas(t *testing.T) {
 	f := newFixture(t)


### PR DESCRIPTION
### Summary

`checkReplicasAvailable` in `rollout/trafficrouting.go` hardcodes a divisor of `100` when calculating the desired replica count from a traffic weight:

```go
desiredReplicas := (desiredWeight * totalReplicas) / 100
```

This assumes `maxTrafficWeight` is always 100 (percentage-based). When a rollout uses a custom `maxTrafficWeight` (e.g., `100000000`), the calculation produces an impossibly large `desiredReplicas`, causing the check to always fail. This results in `reconcileTrafficRouting` returning early before calling `SetWeight`, `UpdateHash`, or populating `Status.Canary.Weights` — meaning **no traffic is ever routed to canary** even though the rollout progresses through steps normally.

### Example

With `maxTrafficWeight: 100000000`, `setWeight: 30000000`, and `replicas: 2`:

| | Expected | Actual (buggy) |
|---|---|---|
| stable weight | 70000000 | 70000000 |
| divisor | **100000000** | **100** |
| desiredReplicas | **1** | **1,400,000** |

The stable ReplicaSet has 2 available replicas. The check requires 1,400,000 → always fails → `SetWeight` is never called.

### Fix

Replace the hardcoded `100` with `weightutil.MaxTrafficWeight(c.rollout)`:

```go
desiredReplicas := (desiredWeight * totalReplicas) / weightutil.MaxTrafficWeight(c.rollout)
```

This is consistent with how the rest of `trafficrouting.go` already uses `weightutil.MaxTrafficWeight()` for weight calculations.

### Testing

Added `TestCheckReplicasAvailableWithCustomMaxTrafficWeight` with 5 test cases covering:
- Custom `maxTrafficWeight` with sufficient replicas available
- Custom `maxTrafficWeight` with insufficient replicas
- Full weight (100%) requiring all replicas
- Zero weight requiring zero replicas
- Default `maxTrafficWeight` (backward compatibility)

### Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] My builds are green. Try syncing with master if they are not.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
