### PR TITLE
fix(controller): reconcile traffic routing during an aborted scaling event

### DIFF
--- a/rollout/context.go
+++ b/rollout/context.go
@@ -69,7 +69,9 @@ func (c *rolloutContext) reconcile() error {
 		return err
 	}
 
-	if isScalingEvent {
+	// Skip the scaling-only short-circuit while aborting: it bypasses traffic reconciliation,
+	// which would freeze the canary weight if spec.replicas changes mid-abort (e.g. HPA).
+	if isScalingEvent && !c.pauseContext.IsAborted() {
 		return c.syncReplicasOnly()
 	}
 

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -984,6 +984,70 @@ func TestDynamicScalingDontIncreaseWeightWhenAborted(t *testing.T) {
 	f.run(getKey(r1, t))
 }
 
+// TestReconcileTrafficRoutingWhenAbortedDuringScalingEvent verifies that an abort still reconciles
+// traffic routing (shifts weight off the canary) even when a concurrent scaling event (e.g. an HPA
+// changing spec.replicas) would otherwise short-circuit reconcile() to syncReplicasOnly.
+func TestReconcileTrafficRoutingWhenAbortedDuringScalingEvent(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{
+		{SetWeight: ptr.To[int32](50)},
+		{Pause: &v1alpha1.RolloutPause{}},
+	}
+	r1 := newCanaryRollout("foo", 5, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(1))
+	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{SMI: &v1alpha1.SMITrafficRouting{}}
+	r1.Spec.Strategy.Canary.CanaryService = "canary"
+	r1.Spec.Strategy.Canary.StableService = "stable"
+	r1.Status.ReadyReplicas = 5
+	r1.Status.AvailableReplicas = 5
+	r1.Status.Abort = true
+	r1.Status.AbortedAt = &metav1.Time{Time: time.Now().Add(-1 * time.Minute)}
+	r2 := bumpVersion(r1)
+
+	rs1 := newReplicaSetWithStatus(r1, 5, 5)
+	rs2 := newReplicaSetWithStatus(r2, 5, 5)
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	canarySvc := newService("canary", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}, r1)
+	stableSvc := newService("stable", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}, r1)
+
+	r2.Status.Abort = true
+	r2.Status.StableRS = rs1PodHash
+	r2.Status.Canary.Weights = &v1alpha1.TrafficWeights{
+		Canary: v1alpha1.WeightDestination{Weight: 50, ServiceName: "canary", PodTemplateHash: rs2PodHash},
+		Stable: v1alpha1.WeightDestination{Weight: 50, ServiceName: "stable", PodTemplateHash: rs1PodHash},
+	}
+	// HPA scaling event during the abort: spec.replicas changed but the RS desired-replicas
+	// annotation hasn't caught up, so isScalingEvent() returns true.
+	r2.Spec.Replicas = ptr.To[int32](4)
+
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2, canarySvc, stableSvc)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2)
+
+	setWeight := int32(-1)
+	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, _ ...v1alpha1.WeightDestination) error {
+		setWeight = desiredWeight
+		return nil
+	})
+	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("RemoveManagedRoutes", mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](true), nil)
+
+	f.expectPatchServiceAction(canarySvc, rs1PodHash) // canary service reset to stable on abort
+	f.expectUpdateReplicaSetAction(rs1)               // scaling event applied to the active RS
+	f.expectPatchRolloutAction(r2)
+	f.run(getKey(r1, t))
+
+	// The abort must reconcile traffic routing (not short-circuit on the scaling event) and shift
+	// the canary weight all the way back to 0 in this single cycle -- not leave it frozen at 50.
+	assert.Equal(t, int32(0), setWeight, "aborted scaling event must reconcile the canary weight to 0")
+}
+
 // TestDynamicScalingDecreaseWeightAccordingToStepWeightsAvailabilityWhenAborted verifies we decrease the weight
 // to the canary depending on the weight in previous Step when aborting
 func TestDynamicScalingDecreaseWeightAccordingToStepWeightsAvailabilityWhenAborted(t *testing.T) {


### PR DESCRIPTION
`reconcile()` in `rollout/context.go` short-circuits to `syncReplicasOnly()` whenever `isScalingEvent()` is true. `syncReplicasOnly()` scales the ReplicaSets but never calls `reconcileTrafficRouting`, so the canary's traffic weight stays at whatever value the previous non-scaling reconcile wrote.

Failure mode: a canary is aborting, and something (typically an HPA reacting to load, but any `spec.replicas` change works) fires `isScalingEvent()` while the abort is in progress. `reconcile()` short-circuits, the traffic weight stays frozen at its pre-abort value, and the abort cannot move traffic off the canary until the scaling event resolves and a subsequent non-scaling reconcile fires. For a wedged rollback that can be arbitrarily long.

This PR narrows the short-circuit to non-aborted rollouts. When `pauseContext.IsAborted()`, `reconcile()` falls through to the strategy-specific path. `rolloutCanary` calls `reconcileTrafficRouting` (which fixes the frozen-weight bug) and `reconcileCanaryReplicaSets` — the exact scaling entry point `syncReplicasOnly` was already invoking for canary — so no scaling behaviour is lost.

`reconcileTrafficRouting` is canary-only; blue-green never called it, so no traffic behaviour changes for blue-green. The blue-green abort+scaling case now runs the full `rolloutBlueGreen` path instead of the shortcut, but both include the same replicaset sync via `reconcileBlueGreenReplicaSets`.

The full canary path also runs `reconcileEphemeralMetadata`, `reconcileStableAndCanaryService`, `reconcileExperiments`, `reconcileAnalysisRuns`, and `stepPluginContext.reconcile` during abort+scaling reconciles that previously skipped them. Each has an explicit abort branch upstream (e.g. `abortExperiments`, canary-service selector reset on abort), so widening the surface here is a strict improvement in the abort case.

Alternatives considered:
- Move `reconcileTrafficRouting` into `syncReplicasOnly` — bigger surface change; `syncReplicasOnly` is intentionally minimal and shared by both strategies.
- Re-enqueue on scaling event during abort — indirect and racy; the fix is a one-condition predicate at the site of the incorrect short-circuit.

## Testing

- Unit: `TestReconcileTrafficRoutingWhenAbortedDuringScalingEvent` in `rollout/trafficrouting_test.go` — constructs an aborted canary with a concurrent scaling event and asserts the traffic router receives `SetWeight(0)` in the same reconcile cycle rather than the frozen pre-abort weight.
- `go build`, `go vet`, `golangci-lint run`, full unit suite: clean.

No filed upstream issue matches this exact failure mode; the closest reports are around abort behaviour with traffic routing (#4626, #1838, #3078) but none pin the scaling-event short-circuit.

Checklist:

* [x] (b) this is a bug fix
* [x] The title of the PR is [conventional](https://www.conventionalcommits.org/en/v1.0.0/) and states what changed. No related upstream issue is filed for this specific behaviour, so no `Fixes #` suffix.
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green.
* [x] I have written unit tests for my change (`TestReconcileTrafficRoutingWhenAbortedDuringScalingEvent`).
* [x] I have run all tests locally and they pass on my workstation.
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR.
* [x] I understand what the code does and WHY/HOW it works in several scenarios.
* [x] I know if my code is just adding new functionality or changing old functionality for existing users.
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).