### PR TITLE
fix(controller): allow Bidirectional mountPropagation on privileged containers. Fixes #3130

### DIFF
--- a/pkg/apis/rollouts/validation/validation.go
+++ b/pkg/apis/rollouts/validation/validation.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/core"
 	corev1defaults "k8s.io/kubernetes/pkg/apis/core/v1"
 	apivalidation "k8s.io/kubernetes/pkg/apis/core/validation"
+	"k8s.io/kubernetes/pkg/capabilities"
 	"k8s.io/kubernetes/pkg/fieldpath"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
@@ -98,6 +99,35 @@ var allowAllPodValidationOptions = apivalidation.PodValidationOptions{
 	AllowIndivisibleHugePagesValues: true,
 }
 
+// The upstream k8s pod-spec validation we reuse reads the process-wide
+// capabilities singleton via capabilities.Get(). When it is left at its zero
+// value, AllowPrivileged defaults to false and validation rejects every
+// container that has securityContext.privileged=true. The kube-apiserver sets
+// this flag to true at startup; we mirror that here so that the validator sees
+// the rollout's pod spec as-is and can correctly evaluate cross-field rules
+// such as "Bidirectional mountPropagation requires privileged container".
+//
+// capabilities.Initialize uses sync.Once internally, so callers (controller,
+// CLI lint command, webhook, tests, etc.) all converge on the same value and
+// later calls become no-ops. Trusting the cluster to ultimately enforce
+// privileged-pod admission is consistent with allowAllPodValidationOptions
+// above.
+//
+// Replaces the previous workaround that stripped Privileged from each
+// container before validation; that workaround broke other cross-field rules.
+// See https://github.com/argoproj/argo-rollouts/issues/796 (original) and
+// https://github.com/argoproj/argo-rollouts/issues/3130 (Bidirectional mounts).
+func init() {
+	capabilities.Initialize(capabilities.Capabilities{
+		AllowPrivileged: true,
+		PrivilegedSources: capabilities.PrivilegedSources{
+			HostNetworkSources: []string{},
+			HostPIDSources:     []string{},
+			HostIPCSources:     []string{},
+		},
+	})
+}
+
 func ValidateRollout(rollout *v1alpha1.Rollout) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, ValidateRolloutSpec(rollout, field.NewPath("spec"))...)
@@ -157,7 +187,6 @@ func ValidateRolloutSpec(rollout *v1alpha1.Rollout, fldPath *field.Path) field.E
 			return allErrs
 		}
 		template.ObjectMeta = spec.Template.ObjectMeta
