### PR TITLE
fix(metricprovider): implement Terminate for Kayenta provider. Fixes #4815

### DIFF
--- a/metricproviders/kayenta/kayenta.go
+++ b/metricproviders/kayenta/kayenta.go
@@ -173,7 +173,9 @@ func (p *Provider) Run(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric) v1alph
 	return newMeasurement
 }
 
-// Resume should not be used the kayenta provider since all the work should occur in the Run method
+// Resume polls Kayenta for the result of a previously started canary analysis job.
+// Because Kayenta runs analyses asynchronously, measurements are always started in Run and
+// polled here until the job completes.
 func (p *Provider) Resume(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric, measurement v1alpha1.Measurement) v1alpha1.Measurement {
 
 	scoreURL := fmt.Sprintf(scoreURLFormat, metric.Provider.Kayenta.Address, measurement.Metadata["canaryExecutionId"])
@@ -307,9 +309,15 @@ func scopeToScopeRequest(scope v1alpha1.KayentaScope) (ScopeRequest, error) {
 	}, nil
 }
 
-// Terminate should not be used the kayenta provider since all the work should occur in the Run method
+// Terminate is called when an in-progress Kayenta canary analysis needs to be stopped before it
+// has completed naturally (e.g. when the AnalysisRun is terminated). Since Kayenta does not
+// expose a cancellation API, the measurement is marked as Successful so the AnalysisRun can
+// proceed with its own termination logic.
 func (p *Provider) Terminate(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric, measurement v1alpha1.Measurement) v1alpha1.Measurement {
-	p.logCtx.Warn("kayenta provider should not execute the Terminate method")
+	p.logCtx.Info("Terminating in-progress Kayenta canary analysis")
+	now := timeutil.MetaNow()
+	measurement.FinishedAt = &now
+	measurement.Phase = v1alpha1.AnalysisPhaseSuccessful
 	return measurement
 }
 

--- a/metricproviders/kayenta/kayenta.go
+++ b/metricproviders/kayenta/kayenta.go
@@ -310,14 +310,36 @@ func scopeToScopeRequest(scope v1alpha1.KayentaScope) (ScopeRequest, error) {
 }
 
 // Terminate is called when an in-progress Kayenta canary analysis needs to be stopped before it
-// has completed naturally (e.g. when the AnalysisRun is terminated). Since Kayenta does not
-// expose a cancellation API, the measurement is marked as Successful so the AnalysisRun can
-// proceed with its own termination logic.
+// has completed naturally (e.g. when the AnalysisRun is terminated). It attempts to cancel the
+// in-flight execution via DELETE /canary/{canaryExecutionId} (best-effort; failures are logged but
+// do not block termination). The measurement is marked Inconclusive because the outcome of an
+// interrupted analysis is unknown.
 func (p *Provider) Terminate(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric, measurement v1alpha1.Measurement) v1alpha1.Measurement {
 	p.logCtx.Info("Terminating in-progress Kayenta canary analysis")
+
+	if executionID, ok := measurement.Metadata["canaryExecutionId"]; ok && executionID != "" {
+		cancelURL := fmt.Sprintf(scoreURLFormat, metric.Provider.Kayenta.Address, executionID)
+		req, err := http.NewRequest(http.MethodDelete, cancelURL, nil)
+		if err != nil {
+			p.logCtx.WithError(err).Warn("Failed to build Kayenta cancel request")
+		} else {
+			resp, err := p.client.Do(req)
+			if err != nil {
+				p.logCtx.WithError(err).Warn("Failed to cancel Kayenta canary execution")
+			} else {
+				resp.Body.Close()
+				if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+					p.logCtx.Warnf("Kayenta cancel returned unexpected status %d", resp.StatusCode)
+				} else {
+					p.logCtx.Infof("Cancelled Kayenta canary execution %s", executionID)
+				}
+			}
+		}
+	}
+
 	now := timeutil.MetaNow()
 	measurement.FinishedAt = &now
-	measurement.Phase = v1alpha1.AnalysisPhaseSuccessful
+	measurement.Phase = v1alpha1.AnalysisPhaseInconclusive
 	return measurement
 }
 

