### PR TITLE
feat: remove validation requiring strategy for argo-rollout

### DIFF
--- a/pkg/apis/rollouts/validation/validation.go
+++ b/pkg/apis/rollouts/validation/validation.go
@@ -200,10 +200,7 @@ func removeSecurityContextPrivileged(template *core.PodTemplateSpec) {
 func ValidateRolloutStrategy(rollout *v1alpha1.Rollout, fldPath *field.Path) field.ErrorList {
 	strategy := rollout.Spec.Strategy
 	allErrs := field.ErrorList{}
-	if strategy.BlueGreen == nil && strategy.Canary == nil {
-		message := fmt.Sprintf(MissingFieldMessage, ".spec.strategy.canary or .spec.strategy.blueGreen")
-		allErrs = append(allErrs, field.Required(fldPath.Child("strategy"), message))
-	} else if strategy.BlueGreen != nil && strategy.Canary != nil {
+	if strategy.BlueGreen != nil && strategy.Canary != nil {
 		errVal := fmt.Sprintf("blueGreen: %t canary: %t", rollout.Spec.Strategy.BlueGreen != nil, rollout.Spec.Strategy.Canary != nil)
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("strategy"), errVal, InvalidStrategyMessage))
 	} else if strategy.BlueGreen != nil {

--- a/pkg/apis/rollouts/validation/validation_test.go
+++ b/pkg/apis/rollouts/validation/validation_test.go
@@ -97,9 +97,9 @@ func TestValidateRolloutStrategy(t *testing.T) {
 		},
 	}
 
+	// No strategy specified should be valid (basic rolling update)
 	allErrs := ValidateRolloutStrategy(&rollout, field.NewPath(""))
-	message := fmt.Sprintf(MissingFieldMessage, ".spec.strategy.canary or .spec.strategy.blueGreen")
-	assert.Equal(t, message, allErrs[0].Detail)
+	assert.Empty(t, allErrs)
 
 	rollout.Spec.Strategy.BlueGreen = &v1alpha1.BlueGreenStrategy{}
 	rollout.Spec.Strategy.Canary = &v1alpha1.CanaryStrategy{}

--- a/rollout/context.go
+++ b/rollout/context.go
@@ -1,6 +1,8 @@
 package rollout
 
 import (
+	"fmt"
+
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 
@@ -67,9 +69,42 @@ func (c *rolloutContext) reconcile() error {
 	if c.rollout.Spec.Strategy.BlueGreen != nil {
 		return c.rolloutBlueGreen()
 	}
+	if c.rollout.Spec.Strategy.Canary != nil {
+		return c.rolloutCanary()
+	}
 
-	// Due to the rollout validation before this, when we get here strategy is canary
-	return c.rolloutCanary()
+	// No strategy specified: treat as a basic rolling update (no canary/blue-green logic)
+	return c.syncRolloutNoStrategy()
+}
+
+// syncRolloutNoStrategy handles reconciliation when neither canary nor blueGreen strategy is specified.
+// This behaves like a basic rolling update: scale up the new ReplicaSet, scale down old ones,
+// and promote the new RS as stable once it's available.
+func (c *rolloutContext) syncRolloutNoStrategy() error {
+	var err error
+	c.newRS, err = c.getAllReplicaSetsAndSyncRevision()
+	if err != nil {
+		return fmt.Errorf("failed to getAllReplicaSetsAndSyncRevision in syncRolloutNoStrategy: %w", err)
+	}
+
+	restarted, err := c.podRestarter.Reconcile(c)
+	if err != nil {
+		return err
+	}
+	if restarted > 0 {
+		c.log.Infof("Finished reconciliation due to %d restarted pods", restarted)
+		return nil
+	}
+
+	if err := c.reconcileRevisionHistoryLimit(c.otherRSs); err != nil {
+		return err
+	}
+
+	if _, err := c.reconcileCanaryReplicaSets(); err != nil {
+		return fmt.Errorf("failed to reconcileCanaryReplicaSets in syncRolloutNoStrategy: %w", err)
+	}
+
+	return c.syncRolloutStatusCanary()
 }
 
 func (c *rolloutContext) SetRestartedAt() {

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -309,6 +309,13 @@ func (c *rolloutContext) syncReplicasOnly() error {
 		}
 		newStatus.AvailableReplicas = replicasetutil.GetAvailableReplicaCountForReplicaSets(c.allRSs)
 		newStatus.HPAReplicas = replicasetutil.GetActualReplicaCountForReplicaSets(c.allRSs)
+	} else if c.rollout.Spec.Strategy.BlueGreen == nil {
+		// No strategy specified: treat scaling like basic canary
+		if _, err := c.reconcileCanaryReplicaSets(); err != nil {
+			return fmt.Errorf("failed to reconcileCanaryReplicaSets in syncReplicasOnly (no strategy): %w", err)
+		}
+		newStatus.AvailableReplicas = replicasetutil.GetAvailableReplicaCountForReplicaSets(c.allRSs)
+		newStatus.HPAReplicas = replicasetutil.GetActualReplicaCountForReplicaSets(c.allRSs)
 	}
 	return c.persistRolloutStatus(newStatus)
 }

--- a/utils/rollout/rolloututil.go
+++ b/utils/rollout/rolloututil.go
@@ -185,6 +185,14 @@ func CalculateRolloutPhase(spec v1alpha1.RolloutSpec, status v1alpha1.RolloutSta
 		if ro.Status.StableRS == "" || !IsFullyPromoted(&ro) {
 			return v1alpha1.RolloutPhaseProgressing, "waiting for all steps to complete"
 		}
+	} else {
+		// No strategy specified (basic rolling update): check if replicas are up to date
+		if ro.Status.Replicas > ro.Status.UpdatedReplicas {
+			return v1alpha1.RolloutPhaseProgressing, "old replicas are pending termination"
+		}
+		if ro.Status.AvailableReplicas < ro.Status.UpdatedReplicas {
+			return v1alpha1.RolloutPhaseProgressing, "updated replicas are still becoming available"
+		}
 	}
 	return v1alpha1.RolloutPhaseHealthy, ""
 }


