### PR TITLE
fix(controller): shift abort traffic to stable before canary scale-do…

### DIFF
--- a/rollout/replicaset.go
+++ b/rollout/replicaset.go
@@ -238,7 +238,7 @@ func (c *rolloutContext) shouldDelayScaleDownOnAbort() bool {
 		return false
 	}
 	usesDynamicStableScaling := c.rollout.Spec.Strategy.Canary != nil && c.rollout.Spec.Strategy.Canary.DynamicStableScale
-	if usesDynamicStableScaling && !defaults.HasExplicitNonZeroAbortScaleDownDelay(c.rollout) {
+	if usesDynamicStableScaling && !defaults.HasExplicitAbortScaleDownDelay(c.rollout) {
 		// we are using dynamic stable/canary scaling and user did not explicitly set abortScaleDownDelay
 		return false
 	}

--- a/rollout/replicaset.go
+++ b/rollout/replicaset.go
@@ -232,13 +232,13 @@ func (c *rolloutContext) shouldDelayScaleDownOnAbort() bool {
 		// basic canary should not use this
 		return false
 	}
-	abortDelay, abortDelayWasSet := defaults.GetAbortScaleDownDelaySecondsOrDefault(c.rollout)
+	abortDelay, _ := defaults.GetAbortScaleDownDelaySecondsOrDefault(c.rollout)
 	if abortDelay == nil {
 		// user explicitly set abortScaleDownDelaySeconds: 0, and wishes to leave canary/preview up indefinitely
 		return false
 	}
 	usesDynamicStableScaling := c.rollout.Spec.Strategy.Canary != nil && c.rollout.Spec.Strategy.Canary.DynamicStableScale
-	if usesDynamicStableScaling && !abortDelayWasSet {
+	if usesDynamicStableScaling && !defaults.HasExplicitNonZeroAbortScaleDownDelay(c.rollout) {
 		// we are using dynamic stable/canary scaling and user did not explicitly set abortScaleDownDelay
 		return false
 	}

--- a/rollout/replicaset.go
+++ b/rollout/replicaset.go
@@ -164,8 +164,12 @@ func (c *rolloutContext) reconcileNewReplicaSet() (bool, error) {
 				}
 			}
 		} else if abortScaleDownDelaySeconds != nil {
-			// Don't annotate until need to ensure the stable RS is fully scaled
-			if c.stableRS.Status.AvailableReplicas == *c.rollout.Spec.Replicas {
+			// Don't annotate until the stable RS is fully scaled, i.e. able to serve 100%
+			// of traffic, since the deadline scales the canary to zero unconditionally.
+			// With dynamicStableScale this holds once the abort weight has stepped down to
+			// zero (see GetDesiredCanaryWeight). >= tolerates stable transiently exceeding
+			// spec.Replicas (e.g. HPA scale-in).
+			if c.stableRS.Status.AvailableReplicas >= *c.rollout.Spec.Replicas {
 				err = c.addScaleDownDelay(c.newRS, *abortScaleDownDelaySeconds)
 				if err != nil {
 					return false, err

--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -672,6 +672,70 @@ func (s *CanarySuite) TestCanaryDynamicStableScale() {
 		ExpectRevisionPodCount("1", 4)
 }
 
+// TestCanaryDynamicStableScaleAbortScaleDownDelay verifies that an abort with
+// dynamicStableScale and an explicitly set abortScaleDownDelaySeconds (1) does not deadlock
+// (issue #4898): traffic steps back to stable and the canary eventually scales down, and
+// (2) stays safe: the canary keeps its pods and is not annotated with a scale-down deadline
+// until traffic weight has fully shifted back to stable (weight 0), so the deadline never
+// scales down a canary that is still serving traffic.
+func (s *CanarySuite) TestCanaryDynamicStableScaleAbortScaleDownDelay() {
+	s.Given().
+		RolloutObjects(`@functional/canary-dynamic-stable-scale-abort-delay.yaml`).
+		When().
+		ApplyManifests().
+		MarkPodsReady("1", 4). // mark all 4 pods ready
+		WaitForRolloutStatus("Healthy").
+		UpdateSpec().          // update to revision 2
+		MarkPodsReady("2", 1). // mark 1 of 1 canary pods ready
+		WaitForRolloutStatus("Paused").
+		PromoteRollout().
+		MarkPodsReady("2", 2). // mark two more canary pods ready (3/3 canaries ready)
+		WaitForRolloutCanaryStepIndex(3).
+		Sleep(2*time.Second).
+		Then().
+		ExpectRevisionPodCount("1", 1).
+		ExpectRevisionPodCount("2", 3).
+		When().
+		AbortRollout().
+		Sleep(2*time.Second).
+		Then().
+		// While stable is still scaling up (its new pods are not yet ready), the canary must
+		// keep its pods, must NOT yet have a scale-down deadline, and must keep its traffic
+		// weight (75%), since stable cannot yet serve that traffic.
+		ExpectRevisionPodCount("2", 3).
+		Assert(func(t *fixtures.Then) {
+			rs2 := t.GetReplicaSetByRevision("2")
+			assert.NotContains(s.T(), rs2.Annotations, rov1.DefaultReplicaSetScaleDownDeadlineAnnotationKey)
+			ro := t.GetRollout()
+			assert.Equal(s.T(), int32(75), ro.Status.Canary.Weights.Canary.Weight)
+		}).
+		When().
+		MarkPodsReady("1", 2).           // mark 2 new stable pods as ready (3/4 stable are ready)
+		WaitForRevisionPodCount("1", 4). // weight steps down to 25, stable scales up for the rest
+		MarkPodsReady("1", 1).           // mark last remaining stable pod as ready (4/4 stable are ready)
+		Sleep(2*time.Second).
+		Then().
+		// All traffic is back on stable, and only now should the canary get its scale-down
+		// deadline. It still holds its pods for the duration of abortScaleDownDelaySeconds.
+		ExpectRevisionPodCount("2", 3).
+		Assert(func(t *fixtures.Then) {
+			ro := t.GetRollout()
+			assert.Equal(s.T(), int32(0), ro.Status.Canary.Weights.Canary.Weight)
+			assert.Equal(s.T(), int32(100), ro.Status.Canary.Weights.Stable.Weight)
+			rs2 := t.GetReplicaSetByRevision("2")
+			assert.Contains(s.T(), rs2.Annotations, rov1.DefaultReplicaSetScaleDownDeadlineAnnotationKey)
+		}).
+		When().
+		WaitForRevisionPodCount("2", 0). // canary drains once the scale-down deadline elapses
+		Then().
+		ExpectRevisionPodCount("1", 4).
+		Assert(func(t *fixtures.Then) {
+			// canary service selector has been reset to stable
+			canarySvc, stableSvc := t.GetServices()
+			assert.Equal(s.T(), stableSvc.Spec.Selector["rollouts-pod-template-hash"], canarySvc.Spec.Selector["rollouts-pod-template-hash"])
+		})
+}
+
 // TestCanaryDynamicStableScaleRollbackToStable verifies when we rollback to stable with
 // DynamicStableScale enabled, we do so in a safe manner without shifting traffic back to stable
 // before it can handle it

--- a/test/e2e/functional/canary-dynamic-stable-scale-abort-delay.yaml
+++ b/test/e2e/functional/canary-dynamic-stable-scale-abort-delay.yaml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dynamic-stable-scale-abort-root
+spec:
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app: dynamic-stable-scale-abort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dynamic-stable-scale-abort-canary
+spec:
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app: dynamic-stable-scale-abort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dynamic-stable-scale-abort-stable
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app: dynamic-stable-scale-abort
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dynamic-stable-scale-abort-ingress
+  annotations:
+    kubernetes.io/ingress.class: alb
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /*
+        pathType: Prefix
+        backend:
+          service:
+            name: dynamic-stable-scale-abort-root
+            port:
+              name: use-annotation
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: dynamic-stable-scale-abort
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: dynamic-stable-scale-abort
+  template:
+    metadata:
+      labels:
+        app: dynamic-stable-scale-abort
+    spec:
+      readinessGates:
+      - conditionType: argoproj.io/e2e-readiness
+      containers:
+      - name: dynamic-stable-scale-abort
+        image: nginx:1.19-alpine
+        ports:
+        - name: http
+          containerPort: 80
+          protocol: TCP
+        resources:
+          requests:
+            memory: 16Mi
+            cpu: 5m
+  strategy:
+    canary:
+      dynamicStableScale: true
+      abortScaleDownDelaySeconds: 10
+      canaryService: dynamic-stable-scale-abort-canary
+      stableService: dynamic-stable-scale-abort-stable
+      steps:
+        - setWeight: 25
+        - pause: {}
+        - setWeight: 75
+        - pause: {}
+      trafficRouting:
+        alb:
+          ingress: dynamic-stable-scale-abort-ingress
+          rootService: dynamic-stable-scale-abort-root
+          servicePort: 80

--- a/utils/defaults/defaults.go
+++ b/utils/defaults/defaults.go
@@ -237,12 +237,14 @@ func GetAbortScaleDownDelaySecondsOrDefault(rollout *v1alpha1.Rollout) (*time.Du
 	return &dur, wasSet
 }
 
-// HasExplicitNonZeroAbortScaleDownDelay returns whether the user explicitly set a non-zero
-// abortScaleDownDelaySeconds. Under dynamicStableScale this is the mode where the canary is
-// held at full scale on abort until it receives a scale-down deadline (rather than draining
-// progressively), which the abort weight calculation (GetDesiredCanaryWeight) and the
-// scale-down delay logic (shouldDelayScaleDownOnAbort) must agree on.
-func HasExplicitNonZeroAbortScaleDownDelay(rollout *v1alpha1.Rollout) bool {
+// HasExplicitAbortScaleDownDelay returns whether the user explicitly configured a delayed
+// scale-down on abort. An explicit abortScaleDownDelaySeconds: 0 returns false, since zero
+// disables scale-down entirely rather than delaying it. Under dynamicStableScale this is the
+// mode where the canary is held at full scale on abort until it receives a scale-down
+// deadline (rather than draining progressively), which the abort weight calculation
+// (GetDesiredCanaryWeight) and the scale-down delay logic (shouldDelayScaleDownOnAbort)
+// must agree on.
+func HasExplicitAbortScaleDownDelay(rollout *v1alpha1.Rollout) bool {
 	abortDelay, wasSet := GetAbortScaleDownDelaySecondsOrDefault(rollout)
 	return wasSet && abortDelay != nil
 }

--- a/utils/defaults/defaults.go
+++ b/utils/defaults/defaults.go
@@ -237,6 +237,16 @@ func GetAbortScaleDownDelaySecondsOrDefault(rollout *v1alpha1.Rollout) (*time.Du
 	return &dur, wasSet
 }
 
+// HasExplicitNonZeroAbortScaleDownDelay returns whether the user explicitly set a non-zero
+// abortScaleDownDelaySeconds. Under dynamicStableScale this is the mode where the canary is
+// held at full scale on abort until it receives a scale-down deadline (rather than draining
+// progressively), which the abort weight calculation (GetDesiredCanaryWeight) and the
+// scale-down delay logic (shouldDelayScaleDownOnAbort) must agree on.
+func HasExplicitNonZeroAbortScaleDownDelay(rollout *v1alpha1.Rollout) bool {
+	abortDelay, wasSet := GetAbortScaleDownDelaySecondsOrDefault(rollout)
+	return wasSet && abortDelay != nil
+}
+
 func GetAutoPromotionEnabledOrDefault(rollout *v1alpha1.Rollout) bool {
 	if rollout.Spec.Strategy.BlueGreen == nil {
 		return DefaultAutoPromotionEnabled

--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -528,6 +528,16 @@ func GetDesiredCanaryWeight(rollout *v1alpha1.Rollout, newRS, stableRS *appsv1.R
 		expectedCanaryReplicas := rolloutSpecReplica - stableRS.Status.AvailableReplicas
 		// max makes sure that scaling down NewRS replicas will catch up with scaling up stableRS replicas
 		canaryReplicas := max(expectedCanaryReplicas, newRS.Status.AvailableReplicas)
+		if abortDelay, wasSet := defaults.GetAbortScaleDownDelaySecondsOrDefault(rollout); wasSet && abortDelay != nil {
+			// An explicitly set abortScaleDownDelaySeconds keeps the canary at full scale
+			// until its scale-down deadline, and the deadline annotation is only added once
+			// the stable RS is fully scaled (see reconcileNewReplicaSet). The canary's size
+			// therefore must not hold the weight up, otherwise the weight can never step
+			// below the smallest setWeight step and the abort deadlocks: weight step-down
+			// waits on canary drain, canary drain waits on stable reaching full scale, and
+			// stable scale-up waits on weight step-down.
+			canaryReplicas = expectedCanaryReplicas
+		}
 		// find next step to scale down NewRS to
 		for i := len(rollout.Spec.Strategy.Canary.Steps) - 1; i >= 0; i-- {
 			step := rollout.Spec.Strategy.Canary.Steps[i]

--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -528,7 +528,7 @@ func GetDesiredCanaryWeight(rollout *v1alpha1.Rollout, newRS, stableRS *appsv1.R
 		expectedCanaryReplicas := rolloutSpecReplica - stableRS.Status.AvailableReplicas
 		// max makes sure that scaling down NewRS replicas will catch up with scaling up stableRS replicas
 		canaryReplicas := max(expectedCanaryReplicas, newRS.Status.AvailableReplicas)
-		if abortDelay, wasSet := defaults.GetAbortScaleDownDelaySecondsOrDefault(rollout); wasSet && abortDelay != nil {
+		if defaults.HasExplicitNonZeroAbortScaleDownDelay(rollout) {
 			// An explicitly set abortScaleDownDelaySeconds keeps the canary at full scale
 			// until its scale-down deadline, and the deadline annotation is only added once
 			// the stable RS is fully scaled (see reconcileNewReplicaSet). The canary's size

--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -528,7 +528,7 @@ func GetDesiredCanaryWeight(rollout *v1alpha1.Rollout, newRS, stableRS *appsv1.R
 		expectedCanaryReplicas := rolloutSpecReplica - stableRS.Status.AvailableReplicas
 		// max makes sure that scaling down NewRS replicas will catch up with scaling up stableRS replicas
 		canaryReplicas := max(expectedCanaryReplicas, newRS.Status.AvailableReplicas)
-		if defaults.HasExplicitNonZeroAbortScaleDownDelay(rollout) {
+		if defaults.HasExplicitAbortScaleDownDelay(rollout) {
 			// An explicitly set abortScaleDownDelaySeconds keeps the canary at full scale
 			// until its scale-down deadline, and the deadline annotation is only added once
 			// the stable RS is fully scaled (see reconcileNewReplicaSet). The canary's size

--- a/utils/replicaset/canary_test.go
+++ b/utils/replicaset/canary_test.go
@@ -1899,3 +1899,76 @@ func TestAllReplicaProgressThresholdMet(t *testing.T) {
 		})
 	}
 }
+
+// TestGetDesiredCanaryWeightOnAbortWithScaleDownDelay verifies that when an explicit
+// abortScaleDownDelaySeconds keeps the canary at full scale on abort, the canary's size
+// does not hold the abort weight up. Without this, the abort deadlocks: the weight can
+// never step below the smallest setWeight step (bounded by newRS availability), so the
+// stable RS never reaches spec.Replicas, so the scale-down-deadline annotation is never
+// added, so the canary never scales down (issue #4898).
+func TestGetDesiredCanaryWeightOnAbortWithScaleDownDelay(t *testing.T) {
+	newAbortedRollout := func(abortDelay *int32) *v1alpha1.Rollout {
+		rollout := newRollout(10, 50, intstr.FromInt(1), intstr.FromInt(0), "canary", "stable", nil, &v1alpha1.RolloutTrafficRouting{})
+		rollout.Spec.Strategy.Canary.Steps = []v1alpha1.CanaryStep{
+			{SetWeight: pointer.Int32Ptr(10)},
+			{SetWeight: pointer.Int32Ptr(50)},
+		}
+		rollout.Spec.Strategy.Canary.DynamicStableScale = true
+		rollout.Spec.Strategy.Canary.AbortScaleDownDelaySeconds = abortDelay
+		rollout.Status.Abort = true
+		return rollout
+	}
+
+	tests := []struct {
+		name            string
+		abortDelay      *int32
+		stableAvailable int32
+		expectedWeight  int32
+	}{
+		{
+			name:            "no explicit delay: weight is held up by canary size (progressive drain unchanged)",
+			abortDelay:      nil,
+			stableAvailable: 9,
+			expectedWeight:  10,
+		},
+		{
+			name:            "explicit delay: weight steps down gradually while stable is scaling up",
+			abortDelay:      pointer.Int32Ptr(30),
+			stableAvailable: 5,
+			expectedWeight:  10,
+		},
+		{
+			name:            "explicit delay: weight reaches zero once stable nearly covers spec.Replicas (deadlock case)",
+			abortDelay:      pointer.Int32Ptr(30),
+			stableAvailable: 9,
+			expectedWeight:  0,
+		},
+		{
+			name:            "explicit zero delay (leave canary up indefinitely): weight is held up by canary size",
+			abortDelay:      pointer.Int32Ptr(0),
+			stableAvailable: 9,
+			expectedWeight:  10,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rollout := newAbortedRollout(test.abortDelay)
+			canaryRS := newRS("canary", 5, 5)
+			stableRS := newRS("stable", test.stableAvailable, test.stableAvailable)
+			assert.Equal(t, test.expectedWeight, GetDesiredCanaryWeight(rollout, canaryRS, stableRS))
+		})
+	}
+
+	t.Run("stable scales to spec.Replicas once weight reaches zero", func(t *testing.T) {
+		rollout := newAbortedRollout(pointer.Int32Ptr(30))
+		canaryRS := newRS("canary", 5, 5)
+		stableRS := newRS("stable", 9, 9)
+		weights := v1alpha1.TrafficWeights{
+			Canary: v1alpha1.WeightDestination{Weight: 10},
+			Stable: v1alpha1.WeightDestination{Weight: 90},
+		}
+		_, stableRSReplicaCount := CalculateReplicaCountsForTrafficRoutedCanary(rollout, canaryRS, stableRS, &weights)
+		assert.Equal(t, int32(10), stableRSReplicaCount)
+	})
+}


### PR DESCRIPTION
…wn delay

Fixes #4898
  Alternative to #4899

  ## Summary

  Aborting a rollout that uses `dynamicStableScale: true` together with an explicitly set
  `abortScaleDownDelaySeconds` deadlocks: the canary is never annotated with a
  scale-down deadline, never scales down, traffic weight never shifts back to stable, and
  the stable RS never returns to `spec.Replicas`.

  ## Root cause

  Four pieces of the abort path form a circular wait:

  1. With an explicit `abortScaleDownDelaySeconds`, the canary is only scaled down via the
     scale-down-deadline annotation (`reconcileNewReplicaSet` early-returns otherwise).
  2. The annotation is only added once `stable.Available == spec.Replicas`.
  3. Under `dynamicStableScale`, stable's desired count only reaches `spec.Replicas` once
     the abort weight reaches 0.
  4. The abort weight is bounded below by the canary's size —
     `max(expectedCanaryReplicas, newRS.Status.AvailableReplicas)` in `GetDesiredCanaryWeight` —
     and the canary never shrinks, per (1).

  Edges (1)–(3) are intentional safety invariants: the deadline path scales the canary to
  zero unconditionally, so the drain clock must not start while the canary still carries
  traffic. Edge (4) is the bug: the `max()` bound (added in #4035) exists to keep the weight
  step-down in sync with the canary's actual drain during a progressive abort — but when
  `abortScaleDownDelaySeconds` deliberately holds the canary at full scale, its size says
  nothing about traffic and must not hold the weight up.

  ## Fix

  - `utils/replicaset/canary.go`: in `GetDesiredCanaryWeight`, when an explicit non-zero
    `abortScaleDownDelaySeconds` is in effect, compute the abort weight from stable
    availability alone. The weight then walks down the `setWeight` steps in reverse as
    stable scales up (each step still capacity-gated by `checkReplicasAvailable`), reaches 0,
    stable reaches `spec.Replicas`, and the existing annotation gate passes naturally. The
    delay window then runs against a canary that no longer receives traffic.
  - `rollout/replicaset.go`: annotation gate `==` → `>=` so a stable RS transiently exceeding
    `spec.Replicas` (e.g. HPA scale-in) doesn't block the annotation, plus a comment
    documenting what the gate protects.

  Compared to relaxing the annotation gate to combined stable+canary capacity (#4899): under
  `dynamicStableScale` that condition is satisfied at the moment of abort, so the deadline
  countdown starts while the canary still holds traffic weight, and when it expires the
  canary is scaled to zero while the traffic router still routes to it — dropping that
  fraction of traffic until stable finishes scaling. This PR instead preserves the invariant
  that the canary is only scaled down after traffic is fully back on stable, and gives
  `abortScaleDownDelaySeconds` the same meaning in both modes: a grace period on drained
  canary pods, starting after traffic is off them.

  ## Behavior notes

  - Progressive abort drain (dynamicStableScale without an explicit delay), explicit
    `abortScaleDownDelaySeconds: 0` ("leave canary up indefinitely"), non-dynamic canary, and
    blue-green are unchanged — the new branch mirrors `shouldDelayScaleDownOnAbort` and only
    executes for abort + dynamicStableScale + explicitly set non-zero delay.
  - The delay window now starts once stable is fully scaled rather than at abort time, so
    time-to-scale-down is stable-ramp + delay. This matches the non-dynamic behavior, where
    the annotation is likewise only added once stable is fully available.

  ## Testing

  - New unit test `TestGetDesiredCanaryWeightOnAbortWithScaleDownDelay`: fails on master with
    the deadlock signature (weight stuck at the smallest step, stable desired count stuck
    below `spec.Replicas`), passes with the fix. No-delay and zero-delay behavior pinned.
  - New e2e test `TestCanaryDynamicStableScaleAbortScaleDownDelay` (+ fixture): aborts from
    the 75% step and asserts the canary keeps its pods and gets no scale-down deadline while
    stable ramps, the annotation appears only once weight is 0/100, and the canary drains to
    zero after the delay. Passes locally; on master it fails at the stable scale-up wait
    (the deadlock), and against the #4899 approach it fails the no-early-annotation assertion.
  - `go test ./rollout/... ./utils/replicaset/...` passes unchanged.