### PR TITLE
fix(analysis): improve error messages for AnalysisRun metric evaluation failures. Fixes #2101

### DIFF
--- a/metricproviders/datadog/datadogV1_test.go
+++ b/metricproviders/datadog/datadogV1_test.go
@@ -164,7 +164,7 @@ func TestRunSuite(t *testing.T) {
 			},
 			expectedIntervalSeconds: 300,
 			expectedPhase:           v1alpha1.AnalysisPhaseError,
-			expectedErrorMessage:    `invalid operation: < (mismatched types unknown and float64)`,
+			expectedErrorMessage:    `metric result is nil or empty: no data returned from the metric provider`,
 			useEnvVarForKeys:        false,
 		},
 

--- a/metricproviders/datadog/datadogV2_test.go
+++ b/metricproviders/datadog/datadogV2_test.go
@@ -192,7 +192,7 @@ func TestRunSuiteV2(t *testing.T) {
 			},
 			expectedIntervalSeconds: 300,
 			expectedPhase:           v1alpha1.AnalysisPhaseError,
-			expectedErrorMessage:    `invalid operation: < (mismatched types unknown and float64)`,
+			expectedErrorMessage:    `metric result is nil or empty: no data returned from the metric provider`,
 			useEnvVarForKeys:        false,
 		},
 