-		removeSecurityContextPrivileged(&template)
 
 		// Skip validating empty template for rollout resolved from ref
 		if rollout.Spec.TemplateResolvedFromRef || spec.WorkloadRef == nil {
@@ -178,23 +207,6 @@ func ValidateRolloutSpec(rollout *v1alpha1.Rollout, fldPath *field.Path) field.E
 	allErrs = append(allErrs, ValidateRolloutStrategy(rollout, fldPath.Child("strategy"))...)
 
 	return allErrs
-}
-
-// removeSecurityContextPrivileged removes the privileged value on containers for the purposes of
-// validation. This is necessary because the k8s ValidateSecurityContext library which we reuse,
-// calls k8s.io/kubernetes/pkg/capabilities.Get(), which determines the security capabilities at a
-// global level. We don't want to call capabilities.Setup(), because it affects it as a global
-// level, so instead we remove the privileged setting on any containers so validation ignores it.
-// See https://github.com/argoproj/argo-rollouts/issues/796
-func removeSecurityContextPrivileged(template *core.PodTemplateSpec) {
-	for _, ctrList := range [][]core.Container{template.Spec.Containers, template.Spec.InitContainers} {
-		for i, ctr := range ctrList {
-			if ctr.SecurityContext != nil && ctr.SecurityContext.Privileged != nil && *ctr.SecurityContext.Privileged {
-				ctr.SecurityContext.Privileged = nil
-				ctrList[i] = ctr
-			}
-		}
-	}
 }
 
 func ValidateRolloutStrategy(rollout *v1alpha1.Rollout, fldPath *field.Path) field.ErrorList {

--- a/pkg/apis/rollouts/validation/validation.go
+++ b/pkg/apis/rollouts/validation/validation.go
@@ -99,33 +99,23 @@ var allowAllPodValidationOptions = apivalidation.PodValidationOptions{
 	AllowIndivisibleHugePagesValues: true,
 }
 
-// The upstream k8s pod-spec validation we reuse reads the process-wide
-// capabilities singleton via capabilities.Get(). When it is left at its zero
-// value, AllowPrivileged defaults to false and validation rejects every
-// container that has securityContext.privileged=true. The kube-apiserver sets
-// this flag to true at startup; we mirror that here so that the validator sees
-// the rollout's pod spec as-is and can correctly evaluate cross-field rules
-// such as "Bidirectional mountPropagation requires privileged container".
-//
-// capabilities.Initialize uses sync.Once internally, so callers (controller,
-// CLI lint command, webhook, tests, etc.) all converge on the same value and
-// later calls become no-ops. Trusting the cluster to ultimately enforce
-// privileged-pod admission is consistent with allowAllPodValidationOptions
-// above.
-//
-// Replaces the previous workaround that stripped Privileged from each
-// container before validation; that workaround broke other cross-field rules.
+// allowPrivilegedCapabilities mirrors what kube-apiserver sets at startup so
+// that the upstream pod-spec validator we reuse below sees the rollout's pod
+// spec as-is and can correctly evaluate cross-field rules such as
+// "Bidirectional mountPropagation requires privileged container". It is
+// applied via capabilities.Initialize() right before invoking the validator;
+// capabilities.Initialize uses sync.Once internally, so subsequent calls are
+// safe no-ops. Replaces the previous workaround that stripped Privileged from
+// each container before validation, which broke other cross-field rules.
 // See https://github.com/argoproj/argo-rollouts/issues/796 (original) and
 // https://github.com/argoproj/argo-rollouts/issues/3130 (Bidirectional mounts).
-func init() {
-	capabilities.Initialize(capabilities.Capabilities{
-		AllowPrivileged: true,
-		PrivilegedSources: capabilities.PrivilegedSources{
-			HostNetworkSources: []string{},
-			HostPIDSources:     []string{},
-			HostIPCSources:     []string{},
-		},
-	})
+var allowPrivilegedCapabilities = capabilities.Capabilities{
+	AllowPrivileged: true,
+	PrivilegedSources: capabilities.PrivilegedSources{
+		HostNetworkSources: []string{},
+		HostPIDSources:     []string{},
+		HostIPCSources:     []string{},
+	},
 }
 
 func ValidateRollout(rollout *v1alpha1.Rollout) field.ErrorList {
@@ -190,6 +180,7 @@ func ValidateRolloutSpec(rollout *v1alpha1.Rollout, fldPath *field.Path) field.E
 
 		// Skip validating empty template for rollout resolved from ref
 		if rollout.Spec.TemplateResolvedFromRef || spec.WorkloadRef == nil {
+			capabilities.Initialize(allowPrivilegedCapabilities)
 			allErrs = append(allErrs, validation.ValidatePodTemplateSpecForReplicaSet(&template, selector, replicas, fldPath.Child("template"), allowAllPodValidationOptions)...)
 		}
 	}

--- a/pkg/apis/rollouts/validation/validation_test.go
+++ b/pkg/apis/rollouts/validation/validation_test.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -110,6 +111,36 @@ func TestValidateRollout(t *testing.T) {
 		}}
 		allErrs := ValidateRollout(ro)
 		assert.Empty(t, allErrs)
+	})
+
+	// Negative counterpart of the test above: a non-privileged container with
+	// Bidirectional mountPropagation must still be rejected, matching the
+	// kube-apiserver behaviour for Deployments. Guards against accidentally
+	// weakening the upstream cross-field rule.
+	t.Run("non-privileged container with bidirectional mount propagation is rejected", func(t *testing.T) {
+		ro := ro.DeepCopy()
+		bidirectional := corev1.MountPropagationBidirectional
+		ro.Spec.Template.Spec.Volumes = []corev1.Volume{{
+			Name: "a-dir-to-mount",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		}}
+		ro.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{{
+			Name:             "a-dir-to-mount",
+			MountPath:        "/tmp",
+			MountPropagation: &bidirectional,
+		}}
+		allErrs := ValidateRollout(ro)
+		assert.NotEmpty(t, allErrs)
+		found := false
+		for _, e := range allErrs {
+			if strings.Contains(e.Error(), "Bidirectional mount propagation") {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "expected Bidirectional mount propagation error, got: %v", allErrs)
 	})
 
 }

