### PR TITLE
fix: leader lease name from instance id

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -108,6 +108,19 @@ type LeaderElectionOptions struct {
 	LeaderElectionRetryPeriod   time.Duration
 }
 
+// leaseLockName returns the name of the lease lock used for leader election. When an
+// instanceID is configured, it is appended to the default lock name so that controllers
+// operating on different instance IDs against a shared cluster elect leaders independently.
+// This mirrors Argo Workflows' behavior:
+// https://github.com/argoproj/argo-workflows/blob/main/cmd/workflow-controller/main.go#L152
+func leaseLockName(instanceID string) string {
+	//Keep backwards compatibility for existing users
+	if instanceID == "" {
+		return defaultLeaderElectionLeaseLockName
+	}
+	return fmt.Sprintf("%s-%s", defaultLeaderElectionLeaseLockName, instanceID)
+}
+
 func NewLeaderElectionOptions() *LeaderElectionOptions {
 	return &LeaderElectionOptions{
 		LeaderElect:                 DefaultLeaderElect,
@@ -153,6 +166,11 @@ type Manager struct {
 	kubeClientSet kubernetes.Interface
 
 	namespace string
+
+	// instanceID is the value of the --instance-id flag. When set, it is appended to the
+	// leader election lease lock name so that controllers operating on different instance IDs
+	// against a shared cluster elect leaders independently (see leaseLockName).
+	instanceID string
 
 	dynamicInformerFactory               dynamicinformer.DynamicSharedInformerFactory
 	clusterDynamicInformerFactory        dynamicinformer.DynamicSharedInformerFactory
@@ -431,6 +449,7 @@ func NewManager(
 		notificationsController:              notificationsController,
 		refResolver:                          refResolver,
 		namespace:                            namespace,
+		instanceID:                           instanceID,
 		kubeClientSet:                        kubeclientset,
 		dynamicInformerFactory:               dynamicInformerFactory,
 		clusterDynamicInformerFactory:        clusterDynamicInformerFactory,
@@ -498,9 +517,12 @@ func (c *Manager) Run(ctx context.Context, rolloutThreadiness, serviceThreadines
 		// add a uniquifier so that two processes on the same host don't accidentally both become active
 		id = id + "_" + string(uuid.NewUUID())
 		log.Infof("Leaderelection get id %s", id)
+
+		lockName := leaseLockName(c.instanceID)
+		log.Infof("Using leader election lease lock name %s", lockName)
 		leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
 			Lock: &resourcelock.LeaseLock{
-				LeaseMeta: metav1.ObjectMeta{Name: defaultLeaderElectionLeaseLockName, Namespace: electOpts.LeaderElectionNamespace}, Client: c.kubeClientSet.CoordinationV1(),
+				LeaseMeta: metav1.ObjectMeta{Name: lockName, Namespace: electOpts.LeaderElectionNamespace}, Client: c.kubeClientSet.CoordinationV1(),
 				LockConfig: resourcelock.ResourceLockConfig{Identity: id},
 			},
 			ReleaseOnCancel: false, // We can not set this to true because our context is sent on sig which means our code

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -274,6 +274,7 @@ func TestNewManager(t *testing.T) {
 	)
 
 	assert.NotNil(t, cm)
+	assert.Equal(t, "test", cm.instanceID)
 }
 
 func TestNewAnalysisManager(t *testing.T) {
@@ -335,4 +336,28 @@ func TestPrimaryControllerSingleInstanceWithShutdown(t *testing.T) {
 		cancel()
 	}()
 	cm.Run(ctx, 1, 1, 1, 1, 1, electOpts)
+}
+
+func TestLeaseLockName(t *testing.T) {
+	tests := []struct {
+		name       string
+		instanceID string
+		expected   string
+	}{
+		{
+			name:       "no instance id uses the default lock name",
+			instanceID: "",
+			expected:   defaultLeaderElectionLeaseLockName,
+		},
+		{
+			name:       "instance id is appended to the default lock name",
+			instanceID: "my-instance",
+			expected:   defaultLeaderElectionLeaseLockName + "-my-instance",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, leaseLockName(tt.instanceID))
+		})
+	}
 }


### PR DESCRIPTION
This closes https://github.com/argoproj/argo-rollouts/issues/4178 where users have conflicts with multiple Argo Rollouts controllers as all of them use the same lease name.

There is already a old PR for this at https://github.com/argoproj/argo-rollouts/pull/4325 but it has no tests and most importantly forces users to manually define their selected lease lock name (and if they forget the same problem appears)

It seems however that Argo Workflows has already solved the same problem in a more elegant way where the lease lock name is automatically derived by the instanceID

So the present PR replicates what was solved implemented in Argo Workflows, having a single alignment between both Argo projects :-)

See discussions at
- https://github.com/argoproj/argo-workflows/pull/5214
- https://github.com/argoproj/argo-workflows/pull/5218
- https://github.com/argoproj/argo-workflows/pull/4622

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green. Try syncing with master if they are not. 
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).