### PR TITLE
test: fixed flaky test close channel

### DIFF
--- a/rollout/templateref_test.go
+++ b/rollout/templateref_test.go
@@ -63,7 +63,7 @@ func newResolver(dynamicClient dynamic.Interface, discoveryClient disco.Discover
 	go rolloutsInformer.Run(stop)
 	cache.WaitForCacheSync(stop, rolloutsInformer.HasSynced)
 	return resolver, func() {
-		stop <- struct{}{}
+		close(stop)
 		resolver.Stop()
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-rollouts/issues/4904

The templateref_test file contains a helper function that stops an informer when the unit test is complete.
This code there send a single struct to the channel to signify that everything needs to be teared down. This worked since 2021 when the code was first introduced into Argo Rollouts.

However in 2025 the following 3 things happened

1. Kubernetes client-go 0.33 now clearly documents the contract that the channel [must be explicitly closed](https://github.com/kubernetes/client-go/blob/v0.34.5/tools/cache/shared_informer.go#L181)
2. The channel is now also used as a context [in the reflector code](https://github.com/kubernetes/client-go/blob/v0.34.5/tools/cache/reflector.go#L350)
3. Argo Rollouts brings the new dependency of client-go https://github.com/argoproj/argo-rollouts/pull/4497/files

This starts a flaky unit test cycle because the message that is now pushed in the channel is only picked by one (the first) consumer of the channel. The second consumer that hits it now gets nothing and the error appears. Flakiness was determined by who was able to pick the message first.

This PR correctly closes the channel so that all consumers are getting notified. This way no panic happens any more.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green. Try syncing with master if they are not. 
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).