### PR TITLE
fix: allow plugins to implement ping-pong (and not just ALB/Istio)

### DIFF
--- a/docs/features/specification.md
+++ b/docs/features/specification.md
@@ -179,6 +179,17 @@ spec:
       # stable pods. Required for traffic routing.
       stableService: stable-service
 
+      # Ping-pong spec allows zero-downtime rollouts for long-lived TCP/gRPC
+      # connections by avoiding service selector swaps at promotion time.
+      # Instead of swapping selectors between canaryService/stableService,
+      # the rollout alternates which of the two persistent services is
+      # "stable" via Status.Canary.StablePingPong. Supported with ALB,
+      # Istio, and plugin-based traffic routers.
+      # When pingPong is set, canaryService and stableService are not required.
+      pingPong:
+        pingService: ping-service
+        pongService: pong-service
+
       # Metadata which will be attached to the canary pods. This metadata will
       # only exist during an update, since there are no canary pods in a fully
       # promoted rollout.
@@ -451,6 +462,7 @@ spec:
           ingress: ingress # required
           servicePort: 443 # required
           annotationPrefix: custom.alb.ingress.kubernetes.io # optional
+          rootService: root-service # required when ping-pong is enabled
 
         # Service Mesh Interface routing configuration
         smi:

--- a/pkg/apis/rollouts/validation/validation.go
+++ b/pkg/apis/rollouts/validation/validation.go
@@ -81,8 +81,8 @@ const (
 	DuplicatedPingPongServicesMessage = "This rollout uses the same service for the ping and pong services, but two different services are required."
 	// MissedAlbRootServiceMessage indicates that the rollout with ALB TrafficRouting and ping pong feature enabled must have root service provided
 	MissedAlbRootServiceMessage = "Root service field is required for the configuration with ALB and ping-pong feature enabled"
-	// PingPongWithRouterOnlyMessage At this moment ping-pong feature works with the ALB traffic routing only
-	PingPongWithRouterOnlyMessage = "Ping-pong feature works with the ALB and Istio traffic routers only"
+	// PingPongWithRouterOnlyMessage At this moment ping-pong feature works with the ALB, Istio, and plugin-based traffic routers only
+	PingPongWithRouterOnlyMessage = "Ping-pong feature works with the ALB, Istio, and plugin-based traffic routers only"
 	// InvalideStepRouteNameNotFoundInManagedRoutes A step has been configured that requires managedRoutes and the route name
 	// is missing from managedRoutes
 	InvalideStepRouteNameNotFoundInManagedRoutes = "Steps define a route that does not exist in spec.strategy.canary.trafficRouting.managedRoutes"
@@ -265,7 +265,7 @@ func ValidateRolloutStrategyCanary(rollout *v1alpha1.Rollout, fldPath *field.Pat
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("stableService"), canary.StableService, DuplicatedServicesCanaryMessage))
 	}
 	if canary.PingPong != nil {
-		if canary.TrafficRouting != nil && canary.TrafficRouting.ALB == nil && canary.TrafficRouting.Istio == nil {
+		if canary.TrafficRouting != nil && canary.TrafficRouting.ALB == nil && canary.TrafficRouting.Istio == nil && len(canary.TrafficRouting.Plugins) == 0 {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("trafficRouting").Child("alb"), canary.TrafficRouting.ALB, PingPongWithRouterOnlyMessage))
 		}
 		if canary.PingPong.PingService == "" {

--- a/pkg/apis/rollouts/validation/validation_test.go
+++ b/pkg/apis/rollouts/validation/validation_test.go
@@ -386,6 +386,19 @@ func TestValidateRolloutStrategyCanary(t *testing.T) {
 		assert.Equal(t, PingPongWithRouterOnlyMessage, allErrs[0].Detail)
 	})
 
+	t.Run("ping-pong feature with plugin-based traffic routing is valid", func(t *testing.T) {
+		validRo := ro.DeepCopy()
+		validRo.Spec.Strategy.Canary.Steps[0].SetWeight = ptr.To[int32](10)
+		validRo.Spec.Strategy.Canary.PingPong = &v1alpha1.PingPongSpec{PingService: "ping", PongService: "pong"}
+		validRo.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
+			Plugins: map[string]json.RawMessage{
+				"my-org/my-plugin": []byte(`{}`),
+			},
+		}
+		allErrs := ValidateRolloutStrategyCanary(validRo, field.NewPath(""))
+		assert.Empty(t, allErrs)
+	})
+
 	t.Run("invalid traffic routing", func(t *testing.T) {
 		invalidRo := ro.DeepCopy()
 		invalidRo.Spec.Strategy.Canary.CanaryService = ""


### PR DESCRIPTION
## Motivation

Closes #4739.

Plugin-based traffic routers (e.g. the [Gateway API plugin](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi)) need to implement ping-pong support for zero-downtime rollouts with long-lived TCP/gRPC connections (e.g. AWS NLB with weighted target groups via AWS Load Balancer Controller).

Currently the validation in `ValidateRolloutStrategyCanary` rejects any `pingPong` configuration unless `trafficRouting.alb` or `trafficRouting.istio` is set, blocking plugins from using the feature at all.

## What this PR does

Relaxes the validation condition to also permit `trafficRouting.plugins` — matching exactly the pattern used in #4643 for traffic mirroring.

**No controller logic changes are required.** Verified by reading the source:
- `reconcilePingAndPongService` (`rollout/service.go`) has no router-type check.
- `GetStableAndCanaryServices` is already router-agnostic.
- `ensureSVCTargets` short-circuits on empty `svcName`, so no selector swap occurs when only `pingPong` is configured.
- `requireCanaryStableServices` does not include `Plugins` in its required-services list.

## Testing

Added a unit test: rollout with `pingPong` + `trafficRouting.plugins` → validation passes.

Existing test `ping-pong feature without the ALB traffic routing` (Nginx router → rejected) is unchanged and still passes.

## Checklist

- [x] Followed the [contributing guidelines](https://github.com/argoproj/argo-rollouts/blob/master/CONTRIBUTING.md)
- [x] DCO signed (`-s`)
- [x] Unit tests added
- [ ] Added entry in `USERS.md` (organization will be added once the plugin PR is open)