### PR TITLE
fix: uprade pnpm for sbom

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -205,29 +205,31 @@ jobs:
           SPDX_GEN_VERSION: v0.0.13
           # defines the sigs.k8s.io/bom version to use.
           SIGS_BOM_VERSION: v0.2.1
-          # comma delimited list of project relative folders to inspect for package
-          # managers (gomod, pnpm, npm).
-          PROJECT_FOLDERS: '.,./ui'
           # full qualified name of the container image to be inspected
           CONTAINER_IMAGE: quay.io/${{ needs.set-registry-namespace.outputs.registry_namespace }}/argo-rollouts:${{ github.ref_name }}
 
         run: |
+          set -euo pipefail
           pnpm install --dir ./ui --frozen-lockfile
           go install github.com/spdx/spdx-sbom-generator/cmd/generator@$SPDX_GEN_VERSION
           go install sigs.k8s.io/bom/cmd/bom@$SIGS_BOM_VERSION
 
-          # Generate SPDX for project dependencies analyzing package managers
-          for folder in $(echo $PROJECT_FOLDERS | sed "s/,/ /g")
-          do
-            generator -p $folder -o /tmp
-          done
+          generator -p . -o /tmp
+          pnpm --dir ./ui sbom --sbom-format spdx --prod > /tmp/bom-ui-pnpm.spdx.json
 
-          # Generate SPDX for binaries analyzing the container image
-          if [[ ! -z CONTAINER_IMAGE ]]; then
-            bom generate -o /tmp/bom-docker-image.spdx -i $CONTAINER_IMAGE
+          if [[ -n "${CONTAINER_IMAGE:-}" ]]; then
+            bom generate -o /tmp/bom-docker-image.spdx -i "${CONTAINER_IMAGE}"
           fi
 
