### PR TITLE
fix(controller): honor stderrthreshold when logtostderr is enabled

### DIFF
--- a/cmd/kubectl-argo-rollouts/main.go
+++ b/cmd/kubectl-argo-rollouts/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -18,6 +19,9 @@ import (
 
 func main() {
 	klog.InitFlags(nil)
+	// Opt into fixed stderrthreshold behavior (kubernetes/klog#212).
+	_ = flag.Set("legacy_stderr_threshold_behavior", "false")
+	_ = flag.Set("stderrthreshold", "INFO")
 	logutil.SetKLogLogger(log.New())
 	streams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
 	o := options.NewArgoRolloutsOptions(streams)

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	k8s.io/client-go v0.34.5
 	k8s.io/code-generator v0.34.5
 	k8s.io/component-base v0.34.5
-	k8s.io/klog/v2 v2.130.1
+	k8s.io/klog/v2 v2.140.0
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912
 	k8s.io/kubectl v0.34.5
 	k8s.io/kubernetes v1.34.5

--- a/go.sum
+++ b/go.sum
@@ -1291,8 +1291,9 @@ k8s.io/gengo/v2 v2.0.0-20250604051438-85fd79dbfd9f/go.mod h1:EJykeLsmFC60UQbYJez
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.5.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
 k8s.io/klog/v2 v2.80.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
-k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
 k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
+k8s.io/klog/v2 v2.140.0 h1:Tf+J3AH7xnUzZyVVXhTgGhEKnFqye14aadWv7bzXdzc=
+k8s.io/klog/v2 v2.140.0/go.mod h1:o+/RWfJ6PwpnFn7OyAG3QnO47BFsymfEfrz6XyYSSp0=
 k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b/go.mod h1:UZ2yyWbFTpuhSbFhv24aGNOdoRdJZgsIObGBUaYVsts=
 k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 h1:Y3gxNAuB0OBLImH611+UDZcmKS3g6CthxToOb37KgwE=
 k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912/go.mod h1:kdmbQkyfwUagLfXIad1y2TdrjPFWp2Q89B3qkRwf/pQ=


### PR DESCRIPTION
## Summary
Opt into the new klog behavior so that `-stderrthreshold` is honored even when `-logtostderr=true` (the default). Set `stderrthreshold=INFO` to preserve backward compatibility.

## Background
When `-logtostderr=true`, `-stderrthreshold` was ignored — all logs went to stderr. Fixed in [kubernetes/klog#432](https://github.com/kubernetes/klog/pull/432) (v2.140.0+), but projects must opt in.

## References
- kubernetes/klog#212
- kubernetes/klog#432