### PR TITLE
fix(controller): avoid duplicate RolloutAborted event on progressDeadlineAbort

### DIFF
--- a/rollout/bluegreen_test.go
+++ b/rollout/bluegreen_test.go
@@ -228,11 +228,30 @@ func TestBlueGreenProgressDeadlineAbort(t *testing.T) {
 		f.run(getKey(r, t))
 
 		f.verifyPatchedRolloutAborted(patchIndex, "foo-"+rsPodHash)
+
+		// The progress-deadline timeout reconcile sets the abort via AddAbort but
+		// must not emit its own RolloutAborted event. The RolloutAborted event is
+		// emitted by the abort handler on the following reconcile, the same single
+		// event a manual abort produces. Emitting it here too caused two
+		// RolloutAborted events (and two notifications) per deadline abort (#4764).
+		assert.Equal(f.t, 0, countEvents(f.events, conditions.RolloutAbortedReason),
+			"progress-deadline timeout reconcile must not emit a RolloutAborted event")
 	}
 
 	for _, tc := range tests {
 		runRolloutProgressDeadlineAbort(tc)
 	}
+}
+
+// countEvents returns how many recorded events match the given EventReason.
+func countEvents(events []string, reason string) int {
+	count := 0
+	for _, e := range events {
+		if e == reason {
+			count++
+		}
+	}
+	return count
 }
 
 // TestSetServiceManagedBy ensures the managed by annotation is set in the service is set
@@ -1545,6 +1564,10 @@ func TestBlueGreenAbort(t *testing.T) {
 	}`, rs1PodHash, expectedConditions, rs1PodHash, conditions.RolloutAbortedReason, fmt.Sprintf(conditions.RolloutAbortedMessage, 2))
 	patch := f.getPatchedRollout(patchIndex)
 	assert.JSONEq(t, calculatePatch(r2, expectedPatch), patch)
+	// A manual abort emits exactly one RolloutAborted event. The progress-deadline
+	// abort path must match this and not double-emit (see #4764).
+	assert.Equal(t, 1, countEvents(f.events, conditions.RolloutAbortedReason),
+		"a manual abort must emit exactly one RolloutAborted event")
 }
 
 func TestBlueGreenHandlePauseAutoPromoteWithConditions(t *testing.T) {

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -681,18 +681,21 @@ func (c *rolloutContext) calculateRolloutConditions(newStatus v1alpha1.RolloutSt
 			condition := conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionFalse, conditions.TimedOutReason, msg)
 			condChanged := conditions.SetRolloutCondition(&newStatus, *condition)
 
-			// If condition is changed and ProgressDeadlineAbort is set, abort the update
+			// If condition is changed and ProgressDeadlineAbort is set, abort the update.
+			// We only record the abort here, we do not emit a RolloutAborted event. The
+			// abort handler above emits a single RolloutAborted event on the following
+			// reconcile (once the abort is persisted), which matches the behavior of a
+			// manual abort. Emitting it here as well produced two RolloutAborted events
+			// per deadline abort and therefore duplicate notifications (#4764).
 			if condChanged {
 				if c.rollout.Spec.ProgressDeadlineAbort {
 					c.pauseContext.AddAbort(msg)
-					c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: conditions.RolloutAbortedReason}, msg)
 				}
 			} else {
 				// Although condition is unchanged, ProgressDeadlineAbort can be set after
 				// an existing update timeout. In this case if update is not aborted, we need to abort.
 				if c.rollout.Spec.ProgressDeadlineAbort && c.pauseContext != nil && !c.pauseContext.IsAborted() {
 					c.pauseContext.AddAbort(msg)
-					c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: conditions.RolloutAbortedReason}, msg)
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #4764

## Problem

With `progressDeadlineAbort: true`, a progress-deadline timeout produces **two** Kubernetes events with `EventReason: RolloutAborted` for a single abort. Each event independently triggers `sendNotifications`, so subscribers receive two notifications (for example two Slack messages, ~350ms apart). A manual abort (`kubectl argo rollouts abort`) emits a single `RolloutAborted` event and a single notification, so the two paths behaved inconsistently.

## Root cause

`calculateRolloutConditions` in `rollout/sync.go` has two emit sites that both use `conditions.RolloutAbortedReason`:

1. The abort handler (around line 615): when the rollout is already aborted, it sets the `RolloutProgressing=False/RolloutAborted` condition and emits one `RolloutAborted` event with the message `Rollout aborted update to revision N`.
2. The progress-deadline timeout-detection path (lines 688 and 695): when the timeout is first detected and `ProgressDeadlineAbort` is set, it calls `AddAbort(msg)` to mark the rollout for abort **and** emitted its own `RolloutAborted` event with the message `ReplicaSet "X" has timed out progressing.`

`isAborted` is computed once at the top of `calculateRolloutConditions`, so the abort handler does not run in the same reconcile that first detects the timeout. The sequence is:

- Reconcile N: `isAborted` is false. The timeout path runs, calls `AddAbort`, and emits event #1 (`ReplicaSet ... has timed out progressing.`). The status patch persists `Abort: true`.
- Reconcile N+1: `isAborted` is now true. The abort handler emits event #2 (`Rollout aborted update to revision N`). The timeout path is skipped because it is guarded by `!isAborted`.

Net result: two `RolloutAborted` events and two notifications per deadline abort. A manual abort sets `Status.Abort=true` directly, so only the abort handler fires, giving one event.

## Fix

Drop the two `Warnf(... RolloutAbortedReason ...)` calls from the timeout-detection path. The timeout path still records the abort via `AddAbort`, and the abort handler still emits exactly one `RolloutAborted` event on the following reconcile, matching the manual-abort path. No condition, status, or abort behavior changes; only the duplicate event (and therefore the duplicate notification) is removed.

## Reproduction and verification

I extended the existing event-aware unit tests in `rollout/bluegreen_test.go`, which use the `record.FakeEventRecorder` harness, to assert on the recorded `RolloutAborted` event count:

- `TestBlueGreenProgressDeadlineAbort` (deadline-abort timeout reconcile): asserts the timeout-detection reconcile emits **zero** `RolloutAborted` events. Before the fix this reconcile emitted one (the duplicate), so the assertion failed:

  ```
  --- FAIL: TestBlueGreenProgressDeadlineAbort
      Error: Not equal: expected: 0  actual: 1
      Messages: progress-deadline timeout reconcile must not emit a RolloutAborted event
  ```

  After the fix it emits zero and the test passes.

- `TestBlueGreenAbort` (manual abort): asserts the manual-abort reconcile emits **exactly one** `RolloutAborted` event. This passes both before and after the fix, locking in parity between the two paths.

Both unit tests pass after the change, and the full affected packages are green: `go test ./rollout/... ./utils/record/... ./utils/conditions/...` and `go build ./...`. The `progressDeadlineAbort` e2e test (`TestBlueGreenExceedProgressDeadlineAbort`) asserts on `Status.Abort` and the condition set, not on event counts, and is unaffected.
