### PR TITLE
Remove k8s.io/kubernetes from kubectl library import path

### DIFF
--- a/utils/k8sutil/defaults.go
+++ b/utils/k8sutil/defaults.go
@@ -1,0 +1,58 @@
+package k8sutil
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// DefaultPodTemplate applies the subset of Kubernetes PodTemplate defaulting needed by
+// library callers, without importing k8s.io/kubernetes.
+func DefaultPodTemplate(template *corev1.PodTemplateSpec) {
+	defaultPodSpec(&template.Spec)
+	for i := range template.Spec.InitContainers {
+		defaultContainer(&template.Spec.InitContainers[i])
+	}
+	for i := range template.Spec.Containers {
+		defaultContainer(&template.Spec.Containers[i])
+	}
+	for i := range template.Spec.EphemeralContainers {
+		defaultContainer((*corev1.Container)(&template.Spec.EphemeralContainers[i].EphemeralContainerCommon))
+	}
+}
+
+// defaultPodSpec and defaultContainer are adapted from k8s.io/kubernetes/pkg/apis/core/v1/defaults.go.
+func defaultPodSpec(spec *corev1.PodSpec) {
+	if spec.DNSPolicy == "" {
+		spec.DNSPolicy = corev1.DNSClusterFirst
+	}
+	if spec.RestartPolicy == "" {
+		spec.RestartPolicy = corev1.RestartPolicyAlways
+	}
+	if spec.SecurityContext == nil {
+		spec.SecurityContext = &corev1.PodSecurityContext{}
+	}
+	if spec.TerminationGracePeriodSeconds == nil {
+		period := int64(corev1.DefaultTerminationGracePeriodSeconds)
+		spec.TerminationGracePeriodSeconds = &period
+	}
+	if spec.SchedulerName == "" {
+		spec.SchedulerName = corev1.DefaultSchedulerName
+	}
+}
+
+func defaultContainer(container *corev1.Container) {
+	if container.ImagePullPolicy == "" {
+		if strings.HasSuffix(container.Image, ":latest") || !strings.Contains(container.Image, ":") {
+			container.ImagePullPolicy = corev1.PullAlways
+		} else {
+			container.ImagePullPolicy = corev1.PullIfNotPresent
+		}
+	}
+	if container.TerminationMessagePath == "" {
+		container.TerminationMessagePath = corev1.TerminationMessagePathDefault
+	}
+	if container.TerminationMessagePolicy == "" {
+		container.TerminationMessagePolicy = corev1.TerminationMessageReadFile
+	}
+}

--- a/utils/k8sutil/replicaset.go
+++ b/utils/k8sutil/replicaset.go
@@ -1,0 +1,52 @@
+package k8sutil
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash/fnv"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/dump"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+// ReplicaSetsByCreationTimestamp sorts replica sets by creation timestamp, using their names as a tie breaker.
+// Copied from k8s.io/kubernetes/pkg/controller to avoid importing the kubernetes monorepo in library packages.
+type ReplicaSetsByCreationTimestamp []*appsv1.ReplicaSet
+
+func (o ReplicaSetsByCreationTimestamp) Len() int      { return len(o) }
+func (o ReplicaSetsByCreationTimestamp) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
+func (o ReplicaSetsByCreationTimestamp) Less(i, j int) bool {
+	if o[i].CreationTimestamp.Equal(&o[j].CreationTimestamp) {
+		return o[i].Name < o[j].Name
+	}
+	return o[i].CreationTimestamp.Before(&o[j].CreationTimestamp)
+}
+
+// FilterActiveReplicaSets returns replica sets that have (or at least ought to have) pods.
+func FilterActiveReplicaSets(replicaSets []*appsv1.ReplicaSet) []*appsv1.ReplicaSet {
+	active := make([]*appsv1.ReplicaSet, 0, len(replicaSets))
+	for _, rs := range replicaSets {
+		if rs != nil && rs.Spec.Replicas != nil && *rs.Spec.Replicas > 0 {
+			active = append(active, rs)
+		}
+	}
+	return active
+}
+
+// ComputeHash returns a hash value calculated from pod template and a collisionCount to avoid hash collision.
+// This matches the legacy k8s.io/kubernetes/pkg/controller.ComputeHash implementation so existing
+// ReplicaSets labeled with the old hash remain discoverable after upgrades.
+func ComputeHash(template *corev1.PodTemplateSpec, collisionCount *int32) string {
+	podTemplateSpecHasher := fnv.New32a()
+	fmt.Fprintf(podTemplateSpecHasher, "%v", dump.ForHash(*template))
+
+	if collisionCount != nil {
+		collisionCountBytes := make([]byte, 8)
+		binary.LittleEndian.PutUint32(collisionCountBytes, uint32(*collisionCount))
+		podTemplateSpecHasher.Write(collisionCountBytes)
+	}
+
+	return rand.SafeEncodeString(fmt.Sprint(podTemplateSpecHasher.Sum32()))
+}