-          cd /tmp && tar -zcf sbom.tar.gz *.spdx
+          cd /tmp
+          shopt -s nullglob
+          spdx_files=( *.spdx )
+          shopt -u nullglob
+          if [[ ${#spdx_files[@]} -eq 0 ]]; then
+            echo "No .spdx files produced under /tmp"
+            exit 1
+          fi
+          tar -zcf sbom.tar.gz "${spdx_files[@]}" bom-ui-pnpm.spdx.json
 
       - name: Sign SBOM
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,11 @@ RUN cd ${GOPATH}/src/dummy && \
 ####################################################################################################
 # UI build stage
 ####################################################################################################
-FROM --platform=$BUILDPLATFORM docker.io/library/node:18 AS argo-rollouts-ui
+FROM --platform=$BUILDPLATFORM docker.io/library/node:22 AS argo-rollouts-ui
 
 WORKDIR /src
-RUN corepack enable
-ADD ["ui/package.json", "ui/pnpm-lock.yaml", "./"]
+RUN npm install -g corepack@0.34.6 && corepack enable
+ADD ["ui/package.json", "ui/pnpm-lock.yaml", "ui/pnpm-workspace.yaml", "./"]
 
 RUN pnpm install --frozen-lockfile
 

--- a/docs/security/signed-release-assets.md
+++ b/docs/security/signed-release-assets.md
@@ -99,6 +99,14 @@ slsa-verifier verify-artifact kubectl-argo-rollouts-linux-amd64 --provenance-pat
 ```
 ## Verification of Sbom
 
+`sbom.tar.gz` contains:
+
+| File | Description |
+|------|-------------|
+| `bom-go-mod.spdx` | Go module dependencies (tag-value SPDX from `spdx-sbom-generator`) |
+| `bom-ui-pnpm.spdx.json` | UI dependencies (SPDX 2.3 JSON from `pnpm sbom`) |
+| `bom-docker-image.spdx` | Published release container image (tag-value SPDX from `sigs.k8s.io/bom`) |
+
 ```bash
 cosign verify-blob --signature sbom.tar.gz.sig --certificate sbom.tar.gz.pem \
 --certificate-identity-regexp ^https://github.com/argoproj/argo-rollouts/.github/workflows/release.yaml@refs/tags/v \

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
     "name": "ui",
     "version": "0.1.0",
     "private": true,
-    "packageManager": "pnpm@10.28.1",
+    "packageManager": "pnpm@11.9.0",
     "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.4.0",
         "@fortawesome/free-regular-svg-icons": "^6.4.0",
@@ -92,15 +92,5 @@
         "webpack-dev-server": "^4.7.4",
         "webpack": "^5.105.4",
         "webpack-merge": "^5.7.3"   
-    },
-    "pnpm": {
-        "overrides": {
-            "@types/react": "16.9.3",
-            "moment": "2.29.4",
-            "@types/react-dom": "^16.8.2",
-            "normalize-url": "4.5.1",
-            "rxjs": "6.6.7",
-            "formidable": "2.1.2"
-        }
     }
 }

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -2386,7 +2386,7 @@ packages:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
   argo-ui@https://codeload.github.com/argoproj/argo-ui/tar.gz/5ff344ac9692c14dd108468bd3c020c3c75181cb:
-    resolution: {tarball: https://codeload.github.com/argoproj/argo-ui/tar.gz/5ff344ac9692c14dd108468bd3c020c3c75181cb}
+    resolution: {gitHosted: true, integrity: sha512-466pbRJUzhrrnPrnccKDcYKNE0ZCz3IHlNGwoAOk5aze0Krd0FIvUp6B2rOA8n+4aGkX/22UvZ+BKSFhpHkYqg==, tarball: https://codeload.github.com/argoproj/argo-ui/tar.gz/5ff344ac9692c14dd108468bd3c020c3c75181cb}
     version: 1.0.0
     peerDependencies:
       '@types/react': 16.9.3
@@ -2929,10 +2929,6 @@ packages:
 
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
-
-  core-js-pure@3.12.1:
-    resolution: {integrity: sha512-1cch+qads4JnDSWsvc7d6nzlKAippwjUlf6vykkTLW53VSV+NkE6muGBToAjEA8pG90cSfcud3JgVmW2ds5TaQ==}
-    deprecated: core-js-pure@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js-pure.
 
   core-js-pure@3.49.0:
     resolution: {integrity: sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==}
@@ -4134,10 +4130,6 @@ packages:
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
-    engines: {node: '>=0.10.0'}
-
-  iconv-lite@0.6.2:
-    resolution: {integrity: sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==}
     engines: {node: '>=0.10.0'}
 
   iconv-lite@0.6.3:
@@ -6407,6 +6399,7 @@ packages:
   recharts@2.9.0:
     resolution: {integrity: sha512-cVgiAU3W5UrA8nRRV/N0JrudgZzY/vjkzrlShbH+EFo1vs4nMlXgshZWLI0DfDLmn4/p4pF7Lq7F5PU+K94Ipg==}
     engines: {node: '>=12'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       prop-types: ^15.6.0
       react: ^16.0.0 || ^17.0.0 || ^18.0.0
@@ -7859,15 +7852,15 @@ snapshots:
       '@ampproject/remapping': 2.2.1
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
-      '@babel/helper-compilation-targets': 7.22.15
-      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.3)
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.23.3)
       '@babel/helpers': 7.23.4
       '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       convert-source-map: 2.0.0
-      debug: 4.3.1
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -8315,17 +8308,17 @@ snapshots:
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.23.3)':
     dependencies:
       '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.23.3)':
     dependencies:
       '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.23.3)':
     dependencies:
       '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-class-static-block@7.12.13(@babel/core@7.23.3)':
     dependencies:
@@ -8365,12 +8358,12 @@ snapshots:
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.23.3)':
     dependencies:
       '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.23.3)':
     dependencies:
       '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-jsx@7.23.3(@babel/core@7.23.3)':
     dependencies:
