### PR TITLE
fix(trafficrouting): drain experiment WeightDestination before Service teardown

### DIFF
--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -440,35 +440,64 @@ func calculateWeightStatus(ro *v1alpha1.Rollout, canaryHash, stableHash string, 
 func (c *rolloutContext) calculateWeightDestinationsFromExperiment() []v1alpha1.WeightDestination {
 	weightDestinations := make([]v1alpha1.WeightDestination, 0)
 	exStep := replicasetutil.GetCurrentExperimentStep(c.rollout)
-	if exStep != nil && c.currentEx != nil && c.currentEx.Status.Phase == v1alpha1.AnalysisPhaseRunning {
-		getTemplateWeight := func(name string) *int32 {
-			for _, tmpl := range exStep.Templates {
-				if tmpl.Name == name {
-					return tmpl.Weight
-				}
-			}
-			return nil
-		}
-		for _, templateStatus := range c.currentEx.Status.TemplateStatuses {
-			templateWeight := getTemplateWeight(templateStatus.Name)
-			// Only build a WeightDestination when the template still has a Service.
-			// When an experiment finishes, the experiment controller scales down the
-			// template ReplicaSets and deletes their Services, clearing
-			// templateStatus.ServiceName (and PodTemplateHash). This can happen while
-			// the experiment is still reported as Running (e.g. a completed template
-			// whose service is torn down before the overall phase transitions). Without
-			// this guard we would emit a WeightDestination with an empty ServiceName,
-			// which the traffic router turns into a route destination with an empty
-			// host, and Istio rejects the VirtualService ("empty domain name not
-			// allowed"), wedging the rollout on the experiment step.
-			if templateWeight != nil && templateStatus.ServiceName != "" {
-				weightDestinations = append(weightDestinations, v1alpha1.WeightDestination{
-					ServiceName:     templateStatus.ServiceName,
-					PodTemplateHash: templateStatus.PodTemplateHash,
-					Weight:          *templateWeight,
-				})
+	// We only build destinations while the experiment is Running. Once the experiment
+	// reaches a terminal phase (Successful/Failed) this returns no destinations, and the
+	// traffic router removes the experiment hosts from the route entirely (returning their
+	// share to stable) - so the drain-to-0 handling below is specifically for the window
+	// where the experiment is still Running but an individual template has already
+	// completed and started tearing down.
+	if exStep == nil || c.currentEx == nil || c.currentEx.Status.Phase != v1alpha1.AnalysisPhaseRunning {
+		return weightDestinations
+	}
+	getTemplateWeight := func(name string) *int32 {
+		for _, tmpl := range exStep.Templates {
+			if tmpl.Name == name {
+				return tmpl.Weight
 			}
 		}
+		return nil
+	}
+	for _, templateStatus := range c.currentEx.Status.TemplateStatuses {
+		templateWeight := getTemplateWeight(templateStatus.Name)
+		if templateWeight == nil {
+			continue
+		}
+		// Only build a WeightDestination when the template still has a Service.
+		// When an experiment finishes, the experiment controller scales down the
+		// template ReplicaSets and deletes their Services, clearing
+		// templateStatus.ServiceName (and PodTemplateHash). This can happen while
+		// the experiment is still reported as Running (e.g. a completed template
+		// whose service is torn down before the overall phase transitions). Without
+		// this guard we would emit a WeightDestination with an empty ServiceName,
+		// which the traffic router turns into a route destination with an empty
+		// host, and Istio rejects the VirtualService ("empty domain name not
+		// allowed"), wedging the rollout on the experiment step.
+		if templateStatus.ServiceName == "" {
+			continue
+		}
+		// Drain the template's traffic before it is torn down. An individual template
+		// can complete (its duration elapsed) while the experiment as a whole is still
+		// Running - e.g. a multi-template experiment where another template is still
+		// running, or a template that finished while a required-for-completion analysis
+		// keeps the experiment Running. Once a template's status is Completed, the
+		// experiment controller begins scaling its ReplicaSet down to 0 and only deletes
+		// the Service after AvailableReplicas reaches 0. During that window the Service
+		// and (draining) pods still exist, so we keep the destination in the route but
+		// set its weight to 0. This stops *new* traffic from being routed to a template
+		// that is being torn down while letting in-flight requests finish, giving a
+		// clean "weight -> 0, drain, delete Service" sequence. The removed weight is
+		// returned to the stable service by the traffic router. If we left the configured
+		// weight in place, the VirtualService would keep routing traffic to pods that are
+		// actively being scaled down, causing resets/5xx until the Service is deleted.
+		weight := *templateWeight
+		if templateStatus.Status.Completed() {
+			weight = 0
+		}
+		weightDestinations = append(weightDestinations, v1alpha1.WeightDestination{
+			ServiceName:     templateStatus.ServiceName,
+			PodTemplateHash: templateStatus.PodTemplateHash,
+			Weight:          weight,
+		})
 	}
 	return weightDestinations
 }

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -451,7 +451,17 @@ func (c *rolloutContext) calculateWeightDestinationsFromExperiment() []v1alpha1.
 		}
 		for _, templateStatus := range c.currentEx.Status.TemplateStatuses {
 			templateWeight := getTemplateWeight(templateStatus.Name)
-			if templateWeight != nil {
+			// Only build a WeightDestination when the template still has a Service.
+			// When an experiment finishes, the experiment controller scales down the
+			// template ReplicaSets and deletes their Services, clearing
+			// templateStatus.ServiceName (and PodTemplateHash). This can happen while
+			// the experiment is still reported as Running (e.g. a completed template
+			// whose service is torn down before the overall phase transitions). Without
+			// this guard we would emit a WeightDestination with an empty ServiceName,
+			// which the traffic router turns into a route destination with an empty
+			// host, and Istio rejects the VirtualService ("empty domain name not
+			// allowed"), wedging the rollout on the experiment step.
+			if templateWeight != nil && templateStatus.ServiceName != "" {
 				weightDestinations = append(weightDestinations, v1alpha1.WeightDestination{
 					ServiceName:     templateStatus.ServiceName,
 					PodTemplateHash: templateStatus.PodTemplateHash,

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -388,6 +388,35 @@ func TestRolloutWithExperimentStep(t *testing.T) {
 		f.fakeTrafficRouting.On("VerifyWeight", mock.Anything, mock.Anything).Return(ptr.To[bool](true), nil)
 		f.run(getKey(r2, t))
 	})
+
+	t.Run("Experiment Running but template Service torn down - no WeightDestination created", func(t *testing.T) {
+		// When an experiment finishes, its controller deletes the template Services
+		// and clears templateStatus.ServiceName, which can be observed while the
+		// experiment is still Running. In that state we must NOT emit a
+		// WeightDestination with an empty ServiceName, otherwise the traffic router
+		// produces a route destination with an empty host and Istio rejects the
+		// VirtualService, wedging the rollout on the experiment step.
+		ex.Status.Phase = v1alpha1.AnalysisPhaseRunning
+		originalServiceName := ex.Status.TemplateStatuses[0].ServiceName
+		ex.Status.TemplateStatuses[0].ServiceName = ""
+		ex.Status.TemplateStatuses[0].PodTemplateHash = ""
+		defer func() {
+			ex.Status.TemplateStatuses[0].ServiceName = originalServiceName
+			ex.Status.TemplateStatuses[0].PodTemplateHash = rs2PodHash
+		}()
+		f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+		f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, weightDestinations ...v1alpha1.WeightDestination) error {
+			// The weighted template's Service is gone, so no WeightDestination
+			// (and therefore no empty-host route destination) should be produced.
+			assert.Equal(t, int32(10), desiredWeight)
+			assert.Len(t, weightDestinations, 0)
+			return nil
+		})
+		f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
+		f.fakeTrafficRouting.On("VerifyWeight", mock.Anything, mock.Anything).Return(ptr.To[bool](true), nil)
+		f.run(getKey(r2, t))
+	})
 }
 
 func TestRolloutUsePreviousSetWeight(t *testing.T) {

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -400,21 +400,11 @@ func TestRolloutWithExperimentStep(t *testing.T) {
 		defer func() {
 			ex.Status.TemplateStatuses[0].Status = ""
 		}()
-		f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
-		f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, weightDestinations ...v1alpha1.WeightDestination) error {
-			assert.Equal(t, int32(10), desiredWeight)
-			assert.Len(t, weightDestinations, 1)
-			// weight drained to 0, but the destination (host) is preserved until the
-			// Service is deleted.
-			assert.Equal(t, int32(0), weightDestinations[0].Weight)
-			assert.Equal(t, ex.Status.TemplateStatuses[0].ServiceName, weightDestinations[0].ServiceName)
-			assert.Equal(t, ex.Status.TemplateStatuses[0].PodTemplateHash, weightDestinations[0].PodTemplateHash)
-			return nil
-		})
-		f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
-		f.fakeTrafficRouting.On("VerifyWeight", mock.Anything, mock.Anything).Return(ptr.To[bool](true), nil)
-		f.run(getKey(r2, t))
+		assertExperimentSetWeight(t, f, r2, 10, []v1alpha1.WeightDestination{{
+			ServiceName:     ex.Status.TemplateStatuses[0].ServiceName,
+			PodTemplateHash: ex.Status.TemplateStatuses[0].PodTemplateHash,
+			Weight:          0,
+		}})
 	})
 
 	t.Run("Experiment Successful - no WeightDestination created", func(t *testing.T) {
@@ -427,16 +417,7 @@ func TestRolloutWithExperimentStep(t *testing.T) {
 		defer func() {
 			ex.Status.TemplateStatuses[0].Status = ""
 		}()
-		f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
-		f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, weightDestinations ...v1alpha1.WeightDestination) error {
-			assert.Equal(t, int32(10), desiredWeight)
-			assert.Len(t, weightDestinations, 0)
-			return nil
-		})
-		f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
-		f.fakeTrafficRouting.On("VerifyWeight", mock.Anything, mock.Anything).Return(ptr.To[bool](true), nil)
-		f.run(getKey(r2, t))
+		assertExperimentSetWeight(t, f, r2, 10, nil)
 	})
 
 	t.Run("Experiment Running due to pending required analysis but template completed - WeightDestination drained to 0", func(t *testing.T) {
@@ -459,19 +440,11 @@ func TestRolloutWithExperimentStep(t *testing.T) {
 			ex.Status.TemplateStatuses[0].Status = ""
 			ex.Status.AnalysisRuns = nil
 		}()
-		f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
-		f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, weightDestinations ...v1alpha1.WeightDestination) error {
-			assert.Equal(t, int32(10), desiredWeight)
-			assert.Len(t, weightDestinations, 1)
-			assert.Equal(t, int32(0), weightDestinations[0].Weight)
-			assert.Equal(t, ex.Status.TemplateStatuses[0].ServiceName, weightDestinations[0].ServiceName)
-			assert.Equal(t, ex.Status.TemplateStatuses[0].PodTemplateHash, weightDestinations[0].PodTemplateHash)
-			return nil
-		})
-		f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
-		f.fakeTrafficRouting.On("VerifyWeight", mock.Anything, mock.Anything).Return(ptr.To[bool](true), nil)
-		f.run(getKey(r2, t))
+		assertExperimentSetWeight(t, f, r2, 10, []v1alpha1.WeightDestination{{
+			ServiceName:     ex.Status.TemplateStatuses[0].ServiceName,
+			PodTemplateHash: ex.Status.TemplateStatuses[0].PodTemplateHash,
+			Weight:          0,
+		}})
 	})
 
 	t.Run("Experiment Running but template Service torn down - no WeightDestination created", func(t *testing.T) {
@@ -489,19 +462,26 @@ func TestRolloutWithExperimentStep(t *testing.T) {
 			ex.Status.TemplateStatuses[0].ServiceName = originalServiceName
 			ex.Status.TemplateStatuses[0].PodTemplateHash = rs2PodHash
 		}()
-		f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
-		f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, weightDestinations ...v1alpha1.WeightDestination) error {
-			// The weighted template's Service is gone, so no WeightDestination
-			// (and therefore no empty-host route destination) should be produced.
-			assert.Equal(t, int32(10), desiredWeight)
-			assert.Len(t, weightDestinations, 0)
-			return nil
-		})
-		f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
-		f.fakeTrafficRouting.On("VerifyWeight", mock.Anything, mock.Anything).Return(ptr.To[bool](true), nil)
-		f.run(getKey(r2, t))
+		assertExperimentSetWeight(t, f, r2, 10, nil)
 	})
