### PR TITLE
fix(controller): delay abort scale-down until canary traffic has shifted away

### DIFF
--- a/docs/features/scaledown-aborted-rs.md
+++ b/docs/features/scaledown-aborted-rs.md
@@ -16,3 +16,5 @@ is scaled down in 30 seconds on abort by default.
 |                   canary w/ traffic routing | scales down immediately       | 0                          | does not scale down           |
 |                   canary w/ traffic routing | scales down immediately       | N                          | scales down after N seconds   |
 | canary w/ traffic routing  + setCanaryScale | does not scale down (bug)     | *                          | should behave like  canary w/ traffic routing     |
+
+For a canary with traffic routing, the delay does not begin until Argo Rollouts has also set the canary's traffic weight to 0, and confirmed it for traffic routers that support weight verification, so that the canary is not scaled down while the traffic router is still sending it requests. If the weight never reaches 0, the canary stays scaled up rather than being scaled down early, and a `CanaryTrafficNotShifted` warning event is recorded on the Rollout while it waits.

--- a/rollout/replicaset.go
+++ b/rollout/replicaset.go
@@ -16,8 +16,10 @@ import (
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/annotations"
+	"github.com/argoproj/argo-rollouts/utils/conditions"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
+	"github.com/argoproj/argo-rollouts/utils/record"
 	replicasetutil "github.com/argoproj/argo-rollouts/utils/replicaset"
 	serviceutil "github.com/argoproj/argo-rollouts/utils/service"
 	timeutil "github.com/argoproj/argo-rollouts/utils/time"
@@ -194,14 +196,24 @@ func (c *rolloutContext) reconcileNewReplicaSet() (bool, error) {
 				return false, fmt.Errorf("failed to sync newRS desired-replicas annotation before adding abort scale-down delay: %w", err)
 			}
 			// Don't annotate until the stable RS is fully scaled, i.e. able to serve 100%
-			// of traffic, since the deadline scales the canary to zero unconditionally.
-			// With dynamicStableScale this holds once the abort weight has stepped down to
-			// zero (see GetDesiredCanaryWeight). >= tolerates stable transiently exceeding
-			// spec.Replicas (e.g. HPA scale-in).
+			// of traffic, AND the router has stopped sending traffic to the canary, since the
+			// deadline scales the canary to zero unconditionally. The latter is the guarantee
+			// scaleDownOldReplicaSetsForCanary already gives old RSs, via
+			// canProceedWithScaleDownAnnotation and isReplicaSetReferenced; neither covered the
+			// aborted canary, because it is the *new* RS. Like those guards, this one waits
+			// indefinitely rather than timing out; a warning event makes the wait visible.
+			// With dynamicStableScale the stable check holds once the abort weight has stepped
+			// down to zero (see GetDesiredCanaryWeight). >= tolerates stable transiently
+			// exceeding spec.Replicas (e.g. HPA scale-in).
 			if c.stableRS.Status.AvailableReplicas >= *c.rollout.Spec.Replicas {
-				err = c.addScaleDownDelay(c.newRS, *abortScaleDownDelaySeconds)
-				if err != nil {
-					return false, err
+				if c.canaryTrafficShiftedAway() {
+					err = c.addScaleDownDelay(c.newRS, *abortScaleDownDelaySeconds)
+					if err != nil {
+						return false, err
+					}
+				} else {
+					c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: conditions.CanaryTrafficNotShiftedReason},
+						conditions.CanaryTrafficNotShiftedMessage, c.newRS.Name)
 				}
 			}
 			// leave newRS scaled up until we annotate
@@ -272,6 +284,28 @@ func (c *rolloutContext) shouldDelayScaleDownOnAbort() bool {
 		return false
 	}
 	return true