### PR DESCRIPTION
## Summary

Removes the validation that required either `.spec.strategy.canary` or `.spec.strategy.blueGreen` to be specified on a Rollout resource. This allows creating Rollouts without a strategy, which behave as a basic rolling update (similar to a Kubernetes Deployment).

Related issue: #540

## Changes

### Validation (`pkg/apis/rollouts/validation/validation.go`)
- Removed the `field.Required` check in `ValidateRolloutStrategy()` that fired when both `strategy.BlueGreen` and `strategy.Canary` were nil
- A Rollout with no strategy specified is now valid

### Controller (`rollout/context.go`)
- Added `syncRolloutNoStrategy()` method to handle reconciliation when neither canary nor blueGreen strategy is set
- This path behaves like a basic rolling update: scales up the new ReplicaSet, scales down old ones, and promotes the new RS as stable
- Updated `reconcile()` to route to the new method instead of falling through to `rolloutCanary()`

### Scaling (`rollout/sync.go`)
- Updated `syncReplicasOnly()` to handle the no-strategy case during scaling events (uses the same `reconcileCanaryReplicaSets()` path as basic canary)

### Phase calculation (`utils/rollout/rolloututil.go`)
- Added explicit `else` clause in `CalculateRolloutPhase()` for the no-strategy case, checking if old replicas are pending termination or if updated replicas are still becoming available

### Tests (`pkg/apis/rollouts/validation/validation_test.go`)
- Updated `TestValidateRolloutStrategy` to assert that a Rollout with no strategy produces no validation errors (was previously asserting it produced an error)

## How it works

When a Rollout is created without specifying a canary or blueGreen strategy:

```yaml
apiVersion: argoproj.io/v1alpha1
kind: Rollout
metadata:
  name: my-app
spec:
  replicas: 3
  selector:
    matchLabels:
      app: my-app
  template:
    spec:
      containers:
      - name: my-app
        image: my-app:1.0
```

The controller will:
1. Create/update the new ReplicaSet to match the desired state
2. Scale up the new RS to the desired replica count
3. Scale down old ReplicaSets
4. Promote the new RS as stable once fully available

This is functionally equivalent to a Kubernetes Deployment with a RollingUpdate strategy.

## Testing

- All existing validation tests pass
- `go vet ./rollout/...` passes
- Build succeeds (`go build ./...`)