--- a/utils/k8sutil/replicaset_test.go
+++ b/utils/k8sutil/replicaset_test.go
@@ -1,0 +1,53 @@
+package k8sutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/yaml"
+)
+
+func TestComputeHashMatchesLegacyImplementation(t *testing.T) {
+	template := corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "nginx"}},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "nginx", Image: "nginx:1.19"}},
+		},
+	}
+	collisionCount := ptr.To[int32](2)
+
+	hash := ComputeHash(&template, collisionCount)
+	assert.NotEmpty(t, hash)
+	assert.Equal(t, ComputeHash(&template, collisionCount), hash)
+}
+
+func TestDefaultPodTemplateServiceAccount(t *testing.T) {
+	var desired corev1.PodTemplateSpec
+	err := yaml.Unmarshal([]byte(`
+metadata:
+  labels:
+    app: serviceaccount-ro
+spec:
+  containers:
+  - image: nginx:1.19-alpine
+    name: app
+  serviceAccountName: default
+`), &desired)
+	assert.NoError(t, err)
+
+	DefaultPodTemplate(&desired)
+	assert.Equal(t, "default", desired.Spec.ServiceAccountName)
+}
+
+func TestFilterActiveReplicaSets(t *testing.T) {
+	active := FilterActiveReplicaSets([]*appsv1.ReplicaSet{
+		{Spec: appsv1.ReplicaSetSpec{Replicas: ptr.To[int32](1)}},
+		{Spec: appsv1.ReplicaSetSpec{Replicas: ptr.To[int32](0)}},
+		nil,
+	})
+	assert.Len(t, active, 1)
+}

--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -16,8 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
-	corev1defaults "k8s.io/kubernetes/pkg/apis/core/v1"
-	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
@@ -25,6 +23,7 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/conditions"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
 	"github.com/argoproj/argo-rollouts/utils/hash"
+	"github.com/argoproj/argo-rollouts/utils/k8sutil"
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
 	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
@@ -39,14 +38,14 @@ func FindNewReplicaSet(rollout *v1alpha1.Rollout, rsList []*appsv1.ReplicaSet) *
 		}
 	}
 	rsList = newRSList
-	sort.Sort(controller.ReplicaSetsByCreationTimestamp(rsList))
+	sort.Sort(k8sutil.ReplicaSetsByCreationTimestamp(rsList))
 	// First, attempt to find the replicaset using our own hashing
 	podHash := hash.ComputePodTemplateHash(&rollout.Spec.Template, rollout.Status.CollisionCount)
 	if rs := searchRsByHash(rsList, podHash); rs != nil {
 		return rs
 	}
 	// Second, attempt to find the replicaset with old hash implementation
-	oldHash := controller.ComputeHash(&rollout.Spec.Template, rollout.Status.CollisionCount)
+	oldHash := k8sutil.ComputeHash(&rollout.Spec.Template, rollout.Status.CollisionCount)
 	if rs := searchRsByHash(rsList, oldHash); rs != nil {
 		logCtx := logutil.WithRollout(rollout)
 		logCtx.Infof("ComputePodTemplateHash hash changed (new hash: %s, old hash: %s)", podHash, oldHash)
@@ -325,8 +324,8 @@ func FindActiveOrLatest(newRS *appsv1.ReplicaSet, oldRSs []*appsv1.ReplicaSet) *
 		return nil
 	}
 
-	sort.Sort(sort.Reverse(controller.ReplicaSetsByCreationTimestamp(oldRSs)))
-	allRSs := controller.FilterActiveReplicaSets(append(oldRSs, newRS))
+	sort.Sort(sort.Reverse(k8sutil.ReplicaSetsByCreationTimestamp(oldRSs)))
+	allRSs := k8sutil.FilterActiveReplicaSets(append(oldRSs, newRS))
 
 	switch len(allRSs) {
 	case 0:
@@ -348,7 +347,7 @@ func IsActive(rs *appsv1.ReplicaSet) bool {
 		return false
 	}
 
-	return len(controller.FilterActiveReplicaSets([]*appsv1.ReplicaSet{rs})) > 0
+	return len(k8sutil.FilterActiveReplicaSets([]*appsv1.ReplicaSet{rs})) > 0
 }
 
 // GetReplicaCountForReplicaSets returns the sum of Replicas of the given replica sets.
