### PR TITLE
fix(trafficrouting): avoid divide-by-zero on PromoteFull with zero-replica rollout

### DIFF
--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -236,7 +236,17 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			// But we can only increase canary weight according to available replica counts of the canary.
 			// we will need to set the desiredWeight to 0 when the newRS is not available.
 			if c.rollout.Spec.Strategy.Canary.DynamicStableScale {
-				desiredWeight = (weightutil.MaxTrafficWeight(c.rollout) * c.newRS.Status.AvailableReplicas) / *c.rollout.Spec.Replicas
+				// A Rollout scaled to zero replicas can still be fully promoted
+				// (see #3686), so guard the division here. With no spec replicas
+				// there is nothing to ratio against; leave desiredWeight at 0 so
+				// we don't shift traffic to a canary that has nowhere to land.
+				var specReplicas int32
+				if c.rollout.Spec.Replicas != nil {
+					specReplicas = *c.rollout.Spec.Replicas
+				}
+				if specReplicas > 0 {
+					desiredWeight = (weightutil.MaxTrafficWeight(c.rollout) * c.newRS.Status.AvailableReplicas) / specReplicas
+				}
 			} else if c.rollout.Status.Canary.Weights != nil {
 				desiredWeight = c.rollout.Status.Canary.Weights.Canary.Weight
 			}


### PR DESCRIPTION
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [ ] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [ ] I understand what the code does and WHY/HOW it works in several scenarios
* [ ] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

---

## Summary

Fixes #3686. In `reconcileTrafficRouting`, the `PromoteFull` + `dynamicStableScale: true` branch divides by `*c.rollout.Spec.Replicas`; when the user temporarily scales a Rollout to zero replicas and then clicks Promote-Full, the divide panics and the controller gets stuck. Guard the division so `desiredWeight` stays at zero when there are no spec replicas to ratio against; non-`PromoteFull` paths and the non-`DynamicStableScale` branch are unchanged.
