### PR TITLE
fix(controller): decouple workloadRef scaleDown from promoteStable. Fixes #4681

### DIFF
--- a/rollout/bluegreen.go
+++ b/rollout/bluegreen.go
@@ -311,6 +311,9 @@ func (c *rolloutContext) syncRolloutStatusBlueGreen(previewSvc *corev1.Service, 
 	}
 
 	newStatus = c.calculateRolloutConditions(newStatus)
+	if err := c.scaleDownWorkloadRef(newStatus); err != nil {
+		return err
+	}
 	return c.persistRolloutStatus(&newStatus)
 }
 

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -390,6 +390,9 @@ func (c *rolloutContext) syncRolloutStatusCanary() error {
 			return err
 		}
 		newStatus = c.calculateRolloutConditions(newStatus)
+		if err := c.scaleDownWorkloadRef(newStatus); err != nil {
+			return err
+		}
 		return c.persistRolloutStatus(&newStatus)
 	}
 

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -1037,13 +1037,18 @@ func (c *rolloutContext) promoteStable(newStatus *v1alpha1.RolloutStatus, reason
 			conditions.RolloutCompletedMessage, revision, newStatus.CurrentPodHash, reason)
 	}
 
-	if revision == 1 && c.rollout.Status.Phase == v1alpha1.RolloutPhaseHealthy && c.rollout.Spec.WorkloadRef != nil && c.rollout.Spec.WorkloadRef.ScaleDown == v1alpha1.ScaleDownOnSuccess {
-		var targetScale int32 = 0
-		err := c.scaleDeployment(&targetScale)
-		if err != nil {
-			return err
-		}
-	}
+	return nil
+}
 
+// scaleDownWorkloadRef scales down the referenced Deployment to 0 when the Rollout is Healthy
+// and workloadRef.scaleDown is set to "onsuccess". This check is decoupled from promoteStable
+// so that it fires based on the computed phase regardless of the promotion path taken.
+func (c *rolloutContext) scaleDownWorkloadRef(newStatus v1alpha1.RolloutStatus) error {
+	if newStatus.Phase == v1alpha1.RolloutPhaseHealthy &&
+		c.rollout.Spec.WorkloadRef != nil &&
+		c.rollout.Spec.WorkloadRef.ScaleDown == v1alpha1.ScaleDownOnSuccess {
+		var targetScale int32 = 0
+		return c.scaleDeployment(&targetScale)
+	}
 	return nil
 }

--- a/rollout/sync_test.go
+++ b/rollout/sync_test.go
@@ -788,29 +788,51 @@ func TestShouldFullPromoteCanaryAvailableVsDesired(t *testing.T) {
 	}
 }
 
-func TestScaleDownDeploymentOnSuccess(t *testing.T) {
+func TestScaleDownWorkloadRefOnSuccess(t *testing.T) {
+	// Test that scaleDownWorkloadRef scales down deployment when phase is Healthy and scaleDown is onsuccess
 	ctx := createScaleDownRolloutContext(v1alpha1.ScaleDownOnSuccess, 5, true, nil)
-	newStatus := &v1alpha1.RolloutStatus{
-		CurrentPodHash: "2f646bf702",
-		StableRS:       "15fb5ffc01",
+	newStatus := v1alpha1.RolloutStatus{
+		Phase: v1alpha1.RolloutPhaseHealthy,
 	}
-	err := ctx.promoteStable(newStatus, "reason")
-
+	err := ctx.scaleDownWorkloadRef(newStatus)
 	assert.Nil(t, err)
 	k8sfakeClient := ctx.kubeclientset.(*k8sfake.Clientset)
 	updatedDeployment, err := k8sfakeClient.AppsV1().Deployments("default").Get(context.TODO(), "workload-test", metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, int32(0), *updatedDeployment.Spec.Replicas)
 
-	// test scale deployment error
-	ctx = createScaleDownRolloutContext(v1alpha1.ScaleDownOnSuccess, 5, false, nil)
-	newStatus = &v1alpha1.RolloutStatus{
-		CurrentPodHash: "2f646bf702",
-		StableRS:       "15fb5ffc01",
+	// Test that scaleDownWorkloadRef does not scale down when phase is not Healthy
+	ctx = createScaleDownRolloutContext(v1alpha1.ScaleDownOnSuccess, 5, true, nil)
+	newStatus = v1alpha1.RolloutStatus{
+		Phase: v1alpha1.RolloutPhaseProgressing,
 	}
-	err = ctx.promoteStable(newStatus, "reason")
+	err = ctx.scaleDownWorkloadRef(newStatus)
+	assert.Nil(t, err)
+	k8sfakeClient = ctx.kubeclientset.(*k8sfake.Clientset)
+	updatedDeployment, err = k8sfakeClient.AppsV1().Deployments("default").Get(context.TODO(), "workload-test", metav1.GetOptions{})
+	assert.Nil(t, err)
+	assert.Equal(t, int32(5), *updatedDeployment.Spec.Replicas)
 
+	// Test that scaleDownWorkloadRef returns error when deployment does not exist
+	ctx = createScaleDownRolloutContext(v1alpha1.ScaleDownOnSuccess, 5, false, nil)
+	newStatus = v1alpha1.RolloutStatus{
+		Phase: v1alpha1.RolloutPhaseHealthy,
+	}
+	err = ctx.scaleDownWorkloadRef(newStatus)
 	assert.NotNil(t, err)
+
+	// Test that scaleDownWorkloadRef works regardless of revision (fixes revision==1 guard bug)
+	ctx = createScaleDownRolloutContext(v1alpha1.ScaleDownOnSuccess, 5, true, nil)
+	ctx.rollout.Annotations["rollout.argoproj.io/revision"] = "3"
+	newStatus = v1alpha1.RolloutStatus{
+		Phase: v1alpha1.RolloutPhaseHealthy,
+	}
+	err = ctx.scaleDownWorkloadRef(newStatus)
+	assert.Nil(t, err)
+	k8sfakeClient = ctx.kubeclientset.(*k8sfake.Clientset)
+	updatedDeployment, err = k8sfakeClient.AppsV1().Deployments("default").Get(context.TODO(), "workload-test", metav1.GetOptions{})
+	assert.Nil(t, err)
+	assert.Equal(t, int32(0), *updatedDeployment.Spec.Replicas)
 }
 
 // This tests validates that when there are old replicasets that have miss matched desired-count annotations aka they do


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] My builds are green. Try syncing with master if they are not. 
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

Moves the workloadRef scaleDown logic out of `promoteStable()` into a standalone `scaleDownWorkloadRef()` that runs after `calculateRolloutConditions` computes the phase. This fixes two interacting bugs where blue-green rollouts with `postPromotionAnalysis` and `workloadRef.scaleDown: onsuccess` never scale down the referenced Deployment: the initial deploy bypasses PostPromotionAnalysis creating a permanent dead state in `shouldFullPromote`, and the hardcoded `revision == 1` guard prevents scaleDown on any subsequent revision.