### PR TITLE
fix(controller): prevent panic when notifications write Unstructured …

### DIFF
--- a/utils/tolerantinformer/analysisrun.go
+++ b/utils/tolerantinformer/analysisrun.go
@@ -13,14 +13,16 @@ import (
 
 func NewTolerantAnalysisRunInformer(factory dynamicinformer.DynamicSharedInformerFactory) rolloutinformers.AnalysisRunInformer {
 	delegate := factory.ForResource(v1alpha1.AnalysisRunGVR)
-	transform := makeTransform(func() *v1alpha1.AnalysisRun { return &v1alpha1.AnalysisRun{} })
+	newFn := func() *v1alpha1.AnalysisRun { return &v1alpha1.AnalysisRun{} }
+	transform := makeTransform(newFn)
 	installTransform(delegate.Informer(), transform, "AnalysisRun")
-	return &tolerantAnalysisRunInformer{delegate: delegate, transform: transform}
+	return &tolerantAnalysisRunInformer{delegate: delegate, transform: transform, newFn: newFn}
 }
 
 type tolerantAnalysisRunInformer struct {
 	delegate  informers.GenericInformer
 	transform cache.TransformFunc
+	newFn     func() *v1alpha1.AnalysisRun
 }
 
 func (i *tolerantAnalysisRunInformer) Informer() cache.SharedIndexInformer {
@@ -28,7 +30,7 @@ func (i *tolerantAnalysisRunInformer) Informer() cache.SharedIndexInformer {
 }
 
 func (i *tolerantAnalysisRunInformer) Lister() rolloutlisters.AnalysisRunLister {
-	return &tolerantAnalysisRunLister{indexer: i.delegate.Informer().GetIndexer()}
+	return &tolerantAnalysisRunLister{indexer: i.delegate.Informer().GetIndexer(), newFn: i.newFn}
 }
 
 // tolerantAnalysisRunLister lists from the indexer and deep-copies each result so
@@ -37,31 +39,27 @@ func (i *tolerantAnalysisRunInformer) Lister() rolloutlisters.AnalysisRunLister 
 // (direct store writes that bypass SetTransform).
 type tolerantAnalysisRunLister struct {
 	indexer cache.Indexer
+	newFn   func() *v1alpha1.AnalysisRun
 }
 
 func (t *tolerantAnalysisRunLister) List(selector labels.Selector) ([]*v1alpha1.AnalysisRun, error) {
-	return listTyped(t.indexer, "", selector,
-		func() *v1alpha1.AnalysisRun { return &v1alpha1.AnalysisRun{} },
-		func(ar *v1alpha1.AnalysisRun) *v1alpha1.AnalysisRun { return ar.DeepCopy() })
+	return listTyped(t.indexer, "", selector, t.newFn)
 }
 
 func (t *tolerantAnalysisRunLister) AnalysisRuns(namespace string) rolloutlisters.AnalysisRunNamespaceLister {
-	return &tolerantAnalysisRunNamespaceLister{indexer: t.indexer, namespace: namespace}
+	return &tolerantAnalysisRunNamespaceLister{indexer: t.indexer, namespace: namespace, newFn: t.newFn}
 }
 
 type tolerantAnalysisRunNamespaceLister struct {
 	indexer   cache.Indexer
 	namespace string
+	newFn     func() *v1alpha1.AnalysisRun
 }
 
 func (t *tolerantAnalysisRunNamespaceLister) Get(name string) (*v1alpha1.AnalysisRun, error) {
-	return getTyped(t.indexer, v1alpha1.Resource("analysisrun"), t.namespace, name,
-		func() *v1alpha1.AnalysisRun { return &v1alpha1.AnalysisRun{} },
-		func(ar *v1alpha1.AnalysisRun) *v1alpha1.AnalysisRun { return ar.DeepCopy() })
+	return getTyped(t.indexer, v1alpha1.Resource("analysisrun"), t.namespace, name, t.newFn)
 }
 
 func (t *tolerantAnalysisRunNamespaceLister) List(selector labels.Selector) ([]*v1alpha1.AnalysisRun, error) {
-	return listTyped(t.indexer, t.namespace, selector,
-		func() *v1alpha1.AnalysisRun { return &v1alpha1.AnalysisRun{} },
-		func(ar *v1alpha1.AnalysisRun) *v1alpha1.AnalysisRun { return ar.DeepCopy() })
+	return listTyped(t.indexer, t.namespace, selector, t.newFn)
 }

--- a/utils/tolerantinformer/analysisrun.go
+++ b/utils/tolerantinformer/analysisrun.go
@@ -13,73 +13,55 @@ import (
 
 func NewTolerantAnalysisRunInformer(factory dynamicinformer.DynamicSharedInformerFactory) rolloutinformers.AnalysisRunInformer {
 	delegate := factory.ForResource(v1alpha1.AnalysisRunGVR)
-	installTransform(delegate.Informer(),
-		makeTransform(func() *v1alpha1.AnalysisRun { return &v1alpha1.AnalysisRun{} }),
-		"AnalysisRun")
-	return &tolerantAnalysisRunInformer{delegate: delegate}
+	transform := makeTransform(func() *v1alpha1.AnalysisRun { return &v1alpha1.AnalysisRun{} })
+	installTransform(delegate.Informer(), transform, "AnalysisRun")
+	return &tolerantAnalysisRunInformer{delegate: delegate, transform: transform}
 }
 
 type tolerantAnalysisRunInformer struct {
-	delegate informers.GenericInformer
+	delegate  informers.GenericInformer
+	transform cache.TransformFunc
 }
 
 func (i *tolerantAnalysisRunInformer) Informer() cache.SharedIndexInformer {
-	return i.delegate.Informer()
+	return &transformingInformer{SharedIndexInformer: i.delegate.Informer(), transform: i.transform}
 }
 
 func (i *tolerantAnalysisRunInformer) Lister() rolloutlisters.AnalysisRunLister {
-	return &tolerantAnalysisRunLister{
-		delegate: rolloutlisters.NewAnalysisRunLister(i.delegate.Informer().GetIndexer()),
-	}
+	return &tolerantAnalysisRunLister{indexer: i.delegate.Informer().GetIndexer()}
 }
 
-// tolerantAnalysisRunLister wraps the generated typed lister and deep-copies each
-// returned object so callers can safely mutate the result without corrupting the
-// shared informer cache. The SetTransform conversion still runs only once per
-// object change, so the dominant cost (unstructured→typed reflection) is paid
-// once; the per-call cost here is a fast generated DeepCopy.
+// tolerantAnalysisRunLister lists from the indexer and deep-copies each result so
+// callers can safely mutate without corrupting the shared cache. Objects are
+// coerced from either the typed form (SetTransform path) or *unstructured.Unstructured
+// (direct store writes that bypass SetTransform).
 type tolerantAnalysisRunLister struct {
-	delegate rolloutlisters.AnalysisRunLister
+	indexer cache.Indexer
 }
 
 func (t *tolerantAnalysisRunLister) List(selector labels.Selector) ([]*v1alpha1.AnalysisRun, error) {
-	items, err := t.delegate.List(selector)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]*v1alpha1.AnalysisRun, len(items))
-	for i, ar := range items {
-		out[i] = ar.DeepCopy()
-	}
-	return out, nil
+	return listTyped(t.indexer, "", selector,
+		func() *v1alpha1.AnalysisRun { return &v1alpha1.AnalysisRun{} },
+		func(ar *v1alpha1.AnalysisRun) *v1alpha1.AnalysisRun { return ar.DeepCopy() })
 }
 
 func (t *tolerantAnalysisRunLister) AnalysisRuns(namespace string) rolloutlisters.AnalysisRunNamespaceLister {
-	return &tolerantAnalysisRunNamespaceLister{
-		delegate: t.delegate.AnalysisRuns(namespace),
-	}
+	return &tolerantAnalysisRunNamespaceLister{indexer: t.indexer, namespace: namespace}
 }
 
 type tolerantAnalysisRunNamespaceLister struct {
-	delegate rolloutlisters.AnalysisRunNamespaceLister
+	indexer   cache.Indexer
+	namespace string
 }
 
 func (t *tolerantAnalysisRunNamespaceLister) Get(name string) (*v1alpha1.AnalysisRun, error) {
-	ar, err := t.delegate.Get(name)
-	if err != nil {
-		return nil, err
-	}
-	return ar.DeepCopy(), nil
+	return getTyped(t.indexer, v1alpha1.Resource("analysisrun"), t.namespace, name,
+		func() *v1alpha1.AnalysisRun { return &v1alpha1.AnalysisRun{} },
+		func(ar *v1alpha1.AnalysisRun) *v1alpha1.AnalysisRun { return ar.DeepCopy() })
 }
 
 func (t *tolerantAnalysisRunNamespaceLister) List(selector labels.Selector) ([]*v1alpha1.AnalysisRun, error) {
-	items, err := t.delegate.List(selector)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]*v1alpha1.AnalysisRun, len(items))
-	for i, ar := range items {
-		out[i] = ar.DeepCopy()
-	}
-	return out, nil
+	return listTyped(t.indexer, t.namespace, selector,
+		func() *v1alpha1.AnalysisRun { return &v1alpha1.AnalysisRun{} },
+		func(ar *v1alpha1.AnalysisRun) *v1alpha1.AnalysisRun { return ar.DeepCopy() })
 }

