### PR TITLE
docs: Added separate developer guide section

### DIFF
--- a/docs/developer-guide/code-quality-and-security-scanning.md
+++ b/docs/developer-guide/code-quality-and-security-scanning.md
@@ -1,0 +1,11 @@
+# Code Quality and Security Scanning
+
+We use the following code quality and security scanning tools:
+
+* `golangci-lint` and `eslint` for compile time linting
+* [CodeQL](https://codeql.github.com/) - for semantic code analysis
+* [codecov.io](https://codecov.io/gh/argoproj/argo-cd) - for code coverage
+* [snyk.io](https://app.snyk.io/org/argoproj/projects) - for image scanning
+* [sonarcloud.io](https://sonarcloud.io/organizations/argoproj/projects) - for code scans and security alerts
+
+These are at least run daily or on each pull request.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,17 +133,19 @@ nav:
     - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_terminate_experiment.md
     - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_undo.md
     - generated/kubectl-argo-rollouts/kubectl-argo-rollouts_version.md
+- Developer Guide:
+  - Code Quality and Security Scanning: developer-guide/code-quality-and-security-scanning.md
+  - Contributing:
+    - Contribution Guide: CONTRIBUTING.md
+    - Environment Setup: getting-started/setup/index.md
+    - Releasing: releasing.md
+    - Plugins: plugins.md
 - Best Practices: best-practices.md
 - Migrating: migrating.md
 - FAQ: FAQ.md
 - Security:
   - Security Policy: security/security.md
   - Verify Release Artifacts: security/signed-release-assets.md
-- Contributing:
-  - Contribution Guide: CONTRIBUTING.md
-  - Environment Setup: getting-started/setup/index.md
-  - Releasing: releasing.md
-  - Plugins: plugins.md
 - Releases ⧉: https://github.com/argoproj/argo-rollouts/releases
 - Roadmap ⧉: https://github.com/argoproj/argo-rollouts/milestones
 - Blog ⧉: https://blog.argoproj.io/


### PR DESCRIPTION
The idea is to create more clear documentation for developers like one which we have in Argo CD. Starting off with **Code Quality and Security Scanning** and will add others files one by one in the upcoming PRs.

**Screenshot from my local machine:**
<img width="1442" height="856" alt="roll-1" src="https://github.com/user-attachments/assets/3df56a41-744e-48ec-8232-bc955417d011" />
<img width="1499" height="976" alt="roll-2" src="https://github.com/user-attachments/assets/1dbd1b52-4ce4-473f-b4a3-42e65caec63b" />


Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [ ] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [ ] I understand what the code does and WHY/HOW it works in several scenarios
* [ ] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).