### PR TITLE
fix(metricprovider): Don't swallow RpcError returned by InitPlugin

### DIFF
--- a/metricproviders/plugin/client/client.go
+++ b/metricproviders/plugin/client/client.go
@@ -89,7 +89,7 @@ func (m *metricPlugin) startPluginSystem(metric v1alpha1.Metric) (rpc.MetricProv
 
 			resp := m.plugin[pluginName].InitPlugin()
 			if resp.HasError() {
-				return nil, fmt.Errorf("unable to initialize plugin via rpc (%s): %w", pluginName, err)
+				return nil, fmt.Errorf("unable to initialize plugin via rpc (%s): %w", pluginName, resp)
 			}
 		}
 


### PR DESCRIPTION
The error returned when InitPlugin failed was wrapping a nil `err` variable instead of the actual `resp` RpcError, swallowing the real failure reason. Wrap `resp` so that the underlying error is logged.

Right now, the errors logged by the Analysis controller look like this:

```
Measurement had error: failed to create plugin: unable to get metric plugin: unable to start plugin system: unable to initialize plugin via rpc (foo/bar): %!w(<nil>)
```

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, **(b) this is a bug fix**, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [ ] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).