+}
+
+// assertExperimentSetWeight runs the rollout reconcile and asserts that SetWeight was invoked
+// with the given desired weight and exactly the given weight destinations (order-sensitive).
+func assertExperimentSetWeight(t *testing.T, f *fixture, r2 *v1alpha1.Rollout, desiredWeight int32, expectedDestinations []v1alpha1.WeightDestination) {
+	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(gotWeight int32, gotDestinations ...v1alpha1.WeightDestination) error {
+		assert.Equal(t, desiredWeight, gotWeight)
+		assert.Len(t, gotDestinations, len(expectedDestinations))
+		for i, expected := range expectedDestinations {
+			assert.Equal(t, expected, gotDestinations[i])
+		}
+		return nil
+	})
+	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything, mock.Anything).Return(ptr.To[bool](true), nil)
+	f.run(getKey(r2, t))
 }
 
 func TestRolloutUsePreviousSetWeight(t *testing.T) {

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -389,6 +389,91 @@ func TestRolloutWithExperimentStep(t *testing.T) {
 		f.run(getKey(r2, t))
 	})
 
+	t.Run("Experiment Running but template completed - WeightDestination drained to 0", func(t *testing.T) {
+		// Once a template completes (its duration elapsed), the experiment controller
+		// begins scaling its ReplicaSet down to 0 and only deletes the Service after the
+		// pods have fully drained. While the Service still exists we must keep the
+		// destination in the route but set its weight to 0 so that no new traffic is sent
+		// to pods that are being torn down. The removed weight is returned to stable.
+		ex.Status.Phase = v1alpha1.AnalysisPhaseRunning
+		ex.Status.TemplateStatuses[0].Status = v1alpha1.TemplateStatusSuccessful
+		defer func() {
+			ex.Status.TemplateStatuses[0].Status = ""
+		}()
+		f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+		f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, weightDestinations ...v1alpha1.WeightDestination) error {
+			assert.Equal(t, int32(10), desiredWeight)
+			assert.Len(t, weightDestinations, 1)
+			// weight drained to 0, but the destination (host) is preserved until the
+			// Service is deleted.
+			assert.Equal(t, int32(0), weightDestinations[0].Weight)
+			assert.Equal(t, ex.Status.TemplateStatuses[0].ServiceName, weightDestinations[0].ServiceName)
+			assert.Equal(t, ex.Status.TemplateStatuses[0].PodTemplateHash, weightDestinations[0].PodTemplateHash)
+			return nil
+		})
+		f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
+		f.fakeTrafficRouting.On("VerifyWeight", mock.Anything, mock.Anything).Return(ptr.To[bool](true), nil)
+		f.run(getKey(r2, t))
+	})
+
+	t.Run("Experiment Successful - no WeightDestination created", func(t *testing.T) {
+		// Once the experiment reaches a terminal phase we emit no destinations; the
+		// traffic router then removes the experiment hosts from the route entirely and
+		// returns their share to stable. The drain-to-0 handling only applies while the
+		// experiment is still Running (see the template-completed cases above/below).
+		ex.Status.Phase = v1alpha1.AnalysisPhaseSuccessful
+		ex.Status.TemplateStatuses[0].Status = v1alpha1.TemplateStatusSuccessful
+		defer func() {
+			ex.Status.TemplateStatuses[0].Status = ""
+		}()
+		f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+		f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, weightDestinations ...v1alpha1.WeightDestination) error {
+			assert.Equal(t, int32(10), desiredWeight)
+			assert.Len(t, weightDestinations, 0)
+			return nil
+		})
+		f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
+		f.fakeTrafficRouting.On("VerifyWeight", mock.Anything, mock.Anything).Return(ptr.To[bool](true), nil)
+		f.run(getKey(r2, t))
+	})
+
+	t.Run("Experiment Running due to pending required analysis but template completed - WeightDestination drained to 0", func(t *testing.T) {
+		// When an experiment's duration elapses, the template status flips to
+		// Successful immediately (it is gated only on the duration and replica
+		// availability, not on analyses - see experiments/experiment.go). If the
+		// experiment also has a required-for-completion analysis that is still
+		// pending, the *experiment phase* is deferred to that analysis and therefore
+		// stays Running while the template's ReplicaSet is already scaling down. We
+		// must still drain the completed template's traffic to 0 in this window,
+		// keyed off the template status rather than the experiment phase.
+		ex.Status.Phase = v1alpha1.AnalysisPhaseRunning
+		ex.Status.TemplateStatuses[0].Status = v1alpha1.TemplateStatusSuccessful
+		ex.Status.AnalysisRuns = []v1alpha1.ExperimentAnalysisRunStatus{{
+			Name:        "required-analysis",
+			AnalysisRun: "required-analysis-run",
+			Phase:       v1alpha1.AnalysisPhaseRunning,
+		}}
+		defer func() {
+			ex.Status.TemplateStatuses[0].Status = ""
+			ex.Status.AnalysisRuns = nil
+		}()
+		f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+		f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, weightDestinations ...v1alpha1.WeightDestination) error {
+			assert.Equal(t, int32(10), desiredWeight)
+			assert.Len(t, weightDestinations, 1)
+			assert.Equal(t, int32(0), weightDestinations[0].Weight)
+			assert.Equal(t, ex.Status.TemplateStatuses[0].ServiceName, weightDestinations[0].ServiceName)
+			assert.Equal(t, ex.Status.TemplateStatuses[0].PodTemplateHash, weightDestinations[0].PodTemplateHash)
+			return nil
+		})
+		f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
+		f.fakeTrafficRouting.On("VerifyWeight", mock.Anything, mock.Anything).Return(ptr.To[bool](true), nil)
+		f.run(getKey(r2, t))
+	})
+
 	t.Run("Experiment Running but template Service torn down - no WeightDestination created", func(t *testing.T) {
 		// When an experiment finishes, its controller deletes the template Services
 		// and clears templateStatus.ServiceName, which can be observed while the


### PR DESCRIPTION
## Summary

When a canary `experiment` step uses weighted templates (traffic routing), the rollout can get **permanently wedged** on the experiment step at teardown, with an Istio admission error:

```
admission webhook "validation.istio.io" denied the request: configuration is invalid: empty domain name not allowed
```

While it is stuck, traffic stays pinned to the experiment services that have already been deleted.

## Root cause

Experiment teardown is driven **per template**: when a template completes, `CalculateTemplateReplicasCount` returns `0` for it, so the experiment controller scales its ReplicaSet down and `deleteTemplateService` clears `templateStatus.ServiceName` (and `PodTemplateHash`). Because templates complete individually, this is observable while the experiment overall is still reported as `Running` (e.g. another template or a required AnalysisRun hasn't finalized yet).

In that window, `calculateWeightDestinationsFromExperiment` (gated on `Phase == Running`) still built a `WeightDestination` for the weighted template using the now-empty `ServiceName`. The Istio reconciler (`processRoutes`/`appendPatch`) turned that into a route destination with an empty `host`, which Istio's validation webhook rejects. The failed `SetWeight` prevents the step from completing, so the rollout retries the same invalid `VirtualService` update indefinitely.

This is timing dependent, which is why it reproduces intermittently.

### Example scenario that triggers this

One concrete way this window opens up:

- The experiment step has `duration: 5m`, and a required `AnalysisRun` is configured with `startingStep`/`initialDelay` of `5m` (i.e. the analysis is meant to start only once the experiment's own duration has elapsed).
- The experiment's `duration` elapses, so its weighted-template ReplicaSet becomes eligible for the `scaleDownDelaySeconds` teardown path.
- The required `AnalysisRun`, for whatever reason (controller backlog, slow provider, etc.), doesn't start promptly or doesn't finish quickly once its delay expires — so the experiment as a whole is still `Running` while it waits on that `AnalysisRun`.
- Because the ReplicaSet already passed its scale-down delay, it gets scaled down and its Service is deleted, clearing `templateStatus.ServiceName`.
- On the next reconcile, `calculateWeightDestinationsFromExperiment` still sees `Phase == Running` and builds a `WeightDestination` using the now-empty `ServiceName`, producing the empty-host route that Istio's admission webhook rejects.
- The `VirtualService` update never succeeds, so the stale experiment destination is never cleaned up and traffic continues to be routed to the deleted experiment Service, resulting in errors until the rollout is manually intervened on.

## Change

1. Guard the destination build on a non-empty `ServiceName`, so a template whose Service has been torn down no longer produces an empty-host route destination. The stale experiment destinations are then removed normally on the next `SetWeight`. This alone fixes the hard wedge/500 above.

2. **Drain the template's weight to `0` as soon as its `TemplateStatus` reaches `Completed()`, before its Service is deleted.**

   The `ServiceName`-empty guard above only takes effect once the Service is actually gone, and the experiment controller doesn't delete a template's Service until its ReplicaSet has scaled all the way down to `AvailableReplicas == 0` (`experiments/experiment.go`). Right up until that point, the completed template's Service still exists with its full configured weight, so `calculateWeightDestinationsFromExperiment` kept routing that share of live traffic at pods that are already being torn down.

   In practice this leaves almost no time for the weight change to actually propagate: the `VirtualService`/`DestinationRule` update has to go through the Kubernetes API, get reconciled by the Istio control plane (Pilot), pushed down over xDS, and applied by each Envoy sidecar — all *after* the pods are already gone. That round trip routinely takes longer than the pod scale-down itself, so requests land on terminated/terminating pods and return connection resets or 5xxs during the gap.

   Now, once a template's status is `Completed` (its `duration` elapsed, independent of whether the *experiment* as a whole is still `Running`), we keep emitting a destination for it as long as its Service still exists, but force its weight to `0` instead of the configured value. This returns the freed weight to the stable service immediately — while the pods are still up and serving in-flight requests — instead of waiting for the Service to be deleted. That gives the traffic-routing update a real buffer to drain through the API server → Istio control plane → Envoy data plane before the Service disappears, rather than racing the pod teardown. Once the Service is actually deleted, the destination drops out of the route entirely (unchanged behavior from fix 1).

## Testing

- Adds regression subtests to `TestRolloutWithExperimentStep`:
  - experiment `Running` with a weighted template whose `ServiceName` is empty → `SetWeight` receives zero weight destinations (fix 1). Verified it fails without the fix (`"[{5  }]" should have 0 item(s)`) and passes with it.
  - experiment `Running` with a template `Completed` but its Service still present → `SetWeight` receives a destination for that template with weight drained to `0` (fix 2).
  - experiment `Running` only because a required `AnalysisRun` is still pending, with the weighted template already `Completed` → same drain-to-0 behavior, keyed off the template status rather than the experiment phase.
  - experiment reaches a terminal phase (`Successful`) → no destinations are built at all (unchanged).
- `go test ./rollout/ ./experiments/ ./rollout/trafficrouting/istio/` passes.

## Checklist

- [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
- [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
- [x] Does this PR require documentation updates?
- [x] I've updated documentation as required by this PR.
- [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal).
- [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
- [x] My build is green ([troubleshooting builds](https://argo-rollouts.readthedocs.io/en/stable/CONTRIBUTING/#troubleshooting)).


