### PR TITLE
docs: clarify basic canary options applicability. Fixes #1821

### DIFF
--- a/docs/features/canary/index.md
+++ b/docs/features/canary/index.md
@@ -174,6 +174,11 @@ spec:
 
 ## Mimicking Rolling Update
 
+!!! important
+    `maxSurge` and `maxUnavailable` control desired replica calculations for **basic canary** only (when `spec.strategy.canary.trafficRouting` is not set).
+    When `trafficRouting` is set, these fields are not used for stable/canary replica counts — the stable ReplicaSet stays at full scale, so total pods can exceed 2× `spec.replicas` (e.g. `spec.replicas: 10` with `setCanaryScale.replicas: 15` runs 25 pods). Use `dynamicStableScale` and `setCanaryScale` instead.
+    Note: even with `trafficRouting`, validation still rejects both values as `0`, and `maxUnavailable` may still throttle old ReplicaSet scale-down.
+
 If the `steps` field is omitted, the canary strategy will mimic the rolling update behavior. Similar to the deployment, the canary strategy has the `maxSurge` and `maxUnavailable` fields to configure how the Rollout should progress to the new version.
 
 ## Other Configurable Features
@@ -219,13 +224,17 @@ Defaults to an empty string
 
 ### maxSurge
 
-`maxSurge` defines the maximum number of replicas the rollout can create to move to the correct ratio set by the last setWeight. Max Surge can either be an integer or percentage as a string (i.e. "20%")
+`maxSurge` controls basic-canary desired replica math when `trafficRouting` is not set; it is not used for traffic-routed desired stable/canary replica counts.
+
+`maxSurge` defines the maximum number of replicas the rollout can create to move to the correct ratio set by the last `setWeight`. `maxSurge` can either be an integer or percentage as a string (i.e. "20%")
 
 Defaults to "25%".
 
 ### maxUnavailable
 
-The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxSurge is 0.
+`maxUnavailable` is used for basic-canary desired replica calculations when `trafficRouting` is not set. With traffic routing, it is not used for desired stable/canary replica counts, but may still throttle old ReplicaSet scale-down.
+
+The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if `maxSurge` is 0.
 
 Defaults to 25%
 


### PR DESCRIPTION
* I wrote this to remove a common operator misread: people treat `maxSurge` and `maxUnavailable` as universal canary controls, then plan capacity incorrectly for traffic-routed rollouts.
* I kept this docs-only and left controller behavior alone because I want to reduce misconfiguration risk without changing rollout semantics.
* I assume the current flow where traffic routing drives desired stable/canary counts, while `maxUnavailable` can still throttle old ReplicaSet scale-down.
* Out of scope: reconciliation changes, validation behavior changes, and new runtime warnings for mixed canary settings.

Closes #1821

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green. Try syncing with master if they are not.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged. N/A (docs-only change)
* [ ] I have run all tests locally (including the flaky ones) and they pass on my workstation. N/A (docs-only change; docs build only)
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md). N/A (individual contributor)