### PR TITLE
fix(dashboard): coalesce buffered watch events into one UI update per window. Fixes #4733

### DIFF
--- a/ui/src/app/shared/utils/watch.test.ts
+++ b/ui/src/app/shared/utils/watch.test.ts
@@ -1,0 +1,38 @@
+import {Subject} from 'rxjs';
+import {coalesceBuffered} from './watch';
+
+describe('coalesceBuffered', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('emits only the most recent value once per buffer window, instead of once per source emission', () => {
+        const source = new Subject<number>();
+        const emissions: number[] = [];
+        source.pipe(coalesceBuffered(500)).subscribe((v) => emissions.push(v));
+
+        // Simulates many watch events (e.g. an initial list of rollouts) arriving in the
+        // same window: this should collapse into a single re-render instead of one-per-event.
+        for (let i = 1; i <= 123; i++) {
+            source.next(i);
+        }
+
+        jest.advanceTimersByTime(500);
+
+        expect(emissions).toEqual([123]);
+    });
+
+    it('does not emit anything for a window with no values', () => {
+        const source = new Subject<number>();
+        const emissions: number[] = [];
+        source.pipe(coalesceBuffered(500)).subscribe((v) => emissions.push(v));
+
+        jest.advanceTimersByTime(500);
+
+        expect(emissions).toEqual([]);
+    });
+});

--- a/ui/src/app/shared/utils/watch.ts
+++ b/ui/src/app/shared/utils/watch.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {fromEvent, Observable, Observer, Subscription} from 'rxjs';
-import {bufferTime, debounceTime, delay, filter, map, mergeMap, repeat, retryWhen, scan, timeout} from 'rxjs/operators';
+import {bufferTime, debounceTime, delay, filter, map, repeat, retryWhen, scan, timeout} from 'rxjs/operators';
 
 enum ReadyState {
     CONNECTING = 0,
@@ -49,6 +49,17 @@ function fromEventSource(url: string): Observable<string> {
 }
 
 const BUFFER_TIME = 500;
+
+// coalesceBuffered collapses all values emitted within each bufferTimeSpan window into a
+// single emission of the most recent value, instead of re-emitting every buffered value.
+export function coalesceBuffered<T>(bufferTimeSpan: number) {
+    return (source: Observable<T>): Observable<T> =>
+        source.pipe(
+            bufferTime(bufferTimeSpan),
+            filter((buffered) => buffered.length > 0),
+            map((buffered) => buffered[buffered.length - 1])
+        );
+}
 
 export function handlePageVisibility<T>(src: () => Observable<T>): Observable<T> {
     return new Observable<T>((observer: Observer<T>) => {
@@ -127,8 +138,7 @@ export function useWatchList<T, E extends WatchEvent>(url: string, findItem: (it
                 }
                 return items;
             }, init || []),
-            bufferTime(BUFFER_TIME),
-            mergeMap((l) => l)
+            coalesceBuffered(BUFFER_TIME)
         );
 
         const sub = handlePageVisibility(() => watch).subscribe((l) => {
@@ -163,12 +173,7 @@ export function useWatch<T>(url: string, subscribe: boolean, isEqual: (a: T, b: 
             map((i) => i.data)
         );
 
-        let liveStream = handlePageVisibility(() =>
-            watch.pipe(
-                bufferTime(BUFFER_TIME),
-                mergeMap((r) => r)
-            )
-        );
+        let liveStream = handlePageVisibility(() => watch.pipe(coalesceBuffered(BUFFER_TIME)));
 
         if (timeoutAfter > 0) {
             liveStream = liveStream.pipe(timeout(timeoutAfter));


### PR DESCRIPTION
Motivation:
The dashboard UI becomes unresponsive while loading a namespace with many
rollouts (reported with 123 rollouts, ~20s load time). No server-side
errors are logged and server CPU/memory stay well under their requests,
pointing to a client-side rendering problem rather than a server issue.

Approach:
ui/src/app/shared/utils/watch.ts buffers incoming SSE watch events over a
500ms window via `bufferTime(BUFFER_TIME)`, intending to coalesce rapid
updates into a single React state update. However the following
`mergeMap((l) => l)` flattens the buffered array and re-emits every
element individually, so the subscriber (and therefore `setState`/a full
list re-render) fires once per buffered event instead of once per window.
Since a fresh watch connection sends one "ADDED" event per existing
rollout during the initial sync, opening the dashboard against a
namespace with N rollouts triggers N separate state updates and
re-renders in quick succession - each doing an O(n) scan over the list -
instead of one. This matches the reported symptoms: freeze while loading,
a CPU spike, and no server-side errors.

This replaces the buffer-then-flatten step with a small `coalesceBuffered`
helper that takes only the most recent value accumulated in each 500ms
window and emits it once, so each window produces at most one update. It
is used by both `useWatchList` (the rollouts list/dashboard) and
`useWatch` (single rollout view), which had the same pattern duplicated.
This is a client-side rendering fix only; it does not change any backend
behavior, wire format, or the final data shown to the user - only how
many times React re-renders while getting there.

This is the most likely root cause based on code analysis of the
reported freeze; a live reproduction with a 123-rollout cluster was not
available in this environment, so the fix is validated by demonstrating
(via test) that the redundant re-renders are eliminated, not by timing a
before/after load against a real large namespace.

Validation:
- ui: npx tsc --noEmit -p tsconfig.json -> same 214 pre-existing errors
  before and after this change (all unrelated recharts/@types/react type
  mismatches already present on master, confirmed by stashing the diff
  and re-running); none reference watch.ts.
- ui: npx jest -> Test Suites: 3 passed, 3 total / Tests: 99 passed, 99
  total (97 pre-existing + 2 new, added in watch.test.ts, which verify
  that 123 rapid events within one window collapse into a single
  emission of the latest value, and that an empty window emits nothing).
- ui: npx webpack --config ./src/app/webpack.prod.js -> production build
  succeeds (only pre-existing bundle-size warnings).

Fixes #4733

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
