### PR TITLE
fix(controller): honor self-service notification flag in event recorder. Fixes #4865

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -222,7 +222,7 @@ func NewAnalysisManager(
 
 	healthzServer := NewHealthzServer(fmt.Sprintf(listenAddr, healthzPort))
 	analysisRunWorkqueue := workqueue.NewNamedRateLimitingQueue(queue.DefaultArgoRolloutsRateLimiter(), "AnalysisRuns")
-	recorder := record.NewEventRecorder(kubeclientset, metrics.MetricRolloutEventsTotal, metrics.MetricNotificationFailedTotal, metrics.MetricNotificationSuccessTotal, metrics.MetricNotificationSend, nil)
+	recorder := record.NewEventRecorder(kubeclientset, metrics.MetricRolloutEventsTotal, metrics.MetricNotificationFailedTotal, metrics.MetricNotificationSuccessTotal, metrics.MetricNotificationSend, nil, false)
 	analysisController := analysis.NewController(analysis.ControllerConfig{
 		KubeClientSet:        kubeclientset,
 		ArgoProjClientset:    argoprojclientset,
@@ -333,7 +333,7 @@ func NewManager(
 
 	refResolver := rollout.NewInformerBasedWorkloadRefResolver(namespace, dynamicclientset, discoveryClient, argoprojclientset, rolloutsInformer.Informer())
 	apiFactory := notificationapi.NewFactory(record.NewAPIFactorySettings(analysisRunInformer), defaults.Namespace(), notificationSecretInformerFactory.Core().V1().Secrets().Informer(), notificationConfigMapInformerFactory.Core().V1().ConfigMaps().Informer())
-	recorder := record.NewEventRecorder(kubeclientset, metrics.MetricRolloutEventsTotal, metrics.MetricNotificationFailedTotal, metrics.MetricNotificationSuccessTotal, metrics.MetricNotificationSend, apiFactory)
+	recorder := record.NewEventRecorder(kubeclientset, metrics.MetricRolloutEventsTotal, metrics.MetricNotificationFailedTotal, metrics.MetricNotificationSuccessTotal, metrics.MetricNotificationSend, apiFactory, selfServiceNotificationEnabled)
 	toUnstructured := notificationcontroller.WithToUnstructured(objectToUnstructured)
 	// The namespace-support controller reads per-namespace configs; that only makes sense with
 	// self-service notifications. Without it a single config is used, and the namespace variant

--- a/utils/record/record.go
+++ b/utils/record/record.go
@@ -82,10 +82,11 @@ type EventRecorderAdapter struct {
 
 	eventf func(object runtime.Object, warn bool, opts EventOptions, messageFmt string, args ...any)
 	// apiFactory is a notifications engine API factory
-	apiFactory api.Factory
+	apiFactory                     api.Factory
+	selfServiceNotificationEnabled bool
 }
 
-func NewEventRecorder(kubeclientset kubernetes.Interface, rolloutEventCounter *prometheus.CounterVec, notificationFailedCounter *prometheus.CounterVec, notificationSuccessCounter *prometheus.CounterVec, notificationSendPerformance *prometheus.HistogramVec, apiFactory api.Factory) EventRecorder {
+func NewEventRecorder(kubeclientset kubernetes.Interface, rolloutEventCounter *prometheus.CounterVec, notificationFailedCounter *prometheus.CounterVec, notificationSuccessCounter *prometheus.CounterVec, notificationSendPerformance *prometheus.HistogramVec, apiFactory api.Factory, selfServiceNotificationEnabled bool) EventRecorder {
 	// Create event broadcaster
 	// Add argo-rollouts custom resources to the default Kubernetes Scheme so Events can be
 	// logged for argo-rollouts types.
@@ -94,12 +95,13 @@ func NewEventRecorder(kubeclientset kubernetes.Interface, rolloutEventCounter *p
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeclientset.CoreV1().Events("")})
 	k8srecorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerAgentName})
 	recorder := &EventRecorderAdapter{
-		Recorder:                    k8srecorder,
-		RolloutEventCounter:         rolloutEventCounter,
-		NotificationFailedCounter:   notificationFailedCounter,
-		NotificationSuccessCounter:  notificationSuccessCounter,
-		NotificationSendPerformance: notificationSendPerformance,
-		apiFactory:                  apiFactory,
+		Recorder:                       k8srecorder,
+		RolloutEventCounter:            rolloutEventCounter,
+		NotificationFailedCounter:      notificationFailedCounter,
+		NotificationSuccessCounter:     notificationSuccessCounter,
+		NotificationSendPerformance:    notificationSendPerformance,
+		apiFactory:                     apiFactory,
+		selfServiceNotificationEnabled: selfServiceNotificationEnabled,
 	}
 	recorder.eventf = recorder.defaultEventf
 	return recorder
@@ -197,6 +199,7 @@ func NewFakeEventRecorder() *FakeEventRecorder {
 			[]string{"namespace", "name"},
 		),
 		NewFakeApiFactory(),
+		false,
 	).(*EventRecorderAdapter)
 	recorder.Recorder = record.NewFakeRecorder(1000)
 	fakeRecorder := &FakeEventRecorder{}
@@ -236,7 +239,7 @@ func (e *EventRecorderAdapter) defaultEventf(object runtime.Object, warn bool, o
 		}
 
 		if e.apiFactory != nil {
-			apis, err := e.apiFactory.GetAPIsFromNamespace(namespace)
+			apis, err := e.getNotificationAPIs(namespace)
 			if err != nil {
 				logCtx.Errorf("notifications failed to get apis for eventReason %s with error: %s", opts.EventReason, err)
 				e.NotificationFailedCounter.WithLabelValues(namespace, name, opts.EventType, opts.EventReason).Inc()
@@ -256,6 +259,19 @@ func (e *EventRecorderAdapter) defaultEventf(object runtime.Object, warn bool, o
 		logFn = logCtx.Warnf
 	}
 	logFn(messageFmt, args...)
+}
+
+func (e *EventRecorderAdapter) getNotificationAPIs(namespace string) (map[string]api.API, error) {
+	if e.selfServiceNotificationEnabled {
+		return e.apiFactory.GetAPIsFromNamespace(namespace)
+	}
+
+	notificationAPI, err := e.apiFactory.GetAPI()
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]api.API{namespace: notificationAPI}, nil
 }
 
 func (e *EventRecorderAdapter) K8sRecorder() record.EventRecorder {

--- a/utils/record/record_test.go
+++ b/utils/record/record_test.go
@@ -43,6 +43,7 @@ var (
 
 type recordingAPIFactory struct {
 	api                       api.API
+	err                       error
 	getAPICalls               int
 	getAPIsFromNamespaceCalls int
 	namespace                 string
@@ -50,12 +51,15 @@ type recordingAPIFactory struct {
 
 func (f *recordingAPIFactory) GetAPI() (api.API, error) {
 	f.getAPICalls++
-	return f.api, nil
+	return f.api, f.err
 }
 
 func (f *recordingAPIFactory) GetAPIsFromNamespace(namespace string) (map[string]api.API, error) {
 	f.getAPIsFromNamespaceCalls++
 	f.namespace = namespace
+	if f.err != nil {
+		return nil, f.err
+	}
 	return map[string]api.API{namespace: f.api}, nil
 }
 
@@ -196,6 +200,47 @@ func TestEventRecorderNotificationAPIScope(t *testing.T) {
 
 			rec.Eventf(&rollout, EventOptions{EventReason: "FooReason"}, "something happened")
 
+			assert.Equal(t, tt.wantGetAPICalls, apiFactory.getAPICalls)
+			assert.Equal(t, tt.wantGetAPIsFromNamespaceCalls, apiFactory.getAPIsFromNamespaceCalls)
+			assert.Equal(t, tt.wantNamespace, apiFactory.namespace)
+		})
+	}
+}
+
+func TestEventRecorderNotificationAPIScopeError(t *testing.T) {
+	expectedErr := errors.New("failed to get notification api")
+
+	tests := []struct {
+		name                           string
+		selfServiceNotificationEnabled bool
+		wantGetAPICalls                int
+		wantGetAPIsFromNamespaceCalls  int
+		wantNamespace                  string
+	}{
+		{
+			name:            "self service disabled returns GetAPI error",
+			wantGetAPICalls: 1,
+		},
+		{
+			name:                           "self service enabled returns namespace API error",
+			selfServiceNotificationEnabled: true,
+			wantGetAPIsFromNamespaceCalls:  1,
+			wantNamespace:                  "team-a",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			apiFactory := &recordingAPIFactory{err: expectedErr}
+			rec := &EventRecorderAdapter{
+				apiFactory:                     apiFactory,
+				selfServiceNotificationEnabled: tt.selfServiceNotificationEnabled,
+			}
+
+			apis, err := rec.getNotificationAPIs("team-a")
+
+			assert.Nil(t, apis)
+			assert.ErrorIs(t, err, expectedErr)
 			assert.Equal(t, tt.wantGetAPICalls, apiFactory.getAPICalls)
 			assert.Equal(t, tt.wantGetAPIsFromNamespaceCalls, apiFactory.getAPIsFromNamespaceCalls)
 			assert.Equal(t, tt.wantNamespace, apiFactory.namespace)

--- a/utils/record/record_test.go
+++ b/utils/record/record_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	k8srecord "k8s.io/client-go/tools/record"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	argofake "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
@@ -39,6 +40,60 @@ import (
 var (
 	noResyncPeriodFunc = func() time.Duration { return 0 }
 )
+
+type recordingAPIFactory struct {
+	api                       api.API
+	getAPICalls               int
+	getAPIsFromNamespaceCalls int
+	namespace                 string
+}
+
+func (f *recordingAPIFactory) GetAPI() (api.API, error) {
+	f.getAPICalls++
+	return f.api, nil
+}
+
+func (f *recordingAPIFactory) GetAPIsFromNamespace(namespace string) (map[string]api.API, error) {
+	f.getAPIsFromNamespaceCalls++
+	f.namespace = namespace
+	return map[string]api.API{namespace: f.api}, nil
+}
+
+func newTestEventRecorder(apiFactory api.Factory, selfServiceNotificationEnabled bool) *EventRecorderAdapter {
+	recorder := NewEventRecorder(
+		fake.NewSimpleClientset(),
+		prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "rollout_events_total",
+			},
+			[]string{"name", "namespace", "type", "reason"},
+		),
+		prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "notification_send_error",
+			},
+			[]string{"name", "namespace", "type", "reason"},
+		),
+		prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "notification_send_success",
+			},
+			[]string{"name", "namespace", "type", "reason"},
+		),
+		prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "notification_send_performance",
+				Help:    "Notification send performance.",
+				Buckets: []float64{0.01, 0.15, .25, .5, 1},
+			},
+			[]string{"namespace", "name"},
+		),
+		apiFactory,
+		selfServiceNotificationEnabled,
+	).(*EventRecorderAdapter)
+	recorder.Recorder = k8srecord.NewFakeRecorder(1000)
+	return recorder
+}
 
 func TestRecordLog(t *testing.T) {
 	prevOutput := log.StandardLogger().Out
@@ -99,6 +154,53 @@ func TestIncCounter(t *testing.T) {
 	m.Write(&buf)
 	assert.Equal(t, float64(3), *buf.Counter.Value)
 	assert.Equal(t, []string{"FooReason", "FooReason", "FooReason"}, rec.Events())
+}
+
+func TestEventRecorderNotificationAPIScope(t *testing.T) {
+	rollout := v1alpha1.Rollout{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "guestbook",
+			Namespace: "team-a",
+		},
+	}
+
+	tests := []struct {
+		name                           string
+		selfServiceNotificationEnabled bool
+		wantGetAPICalls                int
+		wantGetAPIsFromNamespaceCalls  int
+		wantNamespace                  string
+	}{
+		{
+			name:                           "self service disabled uses controller namespace API",
+			selfServiceNotificationEnabled: false,
+			wantGetAPICalls:                1,
+			wantGetAPIsFromNamespaceCalls:  0,
+		},
+		{
+			name:                           "self service enabled uses rollout namespace APIs",
+			selfServiceNotificationEnabled: true,
+			wantGetAPICalls:                0,
+			wantGetAPIsFromNamespaceCalls:  1,
+			wantNamespace:                  "team-a",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			mockAPI := mocks.NewMockAPI(mockCtrl)
+			mockAPI.EXPECT().GetConfig().Return(api.Config{}).AnyTimes()
+			apiFactory := &recordingAPIFactory{api: mockAPI}
+			rec := newTestEventRecorder(apiFactory, tt.selfServiceNotificationEnabled)
+
+			rec.Eventf(&rollout, EventOptions{EventReason: "FooReason"}, "something happened")
+
+			assert.Equal(t, tt.wantGetAPICalls, apiFactory.getAPICalls)
+			assert.Equal(t, tt.wantGetAPIsFromNamespaceCalls, apiFactory.getAPIsFromNamespaceCalls)
+			assert.Equal(t, tt.wantNamespace, apiFactory.namespace)
+		})
+	}
 }
 
 func TestSendNotifications(t *testing.T) {


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is conventional, states what changed, and suffixes the related issue number.
* [x] I've signed my commits with DCO.
* [ ] My builds are green. Try syncing with master if they are not.
* [x] I have written unit and/or e2e tests for my change.
* [ ] I have run all tests locally (including the flaky ones) and they pass on my workstation.
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR.
* [x] I understand what the code does and WHY/HOW it works in several scenarios.
* [x] I know if my code is just adding new functionality or changing old functionality for existing users.
* [ ] My organization is added to USERS.md.

### Fixes #4865 

### What changed

This threads `selfServiceNotificationEnabled` into the event recorder. When self-service notifications are disabled, event-triggered notifications now use the single controller namespace API via `GetAPI()`. When the flag is enabled, the recorder keeps the existing namespace-aware behavior via `GetAPIsFromNamespace(namespace)`.

This keeps the event recorder aligned with the notification controller behavior added in #4851 and avoids building/evaluating empty per-namespace notification APIs when self-service notifications are off.

### Testing

* `go test ./utils/record -run 'TestEventRecorderNotificationAPIScope|TestRecordLog|TestIncCounter'`
* `go test ./controller -run TestNewManager`
* `go test ./utils/record ./controller`
