### PR TITLE
test: use t.Log instead of fmt.Println

### DIFF
--- a/utils/record/record_test.go
+++ b/utils/record/record_test.go
@@ -69,14 +69,14 @@ func TestRecordLog(t *testing.T) {
 	log.SetOutput(buf)
 	rec.Warnf(&r, EventOptions{EventReason: "FooReason"}, "Rollout is %s", "foo")
 	logMessage = buf.String()
-	fmt.Println(logMessage)
+	t.Log(logMessage)
 	assert.True(t, strings.Contains(logMessage, "level=warning"))
 
 	buf = bytes.NewBufferString("")
 	log.SetOutput(buf)
 	rec.Eventf(&r, EventOptions{EventType: "Warning", EventReason: "FooReason"}, "Rollout is %s", "foo")
 	logMessage = buf.String()
-	fmt.Println(logMessage)
+	t.Log(logMessage)
 	assert.True(t, strings.Contains(logMessage, "level=warning"))
 
 }


### PR DESCRIPTION
Replace fmt.Println with t.Log in tests for utils/record package.