--- a/utils/tolerantinformer/analysistemplate.go
+++ b/utils/tolerantinformer/analysistemplate.go
@@ -13,14 +13,16 @@ import (
 
 func NewTolerantAnalysisTemplateInformer(factory dynamicinformer.DynamicSharedInformerFactory) rolloutinformers.AnalysisTemplateInformer {
 	delegate := factory.ForResource(v1alpha1.AnalysisTemplateGVR)
-	transform := makeTransform(func() *v1alpha1.AnalysisTemplate { return &v1alpha1.AnalysisTemplate{} })
+	newFn := func() *v1alpha1.AnalysisTemplate { return &v1alpha1.AnalysisTemplate{} }
+	transform := makeTransform(newFn)
 	installTransform(delegate.Informer(), transform, "AnalysisTemplate")
-	return &tolerantAnalysisTemplateInformer{delegate: delegate, transform: transform}
+	return &tolerantAnalysisTemplateInformer{delegate: delegate, transform: transform, newFn: newFn}
 }
 
 type tolerantAnalysisTemplateInformer struct {
 	delegate  informers.GenericInformer
 	transform cache.TransformFunc
+	newFn     func() *v1alpha1.AnalysisTemplate
 }
 
 func (i *tolerantAnalysisTemplateInformer) Informer() cache.SharedIndexInformer {
@@ -28,36 +30,32 @@ func (i *tolerantAnalysisTemplateInformer) Informer() cache.SharedIndexInformer 
 }
 
 func (i *tolerantAnalysisTemplateInformer) Lister() rolloutlisters.AnalysisTemplateLister {
-	return &tolerantAnalysisTemplateLister{indexer: i.delegate.Informer().GetIndexer()}
+	return &tolerantAnalysisTemplateLister{indexer: i.delegate.Informer().GetIndexer(), newFn: i.newFn}
 }
 
 type tolerantAnalysisTemplateLister struct {
 	indexer cache.Indexer
+	newFn   func() *v1alpha1.AnalysisTemplate
 }
 
 func (t *tolerantAnalysisTemplateLister) List(selector labels.Selector) ([]*v1alpha1.AnalysisTemplate, error) {
-	return listTyped(t.indexer, "", selector,
-		func() *v1alpha1.AnalysisTemplate { return &v1alpha1.AnalysisTemplate{} },
-		func(at *v1alpha1.AnalysisTemplate) *v1alpha1.AnalysisTemplate { return at.DeepCopy() })
+	return listTyped(t.indexer, "", selector, t.newFn)
 }
 
 func (t *tolerantAnalysisTemplateLister) AnalysisTemplates(namespace string) rolloutlisters.AnalysisTemplateNamespaceLister {
-	return &tolerantAnalysisTemplateNamespaceLister{indexer: t.indexer, namespace: namespace}
+	return &tolerantAnalysisTemplateNamespaceLister{indexer: t.indexer, namespace: namespace, newFn: t.newFn}
 }
 
 type tolerantAnalysisTemplateNamespaceLister struct {
 	indexer   cache.Indexer
 	namespace string
+	newFn     func() *v1alpha1.AnalysisTemplate
 }
 
 func (t *tolerantAnalysisTemplateNamespaceLister) Get(name string) (*v1alpha1.AnalysisTemplate, error) {
-	return getTyped(t.indexer, v1alpha1.Resource("analysistemplate"), t.namespace, name,
-		func() *v1alpha1.AnalysisTemplate { return &v1alpha1.AnalysisTemplate{} },
-		func(at *v1alpha1.AnalysisTemplate) *v1alpha1.AnalysisTemplate { return at.DeepCopy() })
+	return getTyped(t.indexer, v1alpha1.Resource("analysistemplate"), t.namespace, name, t.newFn)
 }
 
 func (t *tolerantAnalysisTemplateNamespaceLister) List(selector labels.Selector) ([]*v1alpha1.AnalysisTemplate, error) {
-	return listTyped(t.indexer, t.namespace, selector,
-		func() *v1alpha1.AnalysisTemplate { return &v1alpha1.AnalysisTemplate{} },
-		func(at *v1alpha1.AnalysisTemplate) *v1alpha1.AnalysisTemplate { return at.DeepCopy() })
+	return listTyped(t.indexer, t.namespace, selector, t.newFn)
 }

--- a/utils/tolerantinformer/analysistemplate.go
+++ b/utils/tolerantinformer/analysistemplate.go
@@ -13,68 +13,51 @@ import (
 
 func NewTolerantAnalysisTemplateInformer(factory dynamicinformer.DynamicSharedInformerFactory) rolloutinformers.AnalysisTemplateInformer {
 	delegate := factory.ForResource(v1alpha1.AnalysisTemplateGVR)
-	installTransform(delegate.Informer(),
-		makeTransform(func() *v1alpha1.AnalysisTemplate { return &v1alpha1.AnalysisTemplate{} }),
-		"AnalysisTemplate")
-	return &tolerantAnalysisTemplateInformer{delegate: delegate}
+	transform := makeTransform(func() *v1alpha1.AnalysisTemplate { return &v1alpha1.AnalysisTemplate{} })
+	installTransform(delegate.Informer(), transform, "AnalysisTemplate")
+	return &tolerantAnalysisTemplateInformer{delegate: delegate, transform: transform}
 }
 
 type tolerantAnalysisTemplateInformer struct {
-	delegate informers.GenericInformer
+	delegate  informers.GenericInformer
+	transform cache.TransformFunc
 }
 
 func (i *tolerantAnalysisTemplateInformer) Informer() cache.SharedIndexInformer {
-	return i.delegate.Informer()
+	return &transformingInformer{SharedIndexInformer: i.delegate.Informer(), transform: i.transform}
 }
 
 func (i *tolerantAnalysisTemplateInformer) Lister() rolloutlisters.AnalysisTemplateLister {
-	return &tolerantAnalysisTemplateLister{
-		delegate: rolloutlisters.NewAnalysisTemplateLister(i.delegate.Informer().GetIndexer()),
-	}
+	return &tolerantAnalysisTemplateLister{indexer: i.delegate.Informer().GetIndexer()}
 }
 
 type tolerantAnalysisTemplateLister struct {
-	delegate rolloutlisters.AnalysisTemplateLister
+	indexer cache.Indexer
 }
 
 func (t *tolerantAnalysisTemplateLister) List(selector labels.Selector) ([]*v1alpha1.AnalysisTemplate, error) {
-	items, err := t.delegate.List(selector)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]*v1alpha1.AnalysisTemplate, len(items))
-	for i, at := range items {
-		out[i] = at.DeepCopy()
-	}
-	return out, nil
+	return listTyped(t.indexer, "", selector,
+		func() *v1alpha1.AnalysisTemplate { return &v1alpha1.AnalysisTemplate{} },
+		func(at *v1alpha1.AnalysisTemplate) *v1alpha1.AnalysisTemplate { return at.DeepCopy() })
 }
 
 func (t *tolerantAnalysisTemplateLister) AnalysisTemplates(namespace string) rolloutlisters.AnalysisTemplateNamespaceLister {
-	return &tolerantAnalysisTemplateNamespaceLister{
-		delegate: t.delegate.AnalysisTemplates(namespace),
-	}
+	return &tolerantAnalysisTemplateNamespaceLister{indexer: t.indexer, namespace: namespace}
 }
 
 type tolerantAnalysisTemplateNamespaceLister struct {
-	delegate rolloutlisters.AnalysisTemplateNamespaceLister
+	indexer   cache.Indexer
+	namespace string
 }
 
 func (t *tolerantAnalysisTemplateNamespaceLister) Get(name string) (*v1alpha1.AnalysisTemplate, error) {
-	at, err := t.delegate.Get(name)
-	if err != nil {
-		return nil, err
-	}
-	return at.DeepCopy(), nil
+	return getTyped(t.indexer, v1alpha1.Resource("analysistemplate"), t.namespace, name,
+		func() *v1alpha1.AnalysisTemplate { return &v1alpha1.AnalysisTemplate{} },
+		func(at *v1alpha1.AnalysisTemplate) *v1alpha1.AnalysisTemplate { return at.DeepCopy() })
 }
 
 func (t *tolerantAnalysisTemplateNamespaceLister) List(selector labels.Selector) ([]*v1alpha1.AnalysisTemplate, error) {
-	items, err := t.delegate.List(selector)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]*v1alpha1.AnalysisTemplate, len(items))
-	for i, at := range items {
-		out[i] = at.DeepCopy()
-	}
-	return out, nil
+	return listTyped(t.indexer, t.namespace, selector,
+		func() *v1alpha1.AnalysisTemplate { return &v1alpha1.AnalysisTemplate{} },
+		func(at *v1alpha1.AnalysisTemplate) *v1alpha1.AnalysisTemplate { return at.DeepCopy() })
 }