--- a/metricproviders/graphite/graphite_test.go
+++ b/metricproviders/graphite/graphite_test.go
@@ -93,7 +93,7 @@ func TestRunMeasurementError(t *testing.T) {
 	assert.Equal(t, "[10.000000]", measurement.Value)
 	assert.NotNil(t, measurement.FinishedAt)
 	assert.Equal(t, v1alpha1.AnalysisPhaseError, measurement.Phase)
-	assert.Equal(t, "unexpected token Number(\"10.000000\")", measurement.Message)
+	assert.Equal(t, "could not evaluate successCondition \"result[0] 10.000000\": unexpected token Number(\"10.000000\")", measurement.Message)
 }
 
 func TestRunErrorEvaluationFromNilQueryResponse(t *testing.T) {

--- a/utils/evaluate/evaluate.go
+++ b/utils/evaluate/evaluate.go
@@ -23,13 +23,13 @@ func EvaluateResult(result any, metric v1alpha1.Metric, logCtx logrus.Entry) (v1
 	if metric.SuccessCondition != "" {
 		successCondition, err = EvalCondition(result, metric.SuccessCondition)
 		if err != nil {
-			return v1alpha1.AnalysisPhaseError, err
+			return v1alpha1.AnalysisPhaseError, formatEvalError(err, "successCondition", metric.SuccessCondition, result)
 		}
 	}
 	if metric.FailureCondition != "" {
 		failCondition, err = EvalCondition(result, metric.FailureCondition)
 		if err != nil {
-			return v1alpha1.AnalysisPhaseError, err
+			return v1alpha1.AnalysisPhaseError, formatEvalError(err, "failureCondition", metric.FailureCondition, result)
 		}
 	}
 
@@ -55,6 +55,28 @@ func EvaluateResult(result any, metric v1alpha1.Metric, logCtx logrus.Entry) (v1
 
 	// If we reach this code path, failCondition is false and successCondition is true
 	return v1alpha1.AnalysisPhaseSuccessful, nil
+}
+
+// formatEvalError wraps an expression evaluation error with context about the condition,
+// the expression, and the actual result value to help users understand why the evaluation failed.
+func formatEvalError(err error, conditionType string, expression string, result any) error {
+	if isNilOrEmpty(result) {
+		return fmt.Errorf("could not evaluate %s \"%s\": metric result is nil or empty: no data returned from the metric provider", conditionType, expression)
+	}
+	return fmt.Errorf("could not evaluate %s \"%s\": %w", conditionType, expression, err)
+}
+
+// isNilOrEmpty checks if a result value is nil or an empty slice/array
+func isNilOrEmpty(result any) bool {
+	if isNil(result) {
+		return true
+	}
+	v := reflect.ValueOf(result)
+	switch v.Kind() {
+	case reflect.Slice, reflect.Array:
+		return v.Len() == 0
+	}
+	return false
 }
 
 func EvalTime(expression string) (time.Time, error) {

--- a/utils/evaluate/evaluate_test.go
+++ b/utils/evaluate/evaluate_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 )
 
+const invalidRefCondition = "a == true"
+
 func TestEvaluateResultWithSuccess(t *testing.T) {
 	metric := v1alpha1.Metric{
 		SuccessCondition: "true",
@@ -82,7 +84,7 @@ func TestEvaluateResultNoFailureConditionAndNoSuccessCondition(t *testing.T) {
 
 func TestEvaluateResultWithErrorOnSuccessCondition(t *testing.T) {
 	metric := v1alpha1.Metric{
-		SuccessCondition: "a == true",
+		SuccessCondition: invalidRefCondition,
 		FailureCondition: "true",
 	}
 	logCtx := logrus.WithField("test", "test")
@@ -94,7 +96,7 @@ func TestEvaluateResultWithErrorOnSuccessCondition(t *testing.T) {
 func TestEvaluateResultWithErrorOnFailureCondition(t *testing.T) {
 	metric := v1alpha1.Metric{
 		SuccessCondition: "true",
-		FailureCondition: "a == true",
+		FailureCondition: invalidRefCondition,
 	}
 	logCtx := logrus.WithField("test", "test")
 	status, err := EvaluateResult(true, metric, *logCtx)
@@ -373,13 +375,13 @@ func TestEvaluateResultErrorMessageWithEmptySlice(t *testing.T) {
 
 func TestEvaluateResultErrorMessageWithInvalidExpression(t *testing.T) {
 	metric := v1alpha1.Metric{
-		SuccessCondition: "a == true",
+		SuccessCondition: invalidRefCondition,
 	}
 	logCtx := logrus.WithField("test", "test")
 	status, err := EvaluateResult(true, metric, *logCtx)
 	assert.Equal(t, v1alpha1.AnalysisPhaseError, status)
 	assert.Contains(t, err.Error(), "could not evaluate successCondition")
-	assert.Contains(t, err.Error(), "a == true")
+	assert.Contains(t, err.Error(), invalidRefCondition)
 }
 
 func TestEvaluateResultErrorMessageOnFailureCondition(t *testing.T) {

--- a/utils/evaluate/evaluate_test.go
+++ b/utils/evaluate/evaluate_test.go
@@ -348,3 +348,57 @@ func TestEvalTimeWithInvalidExpression(t *testing.T) {
 	assert.Equal(t, time.Time{}, status)
 	assert.Error(t, err)
 }
+
+func TestEvaluateResultErrorMessageWithNilResult(t *testing.T) {
+	metric := v1alpha1.Metric{
+		SuccessCondition: "result[0] >= 0.95",
+	}
+	logCtx := logrus.WithField("test", "test")
+	status, err := EvaluateResult(nil, metric, *logCtx)
+	assert.Equal(t, v1alpha1.AnalysisPhaseError, status)
+	assert.Contains(t, err.Error(), "metric result is nil or empty")
+	assert.Contains(t, err.Error(), "successCondition")
+}
+
+func TestEvaluateResultErrorMessageWithEmptySlice(t *testing.T) {
+	metric := v1alpha1.Metric{
+		SuccessCondition: "result[0] >= 0.95",
+	}
+	logCtx := logrus.WithField("test", "test")
+	status, err := EvaluateResult([]float64{}, metric, *logCtx)
+	assert.Equal(t, v1alpha1.AnalysisPhaseError, status)
+	assert.Contains(t, err.Error(), "metric result is nil or empty")
+	assert.Contains(t, err.Error(), "successCondition")
+}
+
+func TestEvaluateResultErrorMessageWithInvalidExpression(t *testing.T) {
+	metric := v1alpha1.Metric{
+		SuccessCondition: "a == true",
+	}
+	logCtx := logrus.WithField("test", "test")
+	status, err := EvaluateResult(true, metric, *logCtx)
+	assert.Equal(t, v1alpha1.AnalysisPhaseError, status)
+	assert.Contains(t, err.Error(), "could not evaluate successCondition")
+	assert.Contains(t, err.Error(), "a == true")
+}
+
+func TestEvaluateResultErrorMessageOnFailureCondition(t *testing.T) {
+	metric := v1alpha1.Metric{
+		SuccessCondition: "true",
+		FailureCondition: "invalidVar == true",
+	}
+	logCtx := logrus.WithField("test", "test")
+	status, err := EvaluateResult(true, metric, *logCtx)
+	assert.Equal(t, v1alpha1.AnalysisPhaseError, status)
+	assert.Contains(t, err.Error(), "could not evaluate failureCondition")
+	assert.Contains(t, err.Error(), "invalidVar == true")
+}
+
+func TestIsNilOrEmpty(t *testing.T) {
+	assert.True(t, isNilOrEmpty(nil))
+	assert.True(t, isNilOrEmpty([]float64{}))
+	assert.True(t, isNilOrEmpty([]string{}))
+	assert.False(t, isNilOrEmpty([]float64{1.0}))
+	assert.False(t, isNilOrEmpty(42))
+	assert.False(t, isNilOrEmpty("hello"))
+}


### PR DESCRIPTION
## Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number.
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green. Try syncing with master if they are not.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

## Changes

When `EvalCondition` fails during metric result evaluation (e.g. due to a nil result, empty metric response, or invalid expression), the error message returned to the user was the raw expression evaluator error — often something cryptic like `index out of range [0] with length 0` or `unknown name a`.

This PR wraps evaluation errors with contextual information:

1. **Which condition failed** — `successCondition` vs `failureCondition`
2. **The expression** — shows the exact condition string that was evaluated
3. **Nil/empty result detection** — when the metric provider returned no data, a specific message is shown instead of the raw panic

### Before
```
Error: index out of range [0] with length 0
```

### After
```
Error: could not evaluate successCondition "result[0] >= 0.95": metric result is nil or empty: no data returned from the metric provider
```

For non-empty results with expression errors:
```
Error: could not evaluate successCondition "a == true": unknown name a (1:1)
```

### Files changed
- `utils/evaluate/evaluate.go` — Added `formatEvalError` and `isNilOrEmpty` helpers; wrapped error returns in `EvaluateResult`
- `utils/evaluate/evaluate_test.go` — Added 5 new test cases covering nil results, empty slices, invalid expressions, and the `isNilOrEmpty` helper

Fixes #2101
