### PR TITLE
test: fix flaky unit test TestListWithWatch

### DIFF
--- a/pkg/kubectl-argo-rollouts/cmd/list/list_rollouts.go
+++ b/pkg/kubectl-argo-rollouts/cmd/list/list_rollouts.go
@@ -105,6 +105,7 @@ func (o *ListOptions) PrintRolloutTable(roList *v1alpha1.RolloutList) error {
 // PrintRolloutUpdates watches for changes to rollouts and prints the updates
 func (o *ListOptions) PrintRolloutUpdates(ctx context.Context, rolloutIf argoprojv1alpha1.RolloutInterface, roList *v1alpha1.RolloutList) error {
 	w := tabwriter.NewWriter(o.Out, 0, 0, 2, ' ', 0)
+	defer w.Flush()
 
 	opts := o.ListOptions()
 	opts.ResourceVersion = roList.ListMeta.ResourceVersion


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-rollouts/issues/4896

The TestListWithWatch test prints several lines to a writer and then compares the output against a known result.
The problem with the writer is that flushing is not happening in a deterministic way. Flushing happens on a timer and with a select call https://github.com/argoproj/argo-rollouts/blob/026e0558691fa7e0a4c5cad89501fa6737c671d4/pkg/kubectl-argo-rollouts/cmd/list/list_rollouts.go#L135

So depending on the paths the select call can choose flushing might not actually happen.

This PR adds a determintic defer function to make sure that the write is always flushed

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green. Try syncing with master if they are not. 
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).