### PR TITLE
fix(dashboard): guard null chartValue in metric chart tooltip. Fixes #4743

### DIFF
--- a/ui/src/app/components/analysis-modal/metric-chart/metric-chart.tsx
+++ b/ui/src/app/components/analysis-modal/metric-chart/metric-chart.tsx
@@ -56,10 +56,13 @@ const TooltipContent = ({active, conditionKeys, payload, valueFormatter}: Toolti
     if (data.phase === AnalysisStatus.Error) {
         label = data.message ?? 'Measurement error';
     } else if (conditionKeys.length > 0) {
-        const sublabels = conditionKeys.map((cKey) => (conditionKeys.length > 1 ? `${valueFormatter(data.chartValue[cKey])} (${cKey})` : valueFormatter(data.chartValue[cKey])));
+        const sublabels = conditionKeys.map((cKey) => {
+            const v = data.chartValue?.[cKey] ?? null;
+            return conditionKeys.length > 1 ? `${valueFormatter(v)} (${cKey})` : valueFormatter(v);
+        });
         label = sublabels.join(' , ');
     } else {
-        label = valueFormatter(data.chartValue);
+        label = valueFormatter(data.chartValue ?? null);
     }
 
     return (

--- a/ui/src/app/components/analysis-modal/metric-chart/metric-chart.tsx
+++ b/ui/src/app/components/analysis-modal/metric-chart/metric-chart.tsx
@@ -8,6 +8,7 @@ import {Typography} from 'antd';
 import {AnalysisStatus, FunctionalStatus, TransformedMeasurement} from '../types';
 import {ANALYSIS_STATUS_THEME_MAP} from '../constants';
 import {isValidDate} from '../transforms';
+import {getTooltipLabel} from './tooltip-label';
 
 import StatusIndicator from '../status-indicator/status-indicator';
 
@@ -52,18 +53,7 @@ const TooltipContent = ({active, conditionKeys, payload, valueFormatter}: Toolti
     }
 
     const data = payload[0].payload;
-    let label;
-    if (data.phase === AnalysisStatus.Error) {
-        label = data.message ?? 'Measurement error';
-    } else if (conditionKeys.length > 0) {
-        const sublabels = conditionKeys.map((cKey) => {
-            const v = data.chartValue?.[cKey] ?? null;
-            return conditionKeys.length > 1 ? `${valueFormatter(v)} (${cKey})` : valueFormatter(v);
-        });
-        label = sublabels.join(' , ');
-    } else {
-        label = valueFormatter(data.chartValue ?? null);
-    }
+    const label = getTooltipLabel(data, conditionKeys, valueFormatter);
 
     return (
         <div className={cx('metric-chart-tooltip')}>

--- a/ui/src/app/components/analysis-modal/metric-chart/tooltip-label.test.ts
+++ b/ui/src/app/components/analysis-modal/metric-chart/tooltip-label.test.ts
@@ -1,0 +1,20 @@
+import {getTooltipLabel} from './tooltip-label';
+import {AnalysisStatus} from '../types';
+
+const valueFormatter = (value: number | string | null) => (value === null ? '' : value.toString());
+
+describe('getTooltipLabel()', () => {
+    test.each([
+        ['single condition key with a value', {phase: AnalysisStatus.Successful, chartValue: {0: 5}}, ['0'], '5'],
+        ['multiple condition keys with values', {phase: AnalysisStatus.Successful, chartValue: {0: 5, 1: 10}}, ['0', '1'], '5 (0) , 10 (1)'],
+        ['no condition keys with a scalar value', {phase: AnalysisStatus.Successful, chartValue: 5}, [], '5'],
+        ['error phase with a message', {phase: AnalysisStatus.Error, message: 'boom'}, ['0'], 'boom'],
+        ['error phase without a message', {phase: AnalysisStatus.Error}, ['0'], 'Measurement error'],
+        ['null chartValue with a single condition key', {phase: AnalysisStatus.Successful, chartValue: null}, ['0'], ''],
+        ['null chartValue with multiple condition keys', {phase: AnalysisStatus.Successful, chartValue: null}, ['0', '1'], ' (0) ,  (1)'],
+        ['null chartValue with no condition keys', {phase: AnalysisStatus.Successful, chartValue: null}, [], ''],
+        ['object chartValue missing the requested key', {phase: AnalysisStatus.Successful, chartValue: {0: 5}}, ['1'], ''],
+    ] as [string, {phase: AnalysisStatus; message?: string; chartValue?: any}, string[], string][])('for %s', (_label, data, conditionKeys, expected) => {
+        expect(getTooltipLabel(data, conditionKeys, valueFormatter)).toBe(expected);
+    });
+});

--- a/ui/src/app/components/analysis-modal/metric-chart/tooltip-label.ts
+++ b/ui/src/app/components/analysis-modal/metric-chart/tooltip-label.ts
@@ -1,0 +1,30 @@
+import {AnalysisStatus, TransformedValueObject} from '../types';
+
+/**
+ * Builds the label shown in the metric chart tooltip for a hovered measurement.
+ *
+ * @param data transformed measurement backing the hovered data point (chartValue is null when unchartable)
+ * @param conditionKeys keys used to pull values from the measurement result
+ * @param valueFormatter formats a single value for display
+ * @returns label shown in the metric chart tooltip
+ */
+export const getTooltipLabel = (
+    data: {phase?: string; message?: string; chartValue?: TransformedValueObject | number | string | null},
+    conditionKeys: string[],
+    valueFormatter: (value: number | string | null) => string,
+): string => {
+    if (data.phase === AnalysisStatus.Error) {
+        return data.message ?? 'Measurement error';
+    }
+
+    if (conditionKeys.length > 0) {
+        return conditionKeys
+            .map((cKey) => {
+                const value = (data.chartValue as TransformedValueObject | null)?.[cKey] ?? null;
+                return conditionKeys.length > 1 ? `${valueFormatter(value)} (${cKey})` : valueFormatter(value);
+            })
+            .join(' , ');
+    }
+
+    return valueFormatter((data.chartValue ?? null) as number | string | null);
+};

--- a/ui/src/app/components/analysis-modal/transforms.test.ts
+++ b/ui/src/app/components/analysis-modal/transforms.test.ts
@@ -548,32 +548,18 @@ describe('analysis modal transforms', () => {
             tableValue: {latency: null, cpuUsage: null},
         });
     });
-    test('transformMeasurementValue() for undefined value', () => {
-        expect(transformMeasurementValue(['0'], undefined)).toEqual({canChart: true, chartValue: null, tableValue: null});
-    });
-    test('transformMeasurementValue() for empty string value', () => {
-        expect(transformMeasurementValue(['0'], '')).toEqual({canChart: true, chartValue: null, tableValue: null});
-    });
-    test('transformMeasurementValue() for [NaN] single-item array', () => {
-        expect(transformMeasurementValue(['0'], '[NaN]')).toEqual({canChart: true, chartValue: null, tableValue: null});
-    });
-    test('transformMeasurementValue() for bare NaN', () => {
-        expect(transformMeasurementValue(['0'], 'NaN')).toEqual({canChart: true, chartValue: null, tableValue: null});
-    });
-    test('transformMeasurementValue() for [NaN, 5] multi-item array', () => {
-        expect(transformMeasurementValue(['0', '1'], '[NaN, 5]')).toEqual({canChart: true, chartValue: null, tableValue: null});
-    });
-    test('transformMeasurementValue() for [Infinity] single-item array', () => {
-        expect(transformMeasurementValue(['0'], '[Infinity]')).toEqual({canChart: true, chartValue: null, tableValue: null});
-    });
-    test('transformMeasurementValue() for [-Infinity] single-item array', () => {
-        expect(transformMeasurementValue(['0'], '[-Infinity]')).toEqual({canChart: true, chartValue: null, tableValue: null});
-    });
-    test('transformMeasurementValue() for bare Infinity', () => {
-        expect(transformMeasurementValue(['0'], 'Infinity')).toEqual({canChart: true, chartValue: null, tableValue: null});
-    });
-    test('transformMeasurementValue() for malformed JSON value', () => {
-        expect(transformMeasurementValue(['0'], 'not-json')).toEqual({canChart: true, chartValue: null, tableValue: null});
+    test.each([
+        ['undefined value', ['0'], undefined],
+        ['empty string value', ['0'], ''],
+        ['[NaN] single-item array', ['0'], '[NaN]'],
+        ['bare NaN', ['0'], 'NaN'],
+        ['[NaN, 5] multi-item array', ['0', '1'], '[NaN, 5]'],
+        ['[Infinity] single-item array', ['0'], '[Infinity]'],
+        ['[-Infinity] single-item array', ['0'], '[-Infinity]'],
+        ['bare Infinity', ['0'], 'Infinity'],
+        ['malformed JSON value', ['0'], 'not-json'],
+    ] as [string, string[], string | undefined][])('transformMeasurementValue() for %s', (_label, conditionKeys, value) => {
+        expect(transformMeasurementValue(conditionKeys, value)).toEqual({canChart: true, chartValue: null, tableValue: null});
     });
     const MOCK_MEASUREMENTS: GithubComArgoprojArgoRolloutsPkgApisRolloutsV1alpha1Measurement[] = [{value: '[5]'}, {value: '[10]'}, {value: '[15]'}];
     const MOCK_MEASUREMENTS_WITH_NAN: GithubComArgoprojArgoRolloutsPkgApisRolloutsV1alpha1Measurement[] = [{value: '[NaN]'}, {value: '[10]'}, {value: '[15]'}];

--- a/ui/src/app/components/analysis-modal/transforms.test.ts
+++ b/ui/src/app/components/analysis-modal/transforms.test.ts
@@ -26,6 +26,7 @@ import {
     metricSubstatus,
     printableCloudWatchQuery,
     printableDatadogQuery,
+    transformMeasurementValue,
     transformMeasurements,
 } from './transforms';
 import {AnalysisStatus, FunctionalStatus} from './types';
@@ -546,6 +547,33 @@ describe('analysis modal transforms', () => {
             chartValue: {latency: null, cpuUsage: null},
             tableValue: {latency: null, cpuUsage: null},
         });
+    });
+    test('transformMeasurementValue() for undefined value', () => {
+        expect(transformMeasurementValue(['0'], undefined)).toEqual({canChart: true, chartValue: null, tableValue: null});
+    });
+    test('transformMeasurementValue() for empty string value', () => {
+        expect(transformMeasurementValue(['0'], '')).toEqual({canChart: true, chartValue: null, tableValue: null});
+    });
+    test('transformMeasurementValue() for [NaN] single-item array', () => {
+        expect(transformMeasurementValue(['0'], '[NaN]')).toEqual({canChart: true, chartValue: null, tableValue: null});
+    });
+    test('transformMeasurementValue() for bare NaN', () => {
+        expect(transformMeasurementValue(['0'], 'NaN')).toEqual({canChart: true, chartValue: null, tableValue: null});
+    });
+    test('transformMeasurementValue() for [NaN, 5] multi-item array', () => {
+        expect(transformMeasurementValue(['0', '1'], '[NaN, 5]')).toEqual({canChart: true, chartValue: null, tableValue: null});
+    });
+    test('transformMeasurementValue() for [Infinity] single-item array', () => {
+        expect(transformMeasurementValue(['0'], '[Infinity]')).toEqual({canChart: true, chartValue: null, tableValue: null});
+    });
+    test('transformMeasurementValue() for [-Infinity] single-item array', () => {
+        expect(transformMeasurementValue(['0'], '[-Infinity]')).toEqual({canChart: true, chartValue: null, tableValue: null});
+    });
+    test('transformMeasurementValue() for bare Infinity', () => {
+        expect(transformMeasurementValue(['0'], 'Infinity')).toEqual({canChart: true, chartValue: null, tableValue: null});
+    });
+    test('transformMeasurementValue() for malformed JSON value', () => {
+        expect(transformMeasurementValue(['0'], 'not-json')).toEqual({canChart: true, chartValue: null, tableValue: null});
     });
     const MOCK_MEASUREMENTS: GithubComArgoprojArgoRolloutsPkgApisRolloutsV1alpha1Measurement[] = [{value: '[5]'}, {value: '[10]'}, {value: '[15]'}];
     const MOCK_MEASUREMENTS_WITH_NAN: GithubComArgoprojArgoRolloutsPkgApisRolloutsV1alpha1Measurement[] = [{value: '[NaN]'}, {value: '[10]'}, {value: '[15]'}];

--- a/ui/src/app/components/analysis-modal/transforms.ts
+++ b/ui/src/app/components/analysis-modal/transforms.ts
@@ -609,7 +609,7 @@ export const formatKeyValueMeasurement = (value: {[key: string]: FormattedMeasur
  * @param value measurement value returned by provider
  * @returns chart and table data along with a flag indicating whether the measurement value can be charted
  */
-const transformMeasurementValue = (conditionKeys: string[], value?: string): MeasurementValueInfo => {
+export const transformMeasurementValue = (conditionKeys: string[], value?: string): MeasurementValueInfo => {
     if (value === undefined || value === '') {
         return {
             canChart: true,


### PR DESCRIPTION
Closes #4743.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green. Try syncing with master if they are not. 
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).


## Summary

The analysis modal metric chart crashes the dashboard to a blank white screen when the user hovers a data point whose measurement value is `[NaN]` (or any other value that fails `JSON.parse`). The crash is a `TypeError: Cannot read properties of null (reading '0')` at `ui/src/app/components/analysis-modal/metric-chart/metric-chart.tsx:59`.

This is the same crash family as closed issue #2758. PR #3801 fixed it at the time by switching to `JSON5.parse`. PR #3881 reverted to `JSON.parse + try/catch` for other reasons, which re-introduced the consumer-side crash on a new surface (the metric chart tooltip rather than `revision.tsx`).

## Root cause

When `transformMeasurementValue` cannot parse the measurement value, it returns the documented null sentinel:

```ts
return { canChart: true, chartValue: null, tableValue: null };
```

The metric chart tooltip then dereferences it without a null guard:

```ts
const sublabels = conditionKeys.map((cKey) => (conditionKeys.length > 1
    ? `${valueFormatter(data.chartValue[cKey])} (${cKey})`
    : valueFormatter(data.chartValue[cKey])));
```

null['0'] throws, no error boundary catches it, the whole tree unmounts. The table view path does not crash because it already null-guards.

## Fix

Guard the `chartValue` dereference with optional chaining + nullish coalescing, matching the formatter's existing null contract (`valueFormatter` already accepts `number | string | null`).

The tooltip label derivation was extracted out of `TooltipContent` into a small pure helper, `getTooltipLabel` (`ui/src/app/components/analysis-modal/metric-chart/tooltip-label.ts`), so the guard sits at — and can be unit-tested at — the exact code path that crashed.

Why consumer-side instead of patching `transforms.ts`:

1. Preserves the existing transforms contract. `chartValue: null` is the documented sentinel for unchartable data; the existing `transforms measurements correctly with NaN numbers in list` test in `transforms.test.ts` asserts exactly that. A data-layer fix invalidates it.
2. Smaller blast radius — the guard lives at the actual crash site.
3. Generalizes. Defends every null-`chartValue` path — NaN, Infinity, -Infinity, malformed JSON, future provider quirks — not only NaN.

## Tests

Two layers:

**`getTooltipLabel` (`tooltip-label.test.ts`) — validates the fix.** The label logic was extracted from `TooltipContent` into a pure `getTooltipLabel` helper so it can be tested directly. The null-`chartValue` cases throw `TypeError: Cannot read properties of null (reading '0')` *without* the guard and pass *with* it — so the test exercises the exact code path that crashed.

**`transformMeasurementValue` (`transforms.test.ts`) — pins the data-layer contract the guard relies on.** Unchartable values collapse to `{ canChart: true, chartValue: null, tableValue: null }`, covered for: `undefined`, empty string, `[NaN]`, bare `NaN`, `[NaN, 5]`, `[Infinity]`, `[-Infinity]`, bare `Infinity`, and malformed JSON. `transformMeasurementValue` is now exported so it can be tested directly. These complement the fix by documenting the contract every chart consumer depends on; the `getTooltipLabel` test above is what validates the fix itself.

## Fix Demo

https://github.com/user-attachments/assets/16a35326-ff51-4f76-94c7-7f23d023e283

## Reproducer

See #4743 for the full reproducer (AnalysisRun YAML, steps and crash screen recording).