### PR TITLE
ci: pin k3s version to avoid breakage of e2e tests (#4644)

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -75,15 +75,19 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes:
-          - version: '1.31'
-            latest: false
           - version: '1.32'
+            k3s_version: '1.32.12+k3s1'
             latest: false
           - version: '1.33'
+            k3s_version: '1.33.8+k3s1'
             latest: false
           - version: '1.34'
+            k3s_version: '1.34.4+k3s1'
+            latest: false
+          - version: '1.35'
+            k3s_version: '1.35.1+k3s1'
             latest: true
-    name: Run end-to-end tests
+    name: Run end-to-end tests (${{ matrix.kubernetes.version }}, ${{ matrix.kubernetes.latest }})
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
@@ -93,7 +97,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Setup k3s
         env:
-          INSTALL_K3S_CHANNEL: v${{ matrix.kubernetes.version }}
+          INSTALL_K3S_VERSION: v${{ matrix.kubernetes.k3s_version }}
         run: |
           curl -sfL https://get.k3s.io | sh -
           sudo mkdir ~/.kube

--- a/test/e2e/functional/analysistemplate-web-background-inconclusive.yaml
+++ b/test/e2e/functional/analysistemplate-web-background-inconclusive.yaml
@@ -1,4 +1,6 @@
-# A web metric which uses the httpbin service as a metric provider
+# A web metric which uses Google Public DNS-over-HTTPS API (returns JSON)
+# The conditions check for values that won't match the actual response,
+# causing measurements to be inconclusive (neither success nor failure)
 apiVersion: argoproj.io/v1alpha1
 kind: AnalysisTemplate
 metadata:
@@ -6,17 +8,13 @@ metadata:
 spec:
   args:
     - name: url-val
-      value: "https://httpbin.org/anything"
+      value: "https://dns.google/resolve?name=google.com"
   metrics:
     - name: web
-      interval: 7s
+      interval: 5s
       inconclusiveLimit: 3
-      successCondition: result.json.status == "success"
-      failureCondition: result.json.status == "failure"
+      successCondition: result.Status == 999
+      failureCondition: result.Status == -1
       provider:
         web:
           url: "{{args.url-val}}"
-          method: POST
-          jsonBody:
-            status: "inconclusive"
-          jsonPath: "{$}"


### PR DESCRIPTION
* ci: pin k3s version to avoid breakage of e2e tests
* ci: pin k3s version to avoid breakage of e2e tests
* ci: keep the same name of matrix jobs

Cherry pick k3s pinning to release 
Also cherry-pick the removal of httpbin.org

---------

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [ ] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [ ] I understand what the code does and WHY/HOW it works in several scenarios
* [ ] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).