### PR TITLE
fix(metricprovider): guard against malformed Wavefront datapoints

### DIFF
--- a/metricproviders/wavefront/wavefront.go
+++ b/metricproviders/wavefront/wavefront.go
@@ -140,6 +140,11 @@ func (p *Provider) findDataPointValue(datapoints []wavefrontapi.DataPoint, mTime
 	delta := math.Inf(1)
 	startTimeEpoch := float64(mTime.Unix())
 	for _, dp := range datapoints {
+		if len(dp) < 2 {
+			// A well-formed Wavefront datapoint is [<timestamp>, <value>].
+			// Skip malformed entries so we don't panic on dp[0]/dp[1].
+			continue
+		}
 		newDelta := dp[0] - startTimeEpoch
 		if math.Abs(newDelta) < math.Abs(delta) {
 			currentValue = dp[1]

--- a/metricproviders/wavefront/wavefront_test.go
+++ b/metricproviders/wavefront/wavefront_test.go
@@ -270,4 +270,27 @@ func TestFindDataPointValue(t *testing.T) {
 		assert.Equal(t, int64(0), epoch)
 		assert.Equal(t, int64(0), drift)
 	})
+
+	t.Run("Skip malformed datapoints without panicking", func(t *testing.T) {
+		dataPoints := []wavefrontapi.DataPoint{
+			{},       // zero elements
+			{7},      // one element
+			dp(0, 1), // valid, closest
+			dp(5, 2),
+		}
+		value, epoch, drift := p.findDataPointValue(dataPoints, metav1.Unix(1, 0))
+		assert.Equal(t, float64(1), value)
+		assert.Equal(t, int64(0), epoch)
+		assert.Equal(t, int64(-1), drift)
+	})
+
+	t.Run("Only malformed datapoints returns zero value", func(t *testing.T) {
+		dataPoints := []wavefrontapi.DataPoint{
+			{},
+			{7},
+		}
+		value, epoch, _ := p.findDataPointValue(dataPoints, metav1.Unix(1, 0))
+		assert.Equal(t, float64(0), value)
+		assert.Equal(t, int64(0), epoch)
+	})
 }


### PR DESCRIPTION
As a supply-chain-security researcher I was reading through the metric providers and hit a controller crash in the Wavefront provider.

`findDataPointValue` indexes `dp[0]` and `dp[1]` for every datapoint in the response without checking its length. A Wavefront datapoint is `[<timestamp>, <value>]`, but if the API returns a datapoint with 0 or 1 elements the indexing panics with `index out of range`. That panic runs on the analysis goroutine, which only calls `wg.Done()` and doesn't recover, so it brings the whole rollouts controller down rather than just failing the one measurement.

The fix skips any datapoint shorter than 2 elements, matching how the loop already iterates, so a malformed entry is ignored instead of crashing. I added regression tests for a mix of malformed and valid datapoints and for the all-malformed case.

This is defensive hardening against a malformed metrics response rather than something an unprivileged user can trigger directly, but a single bad datapoint taking down the controller seemed worth guarding.

Verification: `go test ./metricproviders/wavefront/...` panics with `index out of range [0] with length 0` before the change and passes after it.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green. Try syncing with master if they are not.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
