### PR TITLE
fix(trafficrouting): cap canary weight to available replicas on the final step. Fixes #3941

### DIFF
--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -157,10 +157,15 @@ func (c *rolloutContext) checkReplicasAvailable(rs *appsv1.ReplicaSet, desiredWe
 
 }
 
-// canaryWeightFromAvailableReplicas returns the canary weight the canary ReplicaSet's
+// weightFromAvailableReplicas returns the traffic weight that the given ReplicaSet's
 // currently-available replicas can serve without routing to not-ready pods.
-func (c *rolloutContext) canaryWeightFromAvailableReplicas() int32 {
-	return (weightutil.MaxTrafficWeight(c.rollout) * c.newRS.Status.AvailableReplicas) / *c.rollout.Spec.Replicas
+// Returns 0 when the rollout has no desired replicas: nothing is running, so no
+// traffic can be served.
+func (c *rolloutContext) weightFromAvailableReplicas(rs *appsv1.ReplicaSet) int32 {
+	if c.rollout.Spec.Replicas == nil || *c.rollout.Spec.Replicas <= 0 {
+		return 0
+	}
+	return (weightutil.MaxTrafficWeight(c.rollout) * rs.Status.AvailableReplicas) / *c.rollout.Spec.Replicas
 }
 
 // this currently only be used in the canary strategy
@@ -242,7 +247,7 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			// But we can only increase canary weight according to available replica counts of the canary.
 			// we will need to set the desiredWeight to 0 when the newRS is not available.
 			if c.rollout.Spec.Strategy.Canary.DynamicStableScale {
-				desiredWeight = c.canaryWeightFromAvailableReplicas()
+				desiredWeight = c.weightFromAvailableReplicas(c.newRS)
 			} else if c.rollout.Status.Canary.Weights != nil {
 				desiredWeight = c.rollout.Status.Canary.Weights.Canary.Weight
 			}
@@ -275,7 +280,7 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			// Rollback within the rollback window fast-forwards `index` past the last step, at
 			// 100% weight, while the canary may still be scaling up. Cap to what it can serve.
 			if *index == int32(len(c.rollout.Spec.Strategy.Canary.Steps)) && !c.checkReplicasAvailable(c.newRS, desiredWeight) {
-				desiredWeight = c.canaryWeightFromAvailableReplicas()
+				desiredWeight = c.weightFromAvailableReplicas(c.newRS)
 			}
 		}
 
