### PR TITLE
ci: skip checks for documentation PR

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,15 +4,9 @@ on:
     branches:
       - 'master'
       - 'release-*'
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
   pull_request:
     branches:
       - 'master'
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
 env:
   # Golang version to use across CI steps
   GOLANG_VERSION: '1.26'
@@ -25,11 +19,28 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend_any_changed }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        id: filter
+        with:
+          files_yaml: |
+            backend:
+              - '!**.md'
+              - '!docs/**'
+              - '!examples/**'
+
   lint-go:
     permissions:
       contents: read # for actions/checkout to fetch code
       pull-requests: read # for golangci/golangci-lint-action to fetch pull requests
     name: Lint Go code
+    needs: [changes]
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
@@ -45,6 +56,8 @@ jobs:
           args: --timeout 6m
   build:
     name: Build
+    needs: [changes]
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
@@ -79,6 +92,8 @@ jobs:
 
   codegen:
     name: Verify Codegen
+    needs: [changes]
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     env:
       GOPATH: /home/runner/go

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -5,16 +5,10 @@ on:
     branches:
       - 'master'
       - 'release-*'
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/*'
   pull_request:
     branches:
       - 'master'
       - 'release-*'
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
   workflow_dispatch:
 
 env:
@@ -29,6 +23,21 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend_any_changed }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        id: filter
+        with:
+          files_yaml: |
+            backend:
+              - '!**.md'
+              - '!docs/**'
+              - '!examples/**'
+
   event_file:
     name: 'Event File'
     runs-on: ubuntu-latest
@@ -40,6 +49,8 @@ jobs:
           path: ${{ github.event_path }}
   test-unit:
     name: Run unit tests
+    needs: [changes]
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
@@ -81,6 +92,8 @@ jobs:
           path: coverage-output-unit
 
   test-e2e:
+    needs: [changes]
+    if: needs.changes.outputs.backend == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -169,8 +182,10 @@ jobs:
     name: Process Coverage Files
     runs-on: ubuntu-latest
     needs:
+      - changes
       - test-unit
       - test-e2e
+    if: needs.changes.outputs.backend == 'true'
     steps:
       - name: Set up Go
         uses: actions/setup-go@v6.2.0


### PR DESCRIPTION
Work for marking CI checks as "skipped" for documentation only PRs

Taken from Argo CD 

Local testing results

1) PR with docs only everything skipped https://github.com/kostis-codefresh/argo-rollouts/pull/8
2) Normal PR, checks still run https://github.com/kostis-codefresh/argo-rollouts/pull/9

Partial solution for https://github.com/argoproj/argo-rollouts/issues/4803

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).