--- a/utils/tolerantinformer/clusteranalysistemplate.go
+++ b/utils/tolerantinformer/clusteranalysistemplate.go
@@ -13,14 +13,16 @@ import (
 
 func NewTolerantClusterAnalysisTemplateInformer(factory dynamicinformer.DynamicSharedInformerFactory) rolloutinformers.ClusterAnalysisTemplateInformer {
 	delegate := factory.ForResource(v1alpha1.ClusterAnalysisTemplateGVR)
-	transform := makeTransform(func() *v1alpha1.ClusterAnalysisTemplate { return &v1alpha1.ClusterAnalysisTemplate{} })
+	newFn := func() *v1alpha1.ClusterAnalysisTemplate { return &v1alpha1.ClusterAnalysisTemplate{} }
+	transform := makeTransform(newFn)
 	installTransform(delegate.Informer(), transform, "ClusterAnalysisTemplate")
-	return &tolerantClusterAnalysisTemplateInformer{delegate: delegate, transform: transform}
+	return &tolerantClusterAnalysisTemplateInformer{delegate: delegate, transform: transform, newFn: newFn}
 }
 
 type tolerantClusterAnalysisTemplateInformer struct {
 	delegate  informers.GenericInformer
 	transform cache.TransformFunc
+	newFn     func() *v1alpha1.ClusterAnalysisTemplate
 }
 
 func (i *tolerantClusterAnalysisTemplateInformer) Informer() cache.SharedIndexInformer {
@@ -28,21 +30,18 @@ func (i *tolerantClusterAnalysisTemplateInformer) Informer() cache.SharedIndexIn
 }
 
 func (i *tolerantClusterAnalysisTemplateInformer) Lister() rolloutlisters.ClusterAnalysisTemplateLister {
-	return &tolerantClusterAnalysisTemplateLister{indexer: i.delegate.Informer().GetIndexer()}
+	return &tolerantClusterAnalysisTemplateLister{indexer: i.delegate.Informer().GetIndexer(), newFn: i.newFn}
 }
 
 type tolerantClusterAnalysisTemplateLister struct {
 	indexer cache.Indexer
+	newFn   func() *v1alpha1.ClusterAnalysisTemplate
 }
 
 func (t *tolerantClusterAnalysisTemplateLister) List(selector labels.Selector) ([]*v1alpha1.ClusterAnalysisTemplate, error) {
-	return listTyped(t.indexer, "", selector,
-		func() *v1alpha1.ClusterAnalysisTemplate { return &v1alpha1.ClusterAnalysisTemplate{} },
-		func(cat *v1alpha1.ClusterAnalysisTemplate) *v1alpha1.ClusterAnalysisTemplate { return cat.DeepCopy() })
+	return listTyped(t.indexer, "", selector, t.newFn)
 }
 
 func (t *tolerantClusterAnalysisTemplateLister) Get(name string) (*v1alpha1.ClusterAnalysisTemplate, error) {
-	return getTyped(t.indexer, v1alpha1.Resource("clusteranalysistemplate"), "", name,
-		func() *v1alpha1.ClusterAnalysisTemplate { return &v1alpha1.ClusterAnalysisTemplate{} },
-		func(cat *v1alpha1.ClusterAnalysisTemplate) *v1alpha1.ClusterAnalysisTemplate { return cat.DeepCopy() })
+	return getTyped(t.indexer, v1alpha1.Resource("clusteranalysistemplate"), "", name, t.newFn)
 }

--- a/utils/tolerantinformer/clusteranalysistemplate.go
+++ b/utils/tolerantinformer/clusteranalysistemplate.go
@@ -13,46 +13,36 @@ import (
 
 func NewTolerantClusterAnalysisTemplateInformer(factory dynamicinformer.DynamicSharedInformerFactory) rolloutinformers.ClusterAnalysisTemplateInformer {
 	delegate := factory.ForResource(v1alpha1.ClusterAnalysisTemplateGVR)
-	installTransform(delegate.Informer(),
-		makeTransform(func() *v1alpha1.ClusterAnalysisTemplate { return &v1alpha1.ClusterAnalysisTemplate{} }),
-		"ClusterAnalysisTemplate")
-	return &tolerantClusterAnalysisTemplateInformer{delegate: delegate}
+	transform := makeTransform(func() *v1alpha1.ClusterAnalysisTemplate { return &v1alpha1.ClusterAnalysisTemplate{} })
+	installTransform(delegate.Informer(), transform, "ClusterAnalysisTemplate")
+	return &tolerantClusterAnalysisTemplateInformer{delegate: delegate, transform: transform}
 }
 
 type tolerantClusterAnalysisTemplateInformer struct {
-	delegate informers.GenericInformer
+	delegate  informers.GenericInformer
+	transform cache.TransformFunc
 }
 
 func (i *tolerantClusterAnalysisTemplateInformer) Informer() cache.SharedIndexInformer {
-	return i.delegate.Informer()
+	return &transformingInformer{SharedIndexInformer: i.delegate.Informer(), transform: i.transform}
 }
 
 func (i *tolerantClusterAnalysisTemplateInformer) Lister() rolloutlisters.ClusterAnalysisTemplateLister {
-	return &tolerantClusterAnalysisTemplateLister{
-		delegate: rolloutlisters.NewClusterAnalysisTemplateLister(i.delegate.Informer().GetIndexer()),
-	}
+	return &tolerantClusterAnalysisTemplateLister{indexer: i.delegate.Informer().GetIndexer()}
 }
 
 type tolerantClusterAnalysisTemplateLister struct {
-	delegate rolloutlisters.ClusterAnalysisTemplateLister
+	indexer cache.Indexer
 }
 
 func (t *tolerantClusterAnalysisTemplateLister) List(selector labels.Selector) ([]*v1alpha1.ClusterAnalysisTemplate, error) {
-	items, err := t.delegate.List(selector)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]*v1alpha1.ClusterAnalysisTemplate, len(items))
-	for i, cat := range items {
-		out[i] = cat.DeepCopy()
-	}
-	return out, nil
+	return listTyped(t.indexer, "", selector,
+		func() *v1alpha1.ClusterAnalysisTemplate { return &v1alpha1.ClusterAnalysisTemplate{} },
+		func(cat *v1alpha1.ClusterAnalysisTemplate) *v1alpha1.ClusterAnalysisTemplate { return cat.DeepCopy() })
 }
 
 func (t *tolerantClusterAnalysisTemplateLister) Get(name string) (*v1alpha1.ClusterAnalysisTemplate, error) {
-	cat, err := t.delegate.Get(name)
-	if err != nil {
-		return nil, err
-	}
-	return cat.DeepCopy(), nil
+	return getTyped(t.indexer, v1alpha1.Resource("clusteranalysistemplate"), "", name,
+		func() *v1alpha1.ClusterAnalysisTemplate { return &v1alpha1.ClusterAnalysisTemplate{} },
+		func(cat *v1alpha1.ClusterAnalysisTemplate) *v1alpha1.ClusterAnalysisTemplate { return cat.DeepCopy() })
 }

