### PR TITLE
ci: bump k8 version in testing

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -98,9 +98,6 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes:
-          - version: '1.32'
-            k3s_version: '1.32.12+k3s1'
-            latest: false
           - version: '1.33'
             k3s_version: '1.33.8+k3s1'
             latest: false
@@ -109,7 +106,12 @@ jobs:
             latest: false
           - version: '1.35'
             k3s_version: '1.35.1+k3s1'
+            latest: false
+          - version: '1.36'
+            k3s_version: '1.36.1+k3s1'
             latest: true
+          
+          
     name: Run end-to-end tests (${{ matrix.kubernetes.version }}, ${{ matrix.kubernetes.latest }})
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -108,10 +108,8 @@ jobs:
             k3s_version: '1.35.1+k3s1'
             latest: false
           - version: '1.36'
-            k3s_version: '1.36.1+k3s1'
+            k3s_version: '1.36.0+k3s1'
             latest: true
-          
-          
     name: Run end-to-end tests (${{ matrix.kubernetes.version }}, ${{ matrix.kubernetes.latest }})
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Bump K8 version in test to 1.36.0

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [ ] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [ ] I understand what the code does and WHY/HOW it works in several scenarios
* [ ] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).