### PR TITLE
fix(analysis): provide actionable error for empty metric results in AnalysisRun

### DIFF
--- a/metricproviders/prometheus/prometheus_test.go
+++ b/metricproviders/prometheus/prometheus_test.go
@@ -614,6 +614,22 @@ func TestProcessInvalidResponse(t *testing.T) {
 
 }
 
+func TestProcessResponseWithEmptyVectorIndexedCondition(t *testing.T) {
+	logCtx := log.WithField("test", "test")
+	p := Provider{
+		logCtx: *logCtx,
+	}
+	metric := v1alpha1.Metric{
+		SuccessCondition: "result[0] <= 10",
+	}
+
+	value, status, err := p.processResponse(metric, model.Vector{})
+	assert.Equal(t, "[]", value)
+	assert.Equal(t, v1alpha1.AnalysisPhaseError, status)
+	assert.ErrorContains(t, err, "metric result is empty or unavailable")
+	assert.ErrorContains(t, err, "len(result) > 0")
+}
+
 func TestNewPrometheusAPI(t *testing.T) {
 	os.Unsetenv(EnvVarArgoRolloutsPrometheusAddress)
 	address := ":invalid::url"

--- a/utils/evaluate/evaluate.go
+++ b/utils/evaluate/evaluate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -14,6 +15,8 @@ import (
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 )
+
+var indexedResultPattern = regexp.MustCompile(`\bresult\s*\[`)
 
 func EvaluateResult(result any, metric v1alpha1.Metric, logCtx logrus.Entry) (v1alpha1.AnalysisPhase, error) {
 	successCondition := false
@@ -104,6 +107,10 @@ func EvalCondition(resultValue any, condition string) (bool, error) {
 		"default": defaultFunc(resultValue),
 	}
 
+	if err = validateIndexedResultAccess(resultValue, condition); err != nil {
+		return false, err
+	}
+
 	unwrapFileErr := func(e error) error {
 		if fileErr, ok := err.(*file.Error); ok {
 			e = errors.New(fileErr.Message)
@@ -126,6 +133,32 @@ func EvalCondition(resultValue any, condition string) (bool, error) {
 		return val, nil
 	default:
 		return false, fmt.Errorf("expected bool, but got %T", val)
+	}
+}
+
+func validateIndexedResultAccess(resultValue any, condition string) error {
+	if !indexedResultPattern.MatchString(condition) {
+		return nil
+	}
+
+	if !isEmptyIndexableResult(resultValue) {
+		return nil
+	}
+
+	return errors.New("metric result is empty or unavailable, and the condition cannot index into result; guard the condition with len(result) > 0")
+}
+
+func isEmptyIndexableResult(resultValue any) bool {
+	value := valueFromPointer(resultValue)
+	if value == nil {
+		return true
+	}
+
+	switch reflect.ValueOf(value).Kind() {
+	case reflect.Array, reflect.Slice, reflect.String:
+		return reflect.ValueOf(value).Len() == 0
+	default:
+		return false
 	}
 }
 

--- a/utils/evaluate/evaluate.go
+++ b/utils/evaluate/evaluate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -14,6 +15,8 @@ import (
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 )
+
+var indexedResultPattern = regexp.MustCompile(`\bresult\s*\[`)
 
 func EvaluateResult(result any, metric v1alpha1.Metric, logCtx logrus.Entry) (v1alpha1.AnalysisPhase, error) {
 	successCondition := false
@@ -126,6 +129,10 @@ func EvalCondition(resultValue any, condition string) (bool, error) {
 		"default": defaultFunc(resultValue),
 	}
 
+	if err = validateIndexedResultAccess(resultValue, condition); err != nil {
+		return false, err
+	}
+
 	unwrapFileErr := func(e error) error {
 		if fileErr, ok := err.(*file.Error); ok {
 			e = errors.New(fileErr.Message)
@@ -148,6 +155,32 @@ func EvalCondition(resultValue any, condition string) (bool, error) {
 		return val, nil
 	default:
 		return false, fmt.Errorf("expected bool, but got %T", val)
+	}
+}
+
+func validateIndexedResultAccess(resultValue any, condition string) error {
+	if !indexedResultPattern.MatchString(condition) {
+		return nil
+	}
+
+	if !isEmptyIndexableResult(resultValue) {
+		return nil
+	}
+
+	return errors.New("metric result is empty or unavailable, and the condition cannot index into result; guard the condition with len(result) > 0")
+}
+
+func isEmptyIndexableResult(resultValue any) bool {
+	value := valueFromPointer(resultValue)
+	if value == nil {
+		return true
+	}
+
+	switch reflect.ValueOf(value).Kind() {
+	case reflect.Array, reflect.Slice, reflect.String:
+		return reflect.ValueOf(value).Len() == 0
+	default:
+		return false
 	}
 }
 

--- a/utils/evaluate/evaluate_test.go
+++ b/utils/evaluate/evaluate_test.go
@@ -102,6 +102,17 @@ func TestEvaluateResultWithErrorOnFailureCondition(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestEvaluateResultWithIndexedEmptyResult(t *testing.T) {
+	metric := v1alpha1.Metric{
+		SuccessCondition: "result[0] <= 10",
+	}
+	logCtx := logrus.WithField("test", "test")
+	status, err := EvaluateResult([]float64{}, metric, *logCtx)
+	assert.Equal(t, v1alpha1.AnalysisPhaseError, status)
+	assert.ErrorContains(t, err, "metric result is empty or unavailable")
+	assert.ErrorContains(t, err, "len(result) > 0")
+}
+
 func TestEvaluateConditionWithSuccess(t *testing.T) {
 	b, err := EvalCondition(true, "result == true")
 	assert.Nil(t, err)
@@ -112,6 +123,13 @@ func TestEvaluateConditionWithFailure(t *testing.T) {
 	b, err := EvalCondition(true, "result == false")
 	assert.Nil(t, err)
 	assert.False(t, b)
+}
+
+func TestEvaluateConditionWithIndexedEmptyResult(t *testing.T) {
+	b, err := EvalCondition([]float64{}, "result[0] <= 10")
+	assert.False(t, b)
+	assert.ErrorContains(t, err, "metric result is empty or unavailable")
+	assert.ErrorContains(t, err, "len(result) > 0")
 }
 
 func TestErrorWithNonBoolReturn(t *testing.T) {

--- a/utils/evaluate/evaluate_test.go
+++ b/utils/evaluate/evaluate_test.go
@@ -132,6 +132,101 @@ func TestEvaluateConditionWithIndexedEmptyResult(t *testing.T) {
 	assert.ErrorContains(t, err, "len(result) > 0")
 }
 
+func TestEvaluateConditionWithIndexedNonEmptyResult(t *testing.T) {
+	b, err := EvalCondition([]float64{5}, "result[0] <= 10")
+	assert.NoError(t, err)
+	assert.True(t, b)
+}
+
+func TestValidateIndexedResultAccess(t *testing.T) {
+	tests := []struct {
+		name       string
+		result     any
+		condition  string
+		wantErr    bool
+		errMessage string
+	}{
+		{
+			name:      "without indexed access",
+			result:    []float64{},
+			condition: "len(result) == 0",
+		},
+		{
+			name:      "with non-empty slice",
+			result:    []float64{1},
+			condition: "result[0] <= 10",
+		},
+		{
+			name:       "with nil result",
+			result:     nil,
+			condition:  "result[0] <= 10",
+			wantErr:    true,
+			errMessage: "metric result is empty or unavailable",
+		},
+		{
+			name:      "with non-indexable result",
+			result:    true,
+			condition: "result[0] <= 10",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateIndexedResultAccess(test.result, test.condition)
+			if test.wantErr {
+				assert.ErrorContains(t, err, test.errMessage)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestIsEmptyIndexableResult(t *testing.T) {
+	tests := []struct {
+		name   string
+		result any
+		want   bool
+	}{
+		{
+			name:   "nil",
+			result: nil,
+			want:   true,
+		},
+		{
+			name:   "empty slice",
+			result: []float64{},
+			want:   true,
+		},
+		{
+			name:   "non-empty slice",
+			result: []float64{1},
+			want:   false,
+		},
+		{
+			name:   "empty string",
+			result: "",
+			want:   true,
+		},
+		{
+			name:   "non-empty string",
+			result: "ok",
+			want:   false,
+		},
+		{
+			name:   "non-indexable type",
+			result: true,
+			want:   false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, isEmptyIndexableResult(test.result))
+		})
+	}
+}
+
 func TestErrorWithNonBoolReturn(t *testing.T) {
 	b, err := EvalCondition(true, "1")
 	assert.Equal(t, fmt.Errorf("expected bool, but got int"), err)

--- a/utils/evaluate/evaluate_test.go
+++ b/utils/evaluate/evaluate_test.go
@@ -134,6 +134,101 @@ func TestEvaluateConditionWithIndexedEmptyResult(t *testing.T) {
 	assert.ErrorContains(t, err, "len(result) > 0")
 }
 
+func TestEvaluateConditionWithIndexedNonEmptyResult(t *testing.T) {
+	b, err := EvalCondition([]float64{5}, "result[0] <= 10")
+	assert.NoError(t, err)
+	assert.True(t, b)
+}
+
+func TestValidateIndexedResultAccess(t *testing.T) {
+	tests := []struct {
+		name       string
+		result     any
+		condition  string
+		wantErr    bool
+		errMessage string
+	}{
+		{
+			name:      "without indexed access",
+			result:    []float64{},
+			condition: "len(result) == 0",
+		},
+		{
+			name:      "with non-empty slice",
+			result:    []float64{1},
+			condition: "result[0] <= 10",
+		},
+		{
+			name:       "with nil result",
+			result:     nil,
+			condition:  "result[0] <= 10",
+			wantErr:    true,
+			errMessage: "metric result is empty or unavailable",
+		},
+		{
+			name:      "with non-indexable result",
+			result:    true,
+			condition: "result[0] <= 10",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateIndexedResultAccess(test.result, test.condition)
+			if test.wantErr {
+				assert.ErrorContains(t, err, test.errMessage)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestIsEmptyIndexableResult(t *testing.T) {
+	tests := []struct {
+		name   string
+		result any
+		want   bool
+	}{
+		{
+			name:   "nil",
+			result: nil,
+			want:   true,
+		},
+		{
+			name:   "empty slice",
+			result: []float64{},
+			want:   true,
+		},
+		{
+			name:   "non-empty slice",
+			result: []float64{1},
+			want:   false,
+		},
+		{
+			name:   "empty string",
+			result: "",
+			want:   true,
+		},
+		{
+			name:   "non-empty string",
+			result: "ok",
+			want:   false,
+		},
+		{
+			name:   "non-indexable type",
+			result: true,
+			want:   false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, isEmptyIndexableResult(test.result))
+		})
+	}
+}
+
 func TestErrorWithNonBoolReturn(t *testing.T) {
 	b, err := EvalCondition(true, "1")
 	assert.Equal(t, fmt.Errorf("expected bool, but got int"), err)

--- a/utils/evaluate/evaluate_test.go
+++ b/utils/evaluate/evaluate_test.go
@@ -104,6 +104,17 @@ func TestEvaluateResultWithErrorOnFailureCondition(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestEvaluateResultWithIndexedEmptyResult(t *testing.T) {
+	metric := v1alpha1.Metric{
+		SuccessCondition: "result[0] <= 10",
+	}
+	logCtx := logrus.WithField("test", "test")
+	status, err := EvaluateResult([]float64{}, metric, *logCtx)
+	assert.Equal(t, v1alpha1.AnalysisPhaseError, status)
+	assert.ErrorContains(t, err, "metric result is empty or unavailable")
+	assert.ErrorContains(t, err, "len(result) > 0")
+}
+
 func TestEvaluateConditionWithSuccess(t *testing.T) {
 	b, err := EvalCondition(true, "result == true")
 	assert.Nil(t, err)
@@ -114,6 +125,13 @@ func TestEvaluateConditionWithFailure(t *testing.T) {
 	b, err := EvalCondition(true, "result == false")
 	assert.Nil(t, err)
 	assert.False(t, b)
+}
+
+func TestEvaluateConditionWithIndexedEmptyResult(t *testing.T) {
+	b, err := EvalCondition([]float64{}, "result[0] <= 10")
+	assert.False(t, b)
+	assert.ErrorContains(t, err, "metric result is empty or unavailable")
+	assert.ErrorContains(t, err, "len(result) > 0")
 }
 
 func TestErrorWithNonBoolReturn(t *testing.T) {


### PR DESCRIPTION
## Summary
When an AnalysisRun metric condition indexes into `result` (for example `result[0]`) and the provider returns an empty result set, Argo Rollouts currently surfaces a low-level evaluation error.

This change returns a more actionable message explaining that the metric result is empty or unavailable and that the condition should be guarded with `len(result) > 0`.

It adds unit coverage for this behavior in `utils/evaluate/evaluate_test.go` and `metricproviders/prometheus/prometheus_test.go`.

## Testing
- `make lint`
- `PATH="/home/kunal/Desktop/contribute/Argo/argo-rollouts/dist:$PATH" ./test/kustomize/test.sh`
- `go test ./...`

Fixes #2101