### PR TITLE
fix(trafficrouting): remove all experiment destinations from Istio VirtualService on completion

### DIFF
--- a/rollout/trafficrouting/istio/istio.go
+++ b/rollout/trafficrouting/istio/istio.go
@@ -85,6 +85,27 @@ const (
 )
 
 func (patches virtualServicePatches) patchVirtualService(httpRoutes []any, tlsRoutes []any, tcpRoutes []any) error {
+	// Apply patches in an order that keeps destination indices valid. All
+	// non-delete patches (in-place weight updates and appends) are applied
+	// first so they operate on the original indices, then deletions are
+	// applied in descending index order so removing one destination does not
+	// shift the indices of the remaining deletions. Without this ordering,
+	// deleting a lower index first shrinks the slice and makes a later
+	// deletion's index either point at the wrong destination or fall out of
+	// range, which caused leftover experiment destinations in the
+	// VirtualService when an experiment completed.
+	slices.SortStableFunc(patches, func(a, b virtualServicePatch) int {
+		if a.toDelete != b.toDelete {
+			if a.toDelete {
+				return 1
+			}
+			return -1
+		}
+		if a.toDelete {
+			return b.destinationIndex - a.destinationIndex
+		}
+		return 0
+	})
 	for _, patch := range patches {
 		var route map[string]any
 		err := false
@@ -244,9 +265,17 @@ func processRoutes(routeType string, routeIdx int, destinations []VirtualService
 			}
 		}
 	}
-	// Add new destinations for experiment services which don't exist yet
+	// Add new destinations for experiment services which don't exist yet.
+	// Iterate the services in a deterministic (sorted) order so the resulting
+	// destination ordering does not depend on Go's randomized map iteration.
 	idx := len(destinations)
-	for _, dest := range svcToDest {
+	newHosts := make([]string, 0, len(svcToDest))
+	for host := range svcToDest {
+		newHosts = append(newHosts, host)
+	}
+	slices.Sort(newHosts)
+	for _, host := range newHosts {
+		dest := svcToDest[host]
 		patches = appendPatch(routeIdx, routeType, 0, int64(dest.Weight), idx, dest.ServiceName, false, patches)
 		idx += 1
 	}

--- a/rollout/trafficrouting/istio/istio_test.go
+++ b/rollout/trafficrouting/istio/istio_test.go
@@ -1489,6 +1489,46 @@ func TestHostSplitExperimentStep(t *testing.T) {
 	checkDestination(t, httpRoutes[0].Route, "canary", 10)
 }
 
+// TestHostSplitExperimentStepMultipleServicesRemoved verifies that when an
+// experiment adds more than one destination to a route, all of them are
+// removed once the experiment completes. Deleting multiple destinations used
+// to leave one behind because the deletions were applied in ascending index
+// order, so the first deletion shifted the indices of the remaining ones.
+func TestHostSplitExperimentStepMultipleServicesRemoved(t *testing.T) {
+	obj := unstructuredutil.StrToUnstructuredUnsafe(regularVsvc)
+	client := testutil.NewFakeDynamicClient(obj)
+	ro := rolloutWithHttpRoutes("stable", "canary", "vsvc", []string{"primary"})
+	r := NewReconciler(ro, client, record.NewFakeEventRecorder(), nil, nil, nil)
+	additionalDestinations := []v1alpha1.WeightDestination{
+		{ServiceName: "exp-baseline", PodTemplateHash: "", Weight: 20},
+		{ServiceName: "exp-canary", PodTemplateHash: "", Weight: 20},
+	}
+	vsvcRoutes := r.rollout.Spec.Strategy.Canary.TrafficRouting.Istio.VirtualService.Routes
+
+	// Create routes for both experiment services.
+	modifiedObj, _, err := r.reconcileVirtualService(obj, vsvcRoutes, nil, nil, 10, additionalDestinations...)
+	assert.Nil(t, err)
+	httpRoutes := extractHttpRoutes(t, modifiedObj)
+	assert.Len(t, httpRoutes[0].Route, 4)
+	checkDestination(t, httpRoutes[0].Route, "stable", 50)
+	checkDestination(t, httpRoutes[0].Route, "canary", 10)
+	checkDestination(t, httpRoutes[0].Route, "exp-baseline", 20)
+	checkDestination(t, httpRoutes[0].Route, "exp-canary", 20)
+
+	// With no additionalDestinations, both experiment services must be removed,
+	// leaving only stable and canary.
+	modifiedObj, _, err = r.reconcileVirtualService(modifiedObj, vsvcRoutes, nil, nil, 10)
+	assert.Nil(t, err)
+	httpRoutes = extractHttpRoutes(t, modifiedObj)
+	assert.Len(t, httpRoutes[0].Route, 2)
+	checkDestination(t, httpRoutes[0].Route, "stable", 90)
+	checkDestination(t, httpRoutes[0].Route, "canary", 10)
+	for _, dest := range httpRoutes[0].Route {
+		assert.NotContains(t, []string{"exp-baseline", "exp-canary"}, dest.Destination.Host,
+			"experiment destination %q should have been removed", dest.Destination.Host)
+	}
+}
+
 func TestTlsReconcileNoChanges(t *testing.T) {
 	obj := unstructuredutil.StrToUnstructuredUnsafe(regularTlsVsvc)
 	client := testutil.NewFakeDynamicClient(obj)


### PR DESCRIPTION
## What this PR does

When an experiment adds **more than one** destination to an Istio `VirtualService` route (for example a weighted experiment with both a baseline and a canary template `service:`), completing the experiment could leave one of the added destinations behind. Which one was left over was non-deterministic — sometimes the baseline service, sometimes the canary service.

### Root cause

Two interacting issues in `rollout/trafficrouting/istio/istio.go`:

1. **`patchVirtualService`** deleted destinations in place using their original indices, applied in **ascending** order. Removing a lower index first shrinks the destination slice, so a later deletion's index points at the wrong destination or falls out of range. The out-of-range case falls into the append branch and *re-adds* the destination (with `weight: 0`) instead of removing it.
2. **`processRoutes`** appended new experiment destinations while iterating a Go map, so their order in the route was randomized. That randomization decided which service ended up at the surviving higher index — hence the non-determinism.

### Fix

- Sort patches before applying them: all non-delete patches first (so in-place weight updates and appends operate on the original indices), then deletions in **descending** index order so earlier removals do not shift the indices of later ones.
- Iterate the new-destination map in sorted key order so the resulting route ordering is deterministic and reproducible.

### Testing

Added `TestHostSplitExperimentStepMultipleServicesRemoved`, which adds two experiment destinations and then reconciles with no additional destinations. It fails on the old code:

```
"[{stable 90} {canary 10} {exp-baseline 20} {exp-baseline 0}]" should have 2 item(s), but has 4
```

and passes with the fix (route collapses back to just `stable` + `canary`). The full `./rollout/trafficrouting/istio/...` suite passes.

## Checklist

* [x] (b) this is a bug fix
* [x] The title of the PR is conventional and states what changed
* [x] I've signed my commits with DCO
* [x] My builds are green
* [x] I have written unit tests for my change
* [x] I have run all tests locally and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
