### PR TITLE
fix(controller): sync desired-replicas annotation during abort scale-…

### DIFF
--- a/rollout/replicaset.go
+++ b/rollout/replicaset.go
@@ -129,12 +129,13 @@ func (c *rolloutContext) removeScaleDownDeadlines() error {
 }
 
 // syncNewRSReplicasAnnotation updates the newRS desired-replicas annotation to spec.replicas
-// without changing its scale. The paths that intentionally hold the newRS at size during an
-// abort scale-down delay must still do this: isScalingEvent() treats a stale desired-replicas
-// annotation on the newRS as an in-progress scaling event and short-circuits every reconcile
-// to syncReplicasOnly(), which never reconciles traffic routing or services. Without the
-// annotation sync, a spec.replicas change (e.g. HPA) mid-abort freezes traffic reconciliation
-// until the scale-down deadline elapses.
+// without changing its scale. It is a no-op when the annotation already matches spec.replicas
+// (ReplicasAnnotationsNeedUpdate returns false). The paths that intentionally hold the newRS at
+// size during an abort scale-down delay must still call this: isScalingEvent() treats a stale
+// desired-replicas annotation on the newRS as an in-progress scaling event and short-circuits
+// every reconcile to syncReplicasOnly(), which never reconciles traffic routing or services.
+// Without the annotation sync, a spec.replicas change (e.g. HPA) mid-abort freezes traffic
+// reconciliation until the scale-down deadline elapses.
 func (c *rolloutContext) syncNewRSReplicasAnnotation() error {
 	if !annotations.ReplicasAnnotationsNeedUpdate(c.newRS, defaults.GetReplicasOrDefault(c.rollout.Spec.Replicas)) {
 		return nil
@@ -177,7 +178,7 @@ func (c *rolloutContext) reconcileNewReplicaSet() (bool, error) {
 						logCtx.Info("rollout enqueue due to scaleDownDelay")
 						c.enqueueRolloutAfter(c.rollout, remainingTime)
 						if err := c.syncNewRSReplicasAnnotation(); err != nil {
-							return false, err
+							return false, fmt.Errorf("failed to sync newRS desired-replicas annotation while waiting for abort scale-down deadline: %w", err)
 						}
 						return false, nil
 					}
@@ -190,7 +191,7 @@ func (c *rolloutContext) reconcileNewReplicaSet() (bool, error) {
 			// Sync annotations before addScaleDownDelay's patch so a subsequent update of the
 			// stale newRS object cannot clobber the scale-down-deadline annotation.
 			if err := c.syncNewRSReplicasAnnotation(); err != nil {
-				return false, err
+				return false, fmt.Errorf("failed to sync newRS desired-replicas annotation before adding abort scale-down delay: %w", err)
 			}
 			// Don't annotate until the stable RS is fully scaled, i.e. able to serve 100%
 			// of traffic, since the deadline scales the canary to zero unconditionally.

--- a/rollout/replicaset.go
+++ b/rollout/replicaset.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/argoproj/argo-rollouts/utils/annotations"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
 	replicasetutil "github.com/argoproj/argo-rollouts/utils/replicaset"
@@ -127,6 +128,25 @@ func (c *rolloutContext) removeScaleDownDeadlines() error {
 	return nil
 }
 
+// syncNewRSReplicasAnnotation updates the newRS desired-replicas annotation to spec.replicas
+// without changing its scale. The paths that intentionally hold the newRS at size during an
+// abort scale-down delay must still do this: isScalingEvent() treats a stale desired-replicas
+// annotation on the newRS as an in-progress scaling event and short-circuits every reconcile
+// to syncReplicasOnly(), which never reconciles traffic routing or services. Without the
+// annotation sync, a spec.replicas change (e.g. HPA) mid-abort freezes traffic reconciliation
+// until the scale-down deadline elapses.
+func (c *rolloutContext) syncNewRSReplicasAnnotation() error {
+	if !annotations.ReplicasAnnotationsNeedUpdate(c.newRS, defaults.GetReplicasOrDefault(c.rollout.Spec.Replicas)) {
+		return nil
+	}
+	_, newRS, err := c.scaleReplicaSetAndRecordEvent(c.newRS, *c.newRS.Spec.Replicas)
+	if err != nil {
+		return fmt.Errorf("failed to sync replicas annotations in syncNewRSReplicasAnnotation: %w", err)
+	}
+	c.newRS = newRS
+	return nil
+}
+
 func (c *rolloutContext) reconcileNewReplicaSet() (bool, error) {
 	if c.newRS == nil {
 		return false, nil
@@ -156,6 +176,9 @@ func (c *rolloutContext) reconcileNewReplicaSet() (bool, error) {
 						logCtx := logutil.WithRollout(c.rollout)
 						logCtx.Info("rollout enqueue due to scaleDownDelay")
 						c.enqueueRolloutAfter(c.rollout, remainingTime)
+						if err := c.syncNewRSReplicasAnnotation(); err != nil {
+							return false, err
+						}
 						return false, nil
 					}
 				} else {
@@ -164,6 +187,11 @@ func (c *rolloutContext) reconcileNewReplicaSet() (bool, error) {
 				}
 			}
 		} else if abortScaleDownDelaySeconds != nil {
+			// Sync annotations before addScaleDownDelay's patch so a subsequent update of the
+			// stale newRS object cannot clobber the scale-down-deadline annotation.
+			if err := c.syncNewRSReplicasAnnotation(); err != nil {
+				return false, err
+			}
 			// Don't annotate until the stable RS is fully scaled, i.e. able to serve 100%
 			// of traffic, since the deadline scales the canary to zero unconditionally.
 			// With dynamicStableScale this holds once the abort weight has stepped down to

--- a/rollout/replicaset_test.go
+++ b/rollout/replicaset_test.go
@@ -347,6 +347,142 @@ func TestReconcileNewReplicaSet(t *testing.T) {
 	}
 }
 
+// TestReconcileNewReplicaSetAbortDelaySyncsReplicasAnnotation verifies that the abort
+// scale-down-delay paths, which intentionally hold the newRS at its current size, still sync
+// the desired-replicas annotation with spec.replicas. isScalingEvent() compares that
+// annotation to spec.replicas, so leaving it stale would short-circuit every reconcile to
+// syncReplicasOnly() (which skips traffic routing) until the scale-down deadline elapsed.
+func TestReconcileNewReplicaSetAbortDelaySyncsReplicasAnnotation(t *testing.T) {
+	tests := []struct {
+		name              string
+		deadlineAnnotated bool
+	}{
+		{name: "before the scale-down deadline is added", deadlineAnnotated: false},
+		{name: "while waiting out the scale-down deadline", deadlineAnnotated: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stableRS := rs("foo-v1", 5, nil, noTimestamp, nil)
+			newRS := rs("foo-v2", 5, nil, noTimestamp, nil)
+			// HPA scaled the rollout from 5 to 4 mid-abort: the newRS desired-replicas
+			// annotation (5) no longer matches spec.replicas (4)
+			rollout := newBlueGreenRollout("foo", 4, nil, "", "")
+			rollout.Status.Abort = true
+			abortScaleDownDelaySeconds := int32(30)
+			rollout.Spec.Strategy = v1alpha1.RolloutStrategy{
+				BlueGreen: &v1alpha1.BlueGreenStrategy{
+					AbortScaleDownDelaySeconds: &abortScaleDownDelaySeconds,
+				},
+			}
+			stableRS.Status.AvailableReplicas = 4
+			if test.deadlineAnnotated {
+				deadline := timeutil.Now().Add(time.Duration(abortScaleDownDelaySeconds) * time.Second).UTC().Format(time.RFC3339)
+				newRS.Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey] = deadline
+			}
+
+			fake := fake.Clientset{}
+			k8sfake := k8sfake.Clientset{}
+			f := newFixture(t)
+			defer f.Close()
+			f.objects = append(f.objects, rollout)
+			f.replicaSetLister = append(f.replicaSetLister, stableRS, newRS)
+			f.kubeobjects = append(f.kubeobjects, stableRS, newRS)
+			_, informers, k8sInformer := f.newController(noResyncPeriodFunc)
+			stopCh := make(chan struct{})
+			informers.Start(stopCh)
+			informers.WaitForCacheSync(stopCh)
+			close(stopCh)
+
+			roCtx := rolloutContext{
+				log:      logutil.WithRollout(rollout),
+				rollout:  rollout,
+				newRS:    newRS,
+				stableRS: stableRS,
+				reconcilerBase: reconcilerBase{
+					argoprojclientset:  &fake,
+					kubeclientset:      &k8sfake,
+					recorder:           record.NewFakeEventRecorder(),
+					resyncPeriod:       15 * time.Minute,
+					replicaSetInformer: k8sInformer.Apps().V1().ReplicaSets().Informer(),
+				},
+				pauseContext: &pauseContext{
+					rollout: rollout,
+				},
+			}
+			roCtx.enqueueRolloutAfter = func(obj any, duration time.Duration) {}
+
+			scaled, err := roCtx.reconcileNewReplicaSet()
+			assert.NoError(t, err)
+			assert.False(t, scaled)
+
+			actions := k8sfake.Actions()
+			assert.NotEmpty(t, actions, "expected an update syncing the desired-replicas annotation")
+			updated := actions[0].(core.UpdateAction).GetObject().(*appsv1.ReplicaSet)
+			assert.Equal(t, int32(5), *updated.Spec.Replicas, "newRS must be held at scale during the abort delay")
+			assert.Equal(t, "4", updated.Annotations[annotations.DesiredReplicasAnnotation], "desired-replicas annotation must track spec.replicas so isScalingEvent() terminates")
+		})
+	}
+}
+
+// TestAbortScaleDownDelayDoesNotWedgeScalingEvent reconciles an aborted traffic-routed canary
+// that received a spec.replicas change (e.g. from an HPA) mid-abort. reconcile() short-circuits
+// to syncReplicasOnly, which must terminate the scaling event by syncing the newRS
+// desired-replicas annotation even though the canary is held at scale by the abort
+// scale-down delay. If the annotation stayed stale, every subsequent reconcile would
+// short-circuit too, freezing traffic routing at the pre-abort weight until the delay elapsed.
+func TestAbortScaleDownDelayDoesNotWedgeScalingEvent(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{
+		{SetWeight: ptr.To[int32](50)},
+		{Pause: &v1alpha1.RolloutPause{}},
+	}
+	r1 := newCanaryRollout("foo", 5, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(1))
+	r1.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{SMI: &v1alpha1.SMITrafficRouting{}}
+	r1.Spec.Strategy.Canary.CanaryService = "canary"
+	r1.Spec.Strategy.Canary.StableService = "stable"
+	r1.Status.ReadyReplicas = 5
+	r1.Status.AvailableReplicas = 5
+	r2 := bumpVersion(r1)
+
+	// stable RS was already synced to the new size on a previous reconcile; the canary RS is
+	// held at 5 by the abort scale-down delay with a stale desired-replicas annotation, so
+	// isScalingEvent() is true
+	rs1 := newReplicaSetWithStatus(r1, 4, 4)
+	rs2 := newReplicaSetWithStatus(r2, 5, 5)
+	rs1.Annotations[annotations.DesiredReplicasAnnotation] = "4"
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	canarySvc := newService("canary", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}, r1)
+	stableSvc := newService("stable", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}, r1)
+
+	r2.Status.Abort = true
+	r2.Status.AbortedAt = &metav1.Time{Time: timeutil.Now().Add(-1 * time.Minute)}
+	r2.Status.StableRS = rs1PodHash
+	r2.Status.Canary.Weights = &v1alpha1.TrafficWeights{
+		Canary: v1alpha1.WeightDestination{Weight: 50, ServiceName: "canary", PodTemplateHash: rs2PodHash},
+		Stable: v1alpha1.WeightDestination{Weight: 50, ServiceName: "stable", PodTemplateHash: rs1PodHash},
+	}
+	// HPA scaling event during the abort
+	r2.Spec.Replicas = ptr.To[int32](4)
+
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2, canarySvc, stableSvc)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+	f.serviceLister = append(f.serviceLister, canarySvc, stableSvc)
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2)
+
+	updatedRSIndex := f.expectUpdateReplicaSetAction(rs2) // desired-replicas annotation sync
+	f.expectPatchReplicaSetAction(rs2)                    // scale-down-deadline added
+	f.expectPatchRolloutAction(r2)
+	f.run(getKey(r2, t))
+
+	updatedRS := f.getUpdatedReplicaSet(updatedRSIndex)
+	assert.Equal(t, int32(5), *updatedRS.Spec.Replicas, "canary RS must be held at scale during the abort delay")
+	assert.Equal(t, "4", updatedRS.Annotations[annotations.DesiredReplicasAnnotation], "desired-replicas annotation must be synced so the scaling event terminates and the next reconcile takes the full path")
+}
+
 func TestReconcileOldReplicaSet(t *testing.T) {
 	tests := []struct {
 		name                string


### PR DESCRIPTION
…down delay so scaling events terminate

## Problem

  `reconcile()` short-circuits to `syncReplicasOnly()` whenever `isScalingEvent()` is true. `isScalingEvent()` is **level-triggered**: it compares the `desired-replicas` annotation on the new/stable ReplicaSets against `spec.replicas`, so every reconcile — informer event, requeue,
  the 15-minute resync, even a controller restart — takes the same short-circuit until the annotations converge. The design invariant that makes this safe is that `syncReplicasOnly()` itself terminates the scaling event by syncing those annotations.

  The abort scale-down delay breaks that invariant. When `shouldDelayScaleDownOnAbort()` is true (any traffic-routed canary or blue-green rollout that hasn't set `abortScaleDownDelaySeconds: 0`), `reconcileNewReplicaSet()` has two early returns that intentionally hold the newRS at
  scale — but they also skip `scaleReplicaSetAndRecordEvent`, so the newRS `desired-replicas` annotation is never updated.

  Failure mode: a canary is aborting (e.g. failed analysis) and `spec.replicas` changes before the first post-abort traffic reconcile — typically an HPA reacting to the same load problem that failed the analysis. From then on every reconcile short-circuits to `syncReplicasOnly()`,
  which never touches traffic routing or services:

  1. The traffic weight stays frozen at its pre-abort value and the canary service selector is never reset, for the entire stable-scale-up time **plus the full `abortScaleDownDelaySeconds`** (default 30s; users who keep aborted canaries around for debugging set this to minutes or
  hours).
  2. When the deadline finally elapses, the canary RS is scaled to zero **while the mesh is still weighting traffic to it** — briefly black-holing that traffic until the next reconcile (now unblocked) sets the weight to 0.

  Requeueing does not help: the requeued reconcile re-evaluates `isScalingEvent()` from the same stale annotations and short-circuits again (see the discussion in #3413, where re-enqueueing was suggested as the fix for a related symptom).

  ## Fix

  Restore the invariant instead of removing the short-circuit: the two early-return paths in `reconcileNewReplicaSet()` now sync the `desired-replicas` annotation (via the existing annotation-only no-scale behavior of `scaleReplicaSetAndRecordEvent`) while still holding the newRS at
  its current size. The scaling event then terminates within one or two informer-driven cycles, the next reconcile takes the full path, shifts traffic off the canary, and resets the canary service selector — and the canary is never scaled to zero while still receiving weighted
  traffic.

  Compared to dropping the short-circuit when aborted (#4853), this approach:
  - preserves the original design rule that scaling events reconcile nothing but replica counts (see https://github.com/argoproj/argo-rollouts/pull/3413#issuecomment-1984805862), and keeps HPA scale application independent of traffic-router API health;
  - fixes blue-green aborts through the same shared code path without routing them through the full `rolloutBlueGreen()` reconcile;
  - costs one extra reconcile cycle (seconds) before the weight shifts, instead of shifting in the same cycle.

  Related: #3412 / #3413 (same short-circuit, different trigger), #3883 (narrowed `isScalingEvent()` to new/stable RS for stacked rollouts). No filed issue matches this exact failure mode; alternative fix proposed in #4853.