--- a/utils/tolerantinformer/experiment.go
+++ b/utils/tolerantinformer/experiment.go
@@ -13,14 +13,16 @@ import (
 
 func NewTolerantExperimentInformer(factory dynamicinformer.DynamicSharedInformerFactory) rolloutinformers.ExperimentInformer {
 	delegate := factory.ForResource(v1alpha1.ExperimentGVR)
-	transform := makeTransform(func() *v1alpha1.Experiment { return &v1alpha1.Experiment{} })
+	newFn := func() *v1alpha1.Experiment { return &v1alpha1.Experiment{} }
+	transform := makeTransform(newFn)
 	installTransform(delegate.Informer(), transform, "Experiment")
-	return &tolerantExperimentInformer{delegate: delegate, transform: transform}
+	return &tolerantExperimentInformer{delegate: delegate, transform: transform, newFn: newFn}
 }
 
 type tolerantExperimentInformer struct {
 	delegate  informers.GenericInformer
 	transform cache.TransformFunc
+	newFn     func() *v1alpha1.Experiment
 }
 
 func (i *tolerantExperimentInformer) Informer() cache.SharedIndexInformer {
@@ -28,36 +30,32 @@ func (i *tolerantExperimentInformer) Informer() cache.SharedIndexInformer {
 }
 
 func (i *tolerantExperimentInformer) Lister() rolloutlisters.ExperimentLister {
-	return &tolerantExperimentLister{indexer: i.delegate.Informer().GetIndexer()}
+	return &tolerantExperimentLister{indexer: i.delegate.Informer().GetIndexer(), newFn: i.newFn}
 }
 
 type tolerantExperimentLister struct {
 	indexer cache.Indexer
+	newFn   func() *v1alpha1.Experiment
 }
 
 func (t *tolerantExperimentLister) List(selector labels.Selector) ([]*v1alpha1.Experiment, error) {
-	return listTyped(t.indexer, "", selector,
-		func() *v1alpha1.Experiment { return &v1alpha1.Experiment{} },
-		func(ex *v1alpha1.Experiment) *v1alpha1.Experiment { return ex.DeepCopy() })
+	return listTyped(t.indexer, "", selector, t.newFn)
 }
 
 func (t *tolerantExperimentLister) Experiments(namespace string) rolloutlisters.ExperimentNamespaceLister {
-	return &tolerantExperimentNamespaceLister{indexer: t.indexer, namespace: namespace}
+	return &tolerantExperimentNamespaceLister{indexer: t.indexer, namespace: namespace, newFn: t.newFn}
 }
 
 type tolerantExperimentNamespaceLister struct {
 	indexer   cache.Indexer
 	namespace string
+	newFn     func() *v1alpha1.Experiment
 }
 
 func (t *tolerantExperimentNamespaceLister) Get(name string) (*v1alpha1.Experiment, error) {
-	return getTyped(t.indexer, v1alpha1.Resource("experiment"), t.namespace, name,
-		func() *v1alpha1.Experiment { return &v1alpha1.Experiment{} },
-		func(ex *v1alpha1.Experiment) *v1alpha1.Experiment { return ex.DeepCopy() })
+	return getTyped(t.indexer, v1alpha1.Resource("experiment"), t.namespace, name, t.newFn)
 }
 
 func (t *tolerantExperimentNamespaceLister) List(selector labels.Selector) ([]*v1alpha1.Experiment, error) {
-	return listTyped(t.indexer, t.namespace, selector,
-		func() *v1alpha1.Experiment { return &v1alpha1.Experiment{} },
-		func(ex *v1alpha1.Experiment) *v1alpha1.Experiment { return ex.DeepCopy() })
+	return listTyped(t.indexer, t.namespace, selector, t.newFn)
 }

--- a/utils/tolerantinformer/experiment.go
+++ b/utils/tolerantinformer/experiment.go
@@ -13,68 +13,51 @@ import (
 
 func NewTolerantExperimentInformer(factory dynamicinformer.DynamicSharedInformerFactory) rolloutinformers.ExperimentInformer {
 	delegate := factory.ForResource(v1alpha1.ExperimentGVR)
-	installTransform(delegate.Informer(),
-		makeTransform(func() *v1alpha1.Experiment { return &v1alpha1.Experiment{} }),
-		"Experiment")
-	return &tolerantExperimentInformer{delegate: delegate}
+	transform := makeTransform(func() *v1alpha1.Experiment { return &v1alpha1.Experiment{} })
+	installTransform(delegate.Informer(), transform, "Experiment")
+	return &tolerantExperimentInformer{delegate: delegate, transform: transform}
 }
 
 type tolerantExperimentInformer struct {
-	delegate informers.GenericInformer
+	delegate  informers.GenericInformer
+	transform cache.TransformFunc
 }
 
 func (i *tolerantExperimentInformer) Informer() cache.SharedIndexInformer {
-	return i.delegate.Informer()
+	return &transformingInformer{SharedIndexInformer: i.delegate.Informer(), transform: i.transform}
 }
 
 func (i *tolerantExperimentInformer) Lister() rolloutlisters.ExperimentLister {
-	return &tolerantExperimentLister{
-		delegate: rolloutlisters.NewExperimentLister(i.delegate.Informer().GetIndexer()),
-	}
+	return &tolerantExperimentLister{indexer: i.delegate.Informer().GetIndexer()}
 }
 
 type tolerantExperimentLister struct {
-	delegate rolloutlisters.ExperimentLister
+	indexer cache.Indexer
 }
 
 func (t *tolerantExperimentLister) List(selector labels.Selector) ([]*v1alpha1.Experiment, error) {
-	items, err := t.delegate.List(selector)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]*v1alpha1.Experiment, len(items))
-	for i, ex := range items {
-		out[i] = ex.DeepCopy()
-	}
-	return out, nil
+	return listTyped(t.indexer, "", selector,
+		func() *v1alpha1.Experiment { return &v1alpha1.Experiment{} },
+		func(ex *v1alpha1.Experiment) *v1alpha1.Experiment { return ex.DeepCopy() })
 }
 
 func (t *tolerantExperimentLister) Experiments(namespace string) rolloutlisters.ExperimentNamespaceLister {
-	return &tolerantExperimentNamespaceLister{
-		delegate: t.delegate.Experiments(namespace),
-	}
+	return &tolerantExperimentNamespaceLister{indexer: t.indexer, namespace: namespace}
 }
 
 type tolerantExperimentNamespaceLister struct {
-	delegate rolloutlisters.ExperimentNamespaceLister
+	indexer   cache.Indexer
+	namespace string
 }
 
 func (t *tolerantExperimentNamespaceLister) Get(name string) (*v1alpha1.Experiment, error) {
-	ex, err := t.delegate.Get(name)
-	if err != nil {
-		return nil, err
-	}
-	return ex.DeepCopy(), nil
+	return getTyped(t.indexer, v1alpha1.Resource("experiment"), t.namespace, name,
+		func() *v1alpha1.Experiment { return &v1alpha1.Experiment{} },
+		func(ex *v1alpha1.Experiment) *v1alpha1.Experiment { return ex.DeepCopy() })
 }
 
 func (t *tolerantExperimentNamespaceLister) List(selector labels.Selector) ([]*v1alpha1.Experiment, error) {
-	items, err := t.delegate.List(selector)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]*v1alpha1.Experiment, len(items))
-	for i, ex := range items {
-		out[i] = ex.DeepCopy()
-	}
-	return out, nil
+	return listTyped(t.indexer, t.namespace, selector,
+		func() *v1alpha1.Experiment { return &v1alpha1.Experiment{} },
+		func(ex *v1alpha1.Experiment) *v1alpha1.Experiment { return ex.DeepCopy() })
 }

--- a/utils/tolerantinformer/rollout.go
+++ b/utils/tolerantinformer/rollout.go
@@ -13,14 +13,16 @@ import (
 
 func NewTolerantRolloutInformer(factory dynamicinformer.DynamicSharedInformerFactory) rolloutinformers.RolloutInformer {
 	delegate := factory.ForResource(v1alpha1.RolloutGVR)
-	transform := makeTransform(func() *v1alpha1.Rollout { return &v1alpha1.Rollout{} })
+	newFn := func() *v1alpha1.Rollout { return &v1alpha1.Rollout{} }
+	transform := makeTransform(newFn)
 	installTransform(delegate.Informer(), transform, "Rollout")
-	return &tolerantRolloutInformer{delegate: delegate, transform: transform}
+	return &tolerantRolloutInformer{delegate: delegate, transform: transform, newFn: newFn}
 }
 
 type tolerantRolloutInformer struct {
 	delegate  informers.GenericInformer
 	transform cache.TransformFunc
+	newFn     func() *v1alpha1.Rollout
 }
 
 func (i *tolerantRolloutInformer) Informer() cache.SharedIndexInformer {
@@ -28,36 +30,32 @@ func (i *tolerantRolloutInformer) Informer() cache.SharedIndexInformer {
 }
 
 func (i *tolerantRolloutInformer) Lister() rolloutlisters.RolloutLister {
-	return &tolerantRolloutLister{indexer: i.delegate.Informer().GetIndexer()}
+	return &tolerantRolloutLister{indexer: i.delegate.Informer().GetIndexer(), newFn: i.newFn}
 }
 
 type tolerantRolloutLister struct {
 	indexer cache.Indexer
+	newFn   func() *v1alpha1.Rollout
 }
 
 func (t *tolerantRolloutLister) List(selector labels.Selector) ([]*v1alpha1.Rollout, error) {
-	return listTyped(t.indexer, "", selector,
-		func() *v1alpha1.Rollout { return &v1alpha1.Rollout{} },
-		func(ro *v1alpha1.Rollout) *v1alpha1.Rollout { return ro.DeepCopy() })
+	return listTyped(t.indexer, "", selector, t.newFn)
 }
 
 func (t *tolerantRolloutLister) Rollouts(namespace string) rolloutlisters.RolloutNamespaceLister {
-	return &tolerantRolloutNamespaceLister{indexer: t.indexer, namespace: namespace}
+	return &tolerantRolloutNamespaceLister{indexer: t.indexer, namespace: namespace, newFn: t.newFn}
 }
 
 type tolerantRolloutNamespaceLister struct {
 	indexer   cache.Indexer
 	namespace string
+	newFn     func() *v1alpha1.Rollout
 }
 
 func (t *tolerantRolloutNamespaceLister) Get(name string) (*v1alpha1.Rollout, error) {
-	return getTyped(t.indexer, v1alpha1.Resource("rollout"), t.namespace, name,
-		func() *v1alpha1.Rollout { return &v1alpha1.Rollout{} },
-		func(ro *v1alpha1.Rollout) *v1alpha1.Rollout { return ro.DeepCopy() })
+	return getTyped(t.indexer, v1alpha1.Resource("rollout"), t.namespace, name, t.newFn)
 }
 
 func (t *tolerantRolloutNamespaceLister) List(selector labels.Selector) ([]*v1alpha1.Rollout, error) {
-	return listTyped(t.indexer, t.namespace, selector,
-		func() *v1alpha1.Rollout { return &v1alpha1.Rollout{} },
-		func(ro *v1alpha1.Rollout) *v1alpha1.Rollout { return ro.DeepCopy() })
+	return listTyped(t.indexer, t.namespace, selector, t.newFn)
 }

--- a/utils/tolerantinformer/rollout.go
+++ b/utils/tolerantinformer/rollout.go
@@ -13,68 +13,51 @@ import (
 
 func NewTolerantRolloutInformer(factory dynamicinformer.DynamicSharedInformerFactory) rolloutinformers.RolloutInformer {
 	delegate := factory.ForResource(v1alpha1.RolloutGVR)
-	installTransform(delegate.Informer(),
-		makeTransform(func() *v1alpha1.Rollout { return &v1alpha1.Rollout{} }),
-		"Rollout")
-	return &tolerantRolloutInformer{delegate: delegate}
+	transform := makeTransform(func() *v1alpha1.Rollout { return &v1alpha1.Rollout{} })
+	installTransform(delegate.Informer(), transform, "Rollout")
+	return &tolerantRolloutInformer{delegate: delegate, transform: transform}
 }
 
 type tolerantRolloutInformer struct {
-	delegate informers.GenericInformer
+	delegate  informers.GenericInformer
+	transform cache.TransformFunc
 }
 
 func (i *tolerantRolloutInformer) Informer() cache.SharedIndexInformer {
-	return i.delegate.Informer()
+	return &transformingInformer{SharedIndexInformer: i.delegate.Informer(), transform: i.transform}
 }
 
 func (i *tolerantRolloutInformer) Lister() rolloutlisters.RolloutLister {
-	return &tolerantRolloutLister{
-		delegate: rolloutlisters.NewRolloutLister(i.delegate.Informer().GetIndexer()),
-	}
+	return &tolerantRolloutLister{indexer: i.delegate.Informer().GetIndexer()}
 }
 
 type tolerantRolloutLister struct {
-	delegate rolloutlisters.RolloutLister
+	indexer cache.Indexer
 }
 
 func (t *tolerantRolloutLister) List(selector labels.Selector) ([]*v1alpha1.Rollout, error) {
-	items, err := t.delegate.List(selector)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]*v1alpha1.Rollout, len(items))
-	for i, ro := range items {
-		out[i] = ro.DeepCopy()
-	}
-	return out, nil
+	return listTyped(t.indexer, "", selector,
+		func() *v1alpha1.Rollout { return &v1alpha1.Rollout{} },
+		func(ro *v1alpha1.Rollout) *v1alpha1.Rollout { return ro.DeepCopy() })
 }
 
 func (t *tolerantRolloutLister) Rollouts(namespace string) rolloutlisters.RolloutNamespaceLister {
-	return &tolerantRolloutNamespaceLister{
-		delegate: t.delegate.Rollouts(namespace),
-	}
+	return &tolerantRolloutNamespaceLister{indexer: t.indexer, namespace: namespace}
 }
 
 type tolerantRolloutNamespaceLister struct {
-	delegate rolloutlisters.RolloutNamespaceLister
+	indexer   cache.Indexer
+	namespace string
 }
 
 func (t *tolerantRolloutNamespaceLister) Get(name string) (*v1alpha1.Rollout, error) {
-	ro, err := t.delegate.Get(name)
-	if err != nil {
-		return nil, err
-	}
-	return ro.DeepCopy(), nil
+	return getTyped(t.indexer, v1alpha1.Resource("rollout"), t.namespace, name,
+		func() *v1alpha1.Rollout { return &v1alpha1.Rollout{} },
+		func(ro *v1alpha1.Rollout) *v1alpha1.Rollout { return ro.DeepCopy() })
 }
 
 func (t *tolerantRolloutNamespaceLister) List(selector labels.Selector) ([]*v1alpha1.Rollout, error) {
-	items, err := t.delegate.List(selector)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]*v1alpha1.Rollout, len(items))
-	for i, ro := range items {
-		out[i] = ro.DeepCopy()
-	}
-	return out, nil
+	return listTyped(t.indexer, t.namespace, selector,
+		func() *v1alpha1.Rollout { return &v1alpha1.Rollout{} },
+		func(ro *v1alpha1.Rollout) *v1alpha1.Rollout { return ro.DeepCopy() })
 }

