### PR TITLE
fix(controller): use GetScaledValueFromIntOrPercent for maxSurge/maxUnavailable

### DIFF
--- a/utils/defaults/defaults.go
+++ b/utils/defaults/defaults.go
@@ -21,9 +21,9 @@ const (
 	// DefaultAnalysisRunUnsuccessfulHistoryLimit default number of unsuccessful AnalysisRuns to keep if .Spec.Analysis.UnsuccessfulRunHistoryLimit is nil
 	DefaultAnalysisRunUnsuccessfulHistoryLimit = int32(5)
 	// DefaultMaxSurge default number for the max number of additional pods that can be brought up during a rollout
-	DefaultMaxSurge = "25"
+	DefaultMaxSurge = "25%"
 	// DefaultMaxUnavailable default number for the max number of unavailable pods during a rollout
-	DefaultMaxUnavailable = "25"
+	DefaultMaxUnavailable = "25%"
 	// DefaultProgressDeadlineSeconds default number of seconds for the rollout to be making progress
 	DefaultProgressDeadlineSeconds = int32(600)
 	// DefaultScaleDownDelaySeconds default seconds before scaling down old replicaset after switching services

--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -405,11 +405,11 @@ func GetReadyReplicaCountForReplicaSets(replicaSets []*appsv1.ReplicaSet) int32 
 // 2 desired, max unavailable 0%, surge 1% - should scale new(+1), then old(-1), then new(+1), then old(-1)
 // 1 desired, max unavailable 0%, surge 1% - should scale new(+1), then old(-1)
 func resolveFenceposts(maxSurge, maxUnavailable *intstrutil.IntOrString, desired int32) (int32, int32, error) {
-	surge, err := intstrutil.GetValueFromIntOrPercent(intstrutil.ValueOrDefault(maxSurge, intstrutil.FromInt(0)), int(desired), true)
+	surge, err := intstrutil.GetScaledValueFromIntOrPercent(intstrutil.ValueOrDefault(maxSurge, intstrutil.FromInt(0)), int(desired), true)
 	if err != nil {
 		return 0, 0, err
 	}
-	unavailable, err := intstrutil.GetValueFromIntOrPercent(intstrutil.ValueOrDefault(maxUnavailable, intstrutil.FromInt(0)), int(desired), false)
+	unavailable, err := intstrutil.GetScaledValueFromIntOrPercent(intstrutil.ValueOrDefault(maxUnavailable, intstrutil.FromInt(0)), int(desired), false)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -437,7 +437,7 @@ func MaxUnavailable(rollout *v1alpha1.Rollout) int32 {
 	if rollout.Spec.Strategy.Canary != nil {
 		_, maxUnavailable, _ = resolveFenceposts(defaults.GetMaxSurgeOrDefault(rollout), defaults.GetMaxUnavailableOrDefault(rollout), rolloutReplicas)
 	} else {
-		unavailable, _ := intstrutil.GetValueFromIntOrPercent(intstrutil.ValueOrDefault(defaults.GetMaxUnavailableOrDefault(rollout), intstrutil.FromInt(0)), int(rolloutReplicas), false)
+		unavailable, _ := intstrutil.GetScaledValueFromIntOrPercent(intstrutil.ValueOrDefault(defaults.GetMaxUnavailableOrDefault(rollout), intstrutil.FromInt(0)), int(rolloutReplicas), false)
 		maxUnavailable = int32(unavailable)
 	}
 


### PR DESCRIPTION
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [ ] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [ ] I understand what the code does and WHY/HOW it works in several scenarios
* [ ] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

---

## Summary

Fixes #4567. `resolveFenceposts` and `MaxUnavailable` used `intstrutil.GetValueFromIntOrPercent` to resolve `maxSurge`/`maxUnavailable`, which has a long-standing bug: when the `IntOrString` carries a string whose content is an integer (e.g. `maxUnavailable: "1"`) it is interpreted as a percentage instead of an absolute count. Swap the three call sites in `utils/replicaset/replicaset.go` to `GetScaledValueFromIntOrPercent` (the same migration the upstream Deployment controller did), so a Rollout with `maxUnavailable: "1"` now matches Deployment semantics.