@@ -381,7 +386,7 @@ func (c *rolloutContext) calculateDesiredWeightOnAbortOrStableRollback() int32 {
 	// therefore we need to scale based on canary availability
 	desiredCanaryWeight := replicasetutil.GetDesiredCanaryWeight(c.rollout, c.newRS, c.stableRS)
 	// canary weight computed based on available stable replicas
-	expectedCanaryWeight := maxInt(0, maxWeight-((maxWeight*c.stableRS.Status.AvailableReplicas) / *c.rollout.Spec.Replicas))
+	expectedCanaryWeight := maxInt(0, maxWeight-c.weightFromAvailableReplicas(c.stableRS))
 	if c.rollout.Status.Canary.Weights == nil {
 		return maxInt(expectedCanaryWeight, desiredCanaryWeight)
 	}
@@ -396,7 +401,7 @@ func (c *rolloutContext) calculateDesiredWeightOnAbortOrStableRollback() int32 {
 	// this logic __heavily__ relies on the fact that CalculateReplicaCountsForTrafficRoutedCanary.
 	// Controller will scale canary down only if weight is shifted to primary,
 	// therefore we can safely delay shifting weight to primary until enough of them are available.
-	currentStableReplicasWeight := (maxWeight * c.stableRS.Status.AvailableReplicas) / *c.rollout.Spec.Replicas
+	currentStableReplicasWeight := c.weightFromAvailableReplicas(c.stableRS)
 	if desiredCanaryWeight > 0 && currentStableReplicasWeight < (maxWeight-desiredCanaryWeight) {
 		// Current stable is still scalingUp, keep canary weight as is
 		return currentCanaryWeight

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -157,6 +157,12 @@ func (c *rolloutContext) checkReplicasAvailable(rs *appsv1.ReplicaSet, desiredWe
 
 }
 
+// canaryWeightFromAvailableReplicas returns the canary weight the canary ReplicaSet's
+// currently-available replicas can serve without routing to not-ready pods.
+func (c *rolloutContext) canaryWeightFromAvailableReplicas() int32 {
+	return (weightutil.MaxTrafficWeight(c.rollout) * c.newRS.Status.AvailableReplicas) / *c.rollout.Spec.Replicas
+}
+
 // this currently only be used in the canary strategy
 func (c *rolloutContext) reconcileTrafficRouting() error {
 	reconcilers, err := c.newTrafficRoutingReconciler(c)
@@ -236,7 +242,7 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			// But we can only increase canary weight according to available replica counts of the canary.
 			// we will need to set the desiredWeight to 0 when the newRS is not available.
 			if c.rollout.Spec.Strategy.Canary.DynamicStableScale {
-				desiredWeight = (weightutil.MaxTrafficWeight(c.rollout) * c.newRS.Status.AvailableReplicas) / *c.rollout.Spec.Replicas
+				desiredWeight = c.canaryWeightFromAvailableReplicas()
 			} else if c.rollout.Status.Canary.Weights != nil {
 				desiredWeight = c.rollout.Status.Canary.Weights.Canary.Weight
 			}
@@ -265,6 +271,11 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 				weightDestinations = append(weightDestinations, c.calculateWeightDestinationsFromExperiment()...)
 			} else {
 				desiredWeight = weightutil.MaxTrafficWeight(c.rollout)
+			}
+			// Rollback within the rollback window fast-forwards `index` past the last step, at
+			// 100% weight, while the canary may still be scaling up. Cap to what it can serve.
+			if *index == int32(len(c.rollout.Spec.Strategy.Canary.Steps)) && !c.checkReplicasAvailable(c.newRS, desiredWeight) {
+				desiredWeight = c.canaryWeightFromAvailableReplicas()
 			}
 		}
 

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -441,6 +441,57 @@ func TestRolloutUsePreviousSetWeight(t *testing.T) {
 	f.run(getKey(r2, t))
 }
 
+// When the canary step index is fast-forwarded to the final step (as a rollback within the
+// rollback window does) while the canary ReplicaSet is still scaling up, the desired weight
+// resolves to 100%. The weight must be capped to the share the canary's available replicas can
+// serve, otherwise all traffic is routed to a canary that has only a fraction of its pods.
+func TestRolloutCapWeightToAvailableCanaryReplicas(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{
+		{SetWeight: ptr.To[int32](10)},
+		{SetWeight: ptr.To[int32](100)},
+	}
+	// Step index fast-forwarded to the final step (len(steps)).
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](2), intstr.FromInt(1), intstr.FromInt(0))
+	r2 := bumpVersion(r1)
+	r2.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
+	r2.Spec.Strategy.Canary.CanaryService = "canary"
+	r2.Spec.Strategy.Canary.StableService = "stable"
+
+	rs1 := newReplicaSetWithStatus(r1, 10, 10) // stable, fully available
+	rs2 := newReplicaSetWithStatus(r2, 10, 2)  // canary, only 2 of 10 available
+
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	canarySelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}
+	stableSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}
+	canarySvc := newService("canary", 80, canarySelector, r2)
+	stableSvc := newService("stable", 80, stableSelector, r2)
+
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2, canarySvc, stableSvc)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+
+	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 10, 2, 10, false)
+	r2.Status.CurrentStepIndex = ptr.To[int32](int32(len(steps)))
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2)
+
+	f.expectPatchRolloutAction(r2)
+
+	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, additionalDestinations ...v1alpha1.WeightDestination) error {
+		// 2 of 10 canary replicas available -> at most 20% may shift to the canary, not 100%.
+		assert.Equal(t, int32(20), desiredWeight)
+		return nil
+	})
+	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything, mock.Anything).Return(ptr.To[bool](true), nil)
+	f.run(getKey(r2, t))
+}
+
 func TestRolloutUseDynamicWeightOnPromoteFull(t *testing.T) {
 	f := newFixture(t)
 	defer f.Close()

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -480,16 +480,35 @@ func TestRolloutCapWeightToAvailableCanaryReplicas(t *testing.T) {
 
 	f.expectPatchRolloutAction(r2)
 
+	setWeightCalled := false
 	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
 	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, additionalDestinations ...v1alpha1.WeightDestination) error {
 		// 2 of 10 canary replicas available -> at most 20% may shift to the canary, not 100%.
+		setWeightCalled = true
 		assert.Equal(t, int32(20), desiredWeight)
 		return nil
 	})
 	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
 	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything, mock.Anything).Return(ptr.To[bool](true), nil)
 	f.run(getKey(r2, t))
