### PR TITLE
test: make tests resilient to nil ptr

### DIFF
--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -1027,6 +1027,7 @@ func (f *fixture) expectGetEndpointsAction(ep *corev1.Endpoints) int {
 // panicking) when fewer actions occurred than expected. This keeps a single failing test from
 // aborting the rest of the package via an index-out-of-range panic.
 func (f *fixture) kubeActionAt(index int) core.Action {
+	f.t.Helper()
 	actions := filterInformerActions(f.kubeclient.Actions())
 	require.Greaterf(f.t, len(actions), index, "expected at least %d kube actions, got %d", index+1, len(actions))
 	return actions[index]
@@ -1035,6 +1036,7 @@ func (f *fixture) kubeActionAt(index int) core.Action {
 // actionAt returns the filtered argoproj action at the given index, failing the test (instead of
 // panicking) when fewer actions occurred than expected.
 func (f *fixture) actionAt(index int) core.Action {
+	f.t.Helper()
 	actions := filterInformerActions(f.client.Actions())
 	require.Greaterf(f.t, len(actions), index, "expected at least %d rollout actions, got %d", index+1, len(actions))
 	return actions[index]

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -14,6 +14,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
@@ -1022,8 +1023,25 @@ func (f *fixture) expectGetEndpointsAction(ep *corev1.Endpoints) int {
 	return len
 }
 
+// kubeActionAt returns the filtered kube action at the given index, failing the test (instead of
+// panicking) when fewer actions occurred than expected. This keeps a single failing test from
+// aborting the rest of the package via an index-out-of-range panic.
+func (f *fixture) kubeActionAt(index int) core.Action {
+	actions := filterInformerActions(f.kubeclient.Actions())
+	require.Greaterf(f.t, len(actions), index, "expected at least %d kube actions, got %d", index+1, len(actions))
+	return actions[index]
+}
+
+// actionAt returns the filtered argoproj action at the given index, failing the test (instead of
+// panicking) when fewer actions occurred than expected.
+func (f *fixture) actionAt(index int) core.Action {
+	actions := filterInformerActions(f.client.Actions())
+	require.Greaterf(f.t, len(actions), index, "expected at least %d rollout actions, got %d", index+1, len(actions))
+	return actions[index]
+}
+
 func (f *fixture) getCreatedReplicaSet(index int) *appsv1.ReplicaSet {
-	action := filterInformerActions(f.kubeclient.Actions())[index]
+	action := f.kubeActionAt(index)
 	createAction, ok := action.(core.CreateAction)
 	if !ok {
 		assert.Fail(f.t, "Expected Created action, not %s", action.GetVerb())
@@ -1037,7 +1055,7 @@ func (f *fixture) getCreatedReplicaSet(index int) *appsv1.ReplicaSet {
 }
 
 func (f *fixture) getUpdatedReplicaSet(index int) *appsv1.ReplicaSet {
-	action := filterInformerActions(f.kubeclient.Actions())[index]
+	action := f.kubeActionAt(index)
 	updateAction, ok := action.(core.UpdateAction)
 	if !ok {
 		assert.Fail(f.t, "Expected Update action, not %s", action.GetVerb())
@@ -1051,7 +1069,7 @@ func (f *fixture) getUpdatedReplicaSet(index int) *appsv1.ReplicaSet {
 }
 
 func (f *fixture) getPatchedReplicaSet(index int) *appsv1.ReplicaSet { //nolint
-	action := filterInformerActions(f.kubeclient.Actions())[index]
+	action := f.kubeActionAt(index)
 	patchAction, ok := action.(core.PatchAction)
 	if !ok {
 		f.t.Fatalf("Expected Patch action, not %s", action.GetVerb())
@@ -1066,7 +1084,7 @@ func (f *fixture) getPatchedReplicaSet(index int) *appsv1.ReplicaSet { //nolint
 }
 
 func (f *fixture) verifyPatchedReplicaSet(index int, scaleDownDelaySeconds int32) {
-	action := filterInformerActions(f.kubeclient.Actions())[index]
+	action := f.kubeActionAt(index)
 	patchAction, ok := action.(core.PatchAction)
 	if !ok {
 		assert.Fail(f.t, "Expected Patch action, not %s", action.GetVerb())
@@ -1077,7 +1095,7 @@ func (f *fixture) verifyPatchedReplicaSet(index int, scaleDownDelaySeconds int32
 }
 
 func (f *fixture) verifyPatchedService(index int, newPodHash string, managedBy string) {
-	action := filterInformerActions(f.kubeclient.Actions())[index]
+	action := f.kubeActionAt(index)
 	patchAction, ok := action.(core.PatchAction)
 	if !ok {
 		assert.Fail(f.t, "Expected Patch action, not %s", action.GetVerb())
@@ -1105,7 +1123,7 @@ func (f *fixture) verifyPatchedRolloutAborted(index int, rsName string) {
 }
 
 func (f *fixture) verifyPatchedAnalysisRun(index int, ar *v1alpha1.AnalysisRun) bool {
-	action := filterInformerActions(f.client.Actions())[index]
+	action := f.actionAt(index)
 	patchAction, ok := action.(core.PatchAction)
 	if !ok {
 		assert.Fail(f.t, "Expected Patch action, not %s", action.GetVerb())
@@ -1114,7 +1132,7 @@ func (f *fixture) verifyPatchedAnalysisRun(index int, ar *v1alpha1.AnalysisRun) 
 }
 
 func (f *fixture) getUpdatedRollout(index int) *v1alpha1.Rollout {
-	action := filterInformerActions(f.client.Actions())[index]
+	action := f.actionAt(index)
 	updateAction, ok := action.(core.UpdateAction)
 	if !ok {
 		assert.Fail(f.t, "Expected Update action, not %s", action.GetVerb())
@@ -1128,7 +1146,7 @@ func (f *fixture) getUpdatedRollout(index int) *v1alpha1.Rollout {
 }
 
 func (f *fixture) getPatchedAnalysisRun(index int) *v1alpha1.AnalysisRun { //nolint:unused
-	action := filterInformerActions(f.client.Actions())[index]
+	action := f.actionAt(index)
 	patchAction, ok := action.(core.PatchAction)
 	if !ok {
 		f.t.Fatalf("Expected Patch action, not %s", action.GetVerb())
@@ -1142,7 +1160,7 @@ func (f *fixture) getPatchedAnalysisRun(index int) *v1alpha1.AnalysisRun { //nol
 }
 
 func (f *fixture) getCreatedAnalysisRun(index int) *v1alpha1.AnalysisRun {
-	action := filterInformerActions(f.client.Actions())[index]
+	action := f.actionAt(index)
 	createAction, ok := action.(core.CreateAction)
 	if !ok {
 		f.t.Fatalf("Expected Patch action, not %s", action.GetVerb())
@@ -1156,7 +1174,7 @@ func (f *fixture) getCreatedAnalysisRun(index int) *v1alpha1.AnalysisRun {
 }
 
 func (f *fixture) getCreatedExperiment(index int) *v1alpha1.Experiment {
-	action := filterInformerActions(f.client.Actions())[index]
+	action := f.actionAt(index)
 	createAction, ok := action.(core.CreateAction)
 	if !ok {
 		f.t.Fatalf("Expected Patch action, not %s", action.GetVerb())
@@ -1170,7 +1188,7 @@ func (f *fixture) getCreatedExperiment(index int) *v1alpha1.Experiment {
 }
 
 func (f *fixture) getPatchedExperiment(index int) *v1alpha1.Experiment {
-	action := filterInformerActions(f.client.Actions())[index]
+	action := f.actionAt(index)
 	patchAction, ok := action.(core.PatchAction)
 	if !ok {
 		f.t.Fatalf("Expected Patch action, not %s", action.GetVerb())
@@ -1185,7 +1203,7 @@ func (f *fixture) getPatchedExperiment(index int) *v1alpha1.Experiment {
 }
 
 func (f *fixture) getPatchedRollout(index int) string {
-	action := filterInformerActions(f.client.Actions())[index]
+	action := f.actionAt(index)
 	patchAction, ok := action.(core.PatchAction)
 	if !ok {
 		f.t.Fatalf("Expected Patch action, not %s", action.GetVerb())
@@ -1194,7 +1212,7 @@ func (f *fixture) getPatchedRollout(index int) string {
 }
 
 func (f *fixture) getPatchedRolloutWithoutConditions(index int) string {
-	action := filterInformerActions(f.client.Actions())[index]
+	action := f.actionAt(index)
 	patchAction, ok := action.(core.PatchAction)
 	if !ok {
 		f.t.Fatalf("Expected Patch action, not %s", action.GetVerb())
@@ -1213,7 +1231,7 @@ func (f *fixture) getPatchedRolloutWithoutConditions(index int) string {
 }
 
 func (f *fixture) getPatchedRolloutAsObject(index int) *v1alpha1.Rollout {
-	action := filterInformerActions(f.client.Actions())[index]
+	action := f.actionAt(index)
 	patchAction, ok := action.(core.PatchAction)
 	if !ok {
 		f.t.Fatalf("Expected Patch action, not %s", action.GetVerb())
@@ -1248,7 +1266,7 @@ func (f *fixture) expectDeleteReplicaSetAction(rs *appsv1.ReplicaSet) int {
 }
 
 func (f *fixture) getDeletedReplicaSet(index int) string { //nolint:unused
-	action := filterInformerActions(f.kubeclient.Actions())[index]
+	action := f.kubeActionAt(index)
 	deleteAction, ok := action.(core.DeleteAction)
 	if !ok {
 		assert.Fail(f.t, "Expected Delete action, not %s", action.GetVerb())
@@ -1257,7 +1275,7 @@ func (f *fixture) getDeletedReplicaSet(index int) string { //nolint:unused
 }
 
 func (f *fixture) getDeletedAnalysisRun(index int) string {
-	action := filterInformerActions(f.client.Actions())[index]
+	action := f.actionAt(index)
 	deleteAction, ok := action.(core.DeleteAction)
 	if !ok {
 		assert.Fail(f.t, "Expected Delete action, not %s", action.GetVerb())
@@ -1266,7 +1284,7 @@ func (f *fixture) getDeletedAnalysisRun(index int) string {
 }
 
 func (f *fixture) getDeletedExperiment(index int) string {
-	action := filterInformerActions(f.client.Actions())[index]
+	action := f.actionAt(index)
 	deleteAction, ok := action.(core.DeleteAction)
 	if !ok {
 		assert.Fail(f.t, "Expected Delete action, not %s", action.GetVerb())
@@ -1275,7 +1293,7 @@ func (f *fixture) getDeletedExperiment(index int) string {
 }
 
 func (f *fixture) getUpdatedPod(index int) *corev1.Pod {
-	action := filterInformerActions(f.kubeclient.Actions())[index]
+	action := f.kubeActionAt(index)
 	updateAction, ok := action.(core.UpdateAction)
 	if !ok {
 		assert.Fail(f.t, "Expected Update action, not %s", action.GetVerb())

--- a/rollout/sync_test.go
+++ b/rollout/sync_test.go
@@ -235,6 +235,7 @@ func TestPersistWorkloadRefGeneration(t *testing.T) {
 		log:     logutil.WithRollout(r),
 		reconcilerBase: reconcilerBase{
 			argoprojclientset: &fake,
+			recorder:          record.NewFakeEventRecorder(),
 		},
 		pauseContext: &pauseContext{
 			rollout: r,


### PR DESCRIPTION
When running the test suite, some test may fail with nil ptr which stops the test suite immediately instead of evaluating other test scenarios.
