### PR TITLE
fix: reject maxTrafficWeight below 1

### DIFF
--- a/pkg/apis/rollouts/validation/validation.go
+++ b/pkg/apis/rollouts/validation/validation.go
@@ -30,6 +30,8 @@ const (
 	MissingFieldMessage = "Rollout has missing field '%s'"
 	// InvalidSetWeightMessage indicates the setweight value needs to be between 0 and max weight
 	InvalidSetWeightMessage = "SetWeight needs to be between 0 and %d"
+	// InvalidMaxTrafficWeightMessage indicates the maxTrafficWeight value is not a usable total weight
+	InvalidMaxTrafficWeightMessage = "MaxTrafficWeight needs to be greater than 0"
 	// InvalidCanaryExperimentTemplateWeightWithoutTrafficRouting indicates experiment weight cannot be set without trafficRouting
 	InvalidCanaryExperimentTemplateWeightWithoutTrafficRouting = "Experiment template weight cannot be set unless TrafficRouting is enabled"
 	// InvalidSetCanaryScaleTrafficPolicy indicates that TrafficRouting, required for SetCanaryScale, is missing
@@ -305,6 +307,11 @@ func ValidateRolloutStrategyCanary(rollout *v1alpha1.Rollout, fldPath *field.Pat
 		if canary.TrafficRouting.MaxTrafficWeight != nil {
 			if canary.TrafficRouting.Nginx == nil && len(canary.TrafficRouting.Plugins) == 0 {
 				allErrs = append(allErrs, field.Invalid(fldPath.Child("trafficRouting").Child("maxTrafficWeight"), canary.TrafficRouting.MaxTrafficWeight, InvalidCanaryMaxWeightOnlySupportInNginxAndPlugins))
+			}
+			// The total weight divides the replica counts derived from the
+			// traffic weights, so it cannot be zero or negative.
+			if *canary.TrafficRouting.MaxTrafficWeight < 1 {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("trafficRouting").Child("maxTrafficWeight"), *canary.TrafficRouting.MaxTrafficWeight, InvalidMaxTrafficWeightMessage))
 			}
 		}
 	}

--- a/pkg/apis/rollouts/validation/validation_test.go
+++ b/pkg/apis/rollouts/validation/validation_test.go
@@ -428,6 +428,18 @@ func TestValidateRolloutStrategyCanary(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf(InvalidSetWeightMessage, 100), allErrs[0].Detail)
 	})
 
+	t.Run("invalid max traffic weight value", func(t *testing.T) {
+		for _, maxTrafficWeight := range []int32{0, -1} {
+			invalidRo := ro.DeepCopy()
+			invalidRo.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
+				Nginx:            &v1alpha1.NginxTrafficRouting{StableIngress: "some-ingress"},
+				MaxTrafficWeight: &maxTrafficWeight,
+			}
+			allErrs := ValidateRolloutStrategyCanary(invalidRo, field.NewPath(""))
+			assert.Equal(t, InvalidMaxTrafficWeightMessage, allErrs[0].Detail)
+		}
+	})
+
 	t.Run("only nginx/plugins support max weight value", func(t *testing.T) {
 		anyWeight := int32(1)
 


### PR DESCRIPTION
`maxTrafficWeight` is used as a divisor, but nothing stops it from being zero.

### The problem

The CRD puts no bound on the field:

```yaml
maxTrafficWeight:
  description: MaxTrafficWeight The total weight of traffic. If unspecified, it defaults to 100
  format: int32
  type: integer
```

Validation checks that each `setWeight` is between 0 and `maxTrafficWeight`, but never checks `maxTrafficWeight` itself. With `maxTrafficWeight: 0` a `setWeight: 0` step still passes, and `checkReplicasAvailable` divides by it:

```go
desiredReplicas := (desiredWeight * totalReplicas) / weightutil.MaxTrafficWeight(c.rollout)
```

which panics:

```
panic: runtime error: integer divide by zero
    github.com/argoproj/argo-rollouts/rollout.(*rolloutContext).checkReplicasAvailable
```

The panic is recovered by the workqueue, but the reconcile for that rollout fails each time it is retried.

### The fix

Reject values below 1 during validation, next to the existing `maxTrafficWeight` check, so the user gets an `InvalidSpec` condition explaining the problem. `getRolloutValidationErrors` runs before the reconcile touches the traffic weights, so the division is no longer reachable with a zero total weight.

Negative values are rejected too — they produce negative replica counts rather than a panic.

### Test

Added a case to `TestValidateRolloutStrategyCanary` covering `0` and `-1`. It fails without the check and passes with it.