--- a/pkg/apis/rollouts/validation/validation_test.go
+++ b/pkg/apis/rollouts/validation/validation_test.go
@@ -88,6 +88,30 @@ func TestValidateRollout(t *testing.T) {
 		assert.Empty(t, allErrs)
 	})
 
+	// Regression test for https://github.com/argoproj/argo-rollouts/issues/3130:
+	// a privileged container with a Bidirectional mountPropagation must validate
+	// the same way it does in a Deployment.
+	t.Run("privileged container with bidirectional mount propagation", func(t *testing.T) {
+		ro := ro.DeepCopy()
+		bidirectional := corev1.MountPropagationBidirectional
+		ro.Spec.Template.Spec.Volumes = []corev1.Volume{{
+			Name: "a-dir-to-mount",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		}}
+		ro.Spec.Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
+			Privileged: ptr.To[bool](true),
+		}
+		ro.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{{
+			Name:             "a-dir-to-mount",
+			MountPath:        "/tmp",
+			MountPropagation: &bidirectional,
+		}}
+		allErrs := ValidateRollout(ro)
+		assert.Empty(t, allErrs)
+	})
+
 }
 
 func TestValidateRolloutStrategy(t *testing.T) {


### PR DESCRIPTION
## Summary

Rollouts whose pod template has a `securityContext.privileged: true` container with `mountPropagation: Bidirectional` were rejected by the rollout webhook with:

```
Forbidden: Bidirectional mount propagation is available only to privileged containers
```

even though the same pod template applied as a `Deployment` is accepted by `kube-apiserver`. Reported in #3130.

## Root cause

The webhook reuses the upstream Kubernetes pod-spec validator, which reads the process-wide `capabilities` singleton. By default `AllowPrivileged=false`, so any container with `privileged: true` would be rejected. To work around that without touching the global, #802 / 8332cee1 added `removeSecurityContextPrivileged`, which strips `Privileged: true` from every container *before* validation.

That mutation silently disabled every cross-field rule in the upstream validator that depends on the real `Privileged` value. The most visible casualty is the rule "`mountPropagation: Bidirectional` requires a privileged container": after the workaround zeros out `Privileged`, the validator sees a Bidirectional mount on a non-privileged container and rejects it. A `Deployment` with the same spec passes because `kube-apiserver` initializes the singleton with `AllowPrivileged=true` at startup.

## Fix

Initialize the `capabilities` singleton with `AllowPrivileged=true` in the validation package's `init()`, mirroring what `kube-apiserver` does. `capabilities.Initialize` uses `sync.Once` internally, so the controller, the `kubectl-argo-rollouts lint` CLI, the webhook and tests all converge on the same value safely. The `removeSecurityContextPrivileged` workaround is removed.

## Side effects (intentional)

Other privileged-dependent upstream rules (e.g. `procMount: Unmasked`, certain capability combinations) are now honestly evaluated by the rollout webhook, matching `Deployment` validation. Specs that the apiserver would have rejected later are now caught at the webhook instead of slipping through the rollout admission silently.

## Test plan

- New regression test `TestValidateRollout/privileged_container_with_bidirectional_mount_propagation` reproduces the exact YAML from #3130.
- `go test ./pkg/apis/rollouts/validation/...` passes.
- `go test ./...` passes.
- `make plugin && ./dist/kubectl-argo-rollouts lint -f ro-3130.yaml` exits 0 (no errors).

Closes #3130.

Checklist:

- [x] (b) this is a bug fix.
- [x] The title of the PR is conventional, states what changed, and suffixes the related issue number.
- [x] I've signed my commits with DCO.
- [x] My builds are green.
- [x] I have written unit tests for my change.
- [x] I have run all tests locally and they pass on my workstation.
- [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR.
- [x] I understand what the code does and WHY/HOW it works.
- [x] I know if my code is changing old functionality for existing users.
- [ ] My organization is added to USERS.md (N/A)
