### PR TITLE
ci: upload unit and e2e coverage separately with Codecov flags

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,8 @@
+flags:
+  unit-tests:
+    carryforward: true
+  e2e:
+    carryforward: true
 coverage:
   status:
     # allow test coverage to drop by 0.1%, assume that it's typically due to CI problems

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -184,13 +184,28 @@ jobs:
         with:
           name: coverage-output-unit
           path: coverage-output-unit
-      - name: combine-go-coverage
+      - name: Generate unit test coverage profile
         run: |
-          go tool covdata textfmt -i=coverage-output-unit/,coverage-output-e2e/ -o full-coverage.out
-      - name: Upload code coverage information to codecov.io
+          go tool covdata textfmt -i=coverage-output-unit/ -o unit-coverage.out
+      - name: Generate e2e test coverage profile
+        run: |
+          go tool covdata textfmt -i=coverage-output-e2e/ -o e2e-coverage.out
+      - name: Upload unit test coverage to codecov.io
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
-          files: full-coverage.out
+          files: unit-coverage.out
+          flags: unit-tests
+          fail_ci_if_error: false
+          codecov_yml_path: .codecov.yml
+          disable_search: true
+          verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload e2e test coverage to codecov.io
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
+        with:
+          files: e2e-coverage.out
+          flags: e2e
           fail_ci_if_error: false
           codecov_yml_path: .codecov.yml
           disable_search: true


### PR DESCRIPTION
## Summary

- Split the single combined coverage upload into two separate uploads with Codecov flags (`unit-tests` and `e2e`)
- Add flag definitions to `.codecov.yml` with `carryforward: true`
- Unit test and e2e coverage profiles are now generated separately instead of being combined into one file

This enables flag-filtered coverage views on Codecov, allowing teams to track unit test and e2e coverage independently.

## Changes

### `.github/workflows/testing.yaml`
- Replace combined `go tool covdata textfmt` step with two separate steps (one for unit tests, one for e2e)
- Upload unit test coverage with `flags: unit-tests`
- Upload e2e coverage with `flags: e2e`
- Codecov automatically merges both uploads for the overall project coverage view

### `.codecov.yml`
- Add `flags:` section defining `unit-tests` and `e2e` flags
- Both flags exclude `test/` directory and enable `carryforward`

## Test plan
- [ ] Verify CI pipeline passes with the split coverage uploads
- [ ] Confirm both `unit-tests` and `e2e` flags appear on Codecov
- [ ] Verify overall project coverage remains unchanged (Codecov merges flagged uploads)