+}
+
+// canaryTrafficShiftedAway reports whether the traffic router has stopped sending traffic to the
+// canary ReplicaSet: the canary weight has reached 0 and, for routers that verify weights, that
+// shift has been verified.
+//
+// Weights are read from newStatus because reconcileTrafficRouting runs earlier in the same
+// reconcile and records there both the weight it just programmed and the result of the
+// VerifyWeight call it just made. The persisted status is a reconcile behind.
+func (c *rolloutContext) canaryTrafficShiftedAway() bool {
+	if c.rollout.Spec.Strategy.Canary == nil || c.rollout.Spec.Strategy.Canary.TrafficRouting == nil {
+		// Blue-green reaches reconcileNewReplicaSet by the same path, with no router to wait on.
+		return true
+	}
+	weights := c.newStatus.Canary.Weights
+	if weights == nil {
+		// Aborted before any canary traffic was shifted, so there is nothing to wait for.
+		return true
+	}
+	// The weight refers to c.newRS: the one path that records a different canary pod hash,
+	// IsDynamicallyRollingBackToStable, requires a fully promoted rollout, so is never an abort.
+	return weights.Canary.Weight == 0 && (weights.Verified == nil || *weights.Verified)
 }
 
 // reconcileOtherReplicaSets reconciles "other" ReplicaSets.

--- a/rollout/replicaset_test.go
+++ b/rollout/replicaset_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/argoproj/argo-rollouts/rollout/trafficrouting/istio"
 	testutil "github.com/argoproj/argo-rollouts/test/util"
 	"github.com/argoproj/argo-rollouts/utils/annotations"
+	"github.com/argoproj/argo-rollouts/utils/conditions"
 	istioutil "github.com/argoproj/argo-rollouts/utils/istio"
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
 	"github.com/argoproj/argo-rollouts/utils/record"
