### PR TITLE
build: skip full CI for documentation only changes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,6 +3,9 @@ name: "Code scanning - action"
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   pull_request:
     branches: [master]
     paths-ignore:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,9 +5,15 @@ on:
     branches:
       - master
       - release-*
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'    
 
   # Run tests for any PRs.
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,9 +4,15 @@ on:
     branches:
       - 'master'
       - 'release-*'
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   pull_request:
     branches:
       - 'master'
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
 env:
   # Golang version to use across CI steps
   GOLANG_VERSION: '1.26'

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -5,10 +5,16 @@ on:
     branches:
       - 'master'
       - 'release-*'
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/*'
   pull_request:
     branches:
       - 'master'
       - 'release-*'
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Does not run the full CI (build/test/e2e) for documentation only changes.

Closes https://github.com/argoproj/argo-rollouts/issues/4736

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [ ] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [ ] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).