### PR TITLE
feat: add phased Istio traffic router plugin with proportional weight support

### DIFF
--- a/test/cmd/trafficrouter-phased-istio-plugin/README.md
+++ b/test/cmd/trafficrouter-phased-istio-plugin/README.md
@@ -1,0 +1,226 @@
+# Phased Istio Traffic Router Plugin
+
+A custom Argo Rollouts traffic router plugin that advances multiple Istio VirtualService routes **independently and in sequence**, rather than updating all routes to the same weight simultaneously.
+
+## Why this plugin exists
+
+The built-in Istio traffic router applies a single `desiredWeight` to every route listed in `trafficRouting.istio.virtualService.routes` at the same time. There is no way to express "ramp route A to 100% before touching route B."
+
+This plugin solves that by introducing **phases**: an ordered list of VirtualService HTTP routes. Each `setWeight` step advances only the first phase whose canary weight is still below 100. Once a phase reaches 100%, the next phase becomes active automatically.
+
+## How phase detection works
+
+On every `SetWeight(N)` call the plugin:
+
+1. Reads the current VirtualService from the cluster.
+2. Walks the configured phases in order.
+3. The first phase whose named route has a canary weight **below 100** is the active phase.
+4. Applies `desiredWeight` to that route (`canary = N`, `stable = 100 - N`).
+5. All other routes are left unchanged.
+
+When `desiredWeight` is 0, all managed routes are reset to `stable = 100, canary = 0` (used during rollback / `RemoveManagedRoutes`).
+
+Because the active phase is determined by reading live cluster state, the plugin is naturally resilient to `pause`, `analysis`, and any other non-`setWeight` step types — they don't call `SetWeight`, so the VirtualService is untouched until the rollout continues.
+
+## Installation
+
+Build the binary and register it in the argo-rollouts ConfigMap.
+
+### Build
+
+```bash
+go build -o trafficrouter-phased-istio-plugin \
+  ./test/cmd/trafficrouter-phased-istio-plugin/
+```
+
+Place the binary somewhere the rollout controller can reach it (e.g. a shared volume, an object-store URL, or a `file://` path on the controller node).
+
+### Register in the ConfigMap
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argo-rollouts-config
+  namespace: argo-rollouts
+data:
+  trafficRouterPlugins: |
+    - name: argoproj/phased-istio-router
+      location: "file:///usr/local/bin/trafficrouter-phased-istio-plugin"
+```
+
+The `location` field accepts an HTTPS URL or a `file://` path. If an HTTPS URL is used, an optional `sha256` field can be added for checksum verification.
+
+## Configuration reference
+
+The plugin is configured via a JSON (or YAML-as-JSON) string under `trafficRouting.plugins` in the Rollout spec.
+
+```go
+type PluginConfig struct {
+    VirtualService  VSRef   // required
+    DestinationRule DRRef   // required for subset-based routing
+    Phases          []Phase // required; processed in order
+}
+
+type VSRef struct {
+    Name      string // VirtualService name
+    Namespace string // defaults to the Rollout's namespace
+}
+
+type DRRef struct {
+    Name             string // DestinationRule name
+    Namespace        string // defaults to the Rollout's namespace
+    CanarySubsetName string // subset used for canary traffic
+    StableSubsetName string // subset used for stable traffic
+}
+
+type Phase struct {
+    Route string // .spec.http[].name in the VirtualService
+}
+```
+
+The plugin also manages the DestinationRule's pod-template-hash label selectors on each `UpdateHash` call, so a `trafficRouting.istio` block is **not** needed and should not be included (both reconcilers would run and conflict on VS updates).
+
+## Full example
+
+### VirtualService
+
+```yaml
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: my-service
+  namespace: my-namespace
+spec:
+  hosts:
+  - my-service.my-namespace.svc.cluster.local
+  http:
+  - name: stable-route
+    match:
+    - headers:
+        User-Org-Id:
+          regex: "enterprise-1|enterprise-2"
+    route:
+    - destination:
+        host: my-service.my-namespace.svc.cluster.local
+        subset: stable
+      weight: 100
+    - destination:
+        host: my-service.my-namespace.svc.cluster.local
+        subset: canary
+      weight: 0
+  - name: latest-route
+    route:
+    - destination:
+        host: my-service.my-namespace.svc.cluster.local
+        subset: stable
+      weight: 100
+    - destination:
+        host: my-service.my-namespace.svc.cluster.local
+        subset: canary
+      weight: 0
+```
+
+### DestinationRule
+
+```yaml
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: my-service-destination
+  namespace: my-namespace
+spec:
+  host: my-service.my-namespace.svc.cluster.local
+  subsets:
+  - name: stable
+    labels:
+      rollouts-pod-template-hash: ""   # managed by the plugin's UpdateHash
+  - name: canary
+    labels:
+      rollouts-pod-template-hash: ""
+```
+
+### Rollout
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: my-service
+  namespace: my-namespace
+spec:
+  replicas: 5
+  selector:
+    matchLabels:
+      app: my-service
+  template:
+    metadata:
+      labels:
+        app: my-service
+    spec:
+      containers:
+      - name: my-service
+        image: my-service:latest
+  strategy:
+    canary:
+      trafficRouting:
+        plugins:
+          argoproj/phased-istio-router: |
+            virtualService:
+              name: my-service
+              namespace: my-namespace
+            destinationRule:
+              name: my-service-destination
+              namespace: my-namespace
+              canarySubsetName: canary
+              stableSubsetName: stable
+            phases:
+              - route: latest-route
+              - route: stable-route
+      steps:
+      # Phase 1 — ramp catch-all traffic (latest-route)
+      - setWeight: 10
+      - pause: {duration: 10m}
+      - setWeight: 50
+      - pause: {duration: 10m}
+      - setWeight: 80
+      - pause: {duration: 10m}
+      - setWeight: 100
+      # Phase 2 — ramp enterprise header-matched traffic (stable-route)
+      - setWeight: 5
+      - pause: {duration: 10m}
+      - setWeight: 25
+      - pause: {duration: 10m}
+      - setWeight: 75
+      - pause: {duration: 10m}
+      - setWeight: 100
+```
+
+## Weight progression walkthrough
+
+| Step | `desiredWeight` | Active phase | `latest-route` canary | `stable-route` canary |
+|------|-----------------|--------------|-----------------------|-----------------------|
+| 1    | 10              | latest-route | **10**                | 0                     |
+| 2    | 50              | latest-route | **50**                | 0                     |
+| 3    | 80              | latest-route | **80**                | 0                     |
+| 4    | 100             | latest-route | **100**               | 0                     |
+| 5    | 5               | stable-route | 100                   | **5**                 |
+| 6    | 25              | stable-route | 100                   | **25**                |
+| 7    | 75              | stable-route | 100                   | **75**                |
+| 8    | 100             | stable-route | 100                   | **100**               |
+
+`pause` steps between `setWeight` steps do not call the plugin — the VirtualService remains unchanged until the rollout continues.
+
+## Rollback and abort
+
+When a rollout is aborted, the controller calls `RemoveManagedRoutes`, which resets all configured routes to `stable = 100, canary = 0` regardless of which phase was active.
+
+A manual rollback (promoting to a previous revision) triggers `SetWeight(0)` followed by a new rollout, which resets all routes and begins phase 1 fresh.
+
+## Limitations
+
+- Routes are identified by name (`.spec.http[].name`). Routes without a `name` field are ignored.
+- Subset names (`canarySubsetName`, `stableSubsetName`) must match the DestinationRule subsets and the VirtualService destination `.subset` fields exactly.
+- The plugin does not support `SetHeaderRoute` or `SetMirrorRoute` — those return no-ops.
+- Only HTTP routes are managed. TLS and TCP routes in the VirtualService are untouched.
+

--- a/test/cmd/trafficrouter-phased-istio-plugin/README.md
+++ b/test/cmd/trafficrouter-phased-istio-plugin/README.md
@@ -6,21 +6,40 @@ A custom Argo Rollouts traffic router plugin that advances multiple Istio Virtua
 
 The built-in Istio traffic router applies a single `desiredWeight` to every route listed in `trafficRouting.istio.virtualService.routes` at the same time. There is no way to express "ramp route A to 100% before touching route B."
 
-This plugin solves that by introducing **phases**: an ordered list of VirtualService HTTP routes. Each `setWeight` step advances only the first phase whose canary weight is still below 100. Once a phase reaches 100%, the next phase becomes active automatically.
+This plugin solves that by introducing **phases**: an ordered list of VirtualService HTTP routes that are ramped sequentially.
 
-## How phase detection works
+## Modes
 
-On every `SetWeight(N)` call the plugin:
+### Proportional mode (recommended)
 
-1. Reads the current VirtualService from the cluster.
-2. Walks the configured phases in order.
-3. The first phase whose named route has a canary weight **below 100** is the active phase.
-4. Applies `desiredWeight` to that route (`canary = N`, `stable = 100 - N`).
-5. All other routes are left unchanged.
+Each phase carries a `weight` representing its fraction of total traffic (0–100, phases must sum to 100). The Rollout's `desiredWeight` then maps directly to the fraction of total traffic served by canary pods, keeping ReplicaSet counts proportional to actual traffic at every step.
 
-When `desiredWeight` is 0, all managed routes are reset to `stable = 100, canary = 0` (used during rollback / `RemoveManagedRoutes`).
+On every `SetWeight(N)` call the plugin computes each phase's target route weight from `N` and its position in the cumulative weight range:
 
-Because the active phase is determined by reading live cluster state, the plugin is naturally resilient to `pause`, `analysis`, and any other non-`setWeight` step types — they don't call `SetWeight`, so the VirtualService is untouched until the rollout continues.
+```
+phase 1 range:  [0,  w1]       → route weight = N / w1 * 100  (clamped to [0, 100])
+phase 2 range:  [w1, w1+w2]    → route weight = (N - w1) / w2 * 100
+...
+```
+
+All routes are updated in a single VirtualService write.
+
+### Legacy mode
+
+When no phase specifies a `weight`, the plugin uses the original sequential algorithm:
+
+1. Reads the current VirtualService.
+2. Walks phases in order; the first whose route has canary weight **below 100** is active.
+3. Applies `desiredWeight` directly to that route's canary weight.
+4. All other routes are left unchanged.
+
+Legacy mode is preserved for backward compatibility. Existing configurations without `weight` fields continue to work unchanged.
+
+---
+
+When `desiredWeight` is 0 (either mode), all managed routes are reset to `stable = 100, canary = 0`.
+
+`pause`, `analysis`, and other non-`setWeight` steps do not call the plugin — the VirtualService is untouched until the rollout continues.
 
 ## Installation
 
@@ -75,7 +94,9 @@ type DRRef struct {
 }
 
 type Phase struct {
-    Route string // .spec.http[].name in the VirtualService
+    Route  string // .spec.http[].name in the VirtualService
+    Weight int32  // fraction of total traffic (0-100); phases must sum to 100 (proportional mode)
+                  // omit on all phases to use legacy mode
 }
 ```
 
