### PR TITLE
fix(controller): pass log format to plugin subprocess loggers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
+	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.7.0
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
 	github.com/juju/ansiterm v1.0.0
@@ -124,7 +125,6 @@ require (
 	github.com/gregdel/pushover v1.3.1 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect

--- a/metricproviders/plugin/client/client.go
+++ b/metricproviders/plugin/client/client.go
@@ -34,6 +34,9 @@ var pluginMap = map[string]goPlugin.Plugin{
 	"RpcMetricProviderPlugin": &rpc.RpcMetricProviderPlugin{},
 }
 
+// getPluginInfo is a package-level function variable to allow test overrides.
+var getPluginInfo = plugin.GetPluginInfo
+
 // GetMetricPlugin returns a singleton plugin client for the given metric plugin. Calling this multiple times
 // returns the same plugin client instance for the plugin name defined in the metric.
 func GetMetricPlugin(metric v1alpha1.Metric) (rpc.MetricProviderPlugin, error) {
@@ -57,7 +60,7 @@ func (m *metricPlugin) startPluginSystem(metric v1alpha1.Metric) (rpc.MetricProv
 	// There should only ever be one plugin defined in metric.Provider.Plugin per analysis template this gets checked
 	// during validation
 	for pluginName := range metric.Provider.Plugin {
-		pluginPath, args, err := plugin.GetPluginInfo(pluginName, types.PluginTypeMetricProvider)
+		pluginPath, args, err := getPluginInfo(pluginName, types.PluginTypeMetricProvider)
 		if err != nil {
 			return nil, fmt.Errorf("unable to find plugin (%s): %w", pluginName, err)
 		}

--- a/metricproviders/plugin/client/client.go
+++ b/metricproviders/plugin/client/client.go
@@ -37,6 +37,9 @@ var pluginMap = map[string]goPlugin.Plugin{
 // getPluginInfo is a package-level function variable to allow test overrides.
 var getPluginInfo = plugin.GetPluginInfo
 
+// newClient is a package-level function variable to allow test overrides.
+var newClient = goPlugin.NewClient
+
 // GetMetricPlugin returns a singleton plugin client for the given metric plugin. Calling this multiple times
 // returns the same plugin client instance for the plugin name defined in the metric.
 func GetMetricPlugin(metric v1alpha1.Metric) (rpc.MetricProviderPlugin, error) {
@@ -67,7 +70,7 @@ func (m *metricPlugin) startPluginSystem(metric v1alpha1.Metric) (rpc.MetricProv
 
 		if m.pluginClient[pluginName] == nil || m.pluginClient[pluginName].Exited() {
 
-			m.pluginClient[pluginName] = goPlugin.NewClient(&goPlugin.ClientConfig{
+			m.pluginClient[pluginName] = newClient(&goPlugin.ClientConfig{
 				HandshakeConfig: handshakeConfig,
 				Plugins:         pluginMap,
 				Cmd:             exec.Command(pluginPath, args...),

--- a/metricproviders/plugin/client/client.go
+++ b/metricproviders/plugin/client/client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/argoproj/argo-rollouts/metricproviders/plugin/rpc"
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	logutil "github.com/argoproj/argo-rollouts/utils/log"
 	"github.com/argoproj/argo-rollouts/utils/plugin"
 	"github.com/argoproj/argo-rollouts/utils/plugin/types"
 )
@@ -68,6 +69,7 @@ func (m *metricPlugin) startPluginSystem(metric v1alpha1.Metric) (rpc.MetricProv
 				Plugins:         pluginMap,
 				Cmd:             exec.Command(pluginPath, args...),
 				Managed:         true,
+				Logger:          logutil.NewPluginLogger(pluginName),
 			})
 
 			rpcClient, err := m.pluginClient[pluginName].Client()

--- a/metricproviders/plugin/client/client_test.go
+++ b/metricproviders/plugin/client/client_test.go
@@ -3,9 +3,11 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"os/exec"
 	"sync"
 	"testing"
 
+	goPlugin "github.com/hashicorp/go-plugin"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
@@ -17,12 +19,30 @@ func resetMetricSingleton() {
 	pluginClients = nil
 }
 
-func overrideMetricGetPluginInfo(err error) func() {
+func overrideMetricGetPluginInfo(path string, err error) func() {
 	orig := getPluginInfo
 	getPluginInfo = func(pluginName string, pluginType types.PluginType) (string, []string, error) {
-		return "", nil, err
+		return path, nil, err
 	}
 	return func() { getPluginInfo = orig }
+}
+
+func overrideMetricNewClient(c *goPlugin.Client) func() {
+	orig := newClient
+	newClient = func(config *goPlugin.ClientConfig) *goPlugin.Client {
+		return c
+	}
+	return func() { newClient = orig }
+}
+
+func metricWith(pluginName string) v1alpha1.Metric {
+	return v1alpha1.Metric{
+		Provider: v1alpha1.MetricProvider{
+			Plugin: map[string]json.RawMessage{
+				pluginName: json.RawMessage(`{}`),
+			},
+		},
+	}
 }
 
 func TestGetMetricPlugin_NoPlugin(t *testing.T) {
@@ -43,19 +63,31 @@ func TestGetMetricPlugin_NoPlugin(t *testing.T) {
 
 func TestGetMetricPlugin_GetPluginInfoError(t *testing.T) {
 	resetMetricSingleton()
-	defer overrideMetricGetPluginInfo(fmt.Errorf("plugin not found"))()
+	defer overrideMetricGetPluginInfo("", fmt.Errorf("plugin not found"))()
 
-	metric := v1alpha1.Metric{
-		Provider: v1alpha1.MetricProvider{
-			Plugin: map[string]json.RawMessage{
-				"test-plugin": json.RawMessage(`{}`),
-			},
-		},
-	}
-
-	result, err := GetMetricPlugin(metric)
+	result, err := GetMetricPlugin(metricWith("test-plugin"))
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "unable to start plugin system")
+}
+
+func TestGetMetricPlugin_NewClientCalled(t *testing.T) {
+	resetMetricSingleton()
+	defer overrideMetricGetPluginInfo("/nonexistent/binary", nil)()
+
+	// Use a real goPlugin.Client pointing to a nonexistent binary — Client() will fail,
+	// but this covers the NewClient call and Logger assignment.
+	realClient := goPlugin.NewClient(&goPlugin.ClientConfig{
+		HandshakeConfig: handshakeConfig,
+		Plugins:         pluginMap,
+		Cmd:             exec.Command("/nonexistent/binary"),
+	})
+	defer realClient.Kill()
+	defer overrideMetricNewClient(realClient)()
+
+	result, err := GetMetricPlugin(metricWith("test-plugin"))
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
 }

--- a/metricproviders/plugin/client/client_test.go
+++ b/metricproviders/plugin/client/client_test.go
@@ -1,0 +1,61 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/argoproj/argo-rollouts/utils/plugin/types"
+)
+
+func resetMetricSingleton() {
+	once = sync.Once{}
+	pluginClients = nil
+}
+
+func overrideMetricGetPluginInfo(err error) func() {
+	orig := getPluginInfo
+	getPluginInfo = func(pluginName string, pluginType types.PluginType) (string, []string, error) {
+		return "", nil, err
+	}
+	return func() { getPluginInfo = orig }
+}
+
+func TestGetMetricPlugin_NoPlugin(t *testing.T) {
+	resetMetricSingleton()
+
+	metric := v1alpha1.Metric{
+		Provider: v1alpha1.MetricProvider{
+			Plugin: map[string]json.RawMessage{},
+		},
+	}
+
+	result, err := GetMetricPlugin(metric)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "no plugin found")
+}
+
+func TestGetMetricPlugin_GetPluginInfoError(t *testing.T) {
+	resetMetricSingleton()
+	defer overrideMetricGetPluginInfo(fmt.Errorf("plugin not found"))()
+
+	metric := v1alpha1.Metric{
+		Provider: v1alpha1.MetricProvider{
+			Plugin: map[string]json.RawMessage{
+				"test-plugin": json.RawMessage(`{}`),
+			},
+		},
+	}
+
+	result, err := GetMetricPlugin(metric)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "unable to start plugin system")
+}

--- a/rollout/steps/plugin/client/client.go
+++ b/rollout/steps/plugin/client/client.go
@@ -36,6 +36,9 @@ var pluginMap = map[string]goPlugin.Plugin{
 // getPluginInfo is a package-level function variable to allow test overrides.
 var getPluginInfo = plugin.GetPluginInfo
 
+// newClient is a package-level function variable to allow test overrides.
+var newClient = goPlugin.NewClient
+
 // GetPlugin returns a singleton plugin client for the given plugin. Calling this multiple times
 // returns the same plugin client instance for the plugin name defined in the rollout object.
 func GetPlugin(pluginName string) (rpc.StepPlugin, error) {
@@ -63,7 +66,7 @@ func (t *stepPlugin) startPlugin(pluginName string) (rpc.StepPlugin, error) {
 			return nil, fmt.Errorf("unable to find plugin (%s): %w", pluginName, err)
 		}
 
-		t.client[pluginName] = goPlugin.NewClient(&goPlugin.ClientConfig{
+		t.client[pluginName] = newClient(&goPlugin.ClientConfig{
 			HandshakeConfig: handshakeConfig,
 			Plugins:         pluginMap,
 			Cmd:             exec.Command(pluginPath, args...),

--- a/rollout/steps/plugin/client/client.go
+++ b/rollout/steps/plugin/client/client.go
@@ -33,6 +33,9 @@ var pluginMap = map[string]goPlugin.Plugin{
 	"RpcStepPlugin": &rpc.RpcStepPlugin{},
 }
 
+// getPluginInfo is a package-level function variable to allow test overrides.
+var getPluginInfo = plugin.GetPluginInfo
+
 // GetPlugin returns a singleton plugin client for the given plugin. Calling this multiple times
 // returns the same plugin client instance for the plugin name defined in the rollout object.
 func GetPlugin(pluginName string) (rpc.StepPlugin, error) {
@@ -55,7 +58,7 @@ func (t *stepPlugin) startPlugin(pluginName string) (rpc.StepPlugin, error) {
 
 	if t.client[pluginName] == nil || t.client[pluginName].Exited() {
 
-		pluginPath, args, err := plugin.GetPluginInfo(pluginName, types.PluginTypeStep)
+		pluginPath, args, err := getPluginInfo(pluginName, types.PluginTypeStep)
 		if err != nil {
 			return nil, fmt.Errorf("unable to find plugin (%s): %w", pluginName, err)
 		}

--- a/rollout/steps/plugin/client/client.go
+++ b/rollout/steps/plugin/client/client.go
@@ -8,6 +8,7 @@ import (
 	goPlugin "github.com/hashicorp/go-plugin"
 
 	"github.com/argoproj/argo-rollouts/rollout/steps/plugin/rpc"
+	logutil "github.com/argoproj/argo-rollouts/utils/log"
 	"github.com/argoproj/argo-rollouts/utils/plugin"
 	"github.com/argoproj/argo-rollouts/utils/plugin/types"
 )
@@ -64,6 +65,7 @@ func (t *stepPlugin) startPlugin(pluginName string) (rpc.StepPlugin, error) {
 			Plugins:         pluginMap,
 			Cmd:             exec.Command(pluginPath, args...),
 			Managed:         true,
+			Logger:          logutil.NewPluginLogger(pluginName),
 		})
 
 		rpcClient, err := t.client[pluginName].Client()

--- a/rollout/steps/plugin/client/client_test.go
+++ b/rollout/steps/plugin/client/client_test.go
@@ -1,0 +1,45 @@
+package client
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/argoproj/argo-rollouts/utils/plugin/types"
+)
+
+func resetStepSingleton() {
+	once = sync.Once{}
+	pluginClients = nil
+}
+
+func overrideStepGetPluginInfo(err error) func() {
+	orig := getPluginInfo
+	getPluginInfo = func(pluginName string, pluginType types.PluginType) (string, []string, error) {
+		return "", nil, err
+	}
+	return func() { getPluginInfo = orig }
+}
+
+func TestGetPlugin_NotConfigured(t *testing.T) {
+	resetStepSingleton()
+
+	result, err := GetPlugin("nonexistent-plugin")
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "unable to start plugin system")
+}
+
+func TestGetPlugin_GetPluginInfoError(t *testing.T) {
+	resetStepSingleton()
+	defer overrideStepGetPluginInfo(fmt.Errorf("plugin not found"))()
+
+	result, err := GetPlugin("test-plugin")
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "unable to start plugin system")
+}

--- a/rollout/steps/plugin/client/client_test.go
+++ b/rollout/steps/plugin/client/client_test.go
@@ -2,9 +2,11 @@ package client
 
 import (
 	"fmt"
+	"os/exec"
 	"sync"
 	"testing"
 
+	goPlugin "github.com/hashicorp/go-plugin"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/argoproj/argo-rollouts/utils/plugin/types"
@@ -15,12 +17,20 @@ func resetStepSingleton() {
 	pluginClients = nil
 }
 
-func overrideStepGetPluginInfo(err error) func() {
+func overrideStepGetPluginInfo(path string, err error) func() {
 	orig := getPluginInfo
 	getPluginInfo = func(pluginName string, pluginType types.PluginType) (string, []string, error) {
-		return "", nil, err
+		return path, nil, err
 	}
 	return func() { getPluginInfo = orig }
+}
+
+func overrideStepNewClient(c *goPlugin.Client) func() {
+	orig := newClient
+	newClient = func(config *goPlugin.ClientConfig) *goPlugin.Client {
+		return c
+	}
+	return func() { newClient = orig }
 }
 
 func TestGetPlugin_NotConfigured(t *testing.T) {
@@ -35,11 +45,31 @@ func TestGetPlugin_NotConfigured(t *testing.T) {
 
 func TestGetPlugin_GetPluginInfoError(t *testing.T) {
 	resetStepSingleton()
-	defer overrideStepGetPluginInfo(fmt.Errorf("plugin not found"))()
+	defer overrideStepGetPluginInfo("", fmt.Errorf("plugin not found"))()
 
 	result, err := GetPlugin("test-plugin")
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "unable to start plugin system")
+}
+
+func TestGetPlugin_NewClientCalled(t *testing.T) {
+	resetStepSingleton()
+	defer overrideStepGetPluginInfo("/nonexistent/binary", nil)()
+
+	// Use a real goPlugin.Client pointing to a nonexistent binary — Client() will fail,
+	// but this covers the NewClient call and Logger assignment.
+	realClient := goPlugin.NewClient(&goPlugin.ClientConfig{
+		HandshakeConfig: handshakeConfig,
+		Plugins:         pluginMap,
+		Cmd:             exec.Command("/nonexistent/binary"),
+	})
+	defer realClient.Kill()
+	defer overrideStepNewClient(realClient)()
+
+	result, err := GetPlugin("test-plugin")
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
 }

--- a/rollout/trafficrouting/plugin/client/client.go
+++ b/rollout/trafficrouting/plugin/client/client.go
@@ -8,6 +8,7 @@ import (
 	goPlugin "github.com/hashicorp/go-plugin"
 
 	"github.com/argoproj/argo-rollouts/rollout/trafficrouting/plugin/rpc"
+	logutil "github.com/argoproj/argo-rollouts/utils/log"
 	"github.com/argoproj/argo-rollouts/utils/plugin"
 	"github.com/argoproj/argo-rollouts/utils/plugin/types"
 )
@@ -77,6 +78,7 @@ func (t *trafficPlugin) startPluginLocked(pluginName string) (rpc.TrafficRouterP
 			Plugins:         pluginMap,
 			Cmd:             exec.Command(pluginPath, args...),
 			Managed:         true,
+			Logger:          logutil.NewPluginLogger(pluginName),
 		})
 
 		rpcClient, err := t.pluginClient[pluginName].Client()

--- a/utils/log/log.go
+++ b/utils/log/log.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/bombsimon/logrusr/v4"
-
+	hclog "github.com/hashicorp/go-hclog"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -124,5 +124,19 @@ func WithVersionFields(entry *log.Entry, r *v1alpha1.Rollout) *log.Entry {
 	return entry.WithFields(map[string]any{
 		"resourceVersion": r.ResourceVersion,
 		"generation":      r.Generation,
+	})
+}
+
+// NewPluginLogger creates an hclog.Logger for use with go-plugin's ClientConfig.Logger.
+// It mirrors the log format of the controller: JSON when the controller runs with
+// --logformat=json, plain text otherwise. Without this, go-plugin spawns its own
+// default logger and plugin subprocess logs always render as plain text regardless
+// of the controller's log format setting.
+func NewPluginLogger(pluginName string) hclog.Logger {
+	_, jsonFormat := log.StandardLogger().Formatter.(*log.JSONFormatter)
+	return hclog.New(&hclog.LoggerOptions{
+		Name:       pluginName,
+		Level:      hclog.Trace,
+		JSONFormat: jsonFormat,
 	})
 }

--- a/utils/log/log_test.go
+++ b/utils/log/log_test.go
@@ -9,10 +9,10 @@ import (
 	hclog "github.com/hashicorp/go-hclog"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/klog/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 )

--- a/utils/log/log_test.go
+++ b/utils/log/log_test.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/klog/v2"
-
+	hclog "github.com/hashicorp/go-hclog"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/klog/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -294,6 +294,27 @@ func TestWithVersionFields(t *testing.T) {
 	logMessage := buf.String()
 	assert.True(t, strings.Contains(logMessage, "generation=2"))
 	assert.True(t, strings.Contains(logMessage, "resourceVersion=123"))
+}
+
+func TestNewPluginLogger_TextFormat(t *testing.T) {
+	log.SetFormatter(&log.TextFormatter{})
+
+	logger := NewPluginLogger("my-plugin")
+
+	assert.NotNil(t, logger)
+	assert.Implements(t, (*hclog.Logger)(nil), logger)
+	assert.Equal(t, "my-plugin", logger.Name())
+}
+
+func TestNewPluginLogger_JSONFormat(t *testing.T) {
+	log.SetFormatter(&log.JSONFormatter{})
+	defer log.SetFormatter(&log.TextFormatter{})
+
+	logger := NewPluginLogger("my-plugin")
+
+	assert.NotNil(t, logger)
+	assert.Implements(t, (*hclog.Logger)(nil), logger)
+	assert.Equal(t, "my-plugin", logger.Name())
 }
 
 func TestKLogLogger(t *testing.T) {


### PR DESCRIPTION
## What this fixes

When the controller runs with `--logformat=json`, its own logs come out as JSON — but plugin subprocess logs (traffic router, step, metric provider) always came out as plain text. This made structured log ingestion painful: JSON and text lines mixed in the same stream.

The root cause is in how go-plugin works: it reads plugin stderr and re-emits lines through its own internal hclog logger. When no `Logger` is passed in `ClientConfig`, go-plugin creates a default one with `JSONFormat: false`. The controller's `--logformat` flag had no effect on this path at all.

This was discovered while implementing `--logformat` support in the [Gateway API traffic router plugin](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/pull/214). The plugin was updated to write structured logs using hclog's native format (`@level`, `@message`, `@timestamp`), but the output was still rendered as plain text by the controller side. Investigation showed the fix had to be here, in the controller.

## What changed

Added `NewPluginLogger()` to `utils/log` — it creates an hclog logger that mirrors the controller's log format by inspecting the global logrus formatter. Wired it into all three plugin clients:

- `rollout/trafficrouting/plugin/client/client.go`
- `rollout/steps/plugin/client/client.go`
- `metricproviders/plugin/client/client.go`

## Behavior

| Scenario | Before | After |
|---|---|---|
| `--logformat=json` | plugin logs: plain text | plugin logs: JSON |
| default (no flag) | plugin logs: plain text | plugin logs: plain text |

No change in default behavior. All existing plugin integrations unaffected.

## Related

- argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi#214 — the plugin-side PR that triggered this investigation

## Checklist

* [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is conventional with a list of types and scopes found here, states what changed, and suffixes the related issues number.
* [x] I've signed my commits with DCO
* [x] My builds are green. Try syncing with master if they are not.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users