### PR TITLE
fix(controller): log the underlying error when newRolloutContext returns nil

### DIFF
--- a/rollout/controller.go
+++ b/rollout/controller.go
@@ -429,7 +429,11 @@ func (c *Controller) syncHandler(ctx context.Context, key string) error {
 
 	roCtx, err := c.newRolloutContext(r)
 	if roCtx == nil {
-		logCtx.Error("newRolloutContext returned nil")
+		if k8serrors.IsConflict(err) {
+			logCtx.Warnf("newRolloutContext returned nil: %v", err)
+		} else {
+			logCtx.Errorf("newRolloutContext returned nil: %v", err)
+		}
 		return err
 	}
 	if err != nil {

--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -1513,6 +1514,77 @@ func TestSetReplicaToDefault(t *testing.T) {
 	f.runWithSyncs(getKey(r, t), 3)
 	updatedRollout := f.getUpdatedRollout(updateIndex)
 	assert.Equal(t, defaults.DefaultReplicas, *updatedRollout.Spec.Replicas)
+}
+
+func TestSyncHandlerLogsUnderlyingErrorFromNewRolloutContext(t *testing.T) {
+	// When newRolloutContext returns (nil, err), syncHandler must include err in the log
+	// line, and emit at Warn for benign 409 conflicts (the workqueue retries) and Error
+	// for everything else.
+	cases := []struct {
+		name      string
+		injectErr error
+		wantLevel log.Level
+		wantMsg   string
+	}{
+		{
+			name: "conflict is logged at warn",
+			injectErr: errors.NewConflict(
+				schema.GroupResource{Group: "argoproj.io", Resource: "rollouts"},
+				"foo",
+				fmt.Errorf("the object has been modified; please apply your changes to the latest version and try again"),
+			),
+			wantLevel: log.WarnLevel,
+			wantMsg:   "the object has been modified",
+		},
+		{
+			name:      "non-conflict is logged at error",
+			injectErr: fmt.Errorf("boom"),
+			wantLevel: log.ErrorLevel,
+			wantMsg:   "boom",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFixture(t)
+			defer f.Close()
+
+			r := newCanaryRollout("foo", 1, nil, nil, nil, intstr.FromInt(0), intstr.FromInt(1))
+			f.rolloutLister = append(f.rolloutLister, r)
+			f.objects = append(f.objects, r)
+
+			c, i, k8sI := f.newController(noResyncPeriodFunc)
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			i.Start(stopCh)
+			k8sI.Start(stopCh)
+			assert.True(t, cache.WaitForCacheSync(stopCh, c.replicaSetSynced, c.rolloutsSynced))
+
+			f.client.PrependReactor("update", "rollouts", func(action core.Action) (bool, runtime.Object, error) {
+				if action.GetSubresource() == "status" {
+					return true, nil, tc.injectErr
+				}
+				return false, nil, nil
+			})
+
+			hook := logtest.NewGlobal()
+			defer hook.Reset()
+
+			assert.Error(t, c.syncHandler(context.Background(), getKey(r, t)))
+
+			var found *log.Entry
+			for _, e := range hook.AllEntries() {
+				if strings.HasPrefix(e.Message, "newRolloutContext returned nil") {
+					found = e
+					break
+				}
+			}
+			if found == nil {
+				t.Fatal("expected 'newRolloutContext returned nil' log entry, got none")
+			}
+			assert.Contains(t, found.Message, tc.wantMsg)
+			assert.Equal(t, tc.wantLevel, found.Level)
+		})
+	}
 }
 
 // TestSwitchInvalidSpecMessage verifies message is updated when reason for InvalidSpec changes


### PR DESCRIPTION
`syncHandler` logs `"newRolloutContext returned nil"` at ERROR when `newRolloutContext` returns `(nil, err)`, discarding `err`. A common path here is a 409 conflict from a k8s write (e.g. `UpdateStatus` in `createDesiredReplicaSet` when the cached Rollout was modified between read and write by HPA or by the controller reacting to its own writes). The workqueue retries on the next reconcile, so behaviour is already correct, but the log line is misleading — no cause is surfaced — and ERROR severity for a benign, self-healing retry pollutes error-based alerting.

This PR includes the underlying error in the log line and emits at WARN when `k8serrors.IsConflict(err)`, keeping ERROR otherwise, for any conflict returned from `newRolloutContext`. No control-flow change: `syncHandler` still returns `err` and the workqueue still retries.

The twin `newRolloutContext err %v` log line a few lines below is not touched: it lives in the `(roCtx != nil, err != nil)` branch, which today only surfaces spec-validation errors from `newRolloutContext` (workload-ref resolution + field validation) — not k8s API errors — so it cannot see an `IsConflict`.

Checklist:

* [x] (b) this is a bug fix
* [x] The title of the PR is [conventional](https://www.conventionalcommits.org/en/v1.0.0/) and states what changed. No related upstream issue is filed for this behaviour, so no `Fixes #` suffix.
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green.
* [x] I have written unit tests for my change (`TestSyncHandlerLogsUnderlyingErrorFromNewRolloutContext` covers both severity branches).
* [x] I have run all tests locally and they pass on my workstation.
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR.
* [x] I understand what the code does and WHY/HOW it works in several scenarios.
* [x] I know if my code is just adding new functionality or changing old functionality for existing users.
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).