### PR TITLE
fix: avoid int32 overflow when maxTrafficWeight is large

### DIFF
--- a/pkg/kubectl-argo-rollouts/info/rollout_info.go
+++ b/pkg/kubectl-argo-rollouts/info/rollout_info.go
@@ -65,7 +65,7 @@ func NewRolloutInfo(
 			if ro.Spec.Strategy.Canary.TrafficRouting == nil {
 				for _, rs := range roInfo.ReplicaSets {
 					if rs.Canary {
-						roInfo.ActualWeight = fmt.Sprintf("%d", (rs.Available*weightutil.MaxTrafficWeight(ro))/ro.Status.AvailableReplicas)
+						roInfo.ActualWeight = fmt.Sprintf("%d", int64(rs.Available)*int64(weightutil.MaxTrafficWeight(ro))/int64(ro.Status.AvailableReplicas))
 					}
 				}
 			} else {

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -146,7 +146,7 @@ func (c *rolloutContext) checkReplicasAvailable(rs *appsv1.ReplicaSet, desiredWe
 	availableReplicas := rs.Status.AvailableReplicas
 	totalReplicas := *c.rollout.Spec.Replicas
 
-	desiredReplicas := (desiredWeight * totalReplicas) / weightutil.MaxTrafficWeight(c.rollout)
+	desiredReplicas := int32(int64(desiredWeight) * int64(totalReplicas) / int64(weightutil.MaxTrafficWeight(c.rollout)))
 	if availableReplicas < desiredReplicas &&
 		!replicasetutil.ReplicaProgressThresholdMet(c.rollout.Spec.Strategy.Canary.ReplicaProgressThreshold, rs, desiredReplicas) {
 		c.log.Infof("ReplicaSet '%s' has %d available replicas, waiting for %d", rs.Name, availableReplicas, desiredReplicas)
@@ -236,7 +236,7 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			// But we can only increase canary weight according to available replica counts of the canary.
 			// we will need to set the desiredWeight to 0 when the newRS is not available.
 			if c.rollout.Spec.Strategy.Canary.DynamicStableScale {
-				desiredWeight = (weightutil.MaxTrafficWeight(c.rollout) * c.newRS.Status.AvailableReplicas) / *c.rollout.Spec.Replicas
+				desiredWeight = int32(int64(weightutil.MaxTrafficWeight(c.rollout)) * int64(c.newRS.Status.AvailableReplicas) / int64(*c.rollout.Spec.Replicas))
 			} else if c.rollout.Status.Canary.Weights != nil {
 				desiredWeight = c.rollout.Status.Canary.Weights.Canary.Weight
 			}

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -1706,6 +1706,15 @@ func TestCheckReplicasAvailableWithCustomMaxTrafficWeight(t *testing.T) {
 			description:       "With maxTrafficWeight=100000000, 0% weight needs 0 replicas",
 		},
 		{
+			name:              "custom maxTrafficWeight - weight times replicas exceeds int32",
+			totalReplicas:     43,
+			availableReplicas: 0,
+			desiredWeight:     50000000,
+			maxTrafficWeight:  100000000,
+			expectedResult:    false,
+			description:       "With maxTrafficWeight=100000000, 50% weight on 43 replicas needs 21 replicas but 0 available",
+		},
+		{
 			name:              "default maxTrafficWeight - same behavior as before",
 			totalReplicas:     10,
 			availableReplicas: 5,

--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -227,8 +227,9 @@ func approximateWeightedCanaryStableReplicaCounts(specReplicas, desiredWeight, m
 	}
 	var options []canaryOption
 
-	ceilWeightedCanaryCount := int32(math.Ceil(float64(specReplicas*desiredWeight) / float64(maxWeight)))
-	floorWeightedCanaryCount := int32(math.Floor(float64(specReplicas*desiredWeight) / float64(maxWeight)))
+	weightedCanaryCount := float64(specReplicas) * float64(desiredWeight) / float64(maxWeight)
+	ceilWeightedCanaryCount := int32(math.Ceil(weightedCanaryCount))
+	floorWeightedCanaryCount := int32(math.Floor(weightedCanaryCount))
 
 	tied := floorCeilingTied(desiredWeight, maxWeight, specReplicas)
 
@@ -284,7 +285,7 @@ func floorCeilingTied(desiredWeight, maxWeight, totalReplicas int32) bool {
 // weightDelta calculates the difference that the canary replicas will be from the desired weight
 // This is used to pick the closest approximation of canary counts.
 func weightDelta(desiredWeight, maxWeight, canaryReplicas, totalReplicas int32) float64 {
-	actualWeight := float64(canaryReplicas*maxWeight) / float64(totalReplicas)
+	actualWeight := float64(canaryReplicas) * float64(maxWeight) / float64(totalReplicas)
 	return math.Abs(actualWeight - float64(desiredWeight))
 }
 

--- a/utils/replicaset/canary_test.go
+++ b/utils/replicaset/canary_test.go
@@ -860,6 +860,11 @@ func TestApproximateWeightedNewStableReplicaCounts(t *testing.T) {
 		{replicas: 10, weight: 99, maxWeight: 100, maxSurge: 1, expCanary: 10, expStable: 1},  // 90.9%
 		{replicas: 10, weight: 100, maxWeight: 100, maxSurge: 1, expCanary: 10, expStable: 0}, // 100%
 
+		// A large maxWeight makes replicas*weight exceed the int32 range.
+		{replicas: 43, weight: 50000000, maxWeight: 100000000, maxSurge: 0, expCanary: 22, expStable: 21},  // 50%
+		{replicas: 100, weight: 50000000, maxWeight: 100000000, maxSurge: 0, expCanary: 50, expStable: 50}, // 50%
+		{replicas: 43, weight: 100000000, maxWeight: 100000000, maxSurge: 0, expCanary: 43, expStable: 0},  // 100%
+		{replicas: 43, weight: 0, maxWeight: 100000000, maxSurge: 0, expCanary: 0, expStable: 43},          // 0%
 	}
 	for i := range tests {
 		test := tests[i]


### PR DESCRIPTION
Fixes canary replica counts being computed from an overflowed `int32` product when `maxTrafficWeight` is large.

### The problem

Several places multiply a replica count by a traffic weight while both are still `int32`, and only widen the result afterwards:

```go
ceilWeightedCanaryCount := int32(math.Ceil(float64(specReplicas*desiredWeight) / float64(maxWeight)))
```

`maxTrafficWeight` has no upper bound (the CRD only says `format: int32`), and the repo's own tests use `100000000`. At that scale the product exceeds `math.MaxInt32` for quite ordinary replica counts, and the arithmetic wraps.

`approximateWeightedCanaryStableReplicaCounts` with `maxWeight=100000000`, `maxSurge=0`:

| replicas | weight | canary (before) | canary (expected) |
|---------:|-------:|----------------:|------------------:|
| 43 | 50% | **-21** | 22 |
| 100 | 50% | **8** | 50 |
| 43 | 100% | **1** | 43 |

A negative canary count at 50%, and a single canary replica when the rollout is fully shifted to canary.

`checkReplicasAvailable` is affected the same way: the overflowed product goes negative, so `availableReplicas < desiredReplicas` is never true and it reports that there are enough replicas. With 43 replicas at 50% weight and **zero** of them available it returns `true`, which lets traffic shift to pods that are not ready.

The threshold is `replicas * weight > MaxInt32`, so with `maxTrafficWeight=100000000` it starts at about 22 replicas.

### The fix

Widen the operands before multiplying. `trafficWeightToReplicas` in the same file already does exactly this:

```go
func trafficWeightToReplicas(replicas, weight, maxWeight int32) int32 {
	return int32(math.Ceil(float64(weight) * float64(replicas) / float64(maxWeight)))
}
```

The same shape is applied to `approximateWeightedCanaryStableReplicaCounts`, `weightDelta`, `checkReplicasAvailable`, the dynamic-stable-scale weight in `trafficrouting.go`, and the actual-weight display in `rollout_info.go`. Behaviour for the default `maxTrafficWeight=100` is unchanged — the existing table cases all still pass.

### Tests

Added cases to the existing tables. Both fail on `master` and pass with this change:

- `TestApproximateWeightedNewStableReplicaCounts` — `expected: 22, actual: -21` and `expected: 50, actual: 8`
- `TestCheckReplicasAvailableWithCustomMaxTrafficWeight` — 43 replicas, 0 available, 50% weight must not report available