@@ -8385,32 +8378,32 @@ snapshots:
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.23.3)':
     dependencies:
       '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.23.3)':
     dependencies:
       '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.23.3)':
     dependencies:
       '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.23.3)':
     dependencies:
       '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.23.3)':
     dependencies:
       '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.23.3)':
     dependencies:
       '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.23.3)':
     dependencies:
@@ -8420,7 +8413,7 @@ snapshots:
   '@babel/plugin-syntax-top-level-await@7.12.13(@babel/core@7.23.3)':
     dependencies:
       '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-typescript@7.23.3(@babel/core@7.23.3)':
     dependencies:
@@ -9257,7 +9250,7 @@ snapshots:
 
   '@babel/runtime-corejs3@7.14.0':
     dependencies:
-      core-js-pure: 3.12.1
+      core-js-pure: 3.49.0
       regenerator-runtime: 0.13.11
 
   '@babel/runtime@7.23.5':
@@ -9278,7 +9271,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.3.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -9746,7 +9739,7 @@ snapshots:
       jest-haste-map: 29.7.0
       jest-regex-util: 29.6.3
       jest-util: 29.7.0
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       pirates: 4.0.6
       slash: 3.0.0
       write-file-atomic: 4.0.2
@@ -10901,7 +10894,7 @@ snapshots:
 
   babel-plugin-istanbul@6.1.1:
     dependencies:
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.28.6
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 5.2.1
@@ -10927,7 +10920,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.23.5
       cosmiconfig: 7.0.0
-      resolve: 1.22.8
+      resolve: 1.22.12
 
   babel-plugin-named-asset-import@0.3.8(@babel/core@7.23.3):
     dependencies:
@@ -11392,8 +11385,6 @@ snapshots:
   core-js-compat@3.49.0:
     dependencies:
       browserslist: 4.28.2
-
-  core-js-pure@3.12.1: {}
 
   core-js-pure@3.49.0: {}
 
@@ -11864,7 +11855,7 @@ snapshots:
 
   encoding@0.1.13:
     dependencies:
-      iconv-lite: 0.6.2
+      iconv-lite: 0.6.3
 
   enhanced-resolve@4.5.0:
     dependencies:
@@ -12275,7 +12266,7 @@ snapshots:
 
   esrecurse@4.3.0:
     dependencies:
-      estraverse: 5.2.0
+      estraverse: 5.3.0
 
   estraverse@4.3.0: {}
 
@@ -12823,10 +12814,6 @@ snapshots:
   human-signals@2.1.0: {}
 
   iconv-lite@0.4.24:
-    dependencies:
-      safer-buffer: 2.1.2
-
-  iconv-lite@0.6.2:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -13424,7 +13411,7 @@ snapshots:
       jest-regex-util: 29.6.3
       jest-util: 29.7.0
       jest-worker: 29.7.0
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
@@ -16619,7 +16606,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 7.1.7
-      minimatch: 3.0.4
+      minimatch: 3.1.5
 
   text-table@0.2.0: {}
 

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -1,0 +1,15 @@
+allowBuilds:
+  '@fortawesome/fontawesome-common-types': true
+  '@fortawesome/fontawesome-free': true
+  '@fortawesome/fontawesome-svg-core': true
+  '@fortawesome/free-regular-svg-icons': true
+  '@fortawesome/free-solid-svg-icons': true
+  core-js: false
+  core-js-pure: false
+overrides:
+  '@types/react': 16.9.3
+  moment: 2.29.4
+  '@types/react-dom': ^16.8.2
+  normalize-url: 4.5.1
+  rxjs: 6.6.7
+  formidable: 2.1.2


### PR DESCRIPTION
https://github.com/zachaller/argo-rollouts/releases/tag/v1.10.0-rc1

## Summary

