### PR TITLE
fix(trafficrouting): apply SetHeaderRoute/SetMirrorRoute before replica guardrail

### DIFF
--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -268,11 +268,14 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			}
 		}
 
-		// check if the stable RS has enough pods before recalculating the new
-		// weight status.
-		if !c.checkReplicasAvailable(c.stableRS, weightutil.MaxTrafficWeight(c.rollout)-desiredWeight) {
-			return nil
-		}
+		// SetHeaderRoute / SetMirrorRoute do not change the weighted split
+		// between stable and canary, so they should not be gated on the
+		// stable RS being fully available. Apply them before the replica
+		// guardrail so header/mirror steps progress while the stable RS
+		// is still scaling up (for example after `spec.replicas` was just
+		// increased). Issue #4561 -- setHeaderTraffic used to be silently
+		// skipped and marked completed without touching the VirtualService.
+		//
 		// We need to check for revision > 1 because when we first install the rollout we run step 0 this prevents that.
 		// There is a bigger fix needed for the reasons on why we run step 0 on rollout install, that needs to be explored.
 		revision, revisionFound := annotations.GetRevisionAnnotation(c.rollout)
@@ -287,6 +290,12 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 					return err
 				}
 			}
+		}
+
+		// check if the stable RS has enough pods before recalculating the new
+		// weight status.
+		if !c.checkReplicasAvailable(c.stableRS, weightutil.MaxTrafficWeight(c.rollout)-desiredWeight) {
+			return nil
 		}
 
 		// If there was a previous canary weight > 0 and the new canary has no available

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -268,13 +268,7 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			}
 		}
 
-		// SetHeaderRoute / SetMirrorRoute do not change the weighted split
-		// between stable and canary, so they should not be gated on the
-		// stable RS being fully available. Apply them before the replica
-		// guardrail so header/mirror steps progress while the stable RS
-		// is still scaling up (for example after `spec.replicas` was just
-		// increased). Issue #4561 -- setHeaderTraffic used to be silently
-		// skipped and marked completed without touching the VirtualService.
+		// SetHeaderRoute / SetMirrorRoute do not affect the weight split, so apply them before the replica guardrail.
 		//
 		// We need to check for revision > 1 because when we first install the rollout we run step 0 this prevents that.
 		// There is a bigger fix needed for the reasons on why we run step 0 on rollout install, that needs to be explored.

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -269,7 +269,6 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 		}
 
 		// SetHeaderRoute / SetMirrorRoute do not affect the weight split, so apply them before the replica guardrail.
-		//
 		// We need to check for revision > 1 because when we first install the rollout we run step 0 this prevents that.
 		// There is a bigger fix needed for the reasons on why we run step 0 on rollout install, that needs to be explored.
 		revision, revisionFound := annotations.GetRevisionAnnotation(c.rollout)


### PR DESCRIPTION
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [ ] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [ ] I understand what the code does and WHY/HOW it works in several scenarios
* [ ] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

---

## Summary

Fixes #4561. `SetHeaderRoute` and `SetMirrorRoute` do not change the weighted split between stable and canary, so they should not be gated on the stable ReplicaSet being fully available, the `checkReplicasAvailable` guardrail added in #3878 was short-circuiting the entire traffic-routing path and silently skipping header/mirror updates while the stable RS was still scaling. Move `SetHeaderRoute` and `SetMirrorRoute` above the replica guardrail so they progress while the stable RS scales up; the weight logic still waits for the stable RS to catch up, preserving the original intent of #3878.