### PR TITLE
fix: include notification context in template vars

### DIFF
--- a/utils/record/record.go
+++ b/utils/record/record.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubectl/pkg/scheme"
+	"sigs.k8s.io/yaml"
 
 	argoinformers "github.com/argoproj/argo-rollouts/pkg/client/informers/externalversions/rollouts/v1alpha1"
 	timeutil "github.com/argoproj/argo-rollouts/utils/time"
@@ -311,12 +312,18 @@ func NewAPIFactorySettings(arInformer argoinformers.AnalysisRunInformer) api.Set
 		SecretName:    NotificationSecret,
 		ConfigMapName: NotificationConfigMap,
 		InitGetVars: func(cfg *api.Config, configMap *corev1.ConfigMap, secret *corev1.Secret) (api.GetVars, error) {
+			notificationContext, err := getNotificationContext(configMap)
+			if err != nil {
+				return nil, err
+			}
+
 			return func(obj map[string]any, dest services.Destination) map[string]any {
 
 				var vars = map[string]any{
 					"rollout": obj,
 					"time":    timeExprs,
 					"secrets": secret.Data,
+					"context": notificationContext,
 				}
 
 				if arInformer == nil {
@@ -346,11 +353,25 @@ func NewAPIFactorySettings(arInformer argoinformers.AnalysisRunInformer) api.Set
 					"analysisRuns": arsObj,
 					"time":         timeExprs,
 					"secrets":      secret.Data,
+					"context":      notificationContext,
 				}
 				return vars
 			}, nil
 		},
 	}
+}
+
+func getNotificationContext(configMap *corev1.ConfigMap) (map[string]string, error) {
+	notificationContext := map[string]string{}
+	if configMap == nil || configMap.Data == nil {
+		return notificationContext, nil
+	}
+	if contextYAML, ok := configMap.Data["context"]; ok {
+		if err := yaml.Unmarshal([]byte(contextYAML), &notificationContext); err != nil {
+			return nil, err
+		}
+	}
+	return notificationContext, nil
 }
 
 // Send notifications for triggered event if user is subscribed

--- a/utils/record/record_test.go
+++ b/utils/record/record_test.go
@@ -494,6 +494,10 @@ func TestNewAPIFactorySettings(t *testing.T) {
 	expectedSecrets := map[string][]byte{
 		"notification-secret": []byte("secret-value"),
 	}
+	expectedContext := map[string]string{
+		"argocdUrl":   "https://argocd.example.com",
+		"environment": "development",
+	}
 
 	notificationsSecret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -501,6 +505,15 @@ func TestNewAPIFactorySettings(t *testing.T) {
 			Namespace: "default",
 		},
 		Data: expectedSecrets,
+	}
+	notificationsConfigMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "argo-rollouts-notification-configmap",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"context": "argocdUrl: https://argocd.example.com\nenvironment: development",
+		},
 	}
 
 	type expectedFunc func(obj map[string]interface{}, ar any) map[string]interface{}
@@ -526,6 +539,7 @@ func TestNewAPIFactorySettings(t *testing.T) {
 					"analysisRuns": ar,
 					"time":         timeExprs,
 					"secrets":      expectedSecrets,
+					"context":      expectedContext,
 				}
 			},
 		},
@@ -552,6 +566,7 @@ func TestNewAPIFactorySettings(t *testing.T) {
 					"analysisRuns": nil,
 					"time":         timeExprs,
 					"secrets":      expectedSecrets,
+					"context":      expectedContext,
 				}
 			},
 		},
@@ -567,6 +582,7 @@ func TestNewAPIFactorySettings(t *testing.T) {
 					"rollout": obj,
 					"time":    timeExprs,
 					"secrets": expectedSecrets,
+					"context": expectedContext,
 				}
 			},
 		},
@@ -593,6 +609,7 @@ func TestNewAPIFactorySettings(t *testing.T) {
 					"analysisRuns": nil,
 					"time":         timeExprs,
 					"secrets":      expectedSecrets,
+					"context":      expectedContext,
 				}
 			},
 		},
@@ -602,7 +619,7 @@ func TestNewAPIFactorySettings(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 
 			settings := NewAPIFactorySettings(test.arInformer(test.ars))
-			getVars, err := settings.InitGetVars(nil, nil, &notificationsSecret)
+			getVars, err := settings.InitGetVars(nil, &notificationsConfigMap, &notificationsSecret)
 			require.NoError(t, err)
 			if err != nil {
 				t.Errorf("Unexpected error: %v", err)


### PR DESCRIPTION
Code
✕
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] My builds are green. Try syncing with master if they are not.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).