@@ -474,13 +475,162 @@ func TestAbortScaleDownDelayDoesNotWedgeScalingEvent(t *testing.T) {
 	f.objects = append(f.objects, r2)
 
 	updatedRSIndex := f.expectUpdateReplicaSetAction(rs2) // desired-replicas annotation sync
-	f.expectPatchReplicaSetAction(rs2)                    // scale-down-deadline added
+	// The scale-down-deadline is not added in this reconcile: syncReplicasOnly does not reconcile
+	// traffic routing, so the recorded canary weight is still the pre-abort 50 and
+	// canaryTrafficShiftedAway() holds the annotation back. Terminating the scaling event is what
+	// lets the next reconcile take the full path, drive the abort weight to 0, and annotate then.
 	f.expectPatchRolloutAction(r2)
 	f.run(getKey(r2, t))
 
 	updatedRS := f.getUpdatedReplicaSet(updatedRSIndex)
 	assert.Equal(t, int32(5), *updatedRS.Spec.Replicas, "canary RS must be held at scale during the abort delay")
 	assert.Equal(t, "4", updatedRS.Annotations[annotations.DesiredReplicasAnnotation], "desired-replicas annotation must be synced so the scaling event terminates and the next reconcile takes the full path")
+}
+
+// trafficWeightsFn builds recorded traffic weights given the canary and stable pod hashes.
+type trafficWeightsFn func(canaryHash, stableHash string) *v1alpha1.TrafficWeights
+
+// canaryWeightsAt records the canary at the given weight on the current canary RS. A nil verified
+// pointer models a router that does not verify weights (Istio, SMI, Nginx); non-nil models one
+// that does (ALB).
+func canaryWeightsAt(canaryWeight int32, verified *bool) trafficWeightsFn {
+	return func(canaryHash, stableHash string) *v1alpha1.TrafficWeights {
+		return &v1alpha1.TrafficWeights{
+			Canary:   v1alpha1.WeightDestination{Weight: canaryWeight, PodTemplateHash: canaryHash},
+			Stable:   v1alpha1.WeightDestination{Weight: 100 - canaryWeight, PodTemplateHash: stableHash},
+			Verified: verified,
+		}
+	}
+}
+
+func noCanaryWeights(string, string) *v1alpha1.TrafficWeights { return nil }
+
+// abortScaleDown is what reconcileNewReplicaSet did for an aborted rollout: whether it annotated
+// the new RS with the scale-down delay, and the event reasons it recorded.
+type abortScaleDown struct {
+	annotated bool
+	events    []string
+}
+
+// reconcileNewRSOnAbort wires a rolloutContext around ro and reconciles it once. newStatus stands
+// in for what reconcileTrafficRouting recorded earlier in the same reconcile.
+func reconcileNewRSOnAbort(t *testing.T, f *fixture, ro *v1alpha1.Rollout, newRS, stableRS *appsv1.ReplicaSet, newStatus v1alpha1.RolloutStatus) abortScaleDown {
+	t.Helper()
+	f.objects = append(f.objects, ro)
+	f.kubeobjects = append(f.kubeobjects, stableRS, newRS)
+	f.replicaSetLister = append(f.replicaSetLister, stableRS, newRS)
+	c, informers, _ := f.newController(noResyncPeriodFunc)
+	stopCh := make(chan struct{})
+	informers.Start(stopCh)
+	informers.WaitForCacheSync(stopCh)
+	close(stopCh)
+
+	res := abortScaleDown{}
+	fakeRecorder := record.NewFakeEventRecorder()
+	roCtx := rolloutContext{
+		log:            logutil.WithRollout(ro),
+		rollout:        ro,
+		newRS:          newRS,
+		stableRS:       stableRS,
+		allRSs:         []*appsv1.ReplicaSet{newRS, stableRS},
+		newStatus:      newStatus,
+		reconcilerBase: c.reconcilerBase,
+		pauseContext:   &pauseContext{rollout: ro},
+	}
+	roCtx.recorder = fakeRecorder
+
+	_, err := roCtx.reconcileNewReplicaSet()
+	assert.NoError(t, err)
+	res.events = fakeRecorder.Events()
+
+	for _, a := range f.kubeclient.Actions() {
+		if a.GetVerb() == "patch" && a.GetResource().Resource == "replicasets" {
+			res.annotated = true
+		}
+	}
+	return res
+}
+
+// TestScaleDownOnAbortWaitsForCanaryTrafficShift verifies that, on an aborted traffic-routed
+// canary, the scale-down-delay annotation is only added to the canary RS once the router has
+// stopped sending it traffic -- not while the canary is still in the traffic path.
+func TestScaleDownOnAbortWaitsForCanaryTrafficShift(t *testing.T) {
+	// reconcile sets up an aborted, traffic-routed canary with the stable RS fully scaled and
+	// reconciles it once. persisted is what a previous reconcile wrote to status; fresh is what
+	// reconcileTrafficRouting recorded on newStatus earlier in this same reconcile.
+	reconcile := func(persisted, fresh trafficWeightsFn) abortScaleDown {
+		f := newFixture(t)
+		defer f.Close()
+
+		steps := []v1alpha1.CanaryStep{{SetWeight: ptr.To[int32](50)}, {Pause: &v1alpha1.RolloutPause{}}}
+		r1 := newCanaryRollout("foo", 5, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(1))
+		r1.Spec.Strategy.Canary.CanaryService = "canary"
+		r1.Spec.Strategy.Canary.StableService = "stable"
+		r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{SMI: &v1alpha1.SMITrafficRouting{}}
+		r1.Spec.Strategy.Canary.AbortScaleDownDelaySeconds = ptr.To[int32](30)
+		r2 := bumpVersion(r1)
+		r2.Status.Abort = true
+		r2.Status.AbortedAt = ptr.To(timeutil.MetaNow())
+
+		stableRS := newReplicaSetWithStatus(r1, 5, 5)
+		newRS := newReplicaSetWithStatus(r2, 5, 5)
+		stableHash := stableRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+		canaryHash := newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+		r2.Status.StableRS = stableHash
+		r2.Status.Canary.Weights = persisted(canaryHash, stableHash)
+
+		newStatus := *r2.Status.DeepCopy()
+		newStatus.Canary.Weights = fresh(canaryHash, stableHash)
+		return reconcileNewRSOnAbort(t, f, r2, newRS, stableRS, newStatus)
+	}
+	// steady models the common case where the previous reconcile already recorded what this one
+	// recomputed, for a rollout aborted just now.
+	steady := func(w trafficWeightsFn) bool { return reconcile(w, w).annotated }
+
+	assert.False(t, steady(canaryWeightsAt(50, nil)), "canary still has traffic -> no scale-down delay")
+	assert.True(t, steady(canaryWeightsAt(0, nil)), "traffic shifted off canary (router doesn't verify) -> annotate")
+	assert.False(t, steady(canaryWeightsAt(0, ptr.To(false))), "weight 0 but router hasn't verified the shift -> wait")
+	assert.True(t, steady(canaryWeightsAt(0, ptr.To(true))), "weight 0 and verified -> annotate")
+	assert.True(t, steady(noCanaryWeights), "no recorded weights (abort before any canary traffic) -> annotate")
+
+	// The gate must read the weights reconcileTrafficRouting recorded on newStatus earlier in this
+	// reconcile, not the still-serving values a previous reconcile persisted -- otherwise every
+	// abort pays an extra reconcile before the canary can be annotated.
+	assert.True(t, reconcile(canaryWeightsAt(50, nil), canaryWeightsAt(0, ptr.To(true))).annotated,
+		"router shifted away this reconcile -> annotate without waiting for the next one")
+
+	// The wait is indefinite, so it has to be visible to an operator.
+	waiting := reconcile(canaryWeightsAt(50, nil), canaryWeightsAt(50, nil))
+	assert.False(t, waiting.annotated)
+	assert.Contains(t, waiting.events, conditions.CanaryTrafficNotShiftedReason,
+		"waiting on the traffic shift must emit a warning event")
+	assert.NotContains(t, reconcile(canaryWeightsAt(0, nil), canaryWeightsAt(0, nil)).events,
+		conditions.CanaryTrafficNotShiftedReason, "no event once traffic has shifted away")
+}
+
+// TestScaleDownOnAbortBlueGreenUnaffected verifies that the canary traffic-shift gate does not
+// change blue-green abort scale-down, which reaches reconcileNewReplicaSet by the same path but
+// has no canary traffic router to wait on. Leftover status.canary.weights (which a rollout
+// converted from a traffic-routed canary carries until they are recomputed) must not wedge it.
+func TestScaleDownOnAbortBlueGreenUnaffected(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	r1 := newBlueGreenRollout("foo", 5, nil, "active", "preview")
+	r1.Spec.Strategy.BlueGreen.AbortScaleDownDelaySeconds = ptr.To[int32](30)
+	r2 := bumpVersion(r1)
+	r2.Status.Abort = true
+	r2.Status.AbortedAt = ptr.To(timeutil.MetaNow())
+
+	stableRS := newReplicaSetWithStatus(r1, 5, 5)
+	newRS := newReplicaSetWithStatus(r2, 5, 5)
+	r2.Status.StableRS = stableRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	r2.Status.BlueGreen.ActiveSelector = r2.Status.StableRS
+	r2.Status.Canary.Weights = canaryWeightsAt(50, nil)(
+		newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey], r2.Status.StableRS)
+
+	res := reconcileNewRSOnAbort(t, f, r2, newRS, stableRS, *r2.Status.DeepCopy())
+	assert.True(t, res.annotated, "blue-green abort annotates the scale-down delay immediately")
 }
 
 func TestReconcileOldReplicaSet(t *testing.T) {

--- a/rollout/trafficrouting/alb/alb_test.go
+++ b/rollout/trafficrouting/alb/alb_test.go
@@ -875,6 +875,25 @@ func TestVerifyWeight(t *testing.T) {
 		assert.Nil(t, weightVerified)
 	}
 
+	// Aborted from a non-setWeight step: the abort weight of 0 must still be verified, else the
+	// canary can be scaled down while the target group is still routing to it
+	{
+		var status v1alpha1.RolloutStatus
+		r, _ := newFakeReconciler(&status)
+		r.cfg.Rollout.Spec.Strategy.Canary.Steps = []v1alpha1.CanaryStep{{Pause: &v1alpha1.RolloutPause{}}}
+		r.cfg.Rollout.Status.CurrentStepIndex = ptr.To[int32](0)
+		r.cfg.Rollout.Status.Abort = true
+		// The canary still has pods, so the shift away from it is still worth verifying.
+		r.cfg.Rollout.Status.UpdatedReplicas = 1
+		// Already reported once, so an abort that went unrecognised would take the "no need to
+		// verify" early return above and yield a nil (rather than unverified) result.
+		r.cfg.Rollout.Status.ALB = &v1alpha1.ALBStatus{}
+		weightVerified, err := r.VerifyWeight(0)
+		assert.NoError(t, err)
+		assert.NotNil(t, weightVerified, "abort weight must be verified whichever step we aborted from")
+		assert.False(t, *weightVerified)
+	}
+
 	// LoadBalancer found, not at weight
 	{
 		var status v1alpha1.RolloutStatus

--- a/utils/conditions/conditions.go
+++ b/utils/conditions/conditions.go
@@ -179,6 +179,10 @@ const (
 	// TargetGroupVerifyErrorReason is emitted when we fail to verify the health of a target group due to error
 	TargetGroupVerifyErrorReason  = "TargetGroupVerifyError"
 	TargetGroupVerifyErrorMessage = "Failed to verify Service %s (TargetGroup %s): %s"
+	// CanaryTrafficNotShiftedReason is emitted while an aborted canary is held scaled up because the
+	// traffic router has not shifted away from it yet
+	CanaryTrafficNotShiftedReason  = "CanaryTrafficNotShifted"
+	CanaryTrafficNotShiftedMessage = "Delaying scale down of canary ReplicaSet %s on abort: traffic has not shifted away from it yet"
 	// WeightVerifyErrorReason is emitted when there is an error verifying the set weight
 	WeightVerifyErrorReason  = "WeightVerifyError"
 	WeightVerifyErrorMessage = "Failed to verify weight: %s"

--- a/utils/rollout/rolloututil.go
+++ b/utils/rollout/rolloututil.go
@@ -241,12 +241,25 @@ func CanaryStepString(c v1alpha1.CanaryStep) string {
 // ShouldVerifyWeight We use this to test if we should verify weights because weight verification could involve
 // API calls to the cloud provider which could incur rate limiting
 func ShouldVerifyWeight(ro *v1alpha1.Rollout, desiredWeight int32) bool {
+	if ro.Status.StableRS == "" || IsFullyPromoted(ro) {
+		return false
+	}
+	// An abort drives the canary weight to 0, and the canary is scaled down once the router reports
+	// that shift has taken effect, so it has to be verified whichever step the rollout was on when
+	// it was aborted. CurrentStepIndex is reset to 0 on abort and step 0 is not necessarily a
+	// setWeight step, so the check below is not enough on its own.
+	if ro.Status.Abort && desiredWeight == 0 {
+		// Nothing left to protect once the canary is at 0 replicas; skipping avoids polling the
+		// cloud provider every resync for a parked aborted rollout.
+		return ro.Status.UpdatedReplicas > 0
+	}
 	currentStep, _ := replicasetutil.GetCurrentCanaryStep(ro)
 	// If we are in the middle of an update at a setWeight step, also perform weight verification.
 	// Note that we don't do this every reconciliation because weight verification typically involves
-	// API calls to the cloud provider which could incur rate limitingq
-	shouldVerifyWeight := (ro.Status.StableRS != "" && !IsFullyPromoted(ro) && currentStep != nil && currentStep.SetWeight != nil) ||
-		(ro.Status.StableRS != "" && !IsFullyPromoted(ro) && currentStep == nil && desiredWeight == weightutil.MaxTrafficWeight(ro)) // We are at end of rollout
-
-	return shouldVerifyWeight
+	// API calls to the cloud provider which could incur rate limiting
+	if currentStep != nil {
+		return currentStep.SetWeight != nil
+	}
+	// We are at end of rollout
+	return desiredWeight == weightutil.MaxTrafficWeight(ro)
 }

--- a/utils/rollout/rolloututil_test.go
+++ b/utils/rollout/rolloututil_test.go
@@ -452,6 +452,55 @@ func TestShouldVerifyWeight(t *testing.T) {
 	assert.Equal(t, true, ShouldVerifyWeight(ro, 100))
 }
 
+// TestShouldVerifyWeightOnAbort covers the abort case: the canary weight is driven to 0 and the
+// canary is scaled down once the router reports the shift, so the shift must be verified whichever
+// step the rollout was on when it was aborted. CurrentStepIndex is reset to 0 on abort, and step 0
+// is not necessarily a setWeight step.
+func TestShouldVerifyWeightOnAbort(t *testing.T) {
+	newAbortedRollout := func(step v1alpha1.CanaryStep) *v1alpha1.Rollout {
+		ro := newCanaryRollout()
+		ro.Status.StableRS = "34feab23f"
+		ro.Status.CurrentStepIndex = ptr.To[int32](0)
+		ro.Spec.Strategy.Canary.Steps = []v1alpha1.CanaryStep{step}
+		ro.Status.Abort = true
+		return ro
+	}
+
+	pauseStep := v1alpha1.CanaryStep{Pause: &v1alpha1.RolloutPause{}}
+	setWeightStep := v1alpha1.CanaryStep{SetWeight: ptr.To[int32](20)}
+
+	assert.True(t, ShouldVerifyWeight(newAbortedRollout(pauseStep), 0),
+		"aborted from a non-setWeight step: the abort weight of 0 still has to be verified")
+	assert.True(t, ShouldVerifyWeight(newAbortedRollout(setWeightStep), 0),
+		"aborted from a setWeight step: unchanged")
+
+	// The abort clause is specific to the weight being driven to 0; anything else falls through to
+	// the usual step-based check.
+	assert.False(t, ShouldVerifyWeight(newAbortedRollout(pauseStep), 20))
+	assert.True(t, ShouldVerifyWeight(newAbortedRollout(setWeightStep), 20))
+
+	// Not aborted, so a weight of 0 at a non-setWeight step is not verified.
+	notAborted := newAbortedRollout(pauseStep)
+	notAborted.Status.Abort = false
+	assert.False(t, ShouldVerifyWeight(notAborted, 0))
+
+	// Once the canary is at 0 replicas there is nothing left to protect, so stop polling the cloud
+	// provider on every resync of a rollout parked in the aborted state.
+	scaledDown := newAbortedRollout(setWeightStep)
+	scaledDown.Status.UpdatedReplicas = 0
+	assert.False(t, ShouldVerifyWeight(scaledDown, 0), "canary already at 0 replicas -> stop verifying")
+
+	// The preconditions still apply: nothing is verified before there is a stable RS, or once the
+	// rollout is fully promoted.
+	noStable := newAbortedRollout(pauseStep)
+	noStable.Status.StableRS = ""
+	assert.False(t, ShouldVerifyWeight(noStable, 0))
+
+	fullyPromoted := newAbortedRollout(pauseStep)
+	fullyPromoted.Status.CurrentPodHash = fullyPromoted.Status.StableRS
+	assert.False(t, ShouldVerifyWeight(fullyPromoted, 0))
+}
+
 func Test_isGenerationObserved(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
On an aborted traffic-routed canary, the scale-down-delay annotation is added to the canary ReplicaSet as soon as the stable ReplicaSet is fully scaled, without checking that the traffic router has actually stopped sending traffic to the canary. The delay clock starts while `VerifyWeight` may still be in flight, and the ReplicaSet is scaled to 0 at expiry regardless. On ALB this means the canary can be scaled to 0 while the target group still routes to it → 503 UF/UH.

This adds the guard. `scaleDownOldReplicaSetsForCanary` already refuses to annotate **old** ReplicaSets until the router has let go of them — `canProceedWithScaleDownAnnotation` (ALB target-group verification) and `isReplicaSetReferenced` (recorded weights, live Service selectors, Istio DestinationRule subsets). The aborted canary is the **new** RS, so none of those covered it.

Two commits plus a docs update, each independently buildable and testable. Rebased on current master.

## 1. The gate

`addScaleDownDelay` is gated on a new `canaryTrafficShiftedAway()`: the recorded canary weight has reached 0 and, for routers that populate `Weights.Verified`, the shift has been verified. Weights are read from `newStatus`, which `reconcileTrafficRouting` populates earlier in the same reconcile, so the annotation is not delayed an extra reconcile waiting for the previous status to be persisted.

**Primary beneficiary is ALB** with target-group verification enabled (`--aws-verify-target-group`; `defaults.defaultVerifyTargetGroup` is `false`, and every other in-tree router returns `nil` from `VerifyWeight`), plus any plugin that populates `Weights.Verified`:
- `reconcileTrafficRouting` calls `SetWeight(0)` on abort — the K8s object is patched immediately.
- `VerifyWeight` then polls the ALB TargetGroup to confirm the routing actually switched, which can take seconds to minutes.
- Previously the annotation was written in between; now it waits.

For routers that leave `Weights.Verified` nil — which is every in-tree router other than ALB-with-verification — the recorded weight reaches 0 in the same reconcile as `SetWeight`, so the gate opens at the moment the old code would have annotated. This PR is effectively a no-op for them; the gate is only load-bearing where a router actually verifies.

Like `canProceedWithScaleDownAnnotation`, this waits **indefinitely** rather than timing out — an aborted canary that the router never lets go of stays scaled up instead of being scaled down early. A `CanaryTrafficNotShifted` warning event is recorded while it waits, so the reason the canary is still up is visible without reading controller logs. (Earlier revisions of this PR timed the wait out against `progressDeadlineSeconds`; dropped per review — that field is a detection knob, and its only action today is behind `progressDeadlineAbort`.)

**Blue-green** reaches `reconcileNewReplicaSet` by the same path but has no canary traffic router to wait on, so it returns true and abort scale-down is unchanged. Covered by a test, including the case where a rollout converted from a traffic-routed canary still carries stale `status.canary.weights`.

## 2. Verify the abort weight regardless of the current step

`ShouldVerifyWeight` only returns true at a `setWeight` step, or at the end of the rollout. On abort `CurrentStepIndex` is reset to 0, so for a rollout whose steps do not open with `setWeight` — `pause`, `analysis`, `setCanaryScale` — ALB was never asked to confirm the abort weight of 0 had taken effect, and `Weights.Verified` stayed nil. That makes the gate above a no-op for those rollouts: it falls back to the recorded weight value, which reaches 0 as soon as `SetWeight` returns rather than when the target group has converged.

So: verify the weight whenever an aborting rollout is driving it to 0, whichever step it was on. For the common `setWeight`-first layout nothing changes. For the others this adds a target-group check per reconcile while the canary is still up, which is the same cost `setWeight`-first rollouts already pay. Verification stops once the canary reaches 0 replicas, so a rollout parked in the aborted state does not keep polling the cloud provider (per review).

This also hoists the `StableRS`/`IsFullyPromoted` precondition that both existing clauses repeated, rather than repeating it a third time.

**Worth calling out the interaction with the indefinite wait above:** this commit widens the set of aborts where ALB is asked to verify, so it also widens where the gate can block. A wedged target group that never reports weight 0 will now hold the canary scaled up indefinitely, where before this commit it would not have waited at all for those step layouts. That follows from waiting indefinitely rather than timing out, and I think it is the right trade (don't scale down something still in the traffic path, and make it visible via the event) — but it is a consequence worth being explicit about rather than discovering later. Happy to drop this commit if you would rather keep the blast radius to `setWeight`-first rollouts.

## Relation to #4900

Complementary and already rebased over it: #4900 makes the abort weight *value* reach 0 in the `dynamicStableScale=true + explicit abortScaleDownDelaySeconds` case; this PR gates the *annotation* on that recorded weight being 0 and verified. The `>=` tolerance from #4900 for stable transiently exceeding `spec.Replicas` is preserved.

## Related work

- **#4864** gates *background analysis* creation on the canary having received the step's traffic weight. Same underlying idea — don't act until the router has converged — but a different predicate: that one asks "has the weight reached the step's target", this one asks "has it reached zero". They share only the one-line `Weights.Verified` check, so I have kept them as separate helpers in separate files rather than coupling the two PRs to share it. The PRs are independent and can merge in either order.
- **#4195** ("503 NC errors on canary release with Istio ... as well as on rollout abortions") reports an adjacent symptom. The mechanism there is Istio subset/DestinationRule resolution rather than an unconverged ALB target group, so this PR is not a fix for it, but it is the same family.

## Alternatives considered

- **Gate the scale-down at deadline expiry instead of the annotation** — would let the delay run concurrently with router convergence, but `abortScaleDownDelaySeconds` is meant as a drain window *after* traffic stops. Both existing guards gate the annotation.
- **Watch router state directly** (poll the ALB TargetGroup here) — router-specific plumbing, much larger surface.
- **A dedicated `AbortScaleDownGracePeriod` API field**, or timing the wait out against `progressDeadlineSeconds` — both rejected in favour of waiting indefinitely, matching the existing old-RS guard.

## Testing

- `TestScaleDownOnAbortWaitsForCanaryTrafficShift` — the annotation decision across weight > 0, weight 0 unverified, weight 0 verified, weight 0 on a non-verifying router, and nil weights; that the gate reads the freshly-recorded weights rather than the persisted ones; and that a `CanaryTrafficNotShifted` event is recorded while waiting and not once traffic has shifted.
- `TestScaleDownOnAbortBlueGreenUnaffected` — pins the blue-green behaviour.
- `TestShouldVerifyWeightOnAbort` — the abort clause, including that it is specific to weight 0 and that the `StableRS`/`IsFullyPromoted` preconditions still apply.
- `TestVerifyWeight` (ALB) — a rollout aborted from a `pause` step now actually verifies instead of returning early.
- No e2e: reproducing the failure needs a real ALB target group converging slowly, which CI cannot provide.
- Docs: `docs/features/scaledown-aborted-rs.md`, whose table promised "scales down after N seconds" for canary w/ traffic routing, now notes that the delay starts once the weight has reached 0, that the canary otherwise stays up, and that the `CanaryTrafficNotShifted` event records while it waits.
- `go build`, `go vet`, `golangci-lint run`, `gofmt`, and the full `./rollout/...` and `./utils/...` suites: clean, both for the final state and for each of the three commits on its own.

Checklist:

* [x] (b) this is a bug fix
* [x] The title of the PR is [conventional](https://www.conventionalcommits.org/en/v1.0.0/) and states what changed. No related upstream issue is filed for this specific behaviour, so no `Fixes #` suffix.
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green.
* [x] I have written unit tests for my change.
* [x] I have run all tests locally and they pass on my workstation.
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR.
* [x] I understand what the code does and WHY/HOW it works in several scenarios.
* [x] I know if my code is just adding new functionality or changing old functionality for existing users.
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