+	assert.True(t, setWeightCalled, "SetWeight was never invoked; cap assertion did not run")
+}
+
+func TestWeightFromAvailableReplicasZeroReplicas(t *testing.T) {
+	cases := map[string]*int32{
+		"nil":  nil,
+		"zero": ptr.To[int32](0),
+	}
+	for name, replicas := range cases {
+		t.Run(name, func(t *testing.T) {
+			ro := newCanaryRollout("foo", 1, nil, nil, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(0))
+			rs := newReplicaSetWithStatus(ro, 3, 3)
+			ro.Spec.Replicas = replicas
+			c := &rolloutContext{rollout: ro}
+			assert.Equal(t, int32(0), c.weightFromAvailableReplicas(rs))
+		})
+	}
 }
 
 func TestRolloutUseDynamicWeightOnPromoteFull(t *testing.T) {

--- a/test/e2e/istio/istio-rollback-window-cold-canary.yaml
+++ b/test/e2e/istio/istio-rollback-window-cold-canary.yaml
@@ -1,0 +1,93 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-rollback-window-canary
+spec:
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app: istio-rollback-window
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-rollback-window-stable
+spec:
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app: istio-rollback-window
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: istio-rollback-window-vsvc
+spec:
+  hosts:
+  - istio-rollback-window
+  http:
+  - name: primary
+    route:
+    - destination:
+        host: istio-rollback-window-stable
+      weight: 100
+    - destination:
+        host: istio-rollback-window-canary
+      weight: 0
+
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: istio-rollback-window
+spec:
+  replicas: 4
+  revisionHistoryLimit: 5
+  # A redeploy of a recent prior revision is fast-tracked as a "rollback within window".
+  rollbackWindow:
+    revisions: 3
+  strategy:
+    canary:
+      canaryService: istio-rollback-window-canary
+      stableService: istio-rollback-window-stable
+      scaleDownDelaySeconds: 3 # scale the rolled-back RS cold quickly (default is 30s)
+      trafficRouting:
+        istio:
+          virtualService:
+            name: istio-rollback-window-vsvc
+            routes:
+            - primary
+      # Single setWeight:100 step: the rollback fast-forward resolves the weight to this value.
+      steps:
+      - setWeight: 100
+  selector:
+    matchLabels:
+      app: istio-rollback-window
+  template:
+    metadata:
+      labels:
+        app: istio-rollback-window
+        rev: one # distinct pod-template-hash per revision; rollback re-applies an earlier rev
+    spec:
+      # Readiness controlled by the harness (MarkPodsReady) so the canary can be held partial.
+      readinessGates:
+      - conditionType: argoproj.io/e2e-readiness
+      containers:
+      - name: istio-rollback-window
+        image: nginx:1.19-alpine
+        ports:
+        - name: http
+          containerPort: 80
+          protocol: TCP
+        resources:
+          requests:
+            memory: 16Mi
+            cpu: 5m

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -570,3 +570,62 @@ func (s *IstioSuite) TestIstioSubsetSplitInStableDownscaleAfterCanaryAbort() {
 
 	s.TearDownSuite()
 }
+
+// TestIstioRollbackWithinWindowCapsCanaryWeight verifies that a "rollback within window", which
+// fast-forwards the canary step index to the final step, does not shift 100% of traffic onto a
+// canary ReplicaSet that is still scaling up. The weight must be capped to the canary's available
+// proportion. Here the rolled-back canary is held at 1 of 4 available, so the canary route weight
+// must be 25, not 100. Without the cap in reconcileTrafficRouting the weight is 100 with only one
+// pod ready, which blackholes traffic (Envoy "no healthy upstream").
+func (s *IstioSuite) TestIstioRollbackWithinWindowCapsCanaryWeight() {
+	s.Given().
+		RolloutObjects("@istio/istio-rollback-window-cold-canary.yaml").
+		When().
+		ApplyManifests().
+		MarkPodsReady("1", 4). // revision 1 fully available
+		WaitForRolloutStatus("Healthy").
+		UpdateSpec(`
+metadata:
+  labels:
+    rev: two
+spec:
+  template:
+    metadata:
+      labels:
+        rev: two`). // update to revision 2
+		MarkPodsReady("2", 4).           // single setWeight:100 step scales the canary straight to 4
+		WaitForRolloutStatus("Healthy"). // revision 2 promoted to stable
+		WaitForRevisionPodCount("1", 0). // ensure the rollback target is fully cold first
+		Then().
+		Assert(func(t *fixtures.Then) {
+			vsvc := t.GetVirtualService()
+			assert.Equal(s.T(), int64(100), vsvc.Spec.HTTP[0].Route[0].Weight) // stable (rev 2)
+			assert.Equal(s.T(), int64(0), vsvc.Spec.HTTP[0].Route[1].Weight)   // canary
+		}).
+		When().
+		UpdateSpec(`
+metadata:
+  labels:
+    rev: one
+spec:
+  template:
+    metadata:
+      labels:
+        rev: one`). // rollback to revision 1's pod template -> within window -> fast-forward
+		MarkPodsReady("3", 1). // reused RS is now revision 3; only 1 of 4 pods available
+		// Wait on observable state (the controller writing the canary weight) instead of sleeping:
+		// after the rollback the weight settles to the capped 25 (fix) or the un-capped 100 (no fix).
+		WaitForRolloutCondition(func(ro *v1alpha1.Rollout) bool {
+			return ro.Status.Canary.Weights != nil && ro.Status.Canary.Weights.Canary.Weight >= 25
+		}, "canary weight applied after rollback").
+		Then().
+		Assert(func(t *fixtures.Then) {
+			vsvc := t.GetVirtualService()
+			// Canary (rolled-back revision 1) is only 1/4 available, so its weight is capped to
+			// 100*1/4 = 25 rather than the fast-forwarded 100. Stable keeps the remaining 75.
+			assert.Equal(s.T(), int64(75), vsvc.Spec.HTTP[0].Route[0].Weight)
+			assert.Equal(s.T(), int64(25), vsvc.Spec.HTTP[0].Route[1].Weight)
+		})
+
+	s.TearDownSuite()
+}


### PR DESCRIPTION
On a rollback within `spec.rollbackWindow`, `CurrentStepIndex` is set to `int32(len(canary.steps))` — one past the last step. `desiredWeight` then resolves to `weightutil.MaxTrafficWeight(...)` (100% canary). Nothing then caps that weight by canary availability: the stable-only guard `!c.checkReplicasAvailable(c.stableRS, ...)` passes trivially at 100% canary weight, and the existing zero-replica reset (`c.newRS.Status.AvailableReplicas == 0`) only fires when the canary has *zero* available replicas — not when it has some-but-not-all.

Result: 100% of traffic shifts onto a canary ReplicaSet still scaling up. On services with non-trivial startup latency the requests hit not-ready pods and are blackholed — the incident described in #3941.

This PR caps the weight when `index == len(steps)` and canary availability is insufficient, using the existing `checkReplicasAvailable` gate so `ReplicaProgressThreshold` tolerance still applies — you can still promote at less than 100% availability, just not to 100% weight when the canary can't handle it. The DRY helper `weightFromAvailableReplicas()` also replaces the identical inline expression at three pre-existing call sites (the `DynamicStableScale` branch of `reconcileTrafficRouting`, and both weight sites in `calculateDesiredWeightOnAbortOrStableRollback`). Behaviour outside the final-step case is unchanged.

Alternatives considered:
- Cap unconditionally on the final step — drops the `checkReplicasAvailable` gate, which today lets `ReplicaProgressThreshold` promote below full availability. Keeping the gate preserves that opt-in.
- Fix inside `calculateDesiredWeightOnAbortOrStableRollback` — that path is `dynamicallyRollingBackToStable`, a different branch that already caps via `weightFromAvailableReplicas`. The rollback-within-window path evaluated here doesn't route through it.
- Apply the cap at every step — changes intermediate `setWeight` semantics (they'd become "up to N% or as much as the canary can serve"), a behaviour change users haven't opted into.

Out of scope: the analogous `PromoteFull` path with `DynamicStableScale=false` (branch at `reconcileTrafficRouting` line ~247) uses `Status.Canary.Weights.Canary.Weight` uncapped. Same shape of bug; separate change.

## Testing

- Unit: `TestRolloutCapWeightToAvailableCanaryReplicas` in `rollout/trafficrouting_test.go` — asserts the final-step weight is capped when canary is partially available.
- E2E: `TestIstioSuite/TestIstioRollbackWithinWindowCapsCanaryWeight` in `test/e2e/istio_test.go` — reproduces the rollback-within-window scenario, holds the canary at 1/4 available, asserts the VirtualService weight settles at 25 (not 100). Verified passing locally against a k3d cluster.
- `go build`, `go vet`, `golangci-lint run`, full unit suite: clean.

Fixes #3941

Checklist:

* [x] (b) this is a bug fix
* [x] The title of the PR is [conventional](https://www.conventionalcommits.org/en/v1.0.0/), states what changed, and suffixes the related issue number.
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green.
* [x] I have written unit tests for my change (`TestRolloutCapWeightToAvailableCanaryReplicas`) and an Istio e2e test (`TestIstioRollbackWithinWindowCapsCanaryWeight`).
* [x] I have run all tests locally and they pass on my workstation.
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR.
* [x] I understand what the code does and WHY/HOW it works in several scenarios.
* [x] I know if my code is just adding new functionality or changing old functionality for existing users.
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
