### PR TITLE
fix: skip experiment weight destinations with empty ServiceName

### DIFF
--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -440,25 +440,39 @@ func calculateWeightStatus(ro *v1alpha1.Rollout, canaryHash, stableHash string, 
 func (c *rolloutContext) calculateWeightDestinationsFromExperiment() []v1alpha1.WeightDestination {
 	weightDestinations := make([]v1alpha1.WeightDestination, 0)
 	exStep := replicasetutil.GetCurrentExperimentStep(c.rollout)
-	if exStep != nil && c.currentEx != nil && c.currentEx.Status.Phase == v1alpha1.AnalysisPhaseRunning {
-		getTemplateWeight := func(name string) *int32 {
-			for _, tmpl := range exStep.Templates {
-				if tmpl.Name == name {
-					return tmpl.Weight
-				}
-			}
-			return nil
-		}
-		for _, templateStatus := range c.currentEx.Status.TemplateStatuses {
-			templateWeight := getTemplateWeight(templateStatus.Name)
-			if templateWeight != nil {
-				weightDestinations = append(weightDestinations, v1alpha1.WeightDestination{
-					ServiceName:     templateStatus.ServiceName,
-					PodTemplateHash: templateStatus.PodTemplateHash,
-					Weight:          *templateWeight,
-				})
+	if exStep == nil || c.currentEx == nil || c.currentEx.Status.Phase != v1alpha1.AnalysisPhaseRunning {
+		return weightDestinations
+	}
+	getTemplateWeight := func(name string) *int32 {
+		for _, tmpl := range exStep.Templates {
+			if tmpl.Name == name {
+				return tmpl.Weight
 			}
 		}
+		return nil
+	}
+	for _, templateStatus := range c.currentEx.Status.TemplateStatuses {
+		templateWeight := getTemplateWeight(templateStatus.Name)
+		if templateWeight == nil {
+			continue
+		}
+		if templateStatus.ServiceName == "" {
+			// A weighted experiment template requires a Service to route to.
+			// During experiment teardown (or if the experiment's Service is
+			// removed) the template status can momentarily carry an empty
+			// ServiceName while the template weight still applies. Emitting a
+			// WeightDestination without a ServiceName causes traffic routers
+			// to render destinations with an empty host (e.g. an Istio
+			// VirtualService route to host ""), which black-holes that share
+			// of traffic.
+			c.log.Warnf("Skipping weight destination for experiment template '%s': empty ServiceName", templateStatus.Name)
+			continue
+		}
+		weightDestinations = append(weightDestinations, v1alpha1.WeightDestination{
+			ServiceName:     templateStatus.ServiceName,
+			PodTemplateHash: templateStatus.PodTemplateHash,
+			Weight:          *templateWeight,
+		})
 	}
 	return weightDestinations
 }

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -388,6 +388,27 @@ func TestRolloutWithExperimentStep(t *testing.T) {
 		f.fakeTrafficRouting.On("VerifyWeight", mock.Anything, mock.Anything).Return(ptr.To[bool](true), nil)
 		f.run(getKey(r2, t))
 	})
+
+	t.Run("Experiment Running with empty ServiceName - no WeightDestination created", func(t *testing.T) {
+		// Simulates the teardown race where the template status momentarily
+		// carries an empty ServiceName while the template weight still applies.
+		// Without the guard this produced a WeightDestination with an empty
+		// ServiceName, rendered by traffic routers as a destination with an
+		// empty host that black-holes its traffic share.
+		ex.Status.Phase = v1alpha1.AnalysisPhaseRunning
+		ex.Status.TemplateStatuses[0].ServiceName = ""
+		ex.Status.TemplateStatuses[1].ServiceName = ""
+		f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+		f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(func(desiredWeight int32, weightDestinations ...v1alpha1.WeightDestination) error {
+			assert.Equal(t, int32(10), desiredWeight)
+			assert.Len(t, weightDestinations, 0)
+			return nil
+		})
+		f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
+		f.fakeTrafficRouting.On("VerifyWeight", mock.Anything, mock.Anything).Return(ptr.To[bool](true), nil)
+		f.run(getKey(r2, t))
+	})
 }
 
 func TestRolloutUsePreviousSetWeight(t *testing.T) {


### PR DESCRIPTION
Fixes #4890

During experiment teardown the experiment's template statuses can momentarily carry an empty `serviceName` while the template weight from the step spec still applies. `calculateWeightDestinationsFromExperiment` copied the empty ServiceName into a `WeightDestination`, which the Istio reconciler renders as a VirtualService route destination with an empty host carrying the arm's weight. Envoy cannot route such destinations, so that traffic share is black-holed (503s), and the entries are never cleaned up — recovery requires manually restoring the VirtualService. I hit this in a production environment I operate, during normal experiment teardown.

This change skips template statuses with an empty ServiceName (logging a warning) so a route destination without a host can never be emitted, and adds a regression test simulating the teardown race.

The controller's own event stream shows the poisoned state this prevents:

```
TrafficWeightUpdated: Traffic weight updated additional: [{1  } {1  }]
```

### Alternatives considered

- **Gate on `IsTerminating` instead of checking the ServiceName**: terminating is only one of several ways the status can carry a blank ServiceName (Service-creation failure at experiment start, template `Failed`/`Error`, external status writes — the `experiments` CRD has no status subresource). The empty-name check enforces the invariant itself — never emit a destination without a host — rather than one of its causes.
- **Order teardown so the VirtualService is cleaned before arm Services are deleted**: cross-controller ordering fights the level-triggered model and can wedge teardown when the rollout controller is slow or unavailable. Tolerating a mid-transition snapshot is the idiomatic contract.
- **Treat the condition as experiment termination and advance/abort the rollout**: a blank ServiceName is observed-state lag, not a lifecycle signal — it also occurs during healthy teardown seconds before `Phase` leaves `Running`; acting on it would abort healthy releases. Lifecycle decisions stay with experiment phase + analysis results.

### Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number.
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argo-rollouts/blob/master/CONTRIBUTING.md)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not.