### PR TITLE
fix(trafficrouting): do not re-point Istio canary subset to a not-yet-scaled-up ReplicaSet. Fixes #4775

### DIFF
--- a/rollout/trafficrouting/istio/istio.go
+++ b/rollout/trafficrouting/istio/istio.go
@@ -376,10 +376,45 @@ func (r *Reconciler) shouldDelayDestinationRuleUpdate(canaryHash, stableHash str
 	return false, ""
 }
 
+// shouldSkipDestinationRuleUpdate returns true if updating the DestinationRule should be
+// skipped (without failing the reconcile) because the target canary ReplicaSet has not been
+// scaled up yet (spec.replicas == 0). Re-pointing the canary subset at a hash with zero pods
+// de-selects the previous, still-healthy canary pods while the VirtualService weight reset and
+// the DestinationRule subset switch propagate to proxies non-atomically, causing transient
+// "no_healthy_upstream" 503s. Unlike shouldDelayDestinationRuleUpdate, this must not surface
+// as an error: ReplicaSets are scaled up after traffic routing is reconciled, so failing the
+// reconcile here would prevent the ReplicaSet from ever being scaled up.
+// See: https://github.com/argoproj/argo-rollouts/issues/4775
+func (r *Reconciler) shouldSkipDestinationRuleUpdate(canaryHash, stableHash string) (bool, string) {
+	if r.rollout.Spec.Strategy.Canary.CanaryService != "" || r.rollout.Spec.Strategy.Canary.StableService != "" {
+		return false, ""
+	}
+	if canaryHash == "" || canaryHash == stableHash {
+		return false, ""
+	}
+	if rolloututil.AbortOrDynamicRollbackToStable(r.rollout, r.replicaSets, stableHash) {
+		// on abort/rollback, traffic shifts to stable, so re-pointing the canary subset is safe
+		return false, ""
+	}
+	for _, rs := range r.replicaSets {
+		if rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] != canaryHash {
+			continue
+		}
+		if rs.Spec.Replicas != nil && *rs.Spec.Replicas == 0 {
+			return true, rs.Name
+		}
+	}
+	return false, ""
+}
+
 func (r *Reconciler) UpdateHash(canaryHash, stableHash string, additionalDestinations ...v1alpha1.WeightDestination) error {
 	if shouldDelay, rsName := r.shouldDelayDestinationRuleUpdate(canaryHash, stableHash); shouldDelay {
 		r.log.Infof("delaying destination rule switch: ReplicaSet %s not fully available", rsName)
 		return fmt.Errorf("delaying destination rule switch: ReplicaSet %s not fully available", rsName)
+	}
+	if shouldSkip, rsName := r.shouldSkipDestinationRuleUpdate(canaryHash, stableHash); shouldSkip {
+		r.log.Infof("skipping destination rule switch: canary ReplicaSet %s is not scaled up yet", rsName)
+		return nil
 	}
 
 	dRuleSpec := r.rollout.Spec.Strategy.Canary.TrafficRouting.Istio.DestinationRule

--- a/rollout/trafficrouting/istio/istio_test.go
+++ b/rollout/trafficrouting/istio/istio_test.go
@@ -3544,6 +3544,213 @@ func TestShouldDelayDestinationRuleUpdate(t *testing.T) {
 	})
 }
 
