### PR TITLE
fix(controller): select namespace-support notification controller via self-service flag

### DIFF
--- a/cmd/rollouts-controller/main.go
+++ b/cmd/rollouts-controller/main.go
@@ -300,7 +300,8 @@ func newCommand() *cobra.Command {
 					replicaSetInformerFactory,
 					jobInformerFactory,
 					ephemeralMetadataThreads,
-					ephemeralMetadataPodRetries)
+					ephemeralMetadataPodRetries,
+					selfServiceNotificationEnabled)
 			}
 			if err = cm.Run(ctx, rolloutThreads, serviceThreads, ingressThreads, experimentThreads, analysisThreads, electOpts); err != nil {
 				log.Fatalf("Error running controller: %s", err.Error())

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -308,6 +308,7 @@ func NewManager(
 	jobInformerFactory kubeinformers.SharedInformerFactory,
 	ephemeralMetadataThreads int,
 	ephemeralMetadataPodRetries int,
+	selfServiceNotificationEnabled bool,
 ) *Manager {
 	runtime.Must(rolloutscheme.AddToScheme(scheme.Scheme))
 	log.Info("Creating event broadcaster")
@@ -333,20 +334,15 @@ func NewManager(
 	refResolver := rollout.NewInformerBasedWorkloadRefResolver(namespace, dynamicclientset, discoveryClient, argoprojclientset, rolloutsInformer.Informer())
 	apiFactory := notificationapi.NewFactory(record.NewAPIFactorySettings(analysisRunInformer), defaults.Namespace(), notificationSecretInformerFactory.Core().V1().Secrets().Informer(), notificationConfigMapInformerFactory.Core().V1().ConfigMaps().Informer())
 	recorder := record.NewEventRecorder(kubeclientset, metrics.MetricRolloutEventsTotal, metrics.MetricNotificationFailedTotal, metrics.MetricNotificationSuccessTotal, metrics.MetricNotificationSend, apiFactory)
-	notificationsController := notificationcontroller.NewControllerWithNamespaceSupport(dynamicclientset.Resource(v1alpha1.RolloutGVR), rolloutsInformer.Informer(), apiFactory,
-		notificationcontroller.WithToUnstructured(func(obj metav1.Object) (*unstructured.Unstructured, error) {
-			data, err := json.Marshal(obj)
-			if err != nil {
-				return nil, err
-			}
-			res := &unstructured.Unstructured{}
-			err = json.Unmarshal(data, res)
-			if err != nil {
-				return nil, err
-			}
-			return res, nil
-		}),
-	)
+	toUnstructured := notificationcontroller.WithToUnstructured(objectToUnstructured)
+	// The namespace-support controller reads per-namespace configs; that only makes sense with
+	// self-service notifications. Without it a single config is used, and the namespace variant
+	// logs spurious "trigger ... is not configured" errors for triggers it can't see.
+	newNotificationController := notificationcontroller.NewController
+	if selfServiceNotificationEnabled {
+		newNotificationController = notificationcontroller.NewControllerWithNamespaceSupport
+	}
+	notificationsController := newNotificationController(dynamicclientset.Resource(v1alpha1.RolloutGVR), rolloutsInformer.Informer(), apiFactory, toUnstructured)
 
 	rolloutController := rollout.NewController(rollout.ControllerConfig{
 		Namespace:                       namespace,
@@ -483,6 +479,20 @@ func NewManager(
 	}
 
 	return cm
+}
+
+// objectToUnstructured is the notifications-engine `WithToUnstructured` opt: it converts a typed
+// metav1.Object into *unstructured.Unstructured via a JSON round-trip.
+func objectToUnstructured(obj metav1.Object) (*unstructured.Unstructured, error) {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+	res := &unstructured.Unstructured{}
+	if err := json.Unmarshal(data, res); err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 // Run will sync informer caches and start controllers. It will block until stopCh

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -11,6 +11,7 @@ import (
 	notificationcontroller "github.com/argoproj/notifications-engine/pkg/controller"
 	smifake "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/split/clientset/versioned/fake"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -219,66 +220,88 @@ func (f *fixture) newManager(t *testing.T) *Manager {
 }
 
 func TestNewManager(t *testing.T) {
-	f := newFixture(t)
+	// Constructor selection between NewController (global config) and
+	// NewControllerWithNamespaceSupport (per-namespace configs) is driven by
+	// selfServiceNotificationEnabled; both flag values must yield a usable Manager.
+	for _, selfService := range []bool{false, true} {
+		t.Run(fmt.Sprintf("selfService=%v", selfService), func(t *testing.T) {
+			f := newFixture(t)
 
-	i := informers.NewSharedInformerFactory(f.client, noResyncPeriodFunc())
-	k8sI := kubeinformers.NewSharedInformerFactory(f.kubeclient, noResyncPeriodFunc())
+			i := informers.NewSharedInformerFactory(f.client, noResyncPeriodFunc())
+			k8sI := kubeinformers.NewSharedInformerFactory(f.kubeclient, noResyncPeriodFunc())
 
-	scheme := runtime.NewScheme()
-	listMapping := map[schema.GroupVersionResource]string{}
-	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listMapping)
-	dynamicInformerFactory := dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0)
-	istioVirtualServiceInformer := dynamicInformerFactory.ForResource(istioutil.GetIstioVirtualServiceGVR()).Informer()
-	istioDestinationRuleInformer := dynamicInformerFactory.ForResource(istioutil.GetIstioDestinationRuleGVR()).Informer()
+			scheme := runtime.NewScheme()
+			listMapping := map[schema.GroupVersionResource]string{}
+			dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listMapping)
+			dynamicInformerFactory := dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0)
+			istioVirtualServiceInformer := dynamicInformerFactory.ForResource(istioutil.GetIstioVirtualServiceGVR()).Informer()
+			istioDestinationRuleInformer := dynamicInformerFactory.ForResource(istioutil.GetIstioDestinationRuleGVR()).Informer()
 
-	mode, err := ingressutil.DetermineIngressMode("extensions/v1beta1", &discoveryfake.FakeDiscovery{})
-	assert.NoError(t, err)
-	ingressWrapper, err := ingressutil.NewIngressWrapper(mode, f.kubeclient, k8sI)
-	assert.NoError(t, err)
+			mode, err := ingressutil.DetermineIngressMode("extensions/v1beta1", &discoveryfake.FakeDiscovery{})
+			assert.NoError(t, err)
+			ingressWrapper, err := ingressutil.NewIngressWrapper(mode, f.kubeclient, k8sI)
+			assert.NoError(t, err)
 
-	k8sRequestProvider := &metrics.K8sRequestsCountProvider{}
-	cm := NewManager(
-		"default",
-		f.kubeclient,
-		f.client,
-		dynamicClient,
-		smifake.NewSimpleClientset(),
-		&discoveryfake.FakeDiscovery{},
-		k8sI.Apps().V1().ReplicaSets(),
-		k8sI.Core().V1().Services(),
-		ingressWrapper,
-		k8sI.Batch().V1().Jobs(),
-		k8sI.Core().V1().Pods(),
-		i.Argoproj().V1alpha1().Rollouts(),
-		i.Argoproj().V1alpha1().Experiments(),
-		i.Argoproj().V1alpha1().AnalysisRuns(),
-		i.Argoproj().V1alpha1().AnalysisTemplates(),
-		i.Argoproj().V1alpha1().ClusterAnalysisTemplates(),
-		dynamicClient,
-		istioVirtualServiceInformer,
-		istioDestinationRuleInformer,
-		k8sI,
-		k8sI,
-		noResyncPeriodFunc(),
-		"test",
-		8090,
-		8080,
-		k8sRequestProvider,
-		nil,
-		nil,
-		dynamicInformerFactory,
-		nil,
-		nil,
-		false,
-		nil,
-		nil,
-		nil,
-		rolloutController.DefaultEphemeralMetadataThreads,
-		rolloutController.DefaultEphemeralMetadataPodRetries,
-	)
+			k8sRequestProvider := &metrics.K8sRequestsCountProvider{}
+			cm := NewManager(
+				"default",
+				f.kubeclient,
+				f.client,
+				dynamicClient,
+				smifake.NewSimpleClientset(),
+				&discoveryfake.FakeDiscovery{},
+				k8sI.Apps().V1().ReplicaSets(),
+				k8sI.Core().V1().Services(),
+				ingressWrapper,
+				k8sI.Batch().V1().Jobs(),
+				k8sI.Core().V1().Pods(),
+				i.Argoproj().V1alpha1().Rollouts(),
+				i.Argoproj().V1alpha1().Experiments(),
+				i.Argoproj().V1alpha1().AnalysisRuns(),
+				i.Argoproj().V1alpha1().AnalysisTemplates(),
+				i.Argoproj().V1alpha1().ClusterAnalysisTemplates(),
+				dynamicClient,
+				istioVirtualServiceInformer,
+				istioDestinationRuleInformer,
+				k8sI,
+				k8sI,
+				noResyncPeriodFunc(),
+				"test",
+				8090,
+				8080,
+				k8sRequestProvider,
+				nil,
+				nil,
+				dynamicInformerFactory,
+				nil,
+				nil,
+				false,
+				nil,
+				nil,
+				nil,
+				rolloutController.DefaultEphemeralMetadataThreads,
+				rolloutController.DefaultEphemeralMetadataPodRetries,
+				selfService,
+			)
 
-	assert.NotNil(t, cm)
-	assert.Equal(t, "test", cm.instanceID)
+			assert.NotNil(t, cm)
+			assert.NotNil(t, cm.notificationsController)
+			assert.Equal(t, "test", cm.instanceID)
+		})
+	}
+}
+
+func TestObjectToUnstructured(t *testing.T) {
+	obj := &v1alpha1.Rollout{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "argoproj.io/v1alpha1", Kind: "Rollout"},
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar", Labels: map[string]string{"app": "demo"}},
+	}
+	u, err := objectToUnstructured(obj)
+	require.NoError(t, err)
+	assert.Equal(t, "Rollout", u.GetKind())
+	assert.Equal(t, "foo", u.GetName())
+	assert.Equal(t, "bar", u.GetNamespace())
+	assert.Equal(t, "demo", u.GetLabels()["app"])
 }
 
 func TestNewAnalysisManager(t *testing.T) {


### PR DESCRIPTION
The `--self-service-notification-enabled` flag switches the notification config informer's scope: when set, it watches all namespaces; when unset, only the controller's own namespace (`defaults.Namespace()`). The notifications controller itself, however, is always constructed with `NewControllerWithNamespaceSupport` — a constructor whose upstream doc reads `"NewControllerWithNamespaceSupport For self-service notification"`.

When the flag is unset and the rollouts controller watches multiple namespaces, a Rollout in any namespace outside `defaults.Namespace()` carrying a `notifications.argoproj.io/subscribe.*` annotation drives `notifications-engine`'s `processResourceWithAPI` to call `RunTrigger` against an empty per-namespace API. The upstream loop then emits an ERROR log via `logEntry.Errorf("Failed to evaluate condition of trigger …")` **and** a Warning event on the Rollout via `eventSequence.addWarning(...)` — see `notifications-engine/pkg/controller/controller.go:208-210`.

Note: this is a different code path from the `"trigger '%s' is not configured"` log downgraded by #4833 (#3459) — that fix touches argo-rollouts' own `utils/record/record.go` `sendNotifications`. The `notifications-engine` error above still fires at ERROR.

Single-namespace mode (`--namespaced`) was already unaffected: `defaults.Namespace()` is the only namespace observed, so every lookup resolves.

This PR routes the constructor selection through the same flag: `NewController` when self-service is disabled, `NewControllerWithNamespaceSupport` when enabled. The flag now controls informer scope and controller variant coherently.

Alternatives considered: keep the namespace-support constructor and unconditionally expand the informer to all namespaces — silently expands required RBAC (cluster-wide watch on notification configmaps and secrets) for anyone not opted into self-service. Fixing the constructor is the smaller, opt-in change.

**API compatibility note**: `controller.NewManager` is exported and this PR adds a positional `bool` parameter. External callers importing this package need to update. Consistent with the existing 39-parameter positional style; happy to migrate to functional options if that's preferred.

Checklist:

* [x] (b) this is a bug fix
* [x] The title of the PR is [conventional](https://www.conventionalcommits.org/en/v1.0.0/) and states what changed. No related upstream issue is filed for this behaviour, so no `Fixes #` suffix.
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green.
* [x] I have written unit tests for my change (`TestNewManager` runs as subtests for both `selfService=false` and `selfService=true`, exercising both constructor selections).
* [x] I have run all tests locally and they pass on my workstation.
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR.
* [x] I understand what the code does and WHY/HOW it works in several scenarios.
* [x] I know if my code is just adding new functionality or changing old functionality for existing users.
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).