### PR TITLE
ci: Bring Cherry pick functionality from Argo CD

### DIFF
--- a/.github/workflows/cherry-pick-single.yml
+++ b/.github/workflows/cherry-pick-single.yml
@@ -1,0 +1,134 @@
+name: Cherry Pick Single
+
+on:
+  workflow_call:
+    inputs:
+      merge_commit_sha:
+        required: true
+        type: string
+        description: "The merge commit SHA to cherry-pick"
+      version_number:
+        required: true
+        type: string
+        description: "The version number (from cherry-pick/ label)"
+      pr_number:
+        required: true
+        type: string
+        description: "The original PR number"
+      pr_title:
+        required: true
+        type: string
+        description: "The original PR title"
+    secrets:
+      CHERRYPICK_APP_ID:
+        required: true
+      CHERRYPICK_APP_PRIVATE_KEY:
+        required: true
+
+jobs:
+  cherry-pick:
+    name: Cherry Pick to ${{ inputs.version_number }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.CHERRYPICK_APP_ID }}
+          private-key: ${{ secrets.CHERRYPICK_APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+          # Explicitly check out the base repository's default branch. This
+          # workflow runs on pull_request_target but never executes fork code:
+          # it cherry-picks an already-merged commit onto a release branch.
+          # Pinning ref/repository to the base avoids checkout v7's fork-PR
+          # guard ("Refusing to check out fork pull request code...").
+          ref: master
+          repository: ${{ github.repository }}
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Cherry pick commit
+        id: cherry-pick
+        run: |
+          set -e
+
+          MERGE_COMMIT="${{ inputs.merge_commit_sha }}"
+          TARGET_BRANCH="release-${{ inputs.version_number }}"
+
+          echo "🍒 Cherry-picking commit $MERGE_COMMIT to branch $TARGET_BRANCH"
+
+          # Check if target branch exists
+          if ! git show-ref --verify --quiet "refs/remotes/origin/$TARGET_BRANCH"; then
+            echo "❌ Target branch '$TARGET_BRANCH' does not exist"
+            exit 1
+          fi
+
+          # Create new branch for cherry-pick
+          CHERRY_PICK_BRANCH="cherry-pick-${{ inputs.pr_number }}-to-${TARGET_BRANCH}"
+
+          git checkout -b "$CHERRY_PICK_BRANCH" "origin/$TARGET_BRANCH"
+
+          # Perform cherry-pick
+          if git cherry-pick -m 1 "$MERGE_COMMIT"; then
+            echo "✅ Cherry-pick successful"
+
+            # Extract Signed-off-by from the cherry-pick commit
+            SIGNOFF=$(git log -1 --pretty=format:"%B" | grep -E '^Signed-off-by:' || echo "")
+
+            # Push the new branch. Force push to ensure that in case the original cherry-pick branch is stale,
+            # that the current state of the $TARGET_BRANCH + cherry-pick gets in $CHERRY_PICK_BRANCH.
+            git push origin -f "$CHERRY_PICK_BRANCH"
+
+            # Save data for PR creation
+            echo "branch_name=$CHERRY_PICK_BRANCH" >> "$GITHUB_OUTPUT"
+            {
+              echo "signoff<<EOF"
+              echo "$SIGNOFF"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "target_branch=$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
+          else
+            echo "❌ Cherry-pick failed due to conflicts"
+            git cherry-pick --abort
+            exit 1
+          fi
+
+      - name: Create Pull Request
+        run: |
+          # Create cherry-pick PR
+          TITLE="${PR_TITLE} (cherry-pick #${{ inputs.pr_number }} for ${{ inputs.version_number }})"
+          BODY=$(cat <<EOF
+          Cherry-picked ${PR_TITLE} (#${{ inputs.pr_number }})
+
+          ${{ steps.cherry-pick.outputs.signoff }}
+          EOF
+          )
+
+          gh pr create \
+            --title "$TITLE" \
+            --body "$BODY" \
+            --base "${{ steps.cherry-pick.outputs.target_branch }}" \
+            --head "${{ steps.cherry-pick.outputs.branch_name }}"
+
+          # Comment on original PR
+          gh pr comment ${{ inputs.pr_number }} \
+            --body "🍒 Cherry-pick PR created for ${{ inputs.version_number }}: #$(gh pr list --head ${{ steps.cherry-pick.outputs.branch_name }} --json number --jq '.[0].number')"
+        env:
+          PR_TITLE: ${{ inputs.pr_title }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+      - name: Comment on failure
+        if: failure()
+        run: |
+          gh pr comment ${{ inputs.pr_number }} \
+            --body "❌ Cherry-pick failed for ${{ inputs.version_number }}. Please check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,0 +1,53 @@
+name: Cherry Pick
+
+on:
+  pull_request_target:
+    branches:
+      - master
+    types: ["labeled", "closed"]
+
+jobs:
+  find-labels:
+    name: Find Cherry Pick Labels
+    if: |
+      github.event.pull_request.merged == true && (
+        (github.event.action == 'labeled' && startsWith(github.event.label.name, 'cherry-pick/')) ||
+        (github.event.action == 'closed' && contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick/'))
+      )
+    runs-on: ubuntu-24.04
+    outputs:
+      labels: ${{ steps.extract-labels.outputs.labels }}
+    steps:
+      - name: Extract cherry-pick labels
+        id: extract-labels
+        run: |
+          if [[ "${{ github.event.action }}" == "labeled" ]]; then
+            # Label was just added - use it directly
+            LABEL_NAME="${{ github.event.label.name }}"
+            VERSION="${LABEL_NAME#cherry-pick/}"
+            CHERRY_PICK_DATA='[{"label":"'$LABEL_NAME'","version":"'$VERSION'"}]'
+          else
+            # PR was closed - find all cherry-pick labels
+            CHERRY_PICK_DATA=$(echo '${{ toJSON(github.event.pull_request.labels) }}' | jq -c '[.[] | select(.name | startswith("cherry-pick/")) | {label: .name, version: (.name | sub("cherry-pick/"; ""))}]')
+          fi
+
+          echo "labels=$CHERRY_PICK_DATA" >> "$GITHUB_OUTPUT"
+          echo "Found cherry-pick data: $CHERRY_PICK_DATA"
+
+  cherry-pick:
+    name: Cherry Pick
+    needs: find-labels
+    if: needs.find-labels.outputs.labels != '[]'
+    strategy:
+      matrix:
+        include: ${{ fromJSON(needs.find-labels.outputs.labels) }}
+      fail-fast: false
+    uses: ./.github/workflows/cherry-pick-single.yml
+    with:
+      merge_commit_sha: ${{ github.event.pull_request.merge_commit_sha }}
+      version_number: ${{ matrix.version }}
+      pr_number: ${{ github.event.pull_request.number }}
+      pr_title: ${{ github.event.pull_request.title }}
+    secrets:
+      CHERRYPICK_APP_ID: ${{ vars.CHERRYPICK_APP_ID }}
+      CHERRYPICK_APP_PRIVATE_KEY: ${{ secrets.CHERRYPICK_APP_PRIVATE_KEY }}

--- a/docs/backporting.md
+++ b/docs/backporting.md
@@ -1,0 +1,50 @@
+# Backporting Fixes
+
+After submitting your PR and getting it merged, you might want to backport it to previous releases.
+The prerequisites for backporting are:
+
+* Your PR is already merged into the `master` branch
+* The changes are a bugfix
+* The changes are non-breaking
+* The backports are to [actively supported releases](https://github.com/argoproj/argo-rollouts/security/policy#supported-versions)
+
+## Automated Process
+
+Adding a `cherry-pick/x.y` label to your PR (where `x.y` is the version you want to backport to e.g. `1.8`) will
+trigger the cherry pick workflow to open a PR against the targeted release branch. Anyone with
+[Argoproj membership](https://github.com/argoproj/argoproj/blob/main/community/membership.md) can add the label, but an
+Approver must merge the backport PR. If you cannot add the label yourself, ask the person who merged the PR to do it for
+you.
+
+## Manual Process
+
+Sometimes the automation fails, generally because the cherry-pick involves merge conflicts. In that case, you can
+manually create the backport PR. The process generally goes like this:
+
+```shell
+git checkout release-x.y
+git pull origin release-x.y
+git checkout -b backport-my-fix-to-x.y
+git cherry-pick <commit hash of your bugfix's squash commit in master>
+# Resolve any merge conflicts
+git commit
+git push <your fork> backport-my-fix-to-x.y
+# Open a PR against release-x.y
+```
+
+Then repeat for the other release branches you want to backport to. Sometimes it's easier to cherry-pick the commit with
+resolved conflicts from the release branch after you've resolved them for the first backport rather than repeatedly
+resolving the same conflicts from the master branch for each backport. For example, after doing the steps above, do:
+
+```shell
+git rev-parse HEAD
+# Note the commit hash
+git checkout release-x.<y-1>
+git pull origin release-x.<y-1>
+git checkout -b backport-my-fix-to-x.<y-1>
+git cherry-pick <commit hash from previous backport>
+# Resolve any merge conflicts
+git commit
+git push <your fork> backport-my-fix-to-x.<y-1>
+# Open a PR against release-x.<y-1>
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,6 +144,7 @@ nav:
   - Contribution Guide: CONTRIBUTING.md
   - Environment Setup: getting-started/setup/index.md
   - Releasing: releasing.md
+  - Backporting Fixes: backporting.md
   - Plugins: plugins.md
 - Releases ⧉: https://github.com/argoproj/argo-rollouts/releases
 - Roadmap ⧉: https://github.com/argoproj/argo-rollouts/milestones


### PR DESCRIPTION
Bring the Argo CD cherry-pick bot to Argo Rollouts

Like Argo CD this, this PR requires

The creation of a Github app in Argo Rollouts at https://github.com/settings/apps/new with

- Webhooks: uncheck "Active" 
- Permissions (Repository permissions):
  - Contents: Read and write (to push branches)
  - Pull requests: Read and write (to open PRs and comment)
- Everything else: leave as default

After that in the GitHub Web UI:

* var `CHERRYPICK_APP_ID` in https://github.com/argoproj/argo-rollouts/settings/variables/actions
* secret `CHERRYPICK_APP_PRIVATE_KEY` in https://github.com/kostis-codefresh/argo-rollouts/settings/secrets/actions

The first should contain the App ID number as created by the GitHub app
The second is the content of the PEM key file

I don't know whether the Argo CD app is generic enough to be reused by "adding" it to the Argo Rollout repo.

My local testing

Happy path scenario, clean merge 2 labels
PR : https://github.com/kostis-codefresh/argo-rollouts/pull/3
Runs: 
- https://github.com/kostis-codefresh/argo-rollouts/actions/runs/28176821641
- https://github.com/kostis-codefresh/argo-rollouts/actions/runs/28176820711
New PRs
- https://github.com/kostis-codefresh/argo-rollouts/pull/5
- https://github.com/kostis-codefresh/argo-rollouts/pull/6

Failed scenario, one label:

PR https://github.com/kostis-codefresh/argo-rollouts/pull/2
Run https://github.com/kostis-codefresh/argo-rollouts/actions/runs/28176918891
Comment: https://github.com/kostis-codefresh/argo-rollouts/pull/2#issuecomment-4800330307

Solves https://github.com/argoproj/argo-rollouts/issues/4791

Also added documentation page from Argo CD.
I removed the code for the harden runner as we don't use it in Argo Rollouts

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).