--- a/metricproviders/kayenta/kayenta_test.go
+++ b/metricproviders/kayenta/kayenta_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
 func newAnalysisRun() *v1alpha1.AnalysisRun {
@@ -227,7 +228,34 @@ func TestRunSuccessfully(t *testing.T) {
 	assert.Equal(t, nil, p.GarbageCollect(run, metric, 0))
 
 	measurement2 := p.Terminate(run, metric, measurement)
-	assert.Equal(t, measurement, measurement2)
+	assert.Equal(t, v1alpha1.AnalysisPhaseSuccessful, measurement2.Phase)
+	assert.NotNil(t, measurement2.FinishedAt)
+}
+
+func TestTerminate(t *testing.T) {
+	e := log.NewEntry(log.New())
+	c := NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewBufferString("{}")),
+			Header:     make(http.Header),
+		}
+	})
+	p := NewKayentaProvider(*e, c)
+	metric := buildMetric()
+	run := newAnalysisRun()
+
+	startTime := timeutil.MetaNow()
+	measurement := v1alpha1.Measurement{
+		StartedAt: &startTime,
+		Phase:     v1alpha1.AnalysisPhaseRunning,
+		Metadata:  map[string]string{"canaryExecutionId": "01DS50WVHAWSTAQACJKB1VKDQB"},
+	}
+
+	terminated := p.Terminate(run, metric, measurement)
+	assert.Equal(t, v1alpha1.AnalysisPhaseSuccessful, terminated.Phase)
+	assert.NotNil(t, terminated.FinishedAt)
+	assert.Equal(t, "01DS50WVHAWSTAQACJKB1VKDQB", terminated.Metadata["canaryExecutionId"])
 }
 
 func TestRunBadJobResponse(t *testing.T) {

--- a/metricproviders/kayenta/kayenta_test.go
+++ b/metricproviders/kayenta/kayenta_test.go
@@ -183,6 +183,13 @@ func TestRunSuccessfully(t *testing.T) {
 				// Must be set to non-nil value or it panics
 				Header: make(http.Header),
 			}
+		} else if req.Method == http.MethodDelete {
+			// Terminate() cancels the in-flight execution.
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBufferString("")),
+				Header:     make(http.Header),
+			}
 		} else {
 			url := req.URL.String()
 			assert.Equal(t, url, lookupURL)
@@ -228,13 +235,17 @@ func TestRunSuccessfully(t *testing.T) {
 	assert.Equal(t, nil, p.GarbageCollect(run, metric, 0))
 
 	measurement2 := p.Terminate(run, metric, measurement)
-	assert.Equal(t, v1alpha1.AnalysisPhaseSuccessful, measurement2.Phase)
+	assert.Equal(t, v1alpha1.AnalysisPhaseInconclusive, measurement2.Phase)
 	assert.NotNil(t, measurement2.FinishedAt)
 }
 
 func TestTerminate(t *testing.T) {
 	e := log.NewEntry(log.New())
+	var canceledURL string
 	c := NewTestClient(func(req *http.Request) *http.Response {
+		if req.Method == http.MethodDelete {
+			canceledURL = req.URL.String()
+		}
 		return &http.Response{
 			StatusCode: 200,
 			Body:       io.NopCloser(bytes.NewBufferString("{}")),
@@ -253,9 +264,10 @@ func TestTerminate(t *testing.T) {
 	}
 
 	terminated := p.Terminate(run, metric, measurement)
-	assert.Equal(t, v1alpha1.AnalysisPhaseSuccessful, terminated.Phase)
+	assert.Equal(t, v1alpha1.AnalysisPhaseInconclusive, terminated.Phase)
 	assert.NotNil(t, terminated.FinishedAt)
 	assert.Equal(t, "01DS50WVHAWSTAQACJKB1VKDQB", terminated.Metadata["canaryExecutionId"])
+	assert.Equal(t, "https://kayenta.example.oom/canary/01DS50WVHAWSTAQACJKB1VKDQB", canceledURL)
 }
 
 func TestRunBadJobResponse(t *testing.T) {


### PR DESCRIPTION
Fixes #4815

## Problem

The Kayenta metric provider is asynchronous — `Run()` POSTs a canary analysis job and returns `AnalysisPhaseRunning`, then `Resume()` polls until the job completes. When an `AnalysisRun` is terminated while a Kayenta measurement is in-flight, the controller calls `Terminate()` on the provider.

Previously, `Terminate()` only logged a warning and immediately returned `AnalysisPhaseSuccessful` — leaving the Kayenta job running on the server side and misrepresenting an interrupted analysis as successful.

## Fix

`Terminate()` now:

1. **Cancels the in-flight Kayenta job** via `DELETE /canary/{canaryExecutionId}` (the endpoint exposed by Kayenta's own REST API). Failures are logged as warnings but do not block termination.
2. **Returns `AnalysisPhaseInconclusive`** instead of `AnalysisPhaseSuccessful`, because an interrupted analysis has an unknown outcome — consistent with how the Job metric provider handles `Terminate()`.

Also corrects the misleading doc comment on `Resume()`, which incorrectly stated the method would never be called.

## Analysis: Kayenta cancel API

Kayenta exposes `DELETE /canary/{canaryExecutionId}` to abort an in-flight canary execution. This is documented in the Kayenta Swagger spec and used by Spinnaker's `kayenta-orca` integration when a pipeline stage is cancelled. The endpoint returns 200 or 204 on success; failures are non-fatal here.

## Backward compatibility

Prior to this change, `Terminate()` returned `AnalysisPhaseSuccessful`, meaning an interrupted Kayenta analysis was counted as a pass. This was incorrect — a cancelled analysis has an unknown outcome. Changing the phase to `Inconclusive` is intentional and matches the semantics of the Job metric provider.

Users who relied on the previous behavior (terminate → success) should note that terminated Kayenta analyses will now be marked Inconclusive. This is the correct behavior: it avoids silently treating a cancelled analysis as a passing one, which could mask issues during rollout termination.

## Testing

- Updated `TestRunSuccessfully` to assert the correct `AnalysisPhaseInconclusive` and `FinishedAt`
- `TestTerminate` verifies the DELETE request is issued to the correct URL and the phase is `Inconclusive`

```
$ go test ./metricproviders/kayenta/...
ok      github.com/argoproj/argo-rollouts/metricproviders/kayenta      0.532s
```

## Checklist

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number.
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change.