### PR TITLE
fix: remove revision==1 gate for scaleDown onsuccess. Fixes #4681

### DIFF
--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -1099,7 +1099,7 @@ func (c *rolloutContext) promoteStable(newStatus *v1alpha1.RolloutStatus, reason
 			conditions.RolloutCompletedMessage, revision, newStatus.CurrentPodHash, reason)
 	}
 
-	if revision == 1 && c.rollout.Status.Phase == v1alpha1.RolloutPhaseHealthy && c.rollout.Spec.WorkloadRef != nil && c.rollout.Spec.WorkloadRef.ScaleDown == v1alpha1.ScaleDownOnSuccess {
+	if c.rollout.Status.Phase == v1alpha1.RolloutPhaseHealthy && c.rollout.Spec.WorkloadRef != nil && c.rollout.Spec.WorkloadRef.ScaleDown == v1alpha1.ScaleDownOnSuccess {
 		var targetScale int32 = 0
 		err := c.scaleDeployment(&targetScale)
 		if err != nil {

--- a/rollout/sync_test.go
+++ b/rollout/sync_test.go
@@ -882,3 +882,22 @@ func TestIsScalingEventMissMatchedDesiredOldReplicas(t *testing.T) {
 	assert.Equal(t, int32(13), roStatus.Status.ReadyReplicas)
 	assert.Equal(t, int32(0), roStatus.Status.UpdatedReplicas)
 }
+
+// TestScaleDownDeploymentOnSuccessRevision2 verifies that scaleDown: onsuccess
+// triggers scale-down even when revision > 1 (previously gated by revision==1).
+func TestScaleDownDeploymentOnSuccessRevision2(t *testing.T) {
+	ctx := createScaleDownRolloutContext(v1alpha1.ScaleDownOnSuccess, 5, true, nil)
+	// Override the revision annotation to simulate a second rollout revision
+	ctx.rollout.Annotations[annotations.RevisionAnnotation] = "2"
+	newStatus := &v1alpha1.RolloutStatus{
+		CurrentPodHash: "2f646bf702",
+		StableRS:       "15fb5ffc01",
+	}
+	err := ctx.promoteStable(newStatus, "reason")
+
+	assert.Nil(t, err)
+	k8sfakeClient := ctx.kubeclientset.(*k8sfake.Clientset)
+	updatedDeployment, err := k8sfakeClient.AppsV1().Deployments("default").Get(context.TODO(), "workload-test", metav1.GetOptions{})
+	assert.Nil(t, err)
+	assert.Equal(t, int32(0), *updatedDeployment.Spec.Replicas)
+}


### PR DESCRIPTION
## Summary

Remove the `revision == 1` gate from `promoteStable()` so `workloadRef.scaleDown: onsuccess` triggers on every stable promotion, not just the initial deploy.

## Background

When using BlueGreen strategy with `workloadRef.scaleDown: onsuccess`, the referenced Deployment should be scaled down every time a new ReplicaSet is promoted to stable. However, the check in `promoteStable()` (rollout/sync.go:1040) included `revision == 1`, restricting the scale-down to only the very first deployment.

For revision >= 2, `shouldFullPromote()` correctly runs PostPromotionAnalysis (if configured), returns "Completed blue-green update", and calls `promoteStable()`, but the scale-down is silently skipped because `revision != 1`.

## Modifications

- `rollout/sync.go`: Remove `revision == 1 &&` from the scaleDown condition in `promoteStable()`
- `rollout/sync_test.go`: Add `TestScaleDownDeploymentOnSuccessRevision2` verifying scale-down triggers on revision 2

## Verification

```bash
go test ./rollout/ -run 'TestScaleDownDeploymentOnSuccess' -v
# PASS: TestScaleDownDeploymentOnSuccess (revision 1)
# PASS: TestScaleDownDeploymentOnSuccessRevision2 (revision 2)
```

Checklist:

- [x] This is a bug fix
- [x] The title follows conventional commits: `fix: remove revision==1 gate for scaleDown onsuccess`
- [x] DCO sign-off included
- [x] Unit tests written and passing
- [ ] My organization is added to USERS.md (N/A - bug fix)