+// TestUpdateHashSkipsNotYetScaledUpCanary verifies that UpdateHash does not re-point the
+// canary subset to a canary ReplicaSet that has not been scaled up yet (spec.replicas == 0),
+// which would de-select the previous, still-healthy canary pods and cause transient
+// "no_healthy_upstream" 503s. Unlike the unavailable-RS case, no error may be returned,
+// because ReplicaSets are scaled up after traffic routing is reconciled; failing the
+// reconcile would prevent the ReplicaSet from ever being scaled up.
+// See https://github.com/argoproj/argo-rollouts/issues/4775
+func TestUpdateHashSkipsNotYetScaledUpCanary(t *testing.T) {
+	createRollout := func(abort bool) *v1alpha1.Rollout {
+		ro := rolloutWithDestinationRule(nil)
+		ro.Spec.Strategy.Canary.CanaryService = ""
+		ro.Spec.Strategy.Canary.StableService = ""
+		ro.Status.Abort = abort
+		return ro
+	}
+
+	createDestinationRuleObj := func() *unstructured.Unstructured {
+		return unstructuredutil.StrToUnstructuredUnsafe(`
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: istio-destrule
+  namespace: default
+spec:
+  subsets:
+  - name: stable
+  - name: canary
+`)
+	}
+
+	createRS := func(ro *v1alpha1.Rollout, hash string, replicas, availableReplicas int32) *appsv1.ReplicaSet {
+		return &appsv1.ReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "rs-" + hash,
+				UID:       uuid.NewUUID(),
+				Namespace: metav1.NamespaceDefault,
+				Labels: map[string]string{
+					v1alpha1.DefaultRolloutUniqueLabelKey: hash,
+				},
+			},
+			Spec: appsv1.ReplicaSetSpec{
+				Replicas: &replicas,
+				Template: ro.Spec.Template,
+			},
+			Status: appsv1.ReplicaSetStatus{
+				Replicas:          replicas,
+				AvailableReplicas: availableReplicas,
+			},
+		}
+	}
+
+	setupReconciler := func(ro *v1alpha1.Rollout, client *dynamicfake.FakeDynamicClient, rsList []*appsv1.ReplicaSet) *Reconciler {
+		vsvcLister, druleLister := getIstioListers(client)
+		r := NewReconciler(ro, client, record.NewFakeEventRecorder(), vsvcLister, druleLister, rsList)
+		client.ClearActions()
+		return r
+	}
+
+	t.Run("skips DestinationRule update without error when canary RS is not scaled up yet", func(t *testing.T) {
+		ro := createRollout(false)
+		client := testutil.NewFakeDynamicClient(createDestinationRuleObj())
+
+		stableRS := createRS(ro, "stable123", 1, 1)
+		newCanaryRS := createRS(ro, "canary456", 0, 0) // created, but not scaled up yet
+		r := setupReconciler(ro, client, []*appsv1.ReplicaSet{stableRS, newCanaryRS})
+
+		err := r.UpdateHash("canary456", "stable123")
+		assert.NoError(t, err, "must not fail the reconcile; otherwise the canary RS would never be scaled up")
+
+		actions := client.Actions()
+		assert.Len(t, actions, 0, "DestinationRule must not be re-pointed to a canary RS with no pods")
+	})
+
+	t.Run("updates DestinationRule when canary RS is scaled up and available", func(t *testing.T) {
+		ro := createRollout(false)
+		client := testutil.NewFakeDynamicClient(createDestinationRuleObj())
+
+		stableRS := createRS(ro, "stable123", 1, 1)
+		canaryRS := createRS(ro, "canary456", 1, 1)
+		r := setupReconciler(ro, client, []*appsv1.ReplicaSet{stableRS, canaryRS})
+
+		err := r.UpdateHash("canary456", "stable123")
+		assert.NoError(t, err)
+
+		actions := client.Actions()
+		assert.Len(t, actions, 1)
+		assert.Equal(t, "update", actions[0].GetVerb())
+	})
+
+	t.Run("does not skip during abort", func(t *testing.T) {
+		ro := createRollout(true)
+		client := testutil.NewFakeDynamicClient(createDestinationRuleObj())
+
+		stableRS := createRS(ro, "stable123", 1, 1)
+		canaryRS := createRS(ro, "canary456", 0, 0)
+		r := setupReconciler(ro, client, []*appsv1.ReplicaSet{stableRS, canaryRS})
+
+		err := r.UpdateHash("canary456", "stable123")
+		assert.NoError(t, err)
+
+		actions := client.Actions()
+		assert.Len(t, actions, 1, "abort shifts traffic to stable; the canary subset switch is safe and must not be skipped")
+		assert.Equal(t, "update", actions[0].GetVerb())
+	})
+
+	t.Run("does not skip when fully promoted (canaryHash == stableHash)", func(t *testing.T) {
+		ro := createRollout(false)
+		client := testutil.NewFakeDynamicClient(createDestinationRuleObj())
+
+		stableRS := createRS(ro, "stable123", 0, 0) // e.g. user scaled the rollout down
+		r := setupReconciler(ro, client, []*appsv1.ReplicaSet{stableRS})
+
+		err := r.UpdateHash("stable123", "stable123")
+		assert.NoError(t, err)
+
+		actions := client.Actions()
+		assert.Len(t, actions, 1)
+		assert.Equal(t, "update", actions[0].GetVerb())
+	})
+}
+
+// TestShouldSkipDestinationRuleUpdate tests the guard that prevents re-pointing the canary
+// subset to a not-yet-scaled-up canary ReplicaSet.
+// See https://github.com/argoproj/argo-rollouts/issues/4775
+func TestShouldSkipDestinationRuleUpdate(t *testing.T) {
+	ro := rolloutWithDestinationRule(nil)
+	ro.Spec.Strategy.Canary.CanaryService = ""
+	ro.Spec.Strategy.Canary.StableService = ""
+
+	createRS := func(hash string, replicas, availableReplicas int32) *appsv1.ReplicaSet {
+		return &appsv1.ReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "rs-" + hash,
+				UID:       uuid.NewUUID(),
+				Namespace: metav1.NamespaceDefault,
+				Labels:    map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: hash},
+			},
+			Spec: appsv1.ReplicaSetSpec{
+				Replicas: &replicas,
+				Template: ro.Spec.Template,
+			},
+			Status: appsv1.ReplicaSetStatus{Replicas: replicas, AvailableReplicas: availableReplicas},
+		}
+	}
+
+	client := testutil.NewFakeDynamicClient()
+	r := NewReconciler(ro, client, record.NewFakeEventRecorder(), nil, nil, nil)
+
+	t.Run("skip when target canary RS is not scaled up yet", func(t *testing.T) {
+		r.rollout.Status.Abort = false
+		r.replicaSets = []*appsv1.ReplicaSet{createRS("stable123", 1, 1), createRS("canary456", 0, 0)}
+
+		shouldSkip, rsName := r.shouldSkipDestinationRuleUpdate("canary456", "stable123")
+		assert.True(t, shouldSkip)
+		assert.Equal(t, "rs-canary456", rsName)
+	})
+
+	t.Run("no skip when target canary RS is scaled up", func(t *testing.T) {
+		r.rollout.Status.Abort = false
+		r.replicaSets = []*appsv1.ReplicaSet{createRS("stable123", 1, 1), createRS("canary456", 1, 0)}
+
+		shouldSkip, rsName := r.shouldSkipDestinationRuleUpdate("canary456", "stable123")
+		assert.False(t, shouldSkip, "a scaled-up but unavailable canary RS is handled by shouldDelayDestinationRuleUpdate")
+		assert.Empty(t, rsName)
+	})
+
+	t.Run("no skip on abort", func(t *testing.T) {
+		r.rollout.Status.Abort = true
+		r.replicaSets = []*appsv1.ReplicaSet{createRS("stable123", 1, 1), createRS("canary456", 0, 0)}
+
+		shouldSkip, rsName := r.shouldSkipDestinationRuleUpdate("canary456", "stable123")
+		assert.False(t, shouldSkip)
+		assert.Empty(t, rsName)
+	})
+
+	t.Run("no skip when canaryHash is empty or equals stableHash", func(t *testing.T) {
+		r.rollout.Status.Abort = false
+		r.replicaSets = []*appsv1.ReplicaSet{createRS("stable123", 0, 0)}
+
+		shouldSkip, _ := r.shouldSkipDestinationRuleUpdate("", "stable123")
+		assert.False(t, shouldSkip)
+		shouldSkip, _ = r.shouldSkipDestinationRuleUpdate("stable123", "stable123")
+		assert.False(t, shouldSkip)
+	})
+
+	t.Run("no skip when canary/stable services are set", func(t *testing.T) {
+		roWithSvc := rolloutWithDestinationRule(nil)
+		roWithSvc.Spec.Strategy.Canary.CanaryService = "canary-svc"
+		roWithSvc.Spec.Strategy.Canary.StableService = "stable-svc"
+		rSvc := NewReconciler(roWithSvc, client, record.NewFakeEventRecorder(), nil, nil, nil)
+		rSvc.replicaSets = []*appsv1.ReplicaSet{createRS("stable123", 1, 1), createRS("canary456", 0, 0)}
+
+		shouldSkip, rsName := rSvc.shouldSkipDestinationRuleUpdate("canary456", "stable123")
+		assert.False(t, shouldSkip)
+		assert.Empty(t, rsName)
+	})
+
+	t.Run("no skip when no RS matches the canary hash", func(t *testing.T) {
+		r.rollout.Status.Abort = false
+		r.replicaSets = []*appsv1.ReplicaSet{createRS("stable123", 1, 1)}
+
+		shouldSkip, rsName := r.shouldSkipDestinationRuleUpdate("canary456", "stable123")
+		assert.False(t, shouldSkip)
+		assert.Empty(t, rsName)
+	})
+}
+
 func TestUpdateHashInvalidDestinationRule(t *testing.T) {
 	ro := rolloutWithDestinationRule(nil)
 	// set to invalid destination rule


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green. Try syncing with master if they are not.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] I have run all tests locally (including the flaky ones) and they pass on my workstation (ran `./rollout/...` including the full istio package locally; full suite green in CI)
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