@@ -175,39 +196,43 @@ spec:
               canarySubsetName: canary
               stableSubsetName: stable
             phases:
+              # latest-route (catch-all) handles ~70% of traffic
               - route: latest-route
+                weight: 70
+              # stable-route (enterprise header-matched) handles ~30% of traffic
               - route: stable-route
+                weight: 30
       steps:
-      # Phase 1 — ramp catch-all traffic (latest-route)
-      - setWeight: 10
+      # desiredWeight = % of total traffic going to canary (= canary RS size / spec.Replicas).
+      # Phase 1 (latest-route) spans desiredWeight 0–70.
+      - setWeight: 14    # latest-route canary = 20%,  stable-route canary = 0%
       - pause: {duration: 10m}
-      - setWeight: 50
+      - setWeight: 35    # latest-route canary = 50%,  stable-route canary = 0%
       - pause: {duration: 10m}
-      - setWeight: 80
+      - setWeight: 70    # latest-route canary = 100%, stable-route canary = 0%  (phase 1 complete)
       - pause: {duration: 10m}
-      - setWeight: 100
-      # Phase 2 — ramp enterprise header-matched traffic (stable-route)
-      - setWeight: 5
+      # Phase 2 (stable-route) spans desiredWeight 70–100.
+      - setWeight: 80    # latest-route canary = 100%, stable-route canary = 33%
       - pause: {duration: 10m}
-      - setWeight: 25
+      - setWeight: 90    # latest-route canary = 100%, stable-route canary = 67%
       - pause: {duration: 10m}
