### PR TITLE
fix(experiments): add API fallback when ReplicaSet lister is stale on AlreadyExists (#4842)

### DIFF
--- a/experiments/replicaset.go
+++ b/experiments/replicaset.go
@@ -93,7 +93,15 @@ func (ec *experimentContext) createReplicaSet(template v1alpha1.TemplateSpec, co
 		// Fetch a copy of the ReplicaSet.
 		rs, rsErr := ec.replicaSetLister.ReplicaSets(newRS.Namespace).Get(newRS.Name)
 		if rsErr != nil {
-			return nil, rsErr
+			if !errors.IsNotFound(rsErr) {
+				return nil, rsErr
+			}
+			// Lister cache may be stale — fall back to a direct API Get
+			rs, rsErr = ec.kubeclientset.AppsV1().ReplicaSets(newRS.Namespace).Get(ctx, newRS.Name, metav1.GetOptions{})
+			if rsErr != nil {
+				return nil, rsErr
+			}
+			ec.log.Warnf("ReplicaSet '%s' missing from informer cache, fell back to API get", rs.Name)
 		}
 
 		// If the Experiment owns the ReplicaSet and the ReplicaSet's PodTemplateSpec is semantically

--- a/experiments/replicaset_test.go
+++ b/experiments/replicaset_test.go
@@ -1,17 +1,47 @@
 package experiments
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	appslisters "k8s.io/client-go/listers/apps/v1"
+	k8stesting "k8s.io/client-go/testing"
+	corev1defaults "k8s.io/kubernetes/pkg/apis/core/v1"
 	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
 )
+
+// errReplicaSetLister is a fake ReplicaSetLister that always returns a fixed error from Get.
+type errReplicaSetLister struct{ err error }
+
+func (l *errReplicaSetLister) List(_ labels.Selector) ([]*appsv1.ReplicaSet, error) {
+	return nil, l.err
+}
+func (l *errReplicaSetLister) ReplicaSets(_ string) appslisters.ReplicaSetNamespaceLister {
+	return &errReplicaSetNamespaceLister{err: l.err}
+}
+func (l *errReplicaSetLister) GetPodReplicaSets(_ *corev1.Pod) ([]*appsv1.ReplicaSet, error) {
+	return nil, l.err
+}
+
+type errReplicaSetNamespaceLister struct{ err error }
+
+func (l *errReplicaSetNamespaceLister) List(_ labels.Selector) ([]*appsv1.ReplicaSet, error) {
+	return nil, l.err
+}
+func (l *errReplicaSetNamespaceLister) Get(_ string) (*appsv1.ReplicaSet, error) {
+	return nil, l.err
+}
 
 func TestCreateMultipleRS(t *testing.T) {
 	templates := generateTemplates("bar", "baz")
@@ -164,6 +194,81 @@ func TestNameCollisionWithEquivalentPodTemplateAndControllerUID(t *testing.T) {
 		cond := []v1alpha1.ExperimentCondition{*newCondition(conditions.ReplicaSetUpdatedReason, e)}
 		validatePatch(t, patch, "", NoChange, templateStatuses, cond)
 	}
+}
+
+// TestReplicaSetAlreadyExistsMissingFromCacheFallsBackToAPI verifies that when a ReplicaSet already
+// exists in the API but not in the informer cache (stale lister), the AlreadyExists handler falls
+// back to a direct API Get instead of propagating a "not found" error.
+func TestReplicaSetAlreadyExistsMissingFromCacheFallsBackToAPI(t *testing.T) {
+	templates := generateTemplates("bar")
+	e := newExperiment("foo", templates, "")
+
+	// Build the RS exactly as createReplicaSet would, then apply kubernetes defaults to
+	// the pod template so that the "live" side has the same defaults that
+	// PodTemplateEqualIgnoreHash applies to the "desired" side during comparison.
+	rs := newReplicaSetFromTemplate(e, templates[0], nil)
+	pt := corev1.PodTemplate{Template: rs.Spec.Template}
+	corev1defaults.SetObjectDefaults_PodTemplate(&pt)
+	rs.Spec.Template = pt.Template
+
+	// Create a context with an empty lister (informer never started/synced). Pre-load the
+	// RS directly into the kubeclientset to simulate it existing in the API but not yet
+	// visible in the informer cache — the stale-lister race.
+	exCtx := newTestContext(e)
+	_, err := exCtx.kubeclientset.AppsV1().ReplicaSets(e.Namespace).Create(context.TODO(), &rs, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// createReplicaSet: Create → AlreadyExists → lister.Get → NotFound → kubeclientset.Get → found → success
+	createdRS, createErr := exCtx.createReplicaSet(templates[0], nil)
+	assert.NoError(t, createErr)
+	assert.NotNil(t, createdRS)
+	assert.Equal(t, rs.Name, createdRS.Name)
+}
+
+// TestReplicaSetAlreadyExistsListerNonNotFoundError verifies that when the lister returns a
+// non-NotFound error (e.g. indexer failure), it is propagated directly without an API fallback.
+func TestReplicaSetAlreadyExistsListerNonNotFoundError(t *testing.T) {
+	templates := generateTemplates("bar")
+	e := newExperiment("foo", templates, "")
+	rs := newReplicaSetFromTemplate(e, templates[0], nil)
+
+	exCtx := newTestContext(e)
+	// Pre-create RS so Create returns AlreadyExists.
+	_, err := exCtx.kubeclientset.AppsV1().ReplicaSets(e.Namespace).Create(context.TODO(), &rs, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// Replace lister with one that returns a non-NotFound error.
+	listerErr := fmt.Errorf("indexer failure")
+	exCtx.replicaSetLister = &errReplicaSetLister{err: listerErr}
+
+	createdRS, createErr := exCtx.createReplicaSet(templates[0], nil)
+	assert.ErrorIs(t, createErr, listerErr)
+	assert.Nil(t, createdRS)
+}
+
+// TestReplicaSetAlreadyExistsAPIGetFailure verifies that when the lister cache is stale and the
+// direct API Get also fails, the error is propagated to the caller.
+func TestReplicaSetAlreadyExistsAPIGetFailure(t *testing.T) {
+	templates := generateTemplates("bar")
+	e := newExperiment("foo", templates, "")
+
+	rs := newReplicaSetFromTemplate(e, templates[0], nil)
+
+	exCtx := newTestContext(e)
+	// Pre-create RS so Create returns AlreadyExists (lister remains empty/stale).
+	_, err := exCtx.kubeclientset.AppsV1().ReplicaSets(e.Namespace).Create(context.TODO(), &rs, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// Inject an error for all subsequent Get operations on replicasets.
+	exCtx.kubeclientset.(*k8sfake.Clientset).PrependReactor("get", "replicasets", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("API server unavailable")
+	})
+
+	// createReplicaSet: Create → AlreadyExists → lister.Get → miss → kubeclientset.Get → error
+	createdRS, createErr := exCtx.createReplicaSet(templates[0], nil)
+	assert.Error(t, createErr)
+	assert.Nil(t, createdRS)
+	assert.Contains(t, createErr.Error(), "API server unavailable")
 }
 
 // TestNewReplicaSetFromTemplate tests the creation of a new ReplicaSet from a given template.


### PR DESCRIPTION
## What does this PR do?

When the Experiment controller reconciles and tries to create a ReplicaSet that was already created in a prior sync, the \`AlreadyExists\` handler falls back to the lister to fetch the existing RS. If the informer cache is stale (fast resync before the cache updates), the lister misses and the error propagates up — setting \`templateStatus\` to \`Error\` and aborting the Rollout.

This PR adds a direct API \`Get\` fallback when the lister misses, so a stale cache no longer causes a spurious error. The RS is fetched from the API server and the reconciliation continues normally.

Fixes #4842

## Testing

Added two tests in \`experiments/replicaset_test.go\`:

- \`TestReplicaSetAlreadyExistsMissingFromCacheFallsBackToAPI\`: pre-loads the RS into the fake kubeclientset but **not** into the informer cache (simulating a stale lister), then calls \`createReplicaSet\` and asserts it returns the RS successfully instead of an error.
- \`TestReplicaSetAlreadyExistsAPIGetFailure\`: same stale-cache setup, but injects a failure on the API \`Get\` fallback and asserts the error is propagated to the caller.

## Checklist

* [x] (b) this is a bug fix
* [x] The title of the PR is conventional, states what changed, and suffixes the related issue number
* [x] I've signed my commits with DCO
* [x] I have written unit tests for my change
* [x] I have run all tests locally and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users