### PR TITLE
fix(controller): abort deadlock with dynamicStableScale + abortScaleDownDelaySeconds

### DIFF
--- a/rollout/replicaset.go
+++ b/rollout/replicaset.go
@@ -164,12 +164,24 @@ func (c *rolloutContext) reconcileNewReplicaSet() (bool, error) {
 				}
 			}
 		} else if abortScaleDownDelaySeconds != nil {
-			// Ensure combined stable+canary capacity covers spec.Replicas before annotating.
-			// Using equality with only stable.Available deadlocks when dynamicStableScale is
-			// enabled: stable is intentionally kept proportional to reverse traffic weight and
-			// only reaches spec.Replicas once canary is fully drained — which itself is gated
-			// on this annotation.
-			if c.stableRS.Status.AvailableReplicas+c.newRS.Status.AvailableReplicas >= *c.rollout.Spec.Replicas {
+			// Gate the scale-down-deadline annotation on sufficient serving capacity:
+			//   - Non-dynamic canary / BlueGreen: stable is kept at spec.Replicas by design,
+			//     so we retain the original strict check (stable.Available == spec.Replicas).
+			//     This preserves the legacy behavior of waiting for any transient stable
+			//     degradation to heal before starting the drain window.
+			//   - dynamicStableScale: stable is intentionally kept proportional to the reverse
+			//     traffic weight and only reaches spec.Replicas once canary is fully drained.
+			//     Requiring stable == spec.Replicas here deadlocks — canary can't shrink until
+			//     stable grows and vice versa. Fall back to combined stable+canary capacity.
+			usesDynamicStableScale := c.rollout.Spec.Strategy.Canary != nil &&
+				c.rollout.Spec.Strategy.Canary.DynamicStableScale
+			var hasCapacity bool
+			if usesDynamicStableScale {
+				hasCapacity = c.stableRS.Status.AvailableReplicas+c.newRS.Status.AvailableReplicas >= *c.rollout.Spec.Replicas
+			} else {
+				hasCapacity = c.stableRS.Status.AvailableReplicas == *c.rollout.Spec.Replicas
+			}
+			if hasCapacity {
 				err = c.addScaleDownDelay(c.newRS, *abortScaleDownDelaySeconds)
 				if err != nil {
 					return false, err

--- a/rollout/replicaset.go
+++ b/rollout/replicaset.go
@@ -164,8 +164,12 @@ func (c *rolloutContext) reconcileNewReplicaSet() (bool, error) {
 				}
 			}
 		} else if abortScaleDownDelaySeconds != nil {
-			// Don't annotate until need to ensure the stable RS is fully scaled
-			if c.stableRS.Status.AvailableReplicas == *c.rollout.Spec.Replicas {
+			// Ensure combined stable+canary capacity covers spec.Replicas before annotating.
+			// Using equality with only stable.Available deadlocks when dynamicStableScale is
+			// enabled: stable is intentionally kept proportional to reverse traffic weight and
+			// only reaches spec.Replicas once canary is fully drained — which itself is gated
+			// on this annotation.
+			if c.stableRS.Status.AvailableReplicas+c.newRS.Status.AvailableReplicas >= *c.rollout.Spec.Replicas {
 				err = c.addScaleDownDelay(c.newRS, *abortScaleDownDelaySeconds)
 				if err != nil {
 					return false, err

--- a/rollout/replicaset_test.go
+++ b/rollout/replicaset_test.go
@@ -347,39 +347,59 @@ func TestReconcileNewReplicaSet(t *testing.T) {
 	}
 }
 
-// TestReconcileNewReplicaSetAbortDynamicStableScale verifies that on abort with
-// dynamicStableScale + abortScaleDownDelaySeconds, the scale-down-deadline annotation
-// is added as soon as combined stable+canary capacity covers spec.Replicas. Prior to
-// the fix, the gate required stable.Available == spec.Replicas, which never holds under
-// dynamicStableScale (stable is kept proportional to reverse traffic weight), producing
-// a deadlock where the canary was never annotated and never scaled down on abort.
+// TestReconcileNewReplicaSetAbortDynamicStableScale verifies the scale-down-deadline
+// annotation gate on abort with abortScaleDownDelaySeconds. Coverage:
+//   - dynamicStableScale=true: uses combined stable+canary capacity. Prior to the fix
+//     the gate required stable.Available == spec.Replicas, which never holds under
+//     dynamicStableScale (stable is kept proportional to reverse traffic weight),
+//     producing a deadlock where canary was never annotated / never scaled down.
+//   - dynamicStableScale=false: retains the original strict check, waiting for any
+//     transient stable degradation to heal before starting the drain window.
 func TestReconcileNewReplicaSetAbortDynamicStableScale(t *testing.T) {
 	rolloutReplicas := int32(10)
 	abortDelay := int32(30)
 
 	tests := []struct {
-		name              string
-		stableAvailable   int32
-		newAvailable      int32
-		expectAnnotation  bool
+		name               string
+		dynamicStableScale bool
+		stableAvailable    int32
+		newAvailable       int32
+		expectAnnotation   bool
 	}{
 		{
-			name:             "combined capacity meets spec.Replicas -> annotate (deadlock case)",
-			stableAvailable:  9,
-			newAvailable:     2,
-			expectAnnotation: true,
+			name:               "dynamic: combined capacity meets spec.Replicas -> annotate (deadlock case)",
+			dynamicStableScale: true,
+			stableAvailable:    9,
+			newAvailable:       2,
+			expectAnnotation:   true,
 		},
 		{
-			name:             "stable alone meets spec.Replicas -> annotate (non-dynamic-like)",
-			stableAvailable:  10,
-			newAvailable:     0,
-			expectAnnotation: true,
+			name:               "dynamic: stable alone meets spec.Replicas -> annotate",
+			dynamicStableScale: true,
+			stableAvailable:    10,
+			newAvailable:       0,
+			expectAnnotation:   true,
 		},
 		{
-			name:             "combined capacity below spec.Replicas -> do not annotate",
-			stableAvailable:  5,
-			newAvailable:     2,
-			expectAnnotation: false,
+			name:               "dynamic: combined capacity below spec.Replicas -> do not annotate",
+			dynamicStableScale: true,
+			stableAvailable:    5,
+			newAvailable:       2,
+			expectAnnotation:   false,
+		},
+		{
+			name:               "non-dynamic: stable at spec.Replicas -> annotate",
+			dynamicStableScale: false,
+			stableAvailable:    10,
+			newAvailable:       0,
+			expectAnnotation:   true,
+		},
+		{
+			name:               "non-dynamic: stable degraded below spec.Replicas -> do not annotate (legacy strict check preserved)",
+			dynamicStableScale: false,
+			stableAvailable:    9,
+			newAvailable:       2,
+			expectAnnotation:   false,
 		},
 	}
 
@@ -389,7 +409,7 @@ func TestReconcileNewReplicaSetAbortDynamicStableScale(t *testing.T) {
 			steps := []v1alpha1.CanaryStep{{SetWeight: ptr.To[int32](10)}}
 			rollout := newCanaryRollout("foo", int(rolloutReplicas), nil, steps, int32Ptr(0), intstr.FromInt(1), intstr.FromInt(0))
 			rollout.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
-			rollout.Spec.Strategy.Canary.DynamicStableScale = true
+			rollout.Spec.Strategy.Canary.DynamicStableScale = test.dynamicStableScale
 			rollout.Spec.Strategy.Canary.AbortScaleDownDelaySeconds = &abortDelay
 			rollout.Spec.Strategy.Canary.CanaryService = "canary"
 			rollout.Spec.Strategy.Canary.StableService = "stable"

--- a/rollout/replicaset_test.go
+++ b/rollout/replicaset_test.go
@@ -347,6 +347,107 @@ func TestReconcileNewReplicaSet(t *testing.T) {
 	}
 }
 
+// TestReconcileNewReplicaSetAbortDynamicStableScale verifies that on abort with
+// dynamicStableScale + abortScaleDownDelaySeconds, the scale-down-deadline annotation
+// is added as soon as combined stable+canary capacity covers spec.Replicas. Prior to
+// the fix, the gate required stable.Available == spec.Replicas, which never holds under
+// dynamicStableScale (stable is kept proportional to reverse traffic weight), producing
+// a deadlock where the canary was never annotated and never scaled down on abort.
+func TestReconcileNewReplicaSetAbortDynamicStableScale(t *testing.T) {
+	rolloutReplicas := int32(10)
+	abortDelay := int32(30)
+
+	tests := []struct {
+		name              string
+		stableAvailable   int32
+		newAvailable      int32
+		expectAnnotation  bool
+	}{
+		{
+			name:             "combined capacity meets spec.Replicas -> annotate (deadlock case)",
+			stableAvailable:  9,
+			newAvailable:     2,
+			expectAnnotation: true,
+		},
+		{
+			name:             "stable alone meets spec.Replicas -> annotate (non-dynamic-like)",
+			stableAvailable:  10,
+			newAvailable:     0,
+			expectAnnotation: true,
+		},
+		{
+			name:             "combined capacity below spec.Replicas -> do not annotate",
+			stableAvailable:  5,
+			newAvailable:     2,
+			expectAnnotation: false,
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			steps := []v1alpha1.CanaryStep{{SetWeight: ptr.To[int32](10)}}
+			rollout := newCanaryRollout("foo", int(rolloutReplicas), nil, steps, int32Ptr(0), intstr.FromInt(1), intstr.FromInt(0))
+			rollout.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
+			rollout.Spec.Strategy.Canary.DynamicStableScale = true
+			rollout.Spec.Strategy.Canary.AbortScaleDownDelaySeconds = &abortDelay
+			rollout.Spec.Strategy.Canary.CanaryService = "canary"
+			rollout.Spec.Strategy.Canary.StableService = "stable"
+			rollout.Status.Abort = true
+			rollout.Status.StableRS = "abc123"
+			rollout.Status.CurrentPodHash = "def456"
+
+			stableRS := rs("foo-stable", int(rolloutReplicas), nil, noTimestamp, nil)
+			stableRS.Status.AvailableReplicas = test.stableAvailable
+			newRS := rs("foo-canary", int(test.newAvailable), nil, noTimestamp, nil)
+			newRS.Status.AvailableReplicas = test.newAvailable
+
+			f := newFixture(t)
+			defer f.Close()
+			f.objects = append(f.objects, rollout)
+			f.replicaSetLister = append(f.replicaSetLister, stableRS, newRS)
+			f.kubeobjects = append(f.kubeobjects, stableRS, newRS)
+			_, informers, k8sInformer := f.newController(noResyncPeriodFunc)
+			stopCh := make(chan struct{})
+			informers.Start(stopCh)
+			informers.WaitForCacheSync(stopCh)
+			close(stopCh)
+
+			k8sfake := k8sfake.Clientset{}
+			roCtx := rolloutContext{
+				log:      logutil.WithRollout(rollout),
+				rollout:  rollout,
+				newRS:    newRS,
+				stableRS: stableRS,
+				newStatus: v1alpha1.RolloutStatus{
+					Canary: v1alpha1.CanaryStatus{Weights: &v1alpha1.TrafficWeights{}},
+				},
+				reconcilerBase: reconcilerBase{
+					argoprojclientset:  &fake.Clientset{},
+					kubeclientset:      &k8sfake,
+					recorder:           record.NewFakeEventRecorder(),
+					resyncPeriod:       30 * time.Second,
+					replicaSetInformer: k8sInformer.Apps().V1().ReplicaSets().Informer(),
+				},
+				pauseContext: &pauseContext{rollout: rollout},
+			}
+			roCtx.enqueueRolloutAfter = func(obj any, duration time.Duration) {}
+
+			_, err := roCtx.reconcileNewReplicaSet()
+			assert.NoError(t, err)
+
+			annotated := false
+			for _, action := range k8sfake.Actions() {
+				if action.GetVerb() == "patch" && action.GetResource().Resource == "replicasets" {
+					annotated = true
+					break
+				}
+			}
+			assert.Equal(t, test.expectAnnotation, annotated, "unexpected annotation state; actions=%v", k8sfake.Actions())
+		})
+	}
+}
+
 func TestReconcileOldReplicaSet(t *testing.T) {
 	tests := []struct {
 		name                string


### PR DESCRIPTION
## Summary

Fixes #4898.

On abort, `reconcileNewReplicaSet` gated the scale-down-deadline annotation on `stableRS.Available == spec.Replicas`. With `dynamicStableScale: true` this equality never holds (stable is deliberately kept proportional to reverse traffic weight until canary drains), producing a deadlock: canary never gets annotated → never scales down → traffic weight never steps down → stable never grows → gate never satisfied.

This PR splits the gate by mode:

- **Non-dynamic canary / BlueGreen:** preserves the original strict check `stableRS.Available == spec.Replicas`. Stable is kept at `spec.Replicas` by design in this mode, and a transient stable degradation should legitimately hold the drain window.
- **`dynamicStableScale: true`:** relaxes to `stableRS.Available + newRS.Available >= spec.Replicas`. Combined capacity is the safety invariant that actually matters, and it avoids the circular wait.

## Changes

- `rollout/replicaset.go`: split the annotation gate into dynamic vs non-dynamic branches with comments explaining the invariant each preserves.
- `rollout/replicaset_test.go`: new `TestReconcileNewReplicaSetAbortDynamicStableScale` (5 subtests) covering:
  - dynamic: combined capacity meets spec.Replicas (deadlock repro — now annotates)
  - dynamic: stable alone meets spec.Replicas (annotates)
  - dynamic: combined capacity below spec.Replicas (does not annotate)
  - non-dynamic: stable at spec.Replicas (annotates — legacy behavior)
  - non-dynamic: stable degraded (does NOT annotate — legacy strict check preserved)

## Behavior Notes

- **HPA-scaled Rollouts with `dynamicStableScale`:** new dynamic-branch check is tolerant of `stable.Available > spec.Replicas` — previously would never annotate.
- **`setCanaryScale`:** `UseSetCanaryScale` already disables setCanaryScale on abort when `abortScaleDownDelaySeconds` is set; canary sizing falls back to traffic-weight logic. Dynamic-branch check accommodates the higher `newRS.Available` correctly.
- **Traffic-shift ordering unchanged:** the existing `calculateDesiredWeightOnAbortOrStableRollback` guard (`trafficrouting.go:388-392`) still holds traffic shifts until stable has enough available replicas — so stable pods ramp up before traffic moves, preserving the safety-by-design of `dynamicStableScale`.

## Test Plan

- [x] `go test ./rollout/... -count=1` — passes
- [x] Reverted fix locally, ran new subtest — fails as expected (confirms regression coverage)
- [x] CI: golangci-lint + full test suite