-      - setWeight: 75
-      - pause: {duration: 10m}
-      - setWeight: 100
+      - setWeight: 100   # latest-route canary = 100%, stable-route canary = 100%
 ```
 
 ## Weight progression walkthrough
 
-| Step | `desiredWeight` | Active phase | `latest-route` canary | `stable-route` canary |
-|------|-----------------|--------------|-----------------------|-----------------------|
-| 1    | 10              | latest-route | **10**                | 0                     |
-| 2    | 50              | latest-route | **50**                | 0                     |
-| 3    | 80              | latest-route | **80**                | 0                     |
-| 4    | 100             | latest-route | **100**               | 0                     |
-| 5    | 5               | stable-route | 100                   | **5**                 |
-| 6    | 25              | stable-route | 100                   | **25**                |
-| 7    | 75              | stable-route | 100                   | **75**                |
-| 8    | 100             | stable-route | 100                   | **100**               |
+Phases: `latest-route` weight=70, `stable-route` weight=30. `spec.replicas: 10`.
+
+| Step | `desiredWeight` | canary RS pods | `latest-route` canary | `stable-route` canary |
+|------|-----------------|----------------|-----------------------|-----------------------|
+| 1    | 14              | ~1             | **20%**               | 0%                    |
+| 2    | 35              | 3–4            | **50%**               | 0%                    |
+| 3    | 70              | 7              | **100%**              | 0%                    |
+| 4    | 80              | 8              | 100%                  | **33%**               |
+| 5    | 90              | 9              | 100%                  | **67%**               |
+| 6    | 100             | 10             | 100%                  | **100%**              |
+
+At every step, `canary RS pods ≈ desiredWeight / 100 × spec.replicas` — proportional to actual traffic.
 
 `pause` steps between `setWeight` steps do not call the plugin — the VirtualService remains unchanged until the rollout continues.
 

--- a/test/cmd/trafficrouter-phased-istio-plugin/internal/plugin/plugin.go
+++ b/test/cmd/trafficrouter-phased-istio-plugin/internal/plugin/plugin.go
@@ -42,8 +42,12 @@ type DRRef struct {
 }
 
 // Phase names a single VirtualService HTTP route to be ramped.
+// Weight is the fraction of total traffic (0–100) handled by this route; phases must sum to 100.
+// When weight is omitted on all phases the plugin falls back to legacy mode (first incomplete
+// phase receives desiredWeight directly).
 type Phase struct {
-	Route string `json:"route"`
+	Route  string `json:"route"`
+	Weight int32  `json:"weight,omitempty"`
 }
 
 type RpcPlugin struct {
@@ -91,6 +95,35 @@ func (p *RpcPlugin) getVS(ctx context.Context, namespace, name string) (*unstruc
 		return nil, pluginTypes.RpcError{ErrorString: fmt.Sprintf("failed to get VirtualService %s/%s: %v", namespace, name, err)}
 	}
 	return vs, pluginTypes.RpcError{}
+}
+
+// cumulativeRanges returns the [start, end] range in desiredWeight space for each phase, and
+// reports whether any phase has an explicit weight (proportional mode). When the second return
+// value is false, the ranges are meaningless and proportional logic should not be used.
+func cumulativeRanges(phases []Phase) ([][2]int32, bool) {
+	ranges := make([][2]int32, len(phases))
+	var cum int32
+	proportional := false
+	for i, p := range phases {
+		if p.Weight > 0 {
+			proportional = true
+		}
+		ranges[i] = [2]int32{cum, cum + p.Weight}
+		cum += p.Weight
+	}
+	return ranges, proportional
+}
+
+// phaseRouteWeight maps a global desiredWeight to a per-route canary weight [0, 100].
+// start and end are the phase's cumulative range boundaries in desiredWeight space.
+func phaseRouteWeight(desiredWeight, start, end int32) int32 {
+	if desiredWeight >= end {
+		return 100
+	}
+	if desiredWeight <= start {
+		return 0
+	}
+	return (desiredWeight - start) * 100 / (end - start)
 }
 
 func findHTTPRoute(httpRoutes []interface{}, routeName string) (map[string]interface{}, bool) {
@@ -186,7 +219,14 @@ func (p *RpcPlugin) SetWeight(ro *v1alpha1.Rollout, desiredWeight int32, additio
 	canary := cfg.DestinationRule.CanarySubsetName
 	stable := cfg.DestinationRule.StableSubsetName
 
-	if desiredWeight == 0 {
+	if ranges, proportional := cumulativeRanges(cfg.Phases); proportional {
+		for i, phase := range cfg.Phases {
+			rw := phaseRouteWeight(desiredWeight, ranges[i][0], ranges[i][1])
+			if err := applyRouteWeights(httpRoutes, phase.Route, canary, stable, rw); err != nil {
+				p.LogCtx.Warnf("could not set route %s: %v", phase.Route, err)
+			}
+		}
+	} else if desiredWeight == 0 {
 		for _, phase := range cfg.Phases {
 			if err := applyRouteWeights(httpRoutes, phase.Route, canary, stable, 0); err != nil {
 				p.LogCtx.Warnf("could not reset route %s: %v", phase.Route, err)
@@ -297,6 +337,17 @@ func (p *RpcPlugin) VerifyWeight(ro *v1alpha1.Rollout, desiredWeight int32, addi
 	}
 
 	canary := cfg.DestinationRule.CanarySubsetName
+
+	if ranges, proportional := cumulativeRanges(cfg.Phases); proportional {
+		for i, phase := range cfg.Phases {
+			expected := phaseRouteWeight(desiredWeight, ranges[i][0], ranges[i][1])
+			if routeCanaryWeight(httpRoutes, phase.Route, canary) != int64(expected) {
+				return pluginTypes.NotVerified, pluginTypes.RpcError{}
+			}
+		}
+		return pluginTypes.Verified, pluginTypes.RpcError{}
+	}
+
 	for _, phase := range cfg.Phases {
 		w := routeCanaryWeight(httpRoutes, phase.Route, canary)
 		if w < 100 {

--- a/test/cmd/trafficrouter-phased-istio-plugin/internal/plugin/plugin.go
+++ b/test/cmd/trafficrouter-phased-istio-plugin/internal/plugin/plugin.go
@@ -1,0 +1,327 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/argoproj/argo-rollouts/rollout/trafficrouting/plugin/rpc"
+	istioutil "github.com/argoproj/argo-rollouts/utils/istio"
+	pluginTypes "github.com/argoproj/argo-rollouts/utils/plugin/types"
+)
+
+const PluginName = "argoproj/phased-istio-router"
+
+var _ rpc.TrafficRouterPlugin = &RpcPlugin{}
+
+// PluginConfig is unmarshalled from the Rollout's trafficRouting.plugins entry.
+type PluginConfig struct {
+	VirtualService  VSRef   `json:"virtualService"`
+	DestinationRule DRRef   `json:"destinationRule,omitempty"`
+	Phases          []Phase `json:"phases"`
+}
+
+type VSRef struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// DRRef identifies the DestinationRule and names the canary/stable subsets used in the VS routes.
+type DRRef struct {
+	Name             string `json:"name"`
+	Namespace        string `json:"namespace,omitempty"`
+	CanarySubsetName string `json:"canarySubsetName"`
+	StableSubsetName string `json:"stableSubsetName"`
+}
+
+// Phase names a single VirtualService HTTP route to be ramped.
+type Phase struct {
+	Route string `json:"route"`
+}
+
+type RpcPlugin struct {
+	LogCtx        *logrus.Entry
+	dynamicClient dynamic.Interface
+}
+
+func (p *RpcPlugin) InitPlugin() pluginTypes.RpcError {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	configOverrides := &clientcmd.ConfigOverrides{}
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+	restConfig, err := kubeConfig.ClientConfig()
+	if err != nil {
+		return pluginTypes.RpcError{ErrorString: err.Error()}
+	}
+	dynClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return pluginTypes.RpcError{ErrorString: err.Error()}
+	}
+	p.dynamicClient = dynClient
+	return pluginTypes.RpcError{}
+}
+
+func (p *RpcPlugin) parseConfig(ro *v1alpha1.Rollout) (PluginConfig, pluginTypes.RpcError) {
+	var cfg PluginConfig
+	data, ok := ro.Spec.Strategy.Canary.TrafficRouting.Plugins[PluginName]
+	if !ok {
+		return cfg, pluginTypes.RpcError{ErrorString: fmt.Sprintf("plugin config not found for %s", PluginName)}
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return cfg, pluginTypes.RpcError{ErrorString: fmt.Sprintf("failed to unmarshal plugin config: %v", err)}
+	}
+	if cfg.VirtualService.Namespace == "" {
+		cfg.VirtualService.Namespace = ro.Namespace
+	}
+	if cfg.DestinationRule.Namespace == "" {
+		cfg.DestinationRule.Namespace = ro.Namespace
+	}
+	return cfg, pluginTypes.RpcError{}
+}
+
+func (p *RpcPlugin) getVS(ctx context.Context, namespace, name string) (*unstructured.Unstructured, pluginTypes.RpcError) {
+	vs, err := p.dynamicClient.Resource(istioutil.GetIstioVirtualServiceGVR()).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, pluginTypes.RpcError{ErrorString: fmt.Sprintf("failed to get VirtualService %s/%s: %v", namespace, name, err)}
+	}
+	return vs, pluginTypes.RpcError{}
+}
+
+func findHTTPRoute(httpRoutes []interface{}, routeName string) (map[string]interface{}, bool) {
+	for _, r := range httpRoutes {
+		route, ok := r.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if route["name"] == routeName {
+			return route, true
+		}
+	}
+	return nil, false
+}
+
+// routeCanaryWeight returns the current canary destination weight for the named HTTP route.
+// Returns -1 if the route or its canary destination is not found.
+func routeCanaryWeight(httpRoutes []interface{}, routeName, canarySubset string) int64 {
+	route, ok := findHTTPRoute(httpRoutes, routeName)
+	if !ok {
+		return -1
+	}
+	destinations, _ := route["route"].([]interface{})
+	for _, d := range destinations {
+		dest, ok := d.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		destInfo, _ := dest["destination"].(map[string]interface{})
+		if destInfo["subset"] != canarySubset {
+			continue
+		}
+		switch w := dest["weight"].(type) {
+		case int64:
+			return w
+		case float64:
+			return int64(w)
+		case int:
+			return int64(w)
+		default:
+			return 0
+		}
+	}
+	return -1
+}
+
+// applyRouteWeights sets canary=desiredWeight and stable=100-desiredWeight on the named route.
+func applyRouteWeights(httpRoutes []interface{}, routeName, canarySubset, stableSubset string, desiredWeight int32) error {
+	route, ok := findHTTPRoute(httpRoutes, routeName)
+	if !ok {
+		return fmt.Errorf("route %q not found in VirtualService", routeName)
+	}
+	destinations, ok := route["route"].([]interface{})
+	if !ok {
+		return fmt.Errorf("route %q has no destinations", routeName)
+	}
+	for _, d := range destinations {
+		dest, ok := d.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		destInfo, _ := dest["destination"].(map[string]interface{})
+		switch destInfo["subset"] {
+		case canarySubset:
+			dest["weight"] = int64(desiredWeight)
+		case stableSubset:
+			dest["weight"] = int64(100 - desiredWeight)
+		}
+	}
+	return nil
+}
+
+// SetWeight advances the active phase's route to desiredWeight. The active phase is the first
+// phase (in config order) whose route's canary weight is currently below 100. This allows
+// phases to progress sequentially: phase N completes before phase N+1 begins.
+func (p *RpcPlugin) SetWeight(ro *v1alpha1.Rollout, desiredWeight int32, additionalDestinations []v1alpha1.WeightDestination) pluginTypes.RpcError {
+	ctx := context.TODO()
+	cfg, rpcErr := p.parseConfig(ro)
+	if rpcErr.HasError() {
+		return rpcErr
+	}
+
+	vs, rpcErr := p.getVS(ctx, cfg.VirtualService.Namespace, cfg.VirtualService.Name)
+	if rpcErr.HasError() {
+		return rpcErr
+	}
+
+	httpRoutes, _, err := unstructured.NestedSlice(vs.Object, "spec", "http")
+	if err != nil {
+		return pluginTypes.RpcError{ErrorString: fmt.Sprintf("failed to read spec.http: %v", err)}
+	}
+
+	canary := cfg.DestinationRule.CanarySubsetName
+	stable := cfg.DestinationRule.StableSubsetName
+
+	if desiredWeight == 0 {
+		for _, phase := range cfg.Phases {
+			if err := applyRouteWeights(httpRoutes, phase.Route, canary, stable, 0); err != nil {
+				p.LogCtx.Warnf("could not reset route %s: %v", phase.Route, err)
+			}
+		}
+	} else {
+		activeRoute := ""
+		for _, phase := range cfg.Phases {
+			if routeCanaryWeight(httpRoutes, phase.Route, canary) < 100 {
+				activeRoute = phase.Route
+				break
+			}
+		}
+		if activeRoute == "" {
+			return pluginTypes.RpcError{}
+		}
+		if err := applyRouteWeights(httpRoutes, activeRoute, canary, stable, desiredWeight); err != nil {
+			return pluginTypes.RpcError{ErrorString: err.Error()}
+		}
+	}
+
+	if err := unstructured.SetNestedSlice(vs.Object, httpRoutes, "spec", "http"); err != nil {
+		return pluginTypes.RpcError{ErrorString: fmt.Sprintf("failed to set spec.http: %v", err)}
+	}
+
+	if _, err := p.dynamicClient.Resource(istioutil.GetIstioVirtualServiceGVR()).Namespace(cfg.VirtualService.Namespace).Update(ctx, vs, metav1.UpdateOptions{}); err != nil {
+		return pluginTypes.RpcError{ErrorString: fmt.Sprintf("failed to update VirtualService: %v", err)}
+	}
+
+	return pluginTypes.RpcError{}
+}
+
+// UpdateHash sets the rollouts-pod-template-hash selector on the canary and stable DR subsets.
+func (p *RpcPlugin) UpdateHash(ro *v1alpha1.Rollout, canaryHash, stableHash string, additionalDestinations []v1alpha1.WeightDestination) pluginTypes.RpcError {
+	ctx := context.TODO()
+	cfg, rpcErr := p.parseConfig(ro)
+	if rpcErr.HasError() {
+		return rpcErr
+	}
+	if cfg.DestinationRule.Name == "" {
+		return pluginTypes.RpcError{}
+	}
+
+	drGVR := istioutil.GetIstioDestinationRuleGVR()
+	dr, err := p.dynamicClient.Resource(drGVR).Namespace(cfg.DestinationRule.Namespace).Get(ctx, cfg.DestinationRule.Name, metav1.GetOptions{})
+	if err != nil {
+		return pluginTypes.RpcError{ErrorString: fmt.Sprintf("failed to get DestinationRule %s/%s: %v", cfg.DestinationRule.Namespace, cfg.DestinationRule.Name, err)}
+	}
+
+	subsets, _, err := unstructured.NestedSlice(dr.Object, "spec", "subsets")
+	if err != nil {
+		return pluginTypes.RpcError{ErrorString: fmt.Sprintf("failed to read spec.subsets: %v", err)}
+	}
+
+	for _, s := range subsets {
+		subset, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := subset["name"].(string)
+		var hash string
+		switch name {
+		case cfg.DestinationRule.CanarySubsetName:
+			hash = canaryHash
+		case cfg.DestinationRule.StableSubsetName:
+			hash = stableHash
+		default:
+			continue
+		}
+		if hash == "" {
+			continue
+		}
+		labels, _ := subset["labels"].(map[string]interface{})
+		if labels == nil {
+			labels = map[string]interface{}{}
+			subset["labels"] = labels
+		}
+		labels[v1alpha1.DefaultRolloutUniqueLabelKey] = hash
+	}
+
+	if err := unstructured.SetNestedSlice(dr.Object, subsets, "spec", "subsets"); err != nil {
+		return pluginTypes.RpcError{ErrorString: fmt.Sprintf("failed to set spec.subsets: %v", err)}
+	}
+
+	if _, err := p.dynamicClient.Resource(drGVR).Namespace(cfg.DestinationRule.Namespace).Update(ctx, dr, metav1.UpdateOptions{}); err != nil {
+		return pluginTypes.RpcError{ErrorString: fmt.Sprintf("failed to update DestinationRule: %v", err)}
+	}
+
+	return pluginTypes.RpcError{}
+}
+
+// VerifyWeight checks whether the active phase's route is at the expected canary weight.
+func (p *RpcPlugin) VerifyWeight(ro *v1alpha1.Rollout, desiredWeight int32, additionalDestinations []v1alpha1.WeightDestination) (pluginTypes.RpcVerified, pluginTypes.RpcError) {
+	ctx := context.TODO()
+	cfg, rpcErr := p.parseConfig(ro)
+	if rpcErr.HasError() {
+		return pluginTypes.NotVerified, rpcErr
+	}
+
+	vs, rpcErr := p.getVS(ctx, cfg.VirtualService.Namespace, cfg.VirtualService.Name)
+	if rpcErr.HasError() {
+		return pluginTypes.NotVerified, rpcErr
+	}
+
+	httpRoutes, _, err := unstructured.NestedSlice(vs.Object, "spec", "http")
+	if err != nil {
+		return pluginTypes.NotVerified, pluginTypes.RpcError{ErrorString: fmt.Sprintf("failed to read spec.http: %v", err)}
+	}
+
+	canary := cfg.DestinationRule.CanarySubsetName
+	for _, phase := range cfg.Phases {
+		w := routeCanaryWeight(httpRoutes, phase.Route, canary)
+		if w < 100 {
+			if w == int64(desiredWeight) {
+				return pluginTypes.Verified, pluginTypes.RpcError{}
+			}
+			return pluginTypes.NotVerified, pluginTypes.RpcError{}
+		}
+	}
+	return pluginTypes.Verified, pluginTypes.RpcError{}
+}
+
+func (p *RpcPlugin) SetHeaderRoute(ro *v1alpha1.Rollout, headerRouting *v1alpha1.SetHeaderRoute) pluginTypes.RpcError {
+	return pluginTypes.RpcError{}
+}
+
+func (p *RpcPlugin) SetMirrorRoute(ro *v1alpha1.Rollout, setMirrorRoute *v1alpha1.SetMirrorRoute) pluginTypes.RpcError {
+	return pluginTypes.RpcError{}
+}
+
+// RemoveManagedRoutes resets all phase routes to stable=100, canary=0.
+func (p *RpcPlugin) RemoveManagedRoutes(ro *v1alpha1.Rollout) pluginTypes.RpcError {
+	return p.SetWeight(ro, 0, nil)
+}
+
+func (p *RpcPlugin) Type() string {
+	return PluginName
+}

--- a/test/cmd/trafficrouter-phased-istio-plugin/internal/plugin/plugin_test.go
+++ b/test/cmd/trafficrouter-phased-istio-plugin/internal/plugin/plugin_test.go
@@ -1,0 +1,356 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	testutil "github.com/argoproj/argo-rollouts/test/util"
+	istioutil "github.com/argoproj/argo-rollouts/utils/istio"
+)
+
+// --- helpers ---
+
+func buildRoute(name string, canaryWeight int64) map[string]interface{} {
+	return map[string]interface{}{
+		"name": name,
+		"route": []interface{}{
+			map[string]interface{}{
+				"destination": map[string]interface{}{"subset": "stable"},
+				"weight":      int64(100 - canaryWeight),
+			},
+			map[string]interface{}{
+				"destination": map[string]interface{}{"subset": "canary"},
+				"weight":      canaryWeight,
+			},
+		},
+	}
+}
+
+// buildVS creates a VirtualService with latest-route and stable-route at the given canary weights.
+func buildVS(latestCanary, stableCanary int64) *unstructured.Unstructured {
+	gvr := istioutil.GetIstioVirtualServiceGVR()
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": gvr.Group + "/" + gvr.Version,
+			"kind":       "VirtualService",
+			"metadata": map[string]interface{}{
+				"name":      "my-service",
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"http": []interface{}{
+					buildRoute("latest-route", latestCanary),
+					buildRoute("stable-route", stableCanary),
+				},
+			},
+		},
+	}
+}
+
+func buildRollout() *v1alpha1.Rollout {
+	cfg := PluginConfig{
+		VirtualService: VSRef{Name: "my-service", Namespace: "default"},
+		DestinationRule: DRRef{
+			Name:             "my-dr",
+			Namespace:        "default",
+			CanarySubsetName: "canary",
+			StableSubsetName: "stable",
+		},
+		Phases: []Phase{
+			{Route: "latest-route"},
+			{Route: "stable-route"},
+		},
+	}
+	cfgBytes, _ := json.Marshal(cfg)
+	return &v1alpha1.Rollout{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-rollout", Namespace: "default"},
+		Spec: v1alpha1.RolloutSpec{
+			Strategy: v1alpha1.RolloutStrategy{
+				Canary: &v1alpha1.CanaryStrategy{
+					TrafficRouting: &v1alpha1.RolloutTrafficRouting{
+						Plugins: map[string]json.RawMessage{
+							PluginName: cfgBytes,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newTestPlugin(vs *unstructured.Unstructured) *RpcPlugin {
+	client := testutil.NewFakeDynamicClient(vs)
+	return &RpcPlugin{
+		LogCtx:        logrus.NewEntry(logrus.New()),
+		dynamicClient: client,
+	}
+}
+
+// readCanaryWeight reads the current canary weight for routeName from the live VS in the fake client.
+func readCanaryWeight(t *testing.T, p *RpcPlugin, routeName string) int64 {
+	t.Helper()
+	vs, err := p.dynamicClient.Resource(istioutil.GetIstioVirtualServiceGVR()).Namespace("default").Get(context.TODO(), "my-service", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get VS: %v", err)
+	}
+	httpRoutes, _, _ := unstructured.NestedSlice(vs.Object, "spec", "http")
+	w := routeCanaryWeight(httpRoutes, routeName, "canary")
+	if w == -1 {
+		t.Fatalf("route %q not found in VS", routeName)
+	}
+	return w
+}
+
+// --- routeCanaryWeight unit tests ---
+
+func TestRouteCanaryWeight(t *testing.T) {
+	routes := []interface{}{
+		buildRoute("latest-route", 30),
+		buildRoute("stable-route", 0),
+	}
+
+	cases := []struct {
+		name         string
+		routeName    string
+		canarySubset string
+		want         int64
+	}{
+		{
+			name:         "route found returns canary weight",
+			routeName:    "latest-route",
+			canarySubset: "canary",
+			want:         30,
+		},
+		{
+			name:         "second route at zero",
+			routeName:    "stable-route",
+			canarySubset: "canary",
+			want:         0,
+		},
+		{
+			name:         "route not found returns -1",
+			routeName:    "nonexistent",
+			canarySubset: "canary",
+			want:         -1,
+		},
+		{
+			name:         "wrong subset name returns -1",
+			routeName:    "latest-route",
+			canarySubset: "wrong-subset",
+			want:         -1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := routeCanaryWeight(routes, tc.routeName, tc.canarySubset)
+			if got != tc.want {
+				t.Errorf("routeCanaryWeight(%q, %q) = %d, want %d", tc.routeName, tc.canarySubset, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRouteCanaryWeightFloat64(t *testing.T) {
+	// JSON-decoded numbers arrive as float64; the function must handle this.
+	routes := []interface{}{
+		map[string]interface{}{
+			"name": "my-route",
+			"route": []interface{}{
+				map[string]interface{}{
+					"destination": map[string]interface{}{"subset": "canary"},
+					"weight":      float64(42),
+				},
+			},
+		},
+	}
+	got := routeCanaryWeight(routes, "my-route", "canary")
+	if got != 42 {
+		t.Errorf("expected 42, got %d", got)
+	}
+}
+
+// --- applyRouteWeights unit tests ---
+
+func TestApplyRouteWeights(t *testing.T) {
+	cases := []struct {
+		name          string
+		routeName     string
+		desiredWeight int32
+		wantCanary    int64
+		wantStable    int64
+		wantErr       bool
+	}{
+		{
+			name:          "sets canary and stable",
+			routeName:     "latest-route",
+			desiredWeight: 20,
+			wantCanary:    20,
+			wantStable:    80,
+		},
+		{
+			name:          "sets to 100",
+			routeName:     "latest-route",
+			desiredWeight: 100,
+			wantCanary:    100,
+			wantStable:    0,
+		},
+		{
+			name:          "resets to 0",
+			routeName:     "latest-route",
+			desiredWeight: 0,
+			wantCanary:    0,
+			wantStable:    100,
+		},
+		{
+			name:          "unknown route returns error",
+			routeName:     "nonexistent",
+			desiredWeight: 50,
+			wantErr:       true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			routes := []interface{}{
+				buildRoute("latest-route", 10),
+				buildRoute("stable-route", 0),
+			}
+
+			err := applyRouteWeights(routes, tc.routeName, "canary", "stable", tc.desiredWeight)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			gotCanary := routeCanaryWeight(routes, tc.routeName, "canary")
+			if gotCanary != tc.wantCanary {
+				t.Errorf("canary weight = %d, want %d", gotCanary, tc.wantCanary)
+			}
+			// verify stable = 100 - canary
+			if gotCanary+tc.wantStable != 100 {
+				t.Errorf("canary(%d) + stable(%d) != 100", gotCanary, tc.wantStable)
+			}
+		})
+	}
+}
+
+func TestApplyRouteWeightsDoesNotTouchOtherRoutes(t *testing.T) {
+	routes := []interface{}{
+		buildRoute("latest-route", 0),
+		buildRoute("stable-route", 0),
+	}
+
+	if err := applyRouteWeights(routes, "latest-route", "canary", "stable", 50); err != nil {
+		t.Fatal(err)
+	}
+
+	if w := routeCanaryWeight(routes, "stable-route", "canary"); w != 0 {
+		t.Errorf("stable-route canary weight should be unchanged at 0, got %d", w)
+	}
+}
+
+// --- SetWeight phase detection integration tests ---
+
+func TestSetWeightPhaseDetection(t *testing.T) {
+	cases := []struct {
+		name                string
+		latestCanaryBefore  int64
+		stableCanaryBefore  int64
+		desiredWeight       int32
+		wantLatestCanary    int64
+		wantStableCanary    int64
+	}{
+		{
+			name:               "phase 1 active: both at 0, advances latest-route",
+			latestCanaryBefore: 0,
+			stableCanaryBefore: 0,
+			desiredWeight:      10,
+			wantLatestCanary:   10,
+			wantStableCanary:   0,
+		},
+		{
+			name:               "phase 1 active: continues advancing latest-route",
+			latestCanaryBefore: 50,
+			stableCanaryBefore: 0,
+			desiredWeight:      80,
+			wantLatestCanary:   80,
+			wantStableCanary:   0,
+		},
+		{
+			name:               "phase 1 active: completes latest-route",
+			latestCanaryBefore: 80,
+			stableCanaryBefore: 0,
+			desiredWeight:      100,
+			wantLatestCanary:   100,
+			wantStableCanary:   0,
+		},
+		{
+			name:               "phase 2 active: latest-route complete, advances stable-route",
+			latestCanaryBefore: 100,
+			stableCanaryBefore: 0,
+			desiredWeight:      5,
+			wantLatestCanary:   100,
+			wantStableCanary:   5,
+		},
+		{
+			name:               "phase 2 active: continues advancing stable-route",
+			latestCanaryBefore: 100,
+			stableCanaryBefore: 25,
+			desiredWeight:      75,
+			wantLatestCanary:   100,
+			wantStableCanary:   75,
+		},
+		{
+			name:               "all phases complete: setWeight is a no-op",
+			latestCanaryBefore: 100,
+			stableCanaryBefore: 100,
+			desiredWeight:      50,
+			wantLatestCanary:   100,
+			wantStableCanary:   100,
+		},
+		{
+			name:               "desiredWeight 0 resets all routes",
+			latestCanaryBefore: 100,
+			stableCanaryBefore: 25,
+			desiredWeight:      0,
+			wantLatestCanary:   0,
+			wantStableCanary:   0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vs := buildVS(tc.latestCanaryBefore, tc.stableCanaryBefore)
+			p := newTestPlugin(vs)
+			ro := buildRollout()
+
+			rpcErr := p.SetWeight(ro, tc.desiredWeight, nil)
+			if rpcErr.HasError() {
+				t.Fatalf("SetWeight returned error: %s", rpcErr.Error())
+			}
+
+			gotLatest := readCanaryWeight(t, p, "latest-route")
+			gotStable := readCanaryWeight(t, p, "stable-route")
+
+			if gotLatest != tc.wantLatestCanary {
+				t.Errorf("latest-route canary = %d, want %d", gotLatest, tc.wantLatestCanary)
+			}
+			if gotStable != tc.wantStableCanary {
+				t.Errorf("stable-route canary = %d, want %d", gotStable, tc.wantStableCanary)
+			}
+		})
+	}
+}

--- a/test/cmd/trafficrouter-phased-istio-plugin/internal/plugin/plugin_test.go
+++ b/test/cmd/trafficrouter-phased-istio-plugin/internal/plugin/plugin_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	testutil "github.com/argoproj/argo-rollouts/test/util"
 	istioutil "github.com/argoproj/argo-rollouts/utils/istio"
+	pluginTypes "github.com/argoproj/argo-rollouts/utils/plugin/types"
 )
 
 // --- helpers ---
@@ -53,7 +54,10 @@ func buildVS(latestCanary, stableCanary int64) *unstructured.Unstructured {
 	}
 }
 
-func buildRollout() *v1alpha1.Rollout {
+func buildRollout(phases ...Phase) *v1alpha1.Rollout {
+	if len(phases) == 0 {
+		phases = []Phase{{Route: "latest-route"}, {Route: "stable-route"}}
+	}
 	cfg := PluginConfig{
 		VirtualService: VSRef{Name: "my-service", Namespace: "default"},
 		DestinationRule: DRRef{
@@ -62,10 +66,7 @@ func buildRollout() *v1alpha1.Rollout {
 			CanarySubsetName: "canary",
 			StableSubsetName: "stable",
 		},
-		Phases: []Phase{
-			{Route: "latest-route"},
-			{Route: "stable-route"},
-		},
+		Phases: phases,
 	}
 	cfgBytes, _ := json.Marshal(cfg)
 	return &v1alpha1.Rollout{
@@ -350,6 +351,176 @@ func TestSetWeightPhaseDetection(t *testing.T) {
 			}
 			if gotStable != tc.wantStableCanary {
 				t.Errorf("stable-route canary = %d, want %d", gotStable, tc.wantStableCanary)
+			}
+		})
+	}
+}
+
+// --- phaseRouteWeight unit tests ---
+
+func TestPhaseRouteWeight(t *testing.T) {
+	cases := []struct {
+		name          string
+		desiredWeight int32
+		start         int32
+		end           int32
+		want          int32
+	}{
+		{name: "below range returns 0", desiredWeight: 0, start: 0, end: 50, want: 0},
+		{name: "at start returns 0", desiredWeight: 0, start: 0, end: 50, want: 0},
+		{name: "midpoint of first half", desiredWeight: 25, start: 0, end: 50, want: 50},
+		{name: "at end of first half returns 100", desiredWeight: 50, start: 0, end: 50, want: 100},
+		{name: "above end returns 100", desiredWeight: 75, start: 0, end: 50, want: 100},
+		{name: "at start of second half returns 0", desiredWeight: 50, start: 50, end: 100, want: 0},
+		{name: "midpoint of second half", desiredWeight: 75, start: 50, end: 100, want: 50},
+		{name: "at end of second half returns 100", desiredWeight: 100, start: 50, end: 100, want: 100},
+		{name: "unequal split 30/70: phase1 at boundary", desiredWeight: 30, start: 0, end: 30, want: 100},
+		{name: "unequal split 30/70: phase2 midpoint", desiredWeight: 65, start: 30, end: 100, want: 50},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := phaseRouteWeight(tc.desiredWeight, tc.start, tc.end)
+			if got != tc.want {
+				t.Errorf("phaseRouteWeight(%d, %d, %d) = %d, want %d", tc.desiredWeight, tc.start, tc.end, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- SetWeight proportional mode integration tests ---
+
+func TestSetWeightProportional(t *testing.T) {
+	cases := []struct {
+		name             string
+		desiredWeight    int32
+		wantLatestCanary int64
+		wantStableCanary int64
+	}{
+		{
+			name:             "desiredWeight 0: both routes at 0",
+			desiredWeight:    0,
+			wantLatestCanary: 0,
+			wantStableCanary: 0,
+		},
+		{
+			name:             "desiredWeight 25: phase1 at 50%, phase2 at 0%",
+			desiredWeight:    25,
+			wantLatestCanary: 50,
+			wantStableCanary: 0,
+		},
+		{
+			name:             "desiredWeight 50: phase1 complete, phase2 at 0%",
+			desiredWeight:    50,
+			wantLatestCanary: 100,
+			wantStableCanary: 0,
+		},
+		{
+			name:             "desiredWeight 75: phase1 complete, phase2 at 50%",
+			desiredWeight:    75,
+			wantLatestCanary: 100,
+			wantStableCanary: 50,
+		},
+		{
+			name:             "desiredWeight 100: both phases complete",
+			desiredWeight:    100,
+			wantLatestCanary: 100,
+			wantStableCanary: 100,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vs := buildVS(0, 0)
+			p := newTestPlugin(vs)
+			ro := buildRollout(Phase{Route: "latest-route", Weight: 50}, Phase{Route: "stable-route", Weight: 50})
+
+			rpcErr := p.SetWeight(ro, tc.desiredWeight, nil)
+			if rpcErr.HasError() {
+				t.Fatalf("SetWeight returned error: %s", rpcErr.Error())
+			}
+
+			gotLatest := readCanaryWeight(t, p, "latest-route")
+			gotStable := readCanaryWeight(t, p, "stable-route")
+
+			if gotLatest != tc.wantLatestCanary {
+				t.Errorf("latest-route canary = %d, want %d", gotLatest, tc.wantLatestCanary)
+			}
+			if gotStable != tc.wantStableCanary {
+				t.Errorf("stable-route canary = %d, want %d", gotStable, tc.wantStableCanary)
+			}
+		})
+	}
+}
+
+// --- VerifyWeight proportional mode tests ---
+
+func TestVerifyWeightProportional(t *testing.T) {
+	cases := []struct {
+		name              string
+		latestCanaryNow   int64
+		stableCanaryNow   int64
+		desiredWeight     int32
+		wantVerified      bool
+	}{
+		{
+			name:            "both at 0, desiredWeight 0: verified",
+			latestCanaryNow: 0,
+			stableCanaryNow: 0,
+			desiredWeight:   0,
+			wantVerified:    true,
+		},
+		{
+			name:            "phase1 at 50, phase2 at 0, desiredWeight 25: verified",
+			latestCanaryNow: 50,
+			stableCanaryNow: 0,
+			desiredWeight:   25,
+			wantVerified:    true,
+		},
+		{
+			name:            "phase1 at 50, phase2 at 0, desiredWeight 50: not verified (phase1 should be 100)",
+			latestCanaryNow: 50,
+			stableCanaryNow: 0,
+			desiredWeight:   50,
+			wantVerified:    false,
+		},
+		{
+			name:            "phase1 at 100, phase2 at 0, desiredWeight 50: verified",
+			latestCanaryNow: 100,
+			stableCanaryNow: 0,
+			desiredWeight:   50,
+			wantVerified:    true,
+		},
+		{
+			name:            "phase1 at 100, phase2 at 50, desiredWeight 75: verified",
+			latestCanaryNow: 100,
+			stableCanaryNow: 50,
+			desiredWeight:   75,
+			wantVerified:    true,
+		},
+		{
+			name:            "both at 100, desiredWeight 100: verified",
+			latestCanaryNow: 100,
+			stableCanaryNow: 100,
+			desiredWeight:   100,
+			wantVerified:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vs := buildVS(tc.latestCanaryNow, tc.stableCanaryNow)
+			p := newTestPlugin(vs)
+			ro := buildRollout(Phase{Route: "latest-route", Weight: 50}, Phase{Route: "stable-route", Weight: 50})
+
+			verified, rpcErr := p.VerifyWeight(ro, tc.desiredWeight, nil)
+			if rpcErr.HasError() {
+				t.Fatalf("VerifyWeight returned error: %s", rpcErr.Error())
+			}
+
+			gotVerified := verified == pluginTypes.Verified
+			if gotVerified != tc.wantVerified {
+				t.Errorf("VerifyWeight verified=%v, want %v", gotVerified, tc.wantVerified)
 			}
 		})
 	}

--- a/test/cmd/trafficrouter-phased-istio-plugin/main.go
+++ b/test/cmd/trafficrouter-phased-istio-plugin/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"strings"
+
+	goPlugin "github.com/hashicorp/go-plugin"
+	log "github.com/sirupsen/logrus"
+
+	rolloutsPlugin "github.com/argoproj/argo-rollouts/rollout/trafficrouting/plugin/rpc"
+	"github.com/argoproj/argo-rollouts/test/cmd/trafficrouter-phased-istio-plugin/internal/plugin"
+)
+
+var handshakeConfig = goPlugin.HandshakeConfig{
+	ProtocolVersion:  1,
+	MagicCookieKey:   "ARGO_ROLLOUTS_RPC_PLUGIN",
+	MagicCookieValue: "trafficrouter",
+}
+
+func main() {
+	logCtx := log.WithFields(log.Fields{"plugin": "trafficrouter"})
+
+	setLogLevel("debug")
+	log.SetFormatter(createFormatter("text"))
+
+	rpcPluginImp := &plugin.RpcPlugin{
+		LogCtx: logCtx,
+	}
+	var pluginMap = map[string]goPlugin.Plugin{
+		"RpcTrafficRouterPlugin": &rolloutsPlugin.RpcTrafficRouterPlugin{Impl: rpcPluginImp},
+	}
+
+	goPlugin.Serve(&goPlugin.ServeConfig{
+		HandshakeConfig: handshakeConfig,
+		Plugins:         pluginMap,
+	})
+}
+
+func createFormatter(logFormat string) log.Formatter {
+	switch strings.ToLower(logFormat) {
+	case "json":
+		return &log.JSONFormatter{}
+	default:
+		return &log.TextFormatter{FullTimestamp: true}
+	}
+}
+
+func setLogLevel(logLevel string) {
+	level, err := log.ParseLevel(logLevel)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.SetLevel(level)
+}


### PR DESCRIPTION
## Summary

- Adds `test/cmd/trafficrouter-phased-istio-plugin`, an example traffic router plugin that advances canary traffic through sequentially-ordered Istio VirtualService HTTP routes (phases)
- Adds a `weight` field to `Phase` for proportional mode: each route declares its fraction of total traffic (0–100, phases must sum to 100), so the Rollout's `desiredWeight` maps directly to actual traffic share — keeping canary ReplicaSet counts proportional at every step
- Legacy mode (no `weight` fields) is preserved unchanged; existing configurations continue to work

## Test Plan

- [ ] `go test ./test/cmd/trafficrouter-phased-istio-plugin/...` passes (44 tests)
- [ ] Review `Phase.Weight` config schema and proportional mapping formula (`phaseRouteWeight`)
- [ ] Verify README weight progression table matches the implementation for a 70/30 split

🤖 Generated with [Claude Code](https://claude.com/claude-code)