### PR TITLE
fix: guard empty Values in injected anti-affinity check

### DIFF
--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -212,7 +212,7 @@ func IfInjectedAntiAffinityRuleNeedsUpdate(affinity *corev1.Affinity, rollout v1
 	currentPodHash := hash.ComputePodTemplateHash(&rollout.Spec.Template, rollout.Status.CollisionCount)
 	if podAffinityTerm != nil && rollout.Status.StableRS != currentPodHash {
 		for _, labelSelectorRequirement := range podAffinityTerm.LabelSelector.MatchExpressions {
-			if labelSelectorRequirement.Key == v1alpha1.DefaultRolloutUniqueLabelKey && labelSelectorRequirement.Values[0] != rollout.Status.StableRS {
+			if labelSelectorRequirement.Key == v1alpha1.DefaultRolloutUniqueLabelKey && len(labelSelectorRequirement.Values) > 0 && labelSelectorRequirement.Values[0] != rollout.Status.StableRS {
 				return true
 			}
 		}

--- a/utils/replicaset/replicaset_test.go
+++ b/utils/replicaset/replicaset_test.go
@@ -1039,6 +1039,24 @@ func TestIfInjectedAntiAffinityRuleNeedsUpdate(t *testing.T) {
 		}}
 
 	assert.True(t, IfInjectedAntiAffinityRuleNeedsUpdate(rsAffinity, ro))
+
+	// A pod affinity term keyed by the rollout unique label but with no Values
+	// (e.g. Operator: Exists) must not cause an index-out-of-range panic and
+	// should be treated as not needing an update.
+	rsAffinityExists := &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{{
+						Key:      v1alpha1.DefaultRolloutUniqueLabelKey,
+						Operator: metav1.LabelSelectorOperator("Exists"),
+					}},
+				},
+			}},
+		},
+	}
+
+	assert.False(t, IfInjectedAntiAffinityRuleNeedsUpdate(rsAffinityExists, ro))
 }
 
 func TestNeedsRestart(t *testing.T) {


### PR DESCRIPTION
IfInjectedAntiAffinityRuleNeedsUpdate keyed a pod affinity term match by label only (via HasInjectedAntiAffinityRule) and then indexed Values[0]. A user-defined anti-affinity term using the rollouts-pod-template-hash key with Operator: Exists (no Values) made HasInjectedAntiAffinityRule match it, causing an index-out-of-range panic during reconcile.

Guard the access with a length check so such terms are treated as not needing an update.

Added a regression test in TestIfInjectedAntiAffinityRuleNeedsUpdate covering a term with no Values.