### PR TITLE
docs: add missing argoproj-labs plugins to metric and traffic-router lists

### DIFF
--- a/docs/analysis/plugins.md
+++ b/docs/analysis/plugins.md
@@ -101,9 +101,17 @@ If you have created a plugin, please submit a PR to add it to this list.
 
 - An AI-powered metric plugin that delegates analysis to an A2A (Agent-to-Agent) agent. The agent autonomously fetches stable/canary pod logs and returns structured analysis, enabling LLM-driven canary evaluation during rollouts.
 
+### [rollouts-plugin-metric-honeycomb](https://github.com/argoproj-labs/rollouts-plugin-metric-honeycomb)
+
+- A metric plugin that integrates [Honeycomb](https://www.honeycomb.io/) as an analysis provider for Argo Rollouts.
+
 ### [rollouts-plugin-metric-opensearch](https://github.com/argoproj-labs/rollouts-plugin-metric-opensearch)
 
 - The application is an OpenSearch plugin designed for use with the Argo Rollouts plugin system. This plugin enables the integration of OpenSearch metrics into Argo Rollouts, allowing for advanced metric analysis and monitoring during application rollouts.
+
+### [rollouts-opsmx-metric-plugin](https://github.com/argoproj-labs/rollouts-opsmx-metric-plugin)
+
+- An [OpsMx](https://www.opsmx.com/) plugin that performs logs and metrics analysis for Argo Rollouts.
 
 ### [rollouts-plugin-metric-sample-prometheus](https://github.com/argoproj-labs/rollouts-plugin-metric-sample-prometheus)
 

--- a/docs/analysis/plugins.md
+++ b/docs/analysis/plugins.md
@@ -97,6 +97,10 @@ responsibility of the Argo Rollouts administrator to define the plugin installat
 
 If you have created a plugin, please submit a PR to add it to this list.
 
+### [rollouts-plugin-metric-ai](https://github.com/argoproj-labs/rollouts-plugin-metric-ai)
+
+- An AI-powered metric plugin that delegates analysis to an A2A (Agent-to-Agent) agent. The agent autonomously fetches stable/canary pod logs and returns structured analysis, enabling LLM-driven canary evaluation during rollouts.
+
 ### [rollouts-plugin-metric-opensearch](https://github.com/argoproj-labs/rollouts-plugin-metric-opensearch)
 
 - The application is an OpenSearch plugin designed for use with the Argo Rollouts plugin system. This plugin enables the integration of OpenSearch metrics into Argo Rollouts, allowing for advanced metric analysis and monitoring during application rollouts.

--- a/docs/analysis/plugins.md
+++ b/docs/analysis/plugins.md
@@ -103,7 +103,7 @@ If you have created a plugin, please submit a PR to add it to this list.
 
 ### [rollouts-plugin-metric-honeycomb](https://github.com/argoproj-labs/rollouts-plugin-metric-honeycomb)
 
-- A metric plugin that integrates [Honeycomb](https://www.honeycomb.io/) as an analysis provider for Argo Rollouts.
+- A metric plugin that integrates Honeycomb as an analysis provider for Argo Rollouts.
 
 ### [rollouts-plugin-metric-opensearch](https://github.com/argoproj-labs/rollouts-plugin-metric-opensearch)
 
@@ -111,7 +111,7 @@ If you have created a plugin, please submit a PR to add it to this list.
 
 ### [rollouts-opsmx-metric-plugin](https://github.com/argoproj-labs/rollouts-opsmx-metric-plugin)
 
-- An [OpsMx](https://www.opsmx.com/) plugin that performs logs and metrics analysis for Argo Rollouts.
+- An OpsMx plugin that performs logs and metrics analysis for Argo Rollouts.
 
 ### [rollouts-plugin-metric-sample-prometheus](https://github.com/argoproj-labs/rollouts-plugin-metric-sample-prometheus)
 

--- a/docs/features/traffic-management/plugins.md
+++ b/docs/features/traffic-management/plugins.md
@@ -98,3 +98,15 @@ If you have created a plugin, please submit a PR to add it to this list.
 ### [Gateway API](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/)
 
 - Provide support for Gateway API, which includes Kuma, Traefix, cilium, Contour, GloodMesh, HAProxy, and [many others](https://gateway-api.sigs.k8s.io/implementations/#implementation-status).
+
+### [Gloo Edge](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-glooedge)
+
+- A plugin that enables canary rollouts via [Gloo Edge](https://www.solo.io/products/gloo-edge/) by updating route weights on Gloo `VirtualService` resources.
+
+### [Gloo Platform](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-glooplatform)
+
+- A plugin that enables canary rollouts via [Gloo Platform](https://www.solo.io/products/gloo-platform/).
+
+### [OpenShift Route](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-openshift)
+
+- A plugin that allows argo-rollouts to manage traffic shaping using [OpenShift Routes](https://docs.openshift.com/container-platform/latest/networking/routes/route-configuration.html).

--- a/docs/features/traffic-management/plugins.md
+++ b/docs/features/traffic-management/plugins.md
@@ -101,12 +101,12 @@ If you have created a plugin, please submit a PR to add it to this list.
 
 ### [Gloo Edge](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-glooedge)
 
-- A plugin that enables canary rollouts via [Gloo Edge](https://www.solo.io/products/gloo-edge/) by updating route weights on Gloo `VirtualService` resources.
+- A plugin that enables canary rollouts via Gloo Edge by updating route weights on Gloo `VirtualService` resources.
 
 ### [Gloo Platform](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-glooplatform)
 
-- A plugin that enables canary rollouts via [Gloo Platform](https://www.solo.io/products/gloo-platform/).
+- A plugin that enables canary rollouts via Gloo Platform.
 
 ### [OpenShift Route](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-openshift)
 
-- A plugin that allows argo-rollouts to manage traffic shaping using [OpenShift Routes](https://docs.openshift.com/container-platform/latest/networking/routes/route-configuration.html).
+- A plugin that allows argo-rollouts to manage traffic shaping using OpenShift Routes.


### PR DESCRIPTION
## Summary

Adds plugins from [argoproj-labs](https://github.com/argoproj-labs) that exist with releases but are missing from the docs.

**Metric plugins** (`docs/analysis/plugins.md`):
- [`rollouts-plugin-metric-ai`](https://github.com/argoproj-labs/rollouts-plugin-metric-ai) — A2A agent–driven AI analysis
- [`rollouts-plugin-metric-honeycomb`](https://github.com/argoproj-labs/rollouts-plugin-metric-honeycomb) — Honeycomb provider
- [`rollouts-opsmx-metric-plugin`](https://github.com/argoproj-labs/rollouts-opsmx-metric-plugin) — OpsMx logs/metrics analysis

**Traffic router plugins** (`docs/features/traffic-management/plugins.md`):
- [Gloo Edge](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-glooedge)
- [Gloo Platform](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-glooplatform)
- [OpenShift Route](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-openshift)

All entries link to repos under the argoproj-labs org with published releases.

## Checklist

- [x] Documentation only (no code change)
- [x] DCO sign-off included