### PR TITLE
docs: fix broken Anti Affinity link on canary/bluegreen pages

### DIFF
--- a/docs/features/bluegreen.md
+++ b/docs/features/bluegreen.md
@@ -104,7 +104,7 @@ Setting a positive non-zero value here would make the rollout automatically prom
 Defaults to nil
 
 ### antiAffinity
-Check out the [Anti Affinity document](anti-affinity/anti-affinity.md) for more information.
+Check out the [Anti Affinity document](anti-affinity/anti-affinity/) for more information.
 
 Defaults to nil
 

--- a/docs/features/bluegreen.md
+++ b/docs/features/bluegreen.md
@@ -104,7 +104,7 @@ Setting a positive non-zero value here would make the rollout automatically prom
 Defaults to nil
 
 ### antiAffinity
-Check out the [Anti Affinity document](anti-affinity/anti-affinity/) for more information.
+Check out the [Anti Affinity document](../anti-affinity/anti-affinity/) for more information.
 
 Defaults to nil
 

--- a/docs/features/canary/index.md
+++ b/docs/features/canary/index.md
@@ -206,7 +206,7 @@ Defaults to nil
 
 ### antiAffinity
 
-Check out the [Anti Affinity](../anti-affinity/anti-affinity.md) document for more information.
+Check out the [Anti Affinity](../anti-affinity/anti-affinity/) document for more information.
 
 Defaults to nil
 


### PR DESCRIPTION
## Summary

The Canary and Blue-Green feature pages linked to the Anti Affinity doc via `anti-affinity/anti-affinity.md`, which 404s on the hosted readthedocs site (the `.md` suffix is served as-is rather than rewritten). The reporter verified that the extension-less URL `.../features/anti-affinity/anti-affinity/` does work.

This PR switches both links to the extension-less form, which MkDocs generates by default under `use_directory_urls` and resolves correctly on both readthedocs and GitHub Pages.

## Closes

Closes #4691