### PR TITLE
Document Endtest job metric integration

### DIFF
--- a/docs/analysis/job.md
+++ b/docs/analysis/job.md
@@ -35,6 +35,14 @@ The possible outcomes of a job metric are:
 The last case can happen either when another metric has already failed or when the job is running as a background
 analysis and the canary/blue-green process has finished.
 
+## End-to-end testing with Endtest
+
+[Endtest](https://endtest.io/) can be used as a Job metric to run browser and mobile tests during canary or blue-green deployments. The integration starts one or more Endtest executions, waits for their results, and exits with a non-zero status when any execution reports failed assertions or execution errors.
+
+Credentials and the Endtest API request are provided through a Kubernetes Secret. The Job uses the public `ghcr.io/endtest-technologies/endtest-argo` container image and does not require changes to the Argo Rollouts controller.
+
+See the [Endtest AnalysisTemplate example](https://github.com/argoproj/argo-rollouts/blob/master/examples/analysis-endtest.yaml). The runner and additional rollout examples are maintained in the [Endtest Argo integration repository](https://github.com/endtest-technologies/endtest-argo).
+
 ## Control where the jobs run
 
 Argo Rollouts allows you some control over where your metric job runs.

--- a/examples/analysis-endtest.yaml
+++ b/examples/analysis-endtest.yaml
@@ -1,0 +1,48 @@
+# This AnalysisTemplate runs one or more Endtest test suites as a Job metric.
+# Create a Secret named endtest-credentials with ENDTEST_APP_ID,
+# ENDTEST_APP_CODE, and ENDTEST_API_REQUEST before using this template.
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: endtest
+spec:
+  metrics:
+    - name: endtest-release-gate
+      provider:
+        job:
+          spec:
+            backoffLimit: 0
+            activeDeadlineSeconds: 3700
+            template:
+              spec:
+                automountServiceAccountToken: false
+                restartPolicy: Never
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                containers:
+                  - name: endtest
+                    image: ghcr.io/endtest-technologies/endtest-argo:0.2.1
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                        drop:
+                          - ALL
+                    env:
+                      - name: ENDTEST_APP_ID
+                        valueFrom:
+                          secretKeyRef:
+                            name: endtest-credentials
+                            key: ENDTEST_APP_ID
+                      - name: ENDTEST_APP_CODE
+                        valueFrom:
+                          secretKeyRef:
+                            name: endtest-credentials
+                            key: ENDTEST_APP_CODE
+                      - name: ENDTEST_API_REQUEST
+                        valueFrom:
+                          secretKeyRef:
+                            name: endtest-credentials
+                            key: ENDTEST_API_REQUEST


### PR DESCRIPTION
## Summary

Adds an example showing how Endtest can be used with the Argo Rollouts Job Metrics provider to run end-to-end browser and mobile tests during canary or blue-green deployments.

## Changes

- Adds an Endtest section to the Job Metrics documentation
- Adds a reusable `ClusterAnalysisTemplate` example
- Links to the maintained Endtest Argo integration repository

## Validation

- `git diff --check`
- YAML syntax validated locally
- Verified with multiple Endtest executions through an Argo Rollouts `AnalysisRun`