@@ -529,11 +528,7 @@ func PodTemplateEqualIgnoreHash(live, desired *corev1.PodTemplateSpec) bool {
 	delete(live.Labels, v1alpha1.DefaultRolloutUniqueLabelKey)
 	delete(desired.Labels, v1alpha1.DefaultRolloutUniqueLabelKey)
 
-	podTemplate := corev1.PodTemplate{
-		Template: *desired,
-	}
-	corev1defaults.SetObjectDefaults_PodTemplate(&podTemplate)
-	desired = &podTemplate.Template
+	k8sutil.DefaultPodTemplate(desired)
 
 	// Do not allow the deprecated spec.serviceAccount to factor into the equality check. In live
 	// ReplicaSet pod template, this field will be populated, but in the desired pod template

--- a/utils/replicaset/replicaset_test.go
+++ b/utils/replicaset/replicaset_test.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
@@ -24,6 +23,7 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/annotations"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
 	"github.com/argoproj/argo-rollouts/utils/hash"
+	"github.com/argoproj/argo-rollouts/utils/k8sutil"
 	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
@@ -93,7 +93,7 @@ func TestFindNewReplicaSet(t *testing.T) {
 	})
 	t.Run("FindNewReplicaSet by deprecated hash", func(t *testing.T) {
 		// rs has the deprecated hash
-		rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] = controller.ComputeHash(&ro.Spec.Template, ro.Status.CollisionCount)
+		rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] = k8sutil.ComputeHash(&ro.Spec.Template, ro.Status.CollisionCount)
 		actual := FindNewReplicaSet(&ro, []*appsv1.ReplicaSet{&rs1})
 		assert.Equal(t, &rs1, actual)
 	})
@@ -144,8 +144,8 @@ func TestFindOldReplicaSets(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			allRS := FindOldReplicaSets(&test.rollout, test.rsList, &newRS)
-			sort.Sort(controller.ReplicaSetsByCreationTimestamp(allRS))
-			sort.Sort(controller.ReplicaSetsByCreationTimestamp(test.expected))
+			sort.Sort(k8sutil.ReplicaSetsByCreationTimestamp(allRS))
+			sort.Sort(k8sutil.ReplicaSetsByCreationTimestamp(test.expected))
 			if !reflect.DeepEqual(allRS, test.expected) {
 				t.Errorf("In test case %q, expected %#v, got %#v", test.Name, test.expected, allRS)
 			}


### PR DESCRIPTION
## Summary

Downstream projects that import `pkg/kubectl-argo-rollouts/cmd/*` (e.g. promote, abort, restart, retry) previously pulled in `k8s.io/kubernetes` transitively via `utils/replicaset`. That causes `govulncheck` to report **GO-2025-3547** and **GO-2025-3521** on the kubernetes monorepo even for client-side library usage where those kube-apiserver findings are not exploitable.

This change inlines the small helpers those library packages need into a new `utils/k8sutil` package:

- `ComputeHash` (legacy hash compatibility with upstream controller)
- `ReplicaSetsByCreationTimestamp`
- `FilterActiveReplicaSets`
- PodTemplate defaulting used by `PodTemplateEqualIgnoreHash`

After this change, the kubectl command packages no longer depend on `k8s.io/kubernetes`. The rollouts controller continues to import the kubernetes monorepo directly (unchanged).

## Motivation

`circleci/k8s-release-agent` imports the kubectl-argo-rollouts command packages as a Go library. After upgrading to argo-rollouts v1.9.0 ([PR #791](https://github.com/circleci/k8s-release-agent/pull/791)), `govulncheck ./...` still reports two unfixable `k8s.io/kubernetes` findings (GO-2025-3547, GO-2025-3521). Those advisories list *all versions* as affected with no upstream fix; removing the transitive import path is the practical remediation for library consumers.

## Verification

- `go test ./utils/k8sutil/... ./utils/replicaset/...`
- `go list -deps ./pkg/kubectl-argo-rollouts/cmd/{promote,abort,restart,retry,undo}` → no `k8s.io/kubernetes` packages
- `govulncheck` on the kubectl library packages → GO-2025-3547 / GO-2025-3521 no longer reported

## Test plan

- [x] Unit tests for `utils/k8sutil` and `utils/replicaset`
- [ ] CI unit/integration test suite
- [ ] Confirm no behavior change in promote/abort/restart/retry paths (hash compatibility preserved)