### PR TITLE
refactor: use pod.Status.Phase to drop dependency on k8s.io/kubernetes

### DIFF
--- a/pkg/kubectl-argo-rollouts/info/pod_info.go
+++ b/pkg/kubectl-argo-rollouts/info/pod_info.go
@@ -63,8 +63,29 @@ func newPodInfo(pod *corev1.Pod) rollout.PodInfo {
 	readyContainers := 0
 
 	reason := string(pod.Status.Phase)
-	if pod.Status.Reason != "" {
+	if pod.Status.Reason != "" && pod.Status.Phase != corev1.PodUnknown {
 		reason = pod.Status.Reason
+	}
+
+	// If the pod phase is Unknown, the node is unreachable and all container
+	// statuses are stale. Return immediately rather than deriving a misleading
+	// reason from untrustworthy container state.
+	if pod.Status.Phase == corev1.PodUnknown {
+		podInfo.Status = reason
+		podInfo.Icon = podIcon(podInfo.Status)
+		podInfo.Ready = fmt.Sprintf("%d/%d", readyContainers, totalContainers)
+		podInfo.Restarts = int32(restarts)
+		return podInfo
+	}
+
+	// If the pod is being deleted, show "Terminating" immediately. Container
+	// state during a grace period is not meaningful for display purposes.
+	if pod.DeletionTimestamp != nil {
+		podInfo.Status = "Terminating"
+		podInfo.Icon = podIcon(podInfo.Status)
+		podInfo.Ready = fmt.Sprintf("%d/%d", readyContainers, totalContainers)
+		podInfo.Restarts = int32(restarts)
+		return podInfo
 	}
 
 	initializing := false
@@ -124,12 +145,6 @@ func newPodInfo(pod *corev1.Pod) rollout.PodInfo {
 		if reason == "Completed" && hasRunning {
 			reason = "Running"
 		}
-	}
-
-	if pod.DeletionTimestamp != nil && pod.Status.Phase == corev1.PodUnknown {
-		reason = "Unknown"
-	} else if pod.DeletionTimestamp != nil {
-		reason = "Terminating"
 	}
 
 	podInfo.Status = reason

--- a/pkg/kubectl-argo-rollouts/info/pod_info.go
+++ b/pkg/kubectl-argo-rollouts/info/pod_info.go
@@ -8,7 +8,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	k8snode "k8s.io/kubernetes/pkg/util/node"
 
 	"github.com/argoproj/argo-rollouts/pkg/apiclient/rollout"
 )
@@ -127,7 +126,7 @@ func newPodInfo(pod *corev1.Pod) rollout.PodInfo {
 		}
 	}
 
-	if pod.DeletionTimestamp != nil && pod.Status.Reason == k8snode.NodeUnreachablePodReason {
+	if pod.DeletionTimestamp != nil && pod.Status.Phase == corev1.PodUnknown {
 		reason = "Unknown"
 	} else if pod.DeletionTimestamp != nil {
 		reason = "Terminating"

--- a/pkg/kubectl-argo-rollouts/info/pod_info_test.go
+++ b/pkg/kubectl-argo-rollouts/info/pod_info_test.go
@@ -1,0 +1,80 @@
+package info
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func basePod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "main"},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "main",
+					Ready: true,
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				},
+			},
+		},
+	}
+}
+
+func TestNewPodInfo_Unknown(t *testing.T) {
+	pod := basePod()
+	pod.Status.Phase = corev1.PodUnknown
+	// Simulate the node lifecycle controller setting Status.Reason to "NodeLost"
+	// and stale container state from before the node went unreachable.
+	pod.Status.Reason = "NodeLost"
+	pod.Status.ContainerStatuses[0].State = corev1.ContainerState{
+		Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+	}
+
+	info := newPodInfo(pod)
+
+	assert.Equal(t, "Unknown", info.Status)
+	assert.Equal(t, IconUnknown, info.Icon)
+	// Stale container state should not affect ready count or restarts
+	assert.Equal(t, "0/1", info.Ready)
+	assert.Equal(t, int32(0), info.Restarts)
+}
+
+func TestNewPodInfo_Terminating(t *testing.T) {
+	deletionTime := metav1.NewTime(time.Now())
+	pod := basePod()
+	pod.DeletionTimestamp = &deletionTime
+
+	info := newPodInfo(pod)
+
+	assert.Equal(t, "Terminating", info.Status)
+	assert.Equal(t, IconProgressing, info.Icon)
+	assert.Equal(t, "0/1", info.Ready)
+	assert.Equal(t, int32(0), info.Restarts)
+}
+
+func TestNewPodInfo_TerminatingNotUnknown(t *testing.T) {
+	// A pod that is both deleted and in Unknown phase (node lost while being deleted)
+	// should show Unknown, not Terminating — the Unknown early-return fires first.
+	deletionTime := metav1.NewTime(time.Now())
+	pod := basePod()
+	pod.DeletionTimestamp = &deletionTime
+	pod.Status.Phase = corev1.PodUnknown
+
+	info := newPodInfo(pod)
+
+	assert.Equal(t, "Unknown", info.Status)
+	assert.Equal(t, IconUnknown, info.Icon)
+}


### PR DESCRIPTION
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [ ] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [ ] I understand what the code does and WHY/HOW it works in several scenarios
* [ ] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).