### PR TITLE
fix(controller): honor scaleUpPreviewCheckPoint reset on blueGreen pod template change. Fixes #4728

### DIFF
--- a/rollout/bluegreen.go
+++ b/rollout/bluegreen.go
@@ -326,8 +326,11 @@ func (c *rolloutContext) calculateScaleUpPreviewCheckPoint(newStatus v1alpha1.Ro
 	}
 
 	// Once the ScaleUpPreviewCheckPoint is set to true, the rollout should keep that value until
-	// the newRS becomes the new stableRS or there is a template change.
-	prevValue := c.rollout.Status.BlueGreen.ScaleUpPreviewCheckPoint
+	// the newRS becomes the new stableRS or there is a template change. Read from newStatus rather
+	// than c.rollout.Status so that a reset applied earlier in this reconcile (e.g. by
+	// resetRolloutStatus on a pod template change) is honored instead of being clobbered by the
+	// pre-reset value.
+	prevValue := newStatus.BlueGreen.ScaleUpPreviewCheckPoint
 	if prevValue {
 		return true
 	}

--- a/rollout/bluegreen_test.go
+++ b/rollout/bluegreen_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/annotations"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
 	"github.com/argoproj/argo-rollouts/utils/hash"
+	logutil "github.com/argoproj/argo-rollouts/utils/log"
 	rolloututil "github.com/argoproj/argo-rollouts/utils/rollout"
 	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
@@ -1191,6 +1192,46 @@ func TestPreviewReplicaCountHandleScaleUpPreviewCheckPoint(t *testing.T) {
 		f.expectPatchRolloutAction(r2)
 		f.run(getKey(r2, t))
 	})
+}
+
+// TestCalculateScaleUpPreviewCheckPointHonorsReset is a regression test for
+// https://github.com/argoproj/argo-rollouts/issues/<TBD>.
+//
+// When a new pod template arrives while the previous revision had already completed
+// prePromotionAnalysis, syncRolloutStatusBlueGreen calls resetRolloutStatus(&newStatus),
+// which sets newStatus.BlueGreen.ScaleUpPreviewCheckPoint=false. The subsequent call to
+// calculateScaleUpPreviewCheckPoint must honor that reset — i.e. read prevValue from
+// newStatus, not from c.rollout.Status — otherwise the new revision inherits the
+// previous revision's scaleUpPreviewCheckPoint=true and skips its own prePromotionAnalysis.
+func TestCalculateScaleUpPreviewCheckPointHonorsReset(t *testing.T) {
+	r := newBlueGreenRollout("foo", 5, nil, "active", "")
+	r.Spec.Strategy.BlueGreen.PreviewReplicaCount = ptr.To[int32](3)
+	r.Spec.Strategy.BlueGreen.PrePromotionAnalysis = &v1alpha1.RolloutAnalysis{
+		Templates: []v1alpha1.AnalysisTemplateRef{{TemplateName: "test"}},
+	}
+	// The previous revision's status carried ScaleUpPreviewCheckPoint=true (its
+	// prePromotionAnalysis had succeeded). c.rollout.Status still reflects that value
+	// at the start of this reconcile.
+	r.Status.BlueGreen.ScaleUpPreviewCheckPoint = true
+	newRS := newReplicaSetWithStatus(r, 0, 0)
+
+	c := &rolloutContext{
+		rollout:      r,
+		newRS:        newRS,
+		log:          logutil.WithRollout(r),
+		pauseContext: &pauseContext{rollout: r},
+	}
+
+	// resetRolloutStatus has already cleared the checkpoint on newStatus for this
+	// reconcile. With no AnalysisRun yet for the new revision (currentArs is empty),
+	// completedPrePromotionAnalysis() is false, so prePromotion must run before the
+	// checkpoint can flip. The function must read prevValue from newStatus rather than
+	// the stale c.rollout.Status, then fall through and return false.
+	newStatus := v1alpha1.RolloutStatus{}
+	newStatus.BlueGreen.ScaleUpPreviewCheckPoint = false
+
+	assert.False(t, c.calculateScaleUpPreviewCheckPoint(newStatus),
+		"scaleUpPreviewCheckPoint must be reset on pod template change so the new revision's prePromotionAnalysis runs")
 }
 
 func TestBlueGreenRolloutIgnoringScalingUsePreviewRSCount(t *testing.T) {


### PR DESCRIPTION
## What

Read `prevValue` from `newStatus` instead of `c.rollout.Status` in `calculateScaleUpPreviewCheckPoint`. When `syncRolloutStatusBlueGreen` calls `resetRolloutStatus` on pod template change, the reset mutates `newStatus.BlueGreen.ScaleUpPreviewCheckPoint = false`; reading from `c.rollout.Status` immediately afterwards picks up the *pre-reset* value, clobbering the reset.

```diff
- prevValue := c.rollout.Status.BlueGreen.ScaleUpPreviewCheckPoint
+ prevValue := newStatus.BlueGreen.ScaleUpPreviewCheckPoint
```

## Why

Matches the function's documented behavior:

> scaleUpPreviewCheckPoint... gets reset to false when the pod template changes, or the rollout fully promotes

Without this fix, a new revision started while the previous one was in the scale-up / `autoPromotionSeconds` window inherits `scaleUpPreviewCheckPoint: true` and skips `prePromotionAnalysis` entirely — the new preview RS scales straight to `replicas` (bypassing `previewReplicaCount`), no AnalysisRun is created, and cutover proceeds untested.

Full repro + root cause + live-cluster evidence in #4728.

## Tests

* Added unit regression test `TestCalculateScaleUpPreviewCheckPointHonorsReset` in `rollout/bluegreen_test.go`. Verified it fails on the unfixed code (`Should be false`) and passes with the fix.
* Existing `TestPreviewReplicaCountHandleScaleUpPreviewCheckPoint` sub-tests (`TrueAfterMeetingMinAvailable`, `FalseAfterActiveServiceSwitch`, `TrueWhenScalingUpPreview`) continue to pass.
* Full `./rollout/...` package suite passes locally (`make test` equivalent).

## Checklist

* [x] This is a bug fix.
* [x] PR title is conventional (`fix(controller): ...`), states what changed, and suffixes the related issue number (`Fixes #4728`).
* [x] Commits are DCO signed.
* [x] Unit tests written and passing.
* [x] All tests run locally and pass.
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR.
* [x] I understand what the code does and WHY/HOW it works in several scenarios.
* [x] This changes behavior for existing users of `blueGreen` + `previewReplicaCount` + `prePromotionAnalysis`: previously a back-to-back revision would skip the gate; now it correctly runs `prePromotionAnalysis` for the new revision. No API or config change.
* [ ] My organization is added to USERS.md. (Out of scope for this bug fix — separate PR if needed.)