Fixes #4775

## Summary

With subset-based Istio traffic routing (DestinationRule `canarySubsetName`/`stableSubsetName`), pushing a new revision while a canary step is in progress causes a burst of `503 UH no_healthy_upstream` on the canary cluster: `UpdateHash` re-points the canary subset to the new revision's pod-template-hash **before** the new ReplicaSet has been scaled up, de-selecting the still-healthy old canary pods.

## Root cause

`shouldDelayDestinationRuleUpdate` skips ReplicaSets with `spec.replicas == 0`:

https://github.com/argoproj/argo-rollouts/blob/bc55226ee61b1a4f2f1e9313d1a4b3da45825793/rollout/trafficrouting/istio/istio.go#L361-L364

On the reconcile where the new revision is first observed, the new canary RS exists but has not been scaled up yet (`spec.replicas == 0` — scaling happens later in `rolloutCanary`, after `reconcileTrafficRouting`). The guard therefore skips it and returns `false`, and `UpdateHash` switches the canary subset to a hash with zero pods. The guard only starts firing on the *next* reconcile, after scale-up — too late. The "reset weight to 0 before UpdateHash" block (#3273-era mitigation in `reconcileTrafficRouting`) cannot prevent this either, because the VirtualService (weight) and DestinationRule (subset/EDS) are separate resources that proxies apply non-atomically, so the canary cluster is "weighted but empty" during xDS convergence.

## Why not extend the existing delay-error guard

The obvious fix — making `shouldDelayDestinationRuleUpdate` also fire for the zero-replica target canary RS — **deadlocks**: the guard surfaces as an error from `UpdateHash`, which fails `reconcileTrafficRouting`, which returns early from `rolloutCanary` *before* `reconcileCanaryReplicaSets` runs. The new RS would never be scaled up, so the guard would fire forever. (The existing error path is safe only because pod *readiness* progresses via the kubelet, independent of the controller.)

## Fix

Add a separate guard, `shouldSkipDestinationRuleUpdate`: when the target canary hash belongs to a ReplicaSet that has not been scaled up yet (`spec.replicas == 0`), skip the DestinationRule update **without returning an error**. The canary subset stays on the previous (healthy) hash, the reconcile proceeds so the new RS gets scaled up, and once it is scaled up the existing delay guard takes over (delay until fully available, then switch). Net effect: the subset switch now happens only when the new canary RS is fully available, matching the behavior a first-time canary rollout already gets from #2507.

The skip intentionally does **not** apply when:
- aborting or dynamically rolling back to stable (traffic shifts to stable; re-pointing the canary subset is required and safe — same exemption as the existing guard),
- `canaryHash == stableHash` (fully promoted) or `canaryHash == ""`,
- canary/stable Services are configured (guards don't apply, same as existing behavior).

Resulting controller sequence for the issue's repro (revision B pushed while paused at `setWeight: 5` on revision A):

1. weight reset 5→0, DR update **skipped** (canary subset still on A, pods healthy → no 503 during propagation)
2. RS(B) scaled up; DR update delayed by the existing guard while B is unavailable
3. B fully available → DR canary subset switched A→B, weight raised — both targets healthy at all times

## Testing

- `TestUpdateHashSkipsNotYetScaledUpCanary` — reproduces the bug at the `UpdateHash` level (fails without the fix): no DR update and no error for a zero-replica target canary RS; DR still updated when available, on abort, and when fully promoted.
- `TestShouldSkipDestinationRuleUpdate` — unit tests for the new guard (scaled-up RS, abort, empty/equal hashes, services set, no matching RS).
- Full `./rollout/...` test suite passes locally.

I'm happy to add an e2e test if maintainers think it's worthwhile — the timing-sensitive part (xDS propagation) isn't observable in e2e, but the "DR must not switch before the superseding canary RS is available" ordering is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

