### PR TITLE
fix(dashboard): handle empty Rollouts list

### DIFF
--- a/ui/src/app/components/rollouts-home/rollouts-home-state.ts
+++ b/ui/src/app/components/rollouts-home/rollouts-home-state.ts
@@ -1,0 +1,13 @@
+import {ListState} from '../../shared/utils/watch';
+
+export type RolloutsHomeView = 'loading' | 'error' | 'rollouts' | 'empty';
+
+export const getRolloutsHomeView = (state: ListState<unknown>): RolloutsHomeView => {
+    if (state.loading) {
+        return 'loading';
+    }
+    if (state.error) {
+        return 'error';
+    }
+    return state.items.length > 0 ? 'rollouts' : 'empty';
+};

--- a/ui/src/app/components/rollouts-home/rollouts-home.scss
+++ b/ui/src/app/components/rollouts-home/rollouts-home.scss
@@ -98,6 +98,18 @@ $colWidth: ($WIDGET_WIDTH + (2 * $widgetPadding)) + $widgetMarginRight;
         }
     }
 
+    &__error-message {
+        padding-top: 70px;
+        width: 50%;
+        margin: 0 auto;
+        color: $argo-failed-color;
+        text-align: center;
+
+        h1 {
+            margin-bottom: 1em;
+        }
+    }
+
     &__toolbar {
         width: 100%;
         padding: 1em 0;

--- a/ui/src/app/components/rollouts-home/rollouts-home.test.ts
+++ b/ui/src/app/components/rollouts-home/rollouts-home.test.ts
@@ -1,0 +1,28 @@
+import {getRolloutsHomeView} from './rollouts-home-state';
+import {ListState} from '../../shared/utils/watch';
+import {RolloutInfo} from '../../../models/rollout/rollout';
+
+const state = (overrides: Partial<ListState<RolloutInfo>>): ListState<RolloutInfo> => ({
+    items: [],
+    loading: false,
+    error: null,
+    ...overrides,
+});
+
+describe('getRolloutsHomeView', () => {
+    it('shows loading while the initial request is pending', () => {
+        expect(getRolloutsHomeView(state({loading: true}))).toBe('loading');
+    });
+
+    it('shows the empty state after a successful empty response', () => {
+        expect(getRolloutsHomeView(state({items: []}))).toBe('empty');
+    });
+
+    it('shows Rollouts after a successful non-empty response', () => {
+        expect(getRolloutsHomeView(state({items: [{} as RolloutInfo]}))).toBe('rollouts');
+    });
+
+    it('shows a persistent error after a failed response', () => {
+        expect(getRolloutsHomeView(state({error: new Error('request failed')}))).toBe('error');
+    });
+});

--- a/ui/src/app/components/rollouts-home/rollouts-home.tsx
+++ b/ui/src/app/components/rollouts-home/rollouts-home.tsx
@@ -8,12 +8,13 @@ import {useWatchRollouts} from '../../shared/services/rollout';
 import {RolloutsToolbar, defaultDisplayMode, Filters} from '../rollouts-toolbar/rollouts-toolbar';
 import {RolloutsTable} from '../rollouts-table/rollouts-table';
 import {RolloutsGrid} from '../rollouts-grid/rollouts-grid';
+import {getRolloutsHomeView} from './rollouts-home-state';
 import './rollouts-home.scss';
 
 export const RolloutsHome = () => {
     const rolloutsList = useWatchRollouts();
     const rollouts = rolloutsList.items;
-    const loading = rolloutsList.loading;
+    const view = getRolloutsHomeView(rolloutsList);
     const namespaceCtx = React.useContext(NamespaceContext);
 
     const [filters, setFilters] = React.useState<Filters>({
@@ -139,12 +140,14 @@ export const RolloutsHome = () => {
         <div className='rollouts-home'>
             <RolloutsToolbar rollouts={rollouts} favorites={favorites} onFilterChange={handleFilterChange} />
             <div className='rollouts-list'>
-                {loading ? (
+                {view === 'loading' ? (
                     <div style={{fontSize: '20px', padding: '20px', margin: '0 auto'}}>
                         <FontAwesomeIcon icon={faCircleNotch} spin={true} style={{marginRight: '5px'}} />
                         Loading...
                     </div>
-                ) : (rollouts || []).length > 0 ? (
+                ) : view === 'error' ? (
+                    <ErrorMessage error={rolloutsList.error} />
+                ) : view === 'rollouts' ? (
                     <React.Fragment>
                         {filters.displayMode === 'table' && <RolloutsTable rollouts={filteredRollouts} onFavoriteChange={handleFavoriteChange} favorites={favorites} />}
                         {filters.displayMode !== 'table' && <RolloutsGrid rollouts={filteredRollouts} onFavoriteChange={handleFavoriteChange} favorites={favorites} />}
@@ -156,6 +159,13 @@ export const RolloutsHome = () => {
         </div>
     );
 };
+
+const ErrorMessage = (props: {error: Error | null}) => (
+    <div className='rollouts-list__error-message' role='alert'>
+        <h1>Unable to load Rollouts</h1>
+        <div>{props.error?.message || 'An unexpected error occurred while fetching Rollouts.'}</div>
+    </div>
+);
 
 const EmptyMessage = (props: {namespace: string}) => {
     const CodeLine = (props: {children: string}) => {

--- a/ui/src/app/shared/services/rollout-state.test.ts
+++ b/ui/src/app/shared/services/rollout-state.test.ts
@@ -1,0 +1,23 @@
+import {RolloutInfo} from '../../../models/rollout/rollout';
+import {failedListState, loadedListState, loadingListState} from './rollout-state';
+
+const rollout = {objectMeta: {name: 'example'}} as RolloutInfo;
+
+describe('Rollouts list state', () => {
+    it('is loading while the initial request is pending', () => {
+        expect(loadingListState<RolloutInfo>()).toEqual({items: [], loading: true, error: null});
+    });
+
+    it('finishes loading after a successful empty response', () => {
+        expect(loadedListState<RolloutInfo>([])).toEqual({items: [], loading: false, error: null});
+    });
+
+    it('contains Rollouts after a successful non-empty response', () => {
+        expect(loadedListState([rollout])).toEqual({items: [rollout], loading: false, error: null});
+    });
+
+    it('finishes loading and retains an error after a failed response', () => {
+        const error = new Error('request failed');
+        expect(failedListState<RolloutInfo>(error)).toEqual({items: [], loading: false, error});
+    });
+});

--- a/ui/src/app/shared/services/rollout-state.ts
+++ b/ui/src/app/shared/services/rollout-state.ts
@@ -1,0 +1,11 @@
+import {ListState} from '../utils/watch';
+
+export const loadingListState = <T>(): ListState<T> => ({items: [], loading: true, error: null});
+
+export const loadedListState = <T>(items: T[]): ListState<T> => ({items, loading: false, error: null});
+
+export const failedListState = <T>(error: unknown): ListState<T> & {error: Error} => ({
+    items: [],
+    loading: false,
+    error: error instanceof Error ? error : new Error('An unexpected error occurred while fetching rollouts.'),
+});

--- a/ui/src/app/shared/services/rollout.ts
+++ b/ui/src/app/shared/services/rollout.ts
@@ -1,34 +1,49 @@
 import {RolloutRolloutWatchEvent, RolloutServiceApiFetchParamCreator} from '../../../models/rollout/generated';
-import {ListState, useLoading, useWatch, useWatchList} from '../utils/watch';
+import {ListState, useWatch, useWatchList} from '../utils/watch';
 import {RolloutInfo} from '../../../models/rollout/rollout';
 import * as React from 'react';
 import {NamespaceContext, RolloutAPIContext, getApiBasePath} from '../context/api';
 import { notification } from 'antd';
+import {failedListState, loadedListState, loadingListState} from './rollout-state';
 
-export const useRollouts = (): RolloutInfo[] => {
+export const useRollouts = (): ListState<RolloutInfo> => {
     const api = React.useContext(RolloutAPIContext);
     const namespaceCtx = React.useContext(NamespaceContext);
-    const [rollouts, setRollouts] = React.useState([]);
+    const [state, setState] = React.useState<ListState<RolloutInfo>>(loadingListState());
 
     React.useEffect(() => {
+        let cancelled = false;
+
         const fetchList = async () => {
+            setState(loadingListState());
             try {
                 const list = await api.rolloutServiceListRolloutInfos(namespaceCtx.namespace);
-                setRollouts(list.rollouts || []);
+                if (!cancelled) {
+                    setState(loadedListState(list.rollouts || []));
+                }
             } catch (error) {
-                console.error('Error fetching rollouts:', error);
-                notification.error({
-                    message: 'Error fetching rollouts',
-                    description: error.message || 'An unexpected error occurred while fetching rollouts.',
-                    duration: 8,
-                    placement: 'bottomRight',
-                });
+                if (!cancelled) {
+                    const errorState = failedListState<RolloutInfo>(error);
+                    const fetchError = errorState.error;
+                    setState(errorState);
+                    console.error('Error fetching rollouts:', fetchError);
+                    notification.error({
+                        message: 'Error fetching rollouts',
+                        description: fetchError.message,
+                        duration: 8,
+                        placement: 'bottomRight',
+                    });
+                }
             }
         };
         fetchList();
+
+        return () => {
+            cancelled = true;
+        };
     }, [api, namespaceCtx]);
 
-    return rollouts;
+    return state;
 };
 
 export const useWatchRollouts = (): ListState<RolloutInfo> => {
@@ -37,20 +52,20 @@ export const useWatchRollouts = (): ListState<RolloutInfo> => {
     const namespaceCtx = React.useContext(NamespaceContext);
     const streamUrl = getApiBasePath() + RolloutServiceApiFetchParamCreator().rolloutServiceWatchRolloutInfos(namespaceCtx.namespace).url;
 
-    const init = useRollouts();
-    const loading = useLoading(init);
+    const initialState = useRollouts();
 
-    const [rollouts, setRollouts] = React.useState(init);
+    const [rollouts, setRollouts] = React.useState(initialState.items);
     const liveList = useWatchList<RolloutInfo, RolloutRolloutWatchEvent>(streamUrl, findRollout, getRollout, rollouts);
 
     React.useEffect(() => {
-        setRollouts(init);
-    }, [init, loading]);
+        setRollouts(initialState.items);
+    }, [initialState.items]);
 
     return {
         items: liveList,
-        loading,
-    } as ListState<RolloutInfo>;
+        loading: initialState.loading,
+        error: initialState.error,
+    };
 };
 
 export const useWatchRollout = (name: string, subscribe: boolean, timeoutAfter?: number, callback?: (ri: RolloutInfo) => void): [RolloutInfo, boolean] => {

--- a/ui/src/app/shared/utils/watch.ts
+++ b/ui/src/app/shared/utils/watch.ts
@@ -12,20 +12,8 @@ enum ReadyState {
 export interface ListState<T> {
     loading: boolean;
     items: T[];
+    error: Error | null;
 }
-
-export const useLoading = (list: any[], minLength?: number) => {
-    const [loading, setLoading] = React.useState(true);
-    React.useEffect(() => {
-        if (!list) {
-            return;
-        }
-        if (list.length > (minLength || 0)) {
-            setLoading(false);
-        }
-    }, [list, minLength]);
-    return loading;
-};
 
 function fromEventSource(url: string): Observable<string> {
     return Observable.create((observer: Observer<any>) => {


### PR DESCRIPTION
Checklist:

 * [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix,
  or (c) this is a chore.
  * [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-
  rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number.
  * [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal).
  * [x] My builds are green.
  * [x] I have written unit and/or e2e tests for my change.
  * [x] I have run all relevant UI tests locally, including the complete 105-test suite.
  * [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR.
  * [x] I understand what the code does and WHY/HOW it works in several scenarios.
  * [x] I know this changes existing dashboard behavior for empty and failed Rollout-list requests.
  * [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

Fixes #4888 