--- a/utils/tolerantinformer/tolerantinformer_test.go
+++ b/utils/tolerantinformer/tolerantinformer_test.go
@@ -292,6 +292,7 @@ type storeUpdateCase struct {
 	cacheKey     string
 	assertTyped  func(t *testing.T, raw any)
 	list         func(t *testing.T, fi *fakeInformers) (annotations map[string]string, err error)
+	get          func(t *testing.T, fi *fakeInformers, name string) (annotations map[string]string, err error)
 	rawIndexer   func(fi *fakeInformers) cache.Indexer
 	wrappedStore func(fi *fakeInformers) cache.Store
 }
@@ -337,6 +338,13 @@ func storeUpdateCases(t *testing.T) []storeUpdateCase {
 				require.Len(t, list, 1)
 				return list[0].Annotations, nil
 			},
+			get: func(t *testing.T, fi *fakeInformers, name string) (map[string]string, error) {
+				obj, err := fi.rollout.Lister().Rollouts("default").Get(name)
+				if err != nil {
+					return nil, err
+				}
+				return obj.Annotations, nil
+			},
 			rawIndexer: func(fi *fakeInformers) cache.Indexer {
 				return fi.rollout.(*tolerantRolloutInformer).delegate.Informer().GetIndexer()
 			},
@@ -357,6 +365,13 @@ func storeUpdateCases(t *testing.T) []storeUpdateCase {
 				}
 				require.Len(t, list, 1)
 				return list[0].Annotations, nil
