### PR TITLE
fix(trafficrouting): parse VirtualService name containing a period correctly

### DIFF
--- a/utils/istio/istio.go
+++ b/utils/istio/istio.go
@@ -41,10 +41,18 @@ func GetVirtualServiceNamespaceName(vsv string) (string, string) {
 	namespace := ""
 	name := ""
 
+	// Strip the well-known cluster.local DNS suffix before parsing so that a
+	// fully-qualified reference still resolves to the right name/namespace.
+	vsv = strings.TrimSuffix(vsv, ".cluster.local")
+
 	fields := strings.Split(vsv, ".")
 	if len(fields) >= 2 {
-		name = fields[0]
-		namespace = fields[1]
+		// Istio uses the "name.namespace" shorthand and a Kubernetes namespace
+		// cannot contain a period, so the last segment is the namespace and
+		// everything before it is the VirtualService name. This keeps names
+		// that legitimately contain periods intact (see issue #4709).
+		name = strings.Join(fields[:len(fields)-1], ".")
+		namespace = fields[len(fields)-1]
 	} else if len(fields) == 1 {
 		name = fields[0]
 	}

--- a/utils/istio/istio_test.go
+++ b/utils/istio/istio_test.go
@@ -153,3 +153,56 @@ func TestGetRolloutDesinationRuleKeys(t *testing.T) {
 	assert.Len(t, keys, 1)
 	assert.Equal(t, "default/foo", keys[0])
 }
+
+func TestGetVirtualServiceNamespaceName(t *testing.T) {
+	tests := []struct {
+		name              string
+		input             string
+		expectedNamespace string
+		expectedName      string
+	}{
+		{
+			name:              "bare name, no namespace",
+			input:             "virtualservice",
+			expectedNamespace: "",
+			expectedName:      "virtualservice",
+		},
+		{
+			name:              "name.namespace cross-namespace shorthand",
+			input:             "virtualservice.istio",
+			expectedNamespace: "istio",
+			expectedName:      "virtualservice",
+		},
+		{
+			// Issue #4709: a VirtualService whose name contains a period must
+			// not have that period treated as a namespace separator. The VS
+			// "virtualservice.example" lives in namespace "istio" and is
+			// referenced as "virtualservice.example.istio". The namespace is the
+			// last segment; everything before it is the name.
+			name:              "name with period plus cross-namespace",
+			input:             "virtualservice.example.istio",
+			expectedNamespace: "istio",
+			expectedName:      "virtualservice.example",
+		},
+		{
+			name:              "multiple periods in name plus namespace",
+			input:             "my.virtual.service.istio",
+			expectedNamespace: "istio",
+			expectedName:      "my.virtual.service",
+		},
+		{
+			name:              "fully qualified with cluster.local suffix",
+			input:             "test.namespace.cluster.local",
+			expectedNamespace: "namespace",
+			expectedName:      "test",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ns, name := GetVirtualServiceNamespaceName(tc.input)
+			assert.Equal(t, tc.expectedNamespace, ns)
+			assert.Equal(t, tc.expectedName, name)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #4709

## Problem

The Istio traffic-management reconciler resolves the referenced `VirtualService` name and namespace with `GetVirtualServiceNamespaceName` in `utils/istio/istio.go`. The old logic split the reference on `.` and unconditionally took `fields[0]` as the name and `fields[1]` as the namespace, discarding anything after the second field.

A VirtualService name may legitimately contain a period (it only has to satisfy DNS-1123 subdomain validation, unlike a Service). That broke two cases:

- A real cross-namespace reference to a VirtualService whose name contains a period resolved to the wrong name and namespace. For the manifest in the issue, the VS is `virtualservice.example` in namespace `istio`, referenced as `virtualservice.example.istio`. The controller parsed it as name `virtualservice`, namespace `example`, and reported `virtualservices.networking.istio.io "virtualservice" not found`.
- More generally, the period in such a name was treated as a namespace separator instead of part of the name.

The documented contract is `rollout-vsvc.<vsvc namespace name>`, i.e. the Istio `name.namespace` shorthand where the namespace is the trailing segment. Since a Kubernetes namespace cannot contain a period, the correct parse is: the last dotted segment is the namespace and everything before it is the name.

## Fix

In `GetVirtualServiceNamespaceName`:

- Take the last segment as the namespace and join everything before it as the name.
- Strip the well-known `.cluster.local` suffix first so a fully qualified reference still resolves to the intended name and namespace (this keeps the existing FQDN behaviour, e.g. `test.namespace.cluster.local` stays `test` in `namespace`).

Same-namespace references with no trailing namespace (a bare name, no period) are unchanged. Existing cross-namespace support (`name.namespace`) is preserved; the only behaviour change is that periods inside the name are no longer mistaken for the namespace separator.

## Reproduce (before)

Added the expectation from the issue as a unit test and ran it against the unpatched code:

```
$ go test ./utils/istio/ -run TestGetVirtualServiceNamespaceName -v
    expected: "virtualservice.example"
    actual  : "virtualservice"
    expected: "istio"
    actual  : "example"
--- FAIL: TestGetVirtualServiceNamespaceName
FAIL
```

## After

```
$ go test ./utils/istio/...
ok  	github.com/argoproj/argo-rollouts/utils/istio
$ go test ./rollout/trafficrouting/istio/...
ok  	github.com/argoproj/argo-rollouts/rollout/trafficrouting/istio
$ go test ./pkg/apis/rollouts/validation/...
ok  	github.com/argoproj/argo-rollouts/pkg/apis/rollouts/validation
$ go build ./...
```

## Tests

Added a table-driven `TestGetVirtualServiceNamespaceName` covering: bare name, `name.namespace`, name-with-period plus cross-namespace, multiple periods in the name, and the `.cluster.local` fully qualified form. The pre-existing `TestGetRolloutVirtualServiceKeys` cases (including the `.cluster.local` ones) still pass unchanged.
