### PR TITLE
fix: create isolated logger for redactor

### DIFF
--- a/utils/log/log.go
+++ b/utils/log/log.go
@@ -109,12 +109,15 @@ func WithAnalysisRun(ar *v1alpha1.AnalysisRun) *log.Entry {
 
 // WithRedactor returns a log entry with the inputted secret values redacted
 func WithRedactor(entry log.Entry, secrets []string) *log.Entry {
-	newFormatter := RedactorFormatter{
-		entry.Logger.Formatter,
-		secrets,
-	}
-	entry.Logger.SetFormatter(&newFormatter)
-	return &entry
+	newLogger := log.New()
+	newLogger.SetOutput(entry.Logger.Out)
+	newLogger.SetLevel(entry.Logger.Level)
+	newLogger.SetFormatter(&RedactorFormatter{
+		formatter: entry.Logger.Formatter,
+		secrets:   secrets,
+	})
+	newEntry := newLogger.WithFields(entry.Data)
+	return newEntry
 }
 
 func WithVersionFields(entry *log.Entry, r *v1alpha1.Rollout) *log.Entry {

--- a/utils/log/log_test.go
+++ b/utils/log/log_test.go
@@ -218,8 +218,6 @@ func TestWithAnalysis(t *testing.T) {
 // TestWithRedactor verifies that WithRedactor redacts secrets in logger
 func TestWithRedactor(t *testing.T) {
 	buf := bytes.NewBufferString("")
-	logger := log.New()
-	logger.SetOutput(buf)
 	run := v1alpha1.AnalysisRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-name",
@@ -227,7 +225,7 @@ func TestWithRedactor(t *testing.T) {
 		},
 	}
 	entry := WithAnalysisRun(&run)
-	entry.Logger = logger
+	entry.Logger.SetOutput(buf)
 	secrets := []string{"test-name", "test-ns"}
 	logCtx := WithRedactor(*entry, secrets)
 	logCtx.Info("Test")
@@ -240,8 +238,6 @@ func TestWithRedactor(t *testing.T) {
 // TestWithRedactor verifies that WithRedactor ignores secrets that are empty strings (to prevent injection at every character in logger)
 func TestWithRedactorWithEmptySecret(t *testing.T) {
 	buf := bytes.NewBufferString("")
-	logger := log.New()
-	logger.SetOutput(buf)
 	run := v1alpha1.AnalysisRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-name",
@@ -249,12 +245,35 @@ func TestWithRedactorWithEmptySecret(t *testing.T) {
 		},
 	}
 	entry := WithAnalysisRun(&run)
-	entry.Logger = logger
+	entry.Logger.SetOutput(buf)
 	secrets := []string{""}
 	logCtx := WithRedactor(*entry, secrets)
 	logCtx.Info("Test")
 	logMessage := buf.String()
 	assert.False(t, strings.Contains(logMessage, "*****"))
+}
+
+// TestWithRedactorNoFormatterChain verifies that repeated calls to WithRedactor do not
+// grow the formatter chain on the global logger (regression test for the original bug
+// where SetFormatter was called on the shared logger, causing O(N) nesting).
+func TestWithRedactorNoFormatterChain(t *testing.T) {
+	run := v1alpha1.AnalysisRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-name",
+			Namespace: "test-ns",
+		},
+	}
+	originalFormatter := log.StandardLogger().Formatter
+
+	// Call WithRedactor many times, simulating repeated AnalysisRun metric executions
+	for i := 0; i < 100; i++ {
+		entry := WithAnalysisRun(&run)
+		_ = WithRedactor(*entry, []string{"secret"})
+	}
+
+	// The global logger's formatter must not have changed
+	assert.Equal(t, originalFormatter, log.StandardLogger().Formatter,
+		"WithRedactor must not mutate the global logger's formatter")
 }
 
 func TestWithVersionFields(t *testing.T) {


### PR DESCRIPTION
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [ ] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [ ] I understand what the code does and WHY/HOW it works in several scenarios
* [ ] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

### Summary
WithRedactor called entry.Logger.SetFormatter() on the shared logrus global logger, causing RedactorFormatter instances to nest unboundedly over time. Every call to WithRedactor wrapped the existing formatter in a new layer, creating a chain that grew with every AnalysisRun metric execution. This is a CPU/memory leak that causes the controller to progressively slow down until restarted.

### Root Cause
WithRedactor is called in analysis/analysis.go for every metric goroutine spawned during AnalysisRun reconciliation. On a busy cluster this happens thousands of times per day. The original implementation:

```
func WithRedactor(entry log.Entry, secrets []string) *log.Entry {
    newFormatter := RedactorFormatter{
        entry.Logger.Formatter,  // grabs current global formatter
        secrets,
    }
    entry.Logger.SetFormatter(&newFormatter)  // mutates GLOBAL logger
    return &entry
}
```
Each call:

Reads the current global formatter (which may already be a RedactorFormatter from a previous call)
Wraps it in a new RedactorFormatter
Sets this as the new global formatter
After N calls the chain is:

RedactorFormatter(N) → RedactorFormatter(N-1) → ... → RedactorFormatter(1) → TextFormatter
Every log line triggers N rounds of bytes.ReplaceAll. After 4 days on a cluster with hundreds of active AnalysisRuns, N reaches into the millions, causing RedactorFormatter.Format to consume 90%+ of controller CPU.

After N executions
```
log.StandardLogger()
  └── RedactorFormatter (N)
        └── RedactorFormatter (N-1)
              └── RedactorFormatter (N-2)
                    └── ...
                          └── RedactorFormatter (1)
                                └── TextFormatter

```
### Fix
Create a new isolated log.Logger per WithRedactor call instead of mutating the global logger. The new logger inherits the output, level, and formatter from the entry's logger, but has its own lifecycle — it is scoped to the goroutine and discarded when the metric task completes.