+			},
+			get: func(t *testing.T, fi *fakeInformers, name string) (map[string]string, error) {
+				obj, err := fi.analysisRun.Lister().AnalysisRuns("default").Get(name)
+				if err != nil {
+					return nil, err
+				}
+				return obj.Annotations, nil
 			},
 			rawIndexer: func(fi *fakeInformers) cache.Indexer {
 				return fi.analysisRun.(*tolerantAnalysisRunInformer).delegate.Informer().GetIndexer()
@@ -379,6 +394,13 @@ func storeUpdateCases(t *testing.T) []storeUpdateCase {
 				require.Len(t, list, 1)
 				return list[0].Annotations, nil
 			},
+			get: func(t *testing.T, fi *fakeInformers, name string) (map[string]string, error) {
+				obj, err := fi.analysisTemplate.Lister().AnalysisTemplates("default").Get(name)
+				if err != nil {
+					return nil, err
+				}
+				return obj.Annotations, nil
+			},
 			rawIndexer: func(fi *fakeInformers) cache.Indexer {
 				return fi.analysisTemplate.(*tolerantAnalysisTemplateInformer).delegate.Informer().GetIndexer()
 			},
@@ -400,6 +422,13 @@ func storeUpdateCases(t *testing.T) []storeUpdateCase {
 				require.Len(t, list, 1)
 				return list[0].Annotations, nil
 			},
+			get: func(t *testing.T, fi *fakeInformers, name string) (map[string]string, error) {
+				obj, err := fi.experiment.Lister().Experiments("default").Get(name)
+				if err != nil {
+					return nil, err
+				}
+				return obj.Annotations, nil
+			},
 			rawIndexer: func(fi *fakeInformers) cache.Indexer {
 				return fi.experiment.(*tolerantExperimentInformer).delegate.Informer().GetIndexer()
 			},
@@ -420,6 +449,13 @@ func storeUpdateCases(t *testing.T) []storeUpdateCase {
 				}
 				require.Len(t, list, 1)
 				return list[0].Annotations, nil
+			},
+			get: func(t *testing.T, fi *fakeInformers, name string) (map[string]string, error) {
+				obj, err := fi.clusterAnalysisTemplate.Lister().Get(name)
+				if err != nil {
+					return nil, err
+				}
+				return obj.Annotations, nil
 			},
 			rawIndexer: func(fi *fakeInformers) cache.Indexer {
 				return fi.clusterAnalysisTemplate.(*tolerantClusterAnalysisTemplateInformer).delegate.Informer().GetIndexer()
@@ -457,6 +493,8 @@ func TestStoreUpdateWithUnstructuredDoesNotPanicList(t *testing.T) {
 
 // TestPoisonedCacheListRecovers coerces objects that were written to the raw
 // indexer as Unstructured (bypassing both SetTransform and the Informer wrapper).
+// Covers both List and namespaced/cluster Get — Get also goes through getTyped
+// and was on the same hard-cast panic path before the fix.
 func TestPoisonedCacheListRecovers(t *testing.T) {
 	for _, tc := range storeUpdateCases(t) {
 		t.Run(tc.name, func(t *testing.T) {
@@ -467,6 +505,10 @@ func TestPoisonedCacheListRecovers(t *testing.T) {
 			require.NoError(t, tc.rawIndexer(fi).Update(poisoned))
 
 			annotations, err := tc.list(t, fi)
+			require.NoError(t, err)
+			assert.Equal(t, "1", annotations["poison"])
+
+			annotations, err = tc.get(t, fi, tc.obj.GetName())
 			require.NoError(t, err)
 			assert.Equal(t, "1", annotations["poison"])
 		})

--- a/utils/tolerantinformer/tolerantinformer_test.go
+++ b/utils/tolerantinformer/tolerantinformer_test.go
@@ -5,9 +5,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	rolloutinformers "github.com/argoproj/argo-rollouts/pkg/client/informers/externalversions/rollouts/v1alpha1"
@@ -281,54 +284,193 @@ func TestMalformedExperiment(t *testing.T) {
 	verify(obj)
 }
 
+// storeUpdateCase covers one tolerant resource kind for the GetStore().Update /
+// poisoned-indexer regressions introduced by #4745 + notifications-engine.
+type storeUpdateCase struct {
+	name         string
+	obj          *unstructured.Unstructured
+	cacheKey     string
+	assertTyped  func(t *testing.T, raw any)
+	list         func(t *testing.T, fi *fakeInformers) (annotations map[string]string, err error)
+	rawIndexer   func(fi *fakeInformers) cache.Indexer
+	wrappedStore func(fi *fakeInformers) cache.Store
+}
+
+func storeUpdateCases(t *testing.T) []storeUpdateCase {
+	t.Helper()
+
+	rollout := testutil.ObjectFromPath("examples/rollout-canary.yaml")
+	rollout.SetNamespace("default")
+
+	analysisRun := testutil.ObjectFromPath("test/e2e/functional/analysis-run-job.yaml")
+	analysisRun.SetNamespace("default")
+
+	analysisTemplate := testutil.ObjectFromPath("test/e2e/functional/analysis-run-job.yaml")
+	analysisTemplate.SetNamespace("default")
+	analysisTemplate.SetKind("AnalysisTemplate")
+	analysisTemplate.SetName("good-analysis-template")
+
+	experiment := testutil.ObjectFromPath("test/e2e/functional/experiment-basic.yaml")
+	experiment.SetNamespace("default")
+	experiment.SetGenerateName("")
+	experiment.SetName("good-experiment")
+
+	clusterAT := testutil.ObjectFromPath("test/e2e/functional/analysis-run-job.yaml")
+	clusterAT.SetKind("ClusterAnalysisTemplate")
+	clusterAT.SetNamespace("")
+	clusterAT.SetName("good-cluster-analysis-template")
+
+	return []storeUpdateCase{
+		{
+			name:     "Rollout",
+			obj:      rollout,
+			cacheKey: "default/" + rollout.GetName(),
+			assertTyped: func(t *testing.T, raw any) {
+				_, ok := raw.(*v1alpha1.Rollout)
+				assert.True(t, ok, "expected *v1alpha1.Rollout, got %T", raw)
+			},
+			list: func(t *testing.T, fi *fakeInformers) (map[string]string, error) {
+				list, err := fi.rollout.Lister().List(labels.NewSelector())
+				if err != nil {
+					return nil, err
+				}
+				require.Len(t, list, 1)
+				return list[0].Annotations, nil
+			},
+			rawIndexer: func(fi *fakeInformers) cache.Indexer {
+				return fi.rollout.(*tolerantRolloutInformer).delegate.Informer().GetIndexer()
+			},
+			wrappedStore: func(fi *fakeInformers) cache.Store { return fi.rollout.Informer().GetStore() },
+		},
+		{
+			name:     "AnalysisRun",
+			obj:      analysisRun,
+			cacheKey: "default/" + analysisRun.GetName(),
+			assertTyped: func(t *testing.T, raw any) {
+				_, ok := raw.(*v1alpha1.AnalysisRun)
+				assert.True(t, ok, "expected *v1alpha1.AnalysisRun, got %T", raw)
+			},
+			list: func(t *testing.T, fi *fakeInformers) (map[string]string, error) {
+				list, err := fi.analysisRun.Lister().List(labels.NewSelector())
+				if err != nil {
+					return nil, err
+				}
+				require.Len(t, list, 1)
+				return list[0].Annotations, nil
+			},
+			rawIndexer: func(fi *fakeInformers) cache.Indexer {
+				return fi.analysisRun.(*tolerantAnalysisRunInformer).delegate.Informer().GetIndexer()
+			},
+			wrappedStore: func(fi *fakeInformers) cache.Store { return fi.analysisRun.Informer().GetStore() },
+		},
+		{
+			name:     "AnalysisTemplate",
+			obj:      analysisTemplate,
+			cacheKey: "default/" + analysisTemplate.GetName(),
+			assertTyped: func(t *testing.T, raw any) {
+				_, ok := raw.(*v1alpha1.AnalysisTemplate)
+				assert.True(t, ok, "expected *v1alpha1.AnalysisTemplate, got %T", raw)
+			},
+			list: func(t *testing.T, fi *fakeInformers) (map[string]string, error) {
+				list, err := fi.analysisTemplate.Lister().List(labels.NewSelector())
+				if err != nil {
+					return nil, err
+				}
+				require.Len(t, list, 1)
+				return list[0].Annotations, nil
+			},
+			rawIndexer: func(fi *fakeInformers) cache.Indexer {
+				return fi.analysisTemplate.(*tolerantAnalysisTemplateInformer).delegate.Informer().GetIndexer()
+			},
+			wrappedStore: func(fi *fakeInformers) cache.Store { return fi.analysisTemplate.Informer().GetStore() },
+		},
+		{
+			name:     "Experiment",
+			obj:      experiment,
+			cacheKey: "default/" + experiment.GetName(),
+			assertTyped: func(t *testing.T, raw any) {
+				_, ok := raw.(*v1alpha1.Experiment)
+				assert.True(t, ok, "expected *v1alpha1.Experiment, got %T", raw)
+			},
+			list: func(t *testing.T, fi *fakeInformers) (map[string]string, error) {
+				list, err := fi.experiment.Lister().List(labels.NewSelector())
+				if err != nil {
+					return nil, err
+				}
+				require.Len(t, list, 1)
+				return list[0].Annotations, nil
+			},
+			rawIndexer: func(fi *fakeInformers) cache.Indexer {
+				return fi.experiment.(*tolerantExperimentInformer).delegate.Informer().GetIndexer()
+			},
+			wrappedStore: func(fi *fakeInformers) cache.Store { return fi.experiment.Informer().GetStore() },
+		},
+		{
+			name:     "ClusterAnalysisTemplate",
+			obj:      clusterAT,
+			cacheKey: clusterAT.GetName(),
+			assertTyped: func(t *testing.T, raw any) {
+				_, ok := raw.(*v1alpha1.ClusterAnalysisTemplate)
+				assert.True(t, ok, "expected *v1alpha1.ClusterAnalysisTemplate, got %T", raw)
+			},
+			list: func(t *testing.T, fi *fakeInformers) (map[string]string, error) {
+				list, err := fi.clusterAnalysisTemplate.Lister().List(labels.NewSelector())
+				if err != nil {
+					return nil, err
+				}
+				require.Len(t, list, 1)
+				return list[0].Annotations, nil
+			},
+			rawIndexer: func(fi *fakeInformers) cache.Indexer {
+				return fi.clusterAnalysisTemplate.(*tolerantClusterAnalysisTemplateInformer).delegate.Informer().GetIndexer()
+			},
+			wrappedStore: func(fi *fakeInformers) cache.Store { return fi.clusterAnalysisTemplate.Informer().GetStore() },
+		},
+	}
+}
+
 // TestStoreUpdateWithUnstructuredDoesNotPanicList reproduces the notifications-engine
 // pattern: after a dynamic client Patch it writes *unstructured.Unstructured into
 // Informer().GetStore(). Typed listers that hard-cast panic (see prometheus scrape
 // path in controller/metrics). Both the transformingInformer wrapper and coerceToTyped
-// in List must keep this safe.
+// in List must keep this safe for every tolerant resource kind.
 func TestStoreUpdateWithUnstructuredDoesNotPanicList(t *testing.T) {
-	good := testutil.ObjectFromPath("examples/rollout-canary.yaml")
-	good.SetNamespace("default")
-	fi := newFakeDynamicInformer(good)
-	informer := fi.rollout
+	for _, tc := range storeUpdateCases(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			fi := newFakeDynamicInformer(tc.obj)
 
-	// Simulate notifications-engine processResource after Patch: write Unstructured
-	// directly into the store exposed by Informer().
-	patched := good.DeepCopy()
-	patched.SetAnnotations(map[string]string{"notified": "true"})
-	err := informer.Informer().GetStore().Update(patched)
-	assert.NoError(t, err)
+			patched := tc.obj.DeepCopy()
+			patched.SetAnnotations(map[string]string{"notified": "true"})
+			require.NoError(t, tc.wrappedStore(fi).Update(patched))
 
-	// Cache should hold a typed Rollout after the transforming store wrapper runs.
-	raw, exists, err := fi.rollout.Informer().GetIndexer().GetByKey("default/" + good.GetName())
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	_, ok := raw.(*v1alpha1.Rollout)
-	assert.True(t, ok, "expected *v1alpha1.Rollout in cache after GetStore().Update, got %T", raw)
+			raw, exists, err := tc.rawIndexer(fi).GetByKey(tc.cacheKey)
+			require.NoError(t, err)
+			require.True(t, exists)
+			tc.assertTyped(t, raw)
 
-	list, err := informer.Lister().List(labels.NewSelector())
-	assert.NoError(t, err)
-	assert.Len(t, list, 1)
-	assert.Equal(t, "true", list[0].Annotations["notified"])
+			annotations, err := tc.list(t, fi)
+			require.NoError(t, err)
+			assert.Equal(t, "true", annotations["notified"])
+		})
+	}
 }
 
 // TestPoisonedCacheListRecovers coerces objects that were written to the raw
 // indexer as Unstructured (bypassing both SetTransform and the Informer wrapper).
 func TestPoisonedCacheListRecovers(t *testing.T) {
-	good := testutil.ObjectFromPath("examples/rollout-canary.yaml")
-	good.SetNamespace("default")
-	fi := newFakeDynamicInformer(good)
+	for _, tc := range storeUpdateCases(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			fi := newFakeDynamicInformer(tc.obj)
 
-	// Write Unstructured into the underlying indexer, skipping transformingInformer.
-	poisoned := good.DeepCopy()
-	poisoned.SetAnnotations(map[string]string{"poison": "1"})
-	err := fi.rollout.(*tolerantRolloutInformer).delegate.Informer().GetIndexer().Update(poisoned)
-	assert.NoError(t, err)
+			poisoned := tc.obj.DeepCopy()
+			poisoned.SetAnnotations(map[string]string{"poison": "1"})
+			require.NoError(t, tc.rawIndexer(fi).Update(poisoned))
 
-	list, err := fi.rollout.Lister().List(labels.NewSelector())
-	assert.NoError(t, err)
-	assert.Len(t, list, 1)
-	assert.Equal(t, "1", list[0].Annotations["poison"])
+			annotations, err := tc.list(t, fi)
+			require.NoError(t, err)
+			assert.Equal(t, "1", annotations["poison"])
+		})
+	}
 }
 
 // TestListerReturnsIsolatedCopies guards the contract that objects returned from

--- a/utils/tolerantinformer/tolerantinformer_test.go
+++ b/utils/tolerantinformer/tolerantinformer_test.go
@@ -281,6 +281,56 @@ func TestMalformedExperiment(t *testing.T) {
 	verify(obj)
 }
 
+// TestStoreUpdateWithUnstructuredDoesNotPanicList reproduces the notifications-engine
+// pattern: after a dynamic client Patch it writes *unstructured.Unstructured into
+// Informer().GetStore(). Typed listers that hard-cast panic (see prometheus scrape
+// path in controller/metrics). Both the transformingInformer wrapper and coerceToTyped
+// in List must keep this safe.
+func TestStoreUpdateWithUnstructuredDoesNotPanicList(t *testing.T) {
+	good := testutil.ObjectFromPath("examples/rollout-canary.yaml")
+	good.SetNamespace("default")
+	fi := newFakeDynamicInformer(good)
+	informer := fi.rollout
+
+	// Simulate notifications-engine processResource after Patch: write Unstructured
+	// directly into the store exposed by Informer().
+	patched := good.DeepCopy()
+	patched.SetAnnotations(map[string]string{"notified": "true"})
+	err := informer.Informer().GetStore().Update(patched)
+	assert.NoError(t, err)
+
+	// Cache should hold a typed Rollout after the transforming store wrapper runs.
+	raw, exists, err := fi.rollout.Informer().GetIndexer().GetByKey("default/" + good.GetName())
+	assert.NoError(t, err)
+	assert.True(t, exists)
+	_, ok := raw.(*v1alpha1.Rollout)
+	assert.True(t, ok, "expected *v1alpha1.Rollout in cache after GetStore().Update, got %T", raw)
+
+	list, err := informer.Lister().List(labels.NewSelector())
+	assert.NoError(t, err)
+	assert.Len(t, list, 1)
+	assert.Equal(t, "true", list[0].Annotations["notified"])
+}
+
+// TestPoisonedCacheListRecovers coerces objects that were written to the raw
+// indexer as Unstructured (bypassing both SetTransform and the Informer wrapper).
+func TestPoisonedCacheListRecovers(t *testing.T) {
+	good := testutil.ObjectFromPath("examples/rollout-canary.yaml")
+	good.SetNamespace("default")
+	fi := newFakeDynamicInformer(good)
+
+	// Write Unstructured into the underlying indexer, skipping transformingInformer.
+	poisoned := good.DeepCopy()
+	poisoned.SetAnnotations(map[string]string{"poison": "1"})
+	err := fi.rollout.(*tolerantRolloutInformer).delegate.Informer().GetIndexer().Update(poisoned)
+	assert.NoError(t, err)
+
+	list, err := fi.rollout.Lister().List(labels.NewSelector())
+	assert.NoError(t, err)
+	assert.Len(t, list, 1)
+	assert.Equal(t, "1", list[0].Annotations["poison"])
+}
+
 // TestListerReturnsIsolatedCopies guards the contract that objects returned from
 // the tolerant listers can be mutated by callers without corrupting the shared
 // informer cache. Real consumers (e.g. validation_references.go's

--- a/utils/tolerantinformer/tollerantinformer.go
+++ b/utils/tolerantinformer/tollerantinformer.go
@@ -4,8 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
@@ -25,18 +29,7 @@ import (
 // typed object), it is returned unchanged.
 func makeTransform[T runtime.Object](newFn func() T) cache.TransformFunc {
 	return func(obj any) (any, error) {
-		un, ok := obj.(*unstructured.Unstructured)
-		if !ok {
-			return obj, nil
-		}
-		typed := newFn()
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, typed); err != nil {
-			logCtx := logutil.WithObject(un)
-			logCtx.Warnf("malformed object: %v", err)
-			typed = newFn()
-			_ = fromUnstructuredViaJSON(un.Object, typed)
-		}
-		return typed, nil
+		return coerceToTyped(obj, newFn)
 	}
 }
 
@@ -54,4 +47,127 @@ func fromUnstructuredViaJSON(u map[string]any, obj any) error {
 		return err
 	}
 	return json.Unmarshal(data, obj)
+}
+
+// coerceToTyped converts a cache object into T. Already-typed objects are returned
+// as-is (callers DeepCopy when exposing them). Unstructured objects are converted
+// with the same tolerance as makeTransform.
+//
+// This is required because some controllers (notably argoproj/notifications-engine)
+// write dynamic-client Patch results (*unstructured.Unstructured) directly into
+// SharedIndexInformer.GetStore(), bypassing SetTransform. Generated typed listers
+// hard-cast and would panic on those objects.
+func coerceToTyped[T runtime.Object](obj any, newFn func() T) (T, error) {
+	if typed, ok := obj.(T); ok {
+		return typed, nil
+	}
+	un, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		var zero T
+		return zero, fmt.Errorf("unexpected type %T", obj)
+	}
+	typed := newFn()
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, typed); err != nil {
+		logCtx := logutil.WithObject(un)
+		logCtx.Warnf("malformed object: %v", err)
+		typed = newFn()
+		_ = fromUnstructuredViaJSON(un.Object, typed)
+	}
+	return typed, nil
+}
+
+func listTyped[T runtime.Object](indexer cache.Indexer, namespace string, selector labels.Selector, newFn func() T, deepCopy func(T) T) ([]T, error) {
+	var out []T
+	appendOne := func(m any) {
+		typed, err := coerceToTyped(m, newFn)
+		if err != nil {
+			log.Warnf("tolerantinformer: skipping cache object: %v", err)
+			return
+		}
+		out = append(out, deepCopy(typed))
+	}
+	var err error
+	if namespace == "" {
+		err = cache.ListAll(indexer, selector, appendOne)
+	} else {
+		err = cache.ListAllByNamespace(indexer, namespace, selector, appendOne)
+	}
+	return out, err
+}
+
+func getTyped[T runtime.Object](indexer cache.Indexer, resource schema.GroupResource, namespace, name string, newFn func() T, deepCopy func(T) T) (T, error) {
+	var zero T
+	key := name
+	if namespace != "" {
+		key = namespace + "/" + name
+	}
+	obj, exists, err := indexer.GetByKey(key)
+	if err != nil {
+		return zero, err
+	}
+	if !exists {
+		return zero, errors.NewNotFound(resource, name)
+	}
+	typed, err := coerceToTyped(obj, newFn)
+	if err != nil {
+		return zero, err
+	}
+	return deepCopy(typed), nil
+}
+
+// transformingInformer wraps a SharedIndexInformer so callers that mutate the
+// store via GetStore()/GetIndexer() (e.g. notifications-engine after a dynamic
+// Patch) still run the unstructured→typed transform. The Reflector/FIFO path
+// uses the informer's internal indexer field directly and is unaffected.
+type transformingInformer struct {
+	cache.SharedIndexInformer
+	transform cache.TransformFunc
+}
+
+func (t *transformingInformer) GetStore() cache.Store {
+	return &transformingIndexer{Indexer: t.SharedIndexInformer.GetIndexer(), transform: t.transform}
+}
+
+func (t *transformingInformer) GetIndexer() cache.Indexer {
+	return &transformingIndexer{Indexer: t.SharedIndexInformer.GetIndexer(), transform: t.transform}
+}
+
+type transformingIndexer struct {
+	cache.Indexer
+	transform cache.TransformFunc
+}
+
+func (t *transformingIndexer) apply(obj any) (any, error) {
+	if t.transform == nil {
+		return obj, nil
+	}
+	return t.transform(obj)
+}
+
+func (t *transformingIndexer) Add(obj any) error {
+	obj, err := t.apply(obj)
+	if err != nil {
+		return err
+	}
+	return t.Indexer.Add(obj)
+}
+
+func (t *transformingIndexer) Update(obj any) error {
+	obj, err := t.apply(obj)
+	if err != nil {
+		return err
+	}
+	return t.Indexer.Update(obj)
+}
+
+func (t *transformingIndexer) Replace(list []any, resourceVersion string) error {
+	transformed := make([]any, len(list))
+	for i, obj := range list {
+		obj, err := t.apply(obj)
+		if err != nil {
+			return err
+		}
+		transformed[i] = obj
+	}
+	return t.Indexer.Replace(transformed, resourceVersion)
 }