Release SBOM generation has been broken since the UI migrated to pnpm ([#4712](https://github.com/argoproj/argo-rollouts/pull/4712)). The release workflow still used `spdx-sbom-generator` for `./ui`, which does not support `pnpm-lock.yaml`, causing:

```
FATA Failed to run command: No module manager found
```

This PR fixes release SBOM generation by generating UI dependencies with `pnpm sbom` (pnpm 11.9+) and completing the pnpm 11 migration for CI and Docker builds.

## Root cause

| Component | Before (yarn) | After pnpm migration | Issue |
|-----------|---------------|----------------------|-------|
| UI lockfile | `yarn.lock` | `pnpm-lock.yaml` | `spdx-sbom-generator` v0.0.13 has no pnpm plugin |
| Release workflow | `generator -p ./ui` | Same | Fails with `No module manager found` |
| Docker UI stage | Node 18 + pnpm 10 | pnpm 11.9 in `packageManager` | pnpm 11 requires Node 22+ |
| pnpm config | `package.json` `"pnpm"` field | pnpm 11 | Overrides/`allowBuilds` must live in `pnpm-workspace.yaml` |

Same class of issue as [argoproj/argo-cd#27337](https://github.com/argoproj/argo-cd/issues/27337).

## Solution

- Generate **Go** SBOMs with `spdx-sbom-generator` (`generator -p .`)
- Generate **UI** SBOMs with `pnpm sbom --sbom-format spdx --prod`
- Upgrade UI to **pnpm 11.9.0** (required for `pnpm sbom`)
- Upgrade Docker UI build stage to **Node 22** with pinned **corepack@0.34.6**
- Migrate `overrides` and `allowBuilds` to `ui/pnpm-workspace.yaml`

## `sbom.tar.gz` contents

| File | Source |
|------|--------|
| `bom-go-mod.spdx` | Go module dependencies (`spdx-sbom-generator`) |
| `bom-ui-pnpm.spdx.json` | UI dependencies (`pnpm sbom`, SPDX 2.3 JSON) |
| `bom-docker-image.spdx` | Release container image (`sigs.k8s.io/bom`) |

Documented in `docs/security/signed-release-assets.md`.

## Changes

- **`.github/workflows/release.yaml`** — Replace `generator` loop over `.,./ui` with `generator -p .` + `pnpm sbom`; explicitly include `bom-ui-pnpm.spdx.json` in the archive
- **`ui/package.json`** — Bump `packageManager` to `pnpm@11.9.0`; remove `pnpm.overrides` (moved to workspace file)
- **`ui/pnpm-workspace.yaml`** — Add `overrides` and `allowBuilds` for pnpm 11
- **`ui/pnpm-lock.yaml`** — Regenerated for pnpm 11.9
- **`Dockerfile`** — Node 18 → 22; pin corepack; copy `pnpm-workspace.yaml` for frozen installs
- **`docs/security/signed-release-assets.md`** — Document new SBOM archive layout

## Test plan

- [x] Verified locally: `pnpm install --dir ./ui --frozen-lockfile` succeeds
- [x] Verified locally: `pnpm --dir ./ui sbom --sbom-format spdx --prod` produces valid SPDX JSON
- [x] Verified locally: `generator -p . -o /tmp` succeeds; `generator -p ./ui` still fails (confirms original bug)
- [x] Fork release workflow (`zachaller/argo-rollouts`): `release-artifacts` passes; `pnpm install` + `pnpm sbom` + `generator -p .` all succeed in the `generate-sbom` job
- [ ] Full upstream release dry-run with Quay credentials (docker image SBOM requires image pull from registry)

## Notes for reviewers

- UI SBOM format changes from tag-value `.spdx` to **SPDX 2.3 JSON** (`bom-ui-pnpm.spdx.json`). Cosign verification of `sbom.tar.gz` is unchanged; consumers parsing internal files should handle the new JSON file.
- FontAwesome packages are set to `allowBuilds: true`; `core-js` packages are `false` (not needed at install time for the webpack build).


Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [ ] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [ ] I understand what the code does and WHY/HOW it works in several scenarios
* [ ] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).