--- a/utils/tolerantinformer/tollerantinformer.go
+++ b/utils/tolerantinformer/tollerantinformer.go
@@ -15,7 +15,7 @@ import (
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
 )
 
-// deepCopyable is satisfied by the generated ARGO CRD pointer types
+// deepCopyable is satisfied by the generated Rollouts CRD pointer types
 // (e.g. *v1alpha1.Rollout), which implement both runtime.Object and DeepCopy().
 type deepCopyable[T any] interface {
 	runtime.Object

--- a/utils/tolerantinformer/tollerantinformer.go
+++ b/utils/tolerantinformer/tollerantinformer.go
@@ -77,6 +77,10 @@ func coerceToTyped[T runtime.Object](obj any, newFn func() T) (T, error) {
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, typed); err != nil {
 		logCtx := logutil.WithObject(un)
 		logCtx.Warnf("malformed object: %v", err)
+		// FromUnstructured fails fast on the first bad field. encoding/json continues
+		// past invalid fields so we can return a mostly complete, still-usable object
+		// (PR #666 / issues #389, #517). Ignore the JSON error: even a partially
+		// filled or empty object is preferred over dropping it from the cache.
 		typed = newFn()
 		_ = fromUnstructuredViaJSON(un.Object, typed)
 	}

--- a/utils/tolerantinformer/tollerantinformer.go
+++ b/utils/tolerantinformer/tollerantinformer.go
@@ -15,6 +15,13 @@ import (
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
 )
 
+// deepCopyable is satisfied by the generated ARGO CRD pointer types
+// (e.g. *v1alpha1.Rollout), which implement both runtime.Object and DeepCopy().
+type deepCopyable[T any] interface {
+	runtime.Object
+	DeepCopy() T
+}
+
 // makeTransform returns a cache.TransformFunc that converts a *unstructured.Unstructured
 // into a typed pointer produced by newFn. The conversion runs once per object on
 // insert/update into the shared informer cache, so subsequent List/Get calls return
@@ -76,7 +83,7 @@ func coerceToTyped[T runtime.Object](obj any, newFn func() T) (T, error) {
 	return typed, nil
 }
 
-func listTyped[T runtime.Object](indexer cache.Indexer, namespace string, selector labels.Selector, newFn func() T, deepCopy func(T) T) ([]T, error) {
+func listTyped[T deepCopyable[T]](indexer cache.Indexer, namespace string, selector labels.Selector, newFn func() T) ([]T, error) {
 	var out []T
 	appendOne := func(m any) {
 		typed, err := coerceToTyped(m, newFn)
@@ -84,7 +91,7 @@ func listTyped[T runtime.Object](indexer cache.Indexer, namespace string, select
 			warnSkipCacheObject(m, err)
 			return
 		}
-		out = append(out, deepCopy(typed))
+		out = append(out, typed.DeepCopy())
 	}
 	var err error
 	if namespace == "" {
@@ -114,7 +121,7 @@ func warnSkipCacheObject(obj any, err error) {
 	log.WithFields(fields).Warnf("tolerantinformer: skipping cache object: %v", err)
 }
 
-func getTyped[T runtime.Object](indexer cache.Indexer, resource schema.GroupResource, namespace, name string, newFn func() T, deepCopy func(T) T) (T, error) {
+func getTyped[T deepCopyable[T]](indexer cache.Indexer, resource schema.GroupResource, namespace, name string, newFn func() T) (T, error) {
 	var zero T
 	key := name
 	if namespace != "" {
@@ -131,7 +138,7 @@ func getTyped[T runtime.Object](indexer cache.Indexer, resource schema.GroupReso
 	if err != nil {
 		return zero, err
 	}
-	return deepCopy(typed), nil
+	return typed.DeepCopy(), nil
 }
 
 // transformingInformer wraps a SharedIndexInformer so callers that mutate the

--- a/utils/tolerantinformer/tollerantinformer.go
+++ b/utils/tolerantinformer/tollerantinformer.go
@@ -81,7 +81,7 @@ func listTyped[T runtime.Object](indexer cache.Indexer, namespace string, select
 	appendOne := func(m any) {
 		typed, err := coerceToTyped(m, newFn)
 		if err != nil {
-			log.Warnf("tolerantinformer: skipping cache object: %v", err)
+			warnSkipCacheObject(m, err)
 			return
 		}
 		out = append(out, deepCopy(typed))
@@ -93,6 +93,25 @@ func listTyped[T runtime.Object](indexer cache.Indexer, namespace string, select
 		err = cache.ListAllByNamespace(indexer, namespace, selector, appendOne)
 	}
 	return out, err
+}
+
+// warnSkipCacheObject logs a skipped cache object with enough identity for field
+// diagnosis (namespace/name/key when available), matching logutil.WithObject style.
+func warnSkipCacheObject(obj any, err error) {
+	if ro, ok := obj.(runtime.Object); ok {
+		logutil.WithObject(ro).WithField("type", fmt.Sprintf("%T", obj)).
+			Warnf("tolerantinformer: skipping cache object: %v", err)
+		return
+	}
+	fields := log.Fields{"type": fmt.Sprintf("%T", obj)}
+	if key, keyErr := cache.MetaNamespaceKeyFunc(obj); keyErr == nil {
+		fields["key"] = key
+		if ns, name, splitErr := cache.SplitMetaNamespaceKey(key); splitErr == nil {
+			fields["namespace"] = ns
+			fields["name"] = name
+		}
+	}
+	log.WithFields(fields).Warnf("tolerantinformer: skipping cache object: %v", err)
 }
 
 func getTyped[T runtime.Object](indexer cache.Indexer, resource schema.GroupResource, namespace, name string, newFn func() T, deepCopy func(T) T) (T, error) {


### PR DESCRIPTION
…into rollout cache


## Summary
- After #4745, the tolerant informer stores typed objects via `SetTransform`, and listers hard-cast to `*v1alpha1.Rollout`.
- `argoproj/notifications-engine` patches Rollouts with the dynamic client and writes the returned `*unstructured.Unstructured` into `Informer().GetStore()`, bypassing `SetTransform`.
- The next Prometheus scrape (and other `List`/`Get` callers) panics:
  `interface conversion: interface {} is *unstructured.Unstructured, not *v1alpha1.Rollout`.

## Fix
- Wrap `Informer().GetStore()` / `GetIndexer()` so direct `Add`/`Update`/`Replace` still run the unstructured→typed transform.
- Make tolerant listers coerce both typed and Unstructured objects so a already-poisoned cache cannot panic.
- Add regression tests for the notifications-style store update and a raw poisoned indexer.

Fixes panic observed on metrics gather via `tolerantinformer.(*tolerantRolloutLister).List`.

Related: #4745, #4571

## Stack

```
panic: interface conversion: interface {} is *unstructured.Unstructured, not *v1alpha1.Rollout

goroutine 24315 [running]:
[k8s.io/client-go/listers.ResourceIndexer[...].List.func1()](http://k8s.io/client-go/listers.ResourceIndexer[...].List.func1())
/go/src/github.com/argoproj/argo-rollouts/vendor/k8s.io/client-go/listers/generic_helpers.go:51 +0xc5
[k8s.io/client-go/tools/cache.ListAll({0x3a20ba0](http://k8s.io/client-go/tools/cache.ListAll(%7B0x3a20ba0), 0x1e14c8828240}, {0x3a18ef0, 0x5dac8c0}, 0x1e15020c7d98)
/go/src/github.com/argoproj/argo-rollouts/vendor/k8s.io/client-go/tools/cache/listers.go:44 +0xd5
[k8s.io/client-go/tools/cache.ListAllByNamespace({0x3a2a300](http://k8s.io/client-go/tools/cache.ListAllByNamespace(%7B0x3a2a300), 0x1e14c8828240}, {0x0, 0x0}, {0x3a18ef0, 0x5dac8c0}, 0x1e15020c7d98)
/go/src/github.com/argoproj/argo-rollouts/vendor/k8s.io/client-go/tools/cache/listers.go:67 +0x4b3
[k8s.io/client-go/listers.ResourceIndexer[...].List(0x1e15020c7e98](http://k8s.io/client-go/listers.ResourceIndexer[...].List(0x1e15020c7e98)?, {0x3a18ef0, 0x5dac8c0})
/go/src/github.com/argoproj/argo-rollouts/vendor/k8s.io/client-go/listers/generic_helpers.go:50 +0xb3
[github.com/argoproj/argo-rollouts/utils/tolerantinformer.(*tolerantRolloutLister).List(0x0](http://github.com/argoproj/argo-rollouts/utils/tolerantinformer.(*tolerantRolloutLister).List(0x0)?, {0x3a18ef0?, 0x5dac8c0?})
/go/src/github.com/argoproj/argo-rollouts/utils/tolerantinformer/rollout.go:41 +0x29
[github.com/argoproj/argo-rollouts/controller/metrics.(*rolloutCollector).Collect(0x1e14c824e3f0](http://github.com/argoproj/argo-rollouts/controller/metrics.(*rolloutCollector).Collect(0x1e14c824e3f0), 0x1e15064205b0)
/go/src/github.com/argoproj/argo-rollouts/controller/metrics/rollouts.go:53 +0x47
[github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()](http://github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1())
/go/src/github.com/argoproj/argo-rollouts/vendor/github.com/prometheus/client_golang/prometheus/registry.go:456 +0xfa
created by [github.com/prometheus/client_golang/prometheus.(*Registry).Gather](http://github.com/prometheus/client_golang/prometheus.(*Registry).Gather) in goroutine 23928
/go/src/github.com/argoproj/argo-rollouts/vendor/github.com/prometheus/client_golang/prometheus/registry.go:548 +0xbcc
```

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [ ] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [ ] I understand what the code does and WHY/HOW it works in several scenarios
* [ ] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).