### PR TITLE
fix(trafficrouting): repair APISIX managed route permissions and guide. Fixes #4185

### DIFF
--- a/docs/features/traffic-management/apisix.md
+++ b/docs/features/traffic-management/apisix.md
@@ -204,10 +204,13 @@ kubectl port-forward --namespace ingress-apisix \
 Verify that the initial version is blue:
 
 ```bash
-curl --silent --show-error \
+curl --fail --silent --show-error \
+  --write-out '\n' \
   --header 'Host: rollouts-demo.apisix.local' \
   http://127.0.0.1:9080/color
 ```
+
+The response should be `"blue"`.
 
 ## Trigger a rollout
 
@@ -231,16 +234,18 @@ When the rollout shows `Paused`, press `Ctrl+C` to stop watching.
 A request without the `trace` header still goes to the stable version:
 
 ```bash
-curl --silent --show-error \
+curl --fail --silent --show-error \
+  --write-out '\n' \
   --header 'Host: rollouts-demo.apisix.local' \
   http://127.0.0.1:9080/color
 ```
 
-The response should be `blue`. The same request with `trace: debug` goes to the
-canary and should return `yellow`:
+The response should be `"blue"`. The same request with `trace: debug` goes to
+the canary and should return `"yellow"`:
 
 ```bash
-curl --silent --show-error \
+curl --fail --silent --show-error \
+  --write-out '\n' \
   --header 'Host: rollouts-demo.apisix.local' \
   --header 'trace: debug' \
   http://127.0.0.1:9080/color
@@ -275,13 +280,14 @@ observe the actual responses:
 
 ```bash
 for i in $(seq 1 100); do
-  curl --silent --show-error \
+  curl --fail --silent --show-error \
+    --write-out '\n' \
     --header 'Host: rollouts-demo.apisix.local' \
     http://127.0.0.1:9080/color
 done | sort | uniq -c
 ```
 
-Both `blue` and `yellow` should appear, with a distribution close to the
+Both `"blue"` and `"yellow"` should appear, with a distribution close to the
 configured weights. A small sample is not expected to produce an exact 80/20
 split.
 
@@ -301,10 +307,13 @@ to 100% stable traffic. Verify the weights and request result:
 kubectl get apisixroute rollouts-apisix-route \
   --output=jsonpath='{range .spec.http[0].backends[*]}{.serviceName}={.weight}{"\n"}{end}'
 
-curl --silent --show-error \
+curl --fail --silent --show-error \
+  --write-out '\n' \
   --header 'Host: rollouts-demo.apisix.local' \
   http://127.0.0.1:9080/color
 ```
+
+The response should be `"blue"`.
 
 An aborted Rollout remains `Degraded` until its desired state is changed back
 to the stable version. Restore the blue image:

--- a/docs/features/traffic-management/apisix.md
+++ b/docs/features/traffic-management/apisix.md
@@ -1,30 +1,121 @@
 # Apache APISIX
 
-You can use the [Apache APISIX](https://apisix.apache.org/) and [Apache APISIX Ingress Controller](https://apisix.apache.org/docs/ingress-controller/getting-started/) for traffic management with Argo Rollouts.
+[Apache APISIX](https://apisix.apache.org/) and the
+[Apache APISIX Ingress Controller](https://apisix.apache.org/docs/ingress-controller/)
+can manage traffic for an Argo Rollouts canary through an `ApisixRoute`.
+Argo Rollouts updates the route's backend weights and can create a higher-priority
+route that sends requests with a matching header to the canary.
 
-The [ApisixRoute](https://apisix.apache.org/docs/ingress-controller/concepts/apisix_route/) is the object that supports the ability for [weighted round robin load balancing](https://apisix.apache.org/docs/ingress-controller/concepts/apisix_route/#weight-based-traffic-split)  when using Apache APISIX Ingress Controller as ingress.
+## Supported capabilities
 
-This guide shows you how to integrate ApisixRoute with Argo Rollouts using it as weighted round robin load balancer
+The APISIX traffic router currently has the following support status:
+
+| Capability | Status |
+| --- | --- |
+| Weighted traffic routing (`setWeight`) | Alpha |
+| Header-based routing (`setHeaderRoute`) | Alpha |
+| Experiment weights | Not supported |
+| Traffic mirroring | Not supported |
+
+See the project-wide
+[traffic shaping support matrix](https://github.com/argoproj/argo-rollouts#supported-traffic-shaping-integrations)
+for the current status of every traffic router.
+
+When header-based routing is active, Argo Rollouts creates a managed
+`ApisixRoute` with the name specified in `managedRoutes`. The controller deletes
+that route when the rollout completes or is aborted. Its ServiceAccount therefore
+needs `get`, `watch`, `update`, `create`, and `delete` access to `ApisixRoute`
+resources.
 
 ## Prerequisites
 
-Argo Rollouts requires  Apache APISIX v2.15 or newer and Apache APISIX Ingress Controller v1.5.0 or newer.
+You need:
 
-Install Apache APISIX and Apache APISIX Ingress Controller with Helm v3:
+- Kubernetes 1.26 or newer
+- Helm 3.8 or newer
+- `kubectl`
+- the [Argo Rollouts kubectl plugin](../../installation.md#kubectl-plugin-installation)
+
+This example targets the following component versions:
+
+| Component | Version |
+| --- | --- |
+| Apache APISIX Helm chart | 2.16.0 |
+| Apache APISIX | 3.17.0 |
+| Apache APISIX Ingress Controller | 2.1.0 |
+
+The table records the versions pinned by this example. It is not a minimum-version
+compatibility guarantee. Validate the complete workflow in your own environment
+before using it for production traffic.
+
+## Install APISIX and Argo Rollouts
+
+Add the official APISIX Helm repository and install APISIX together with the
+Ingress Controller:
 
 ```bash
-helm repo add apisix https://charts.apiseven.com
-kubectl create ns apisix
+helm repo add apisix https://apache.github.io/apisix-helm-chart
+helm repo update apisix
 
-helm upgrade -i apisix apisix/apisix --version=0.11.3 \
---namespace apisix \
---set ingress-controller.enabled=true \
---set ingress-controller.config.apisix.serviceNamespace=apisix
+helm upgrade --install apisix apisix/apisix \
+  --version 2.16.0 \
+  --namespace ingress-apisix \
+  --create-namespace \
+  --set ingress-controller.enabled=true \
+  --set ingress-controller.apisix.adminService.namespace=ingress-apisix \
+  --set ingress-controller.gatewayProxy.createDefault=true
 ```
 
-## Bootstrap
+These values follow the APISIX Ingress Controller
+[Helm installation guide](https://apisix.apache.org/docs/ingress-controller/install/).
+Wait for the APISIX workloads before continuing:
 
-First, we need to create the ApisixRoute object using its ability for weighted round robin load balancing.
+```bash
+kubectl rollout status --namespace ingress-apisix \
+  deployment/apisix --timeout=300s
+kubectl rollout status --namespace ingress-apisix \
+  deployment/apisix-ingress-controller --timeout=300s
+kubectl rollout status --namespace ingress-apisix \
+  statefulset/apisix-etcd --timeout=300s
+```
+
+Install Argo Rollouts using the
+[standard installation](../../installation.md#controller-installation):
+
+```bash
+kubectl create namespace argo-rollouts
+kubectl apply --namespace argo-rollouts \
+  --filename https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml
+
+kubectl wait --namespace argo-rollouts \
+  --for=condition=Available deployment/argo-rollouts --timeout=180s
+```
+
+If you maintain custom controller RBAC, verify the permissions required for
+managed APISIX routes:
+
+```bash
+kubectl auth can-i create apisixroutes.apisix.apache.org \
+  --namespace default \
+  --as=system:serviceaccount:argo-rollouts:argo-rollouts
+kubectl auth can-i delete apisixroutes.apisix.apache.org \
+  --namespace default \
+  --as=system:serviceaccount:argo-rollouts:argo-rollouts
+```
+
+Both commands should return `yes`.
+
+## Deploy the example
+
+The example contains stable and canary Services, an `ApisixRoute`, and a
+Rollout:
+
+```bash
+kubectl apply --kustomize \
+  "https://github.com/argoproj/argo-rollouts//examples/apisix?ref=stable"
+```
+
+The route uses the `apisix` IngressClass and references both Services:
 
 ```yaml
 apiVersion: apisix.apache.org/v2
@@ -32,11 +123,18 @@ kind: ApisixRoute
 metadata:
   name: rollouts-apisix-route
 spec:
+  ingressClassName: apisix
   http:
     - name: rollouts-apisix
       match:
         paths:
           - /*
+        methods:
+          - GET
+          - POST
+          - PUT
+          - DELETE
+          - PATCH
         hosts:
           - rollouts-demo.apisix.local
       backends:
@@ -46,171 +144,253 @@ spec:
           servicePort: 80
 ```
 
-```bash
-kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-rollouts/master/examples/apisix/route.yaml
-```
-
-Notice, we don't specify the `weight` field. It is necessary to be synced with ArgoCD. If we specify this field and Argo Rollouts controller changes it, then the ArgoCD controller will notice it and will show that this resource is out of sync (if you are using Argo CD to manage your Rollout).
-
-Secondly, we need to create the Argo Rollouts object.
+The Rollout directs matching `trace: debug` requests to the canary before it
+starts changing the primary route's weights:
 
 ```yaml
-apiVersion: argoproj.io/v1alpha1
-kind: Rollout
-metadata:
-  name: rollout-apisix-canary
-spec:
-  replicas: 5
-  strategy:
-    canary:
-      canaryService: rollout-apisix-canary-canary
-      stableService: rollout-apisix-canary-stable
-      trafficRouting:
-        managedRoutes:
-          - name: set-header
-        apisix:
-          route:
-            name: rollouts-apisix-route
-            rules:
-              - rollouts-apisix
-      steps:
-        - setCanaryScale:
-            replicas: 1
-          setHeaderRoute:
-            match:
-              - headerName: trace
-                headerValue:
-                  exact: debug
-            name: set-header
-        - setWeight: 20
-        - pause: {}
-        - setWeight: 40
-        - pause:
-            duration: 15
-        - setWeight: 60
-        - pause:
-            duration: 15
-        - setWeight: 80
-        - pause:
-            duration: 15
-  revisionHistoryLimit: 2
-  selector:
-    matchLabels:
-      app: rollout-apisix-canary
-  template:
-    metadata:
-      labels:
-        app: rollout-apisix-canary
-    spec:
-      containers:
-        - name: rollout-apisix-canary
-          image: argoproj/rollouts-demo:blue
-          ports:
-            - name: http
-              containerPort: 8080
-              protocol: TCP
-          resources:
-            requests:
-              memory: 32Mi
-              cpu: 5m
+strategy:
+  canary:
+    canaryService: rollout-apisix-canary-canary
+    stableService: rollout-apisix-canary-stable
+    trafficRouting:
+      managedRoutes:
+        - name: set-header
+      apisix:
+        route:
+          name: rollouts-apisix-route
+          rules:
+            - rollouts-apisix
+    steps:
+      - setCanaryScale:
+          replicas: 1
+        setHeaderRoute:
+          name: set-header
+          match:
+            - headerName: trace
+              headerValue:
+                exact: debug
+      - pause: {}
+      - setWeight: 20
+      - pause: {}
+      - setWeight: 40
+      - pause:
+          duration: 15
+      - setWeight: 60
+      - pause:
+          duration: 15
+      - setWeight: 80
+      - pause:
+          duration: 15
 ```
+
+The initial creation skips the canary steps because there is no update yet.
+Wait for it to become healthy:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-rollouts/master/examples/apisix/rollout.yaml
+kubectl argo rollouts status rollout-apisix-canary --timeout 180s
 ```
 
-Finally, we need to create the services for the Argo Rollouts object.
-
-```yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: rollout-apisix-canary-canary
-spec:
-  ports:
-    - port: 80
-      targetPort: http
-      protocol: TCP
-      name: http
-  selector:
-    app: rollout-apisix-canary
-    # This selector will be updated with the pod-template-hash of the canary ReplicaSet. e.g.:
-    # rollouts-pod-template-hash: 7bf84f9696
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: rollout-apisix-canary-stable
-spec:
-  ports:
-    - port: 80
-      targetPort: http
-      protocol: TCP
-      name: http
-  selector:
-    app: rollout-apisix-canary
-    # This selector will be updated with the pod-template-hash of the stable ReplicaSet. e.g.:
-    # rollouts-pod-template-hash: 789746c88d
-```
+Forward the APISIX gateway port in a separate terminal:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-rollouts/master/examples/apisix/services.yaml
+kubectl port-forward --namespace ingress-apisix \
+  service/apisix-gateway 9080:80
 ```
 
-Initial creations of any Rollout will immediately scale up the replicas to 100% (skipping any canary upgrade steps, analysis, etc...) since there was no upgrade that occurred.
+Verify that the initial version is blue:
 
-The Argo Rollouts kubectl plugin allows you to visualize the Rollout, its related resources (ReplicaSets, Pods, AnalysisRuns), and presents live state changes as they occur. To watch the rollout as it deploys, run the get rollout --watch command from plugin:
+```bash
+curl --silent --show-error \
+  --header 'Host: rollouts-demo.apisix.local' \
+  http://127.0.0.1:9080/color
+```
+
+## Trigger a rollout
+
+Update the `rollouts-demo` container to the yellow image:
+
+```bash
+kubectl argo rollouts set image rollout-apisix-canary \
+  rollouts-demo=argoproj/rollouts-demo:yellow
+```
+
+Watch the rollout until it pauses after creating the header route:
 
 ```bash
 kubectl argo rollouts get rollout rollout-apisix-canary --watch
 ```
 
-## Updating a Rollout
+When the rollout shows `Paused`, press `Ctrl+C` to stop watching.
 
-Next it is time to perform an update. Just as with Deployments, any change to the Pod template field (`spec.template`) results in a new version (i.e. ReplicaSet) to be deployed. Updating a Rollout involves modifying the rollout spec, typically changing the container image field with a new version, and then running  `kubectl apply` against the new manifest. As a convenience, the rollouts plugin provides a `set image` command, which performs these steps against the live rollout object in-place. Run the following command to update the `rollout-apisix-canary` Rollout with the "yellow" version of the container:
+## Verify header-based routing
 
-```shell
+A request without the `trace` header still goes to the stable version:
+
+```bash
+curl --silent --show-error \
+  --header 'Host: rollouts-demo.apisix.local' \
+  http://127.0.0.1:9080/color
+```
+
+The response should be `blue`. The same request with `trace: debug` goes to the
+canary and should return `yellow`:
+
+```bash
+curl --silent --show-error \
+  --header 'Host: rollouts-demo.apisix.local' \
+  --header 'trace: debug' \
+  http://127.0.0.1:9080/color
+```
+
+Inspect the managed route created by Argo Rollouts:
+
+```bash
+kubectl get apisixroute set-header --output yaml
+```
+
+The route has a higher priority than the primary route, matches the `trace`
+header, and has only the canary Service as its backend.
+
+## Verify weighted traffic
+
+Promote the rollout to the 20% weight step:
+
+```bash
+kubectl argo rollouts promote rollout-apisix-canary
+```
+
+Inspect the backend weights:
+
+```bash
+kubectl get apisixroute rollouts-apisix-route \
+  --output=jsonpath='{range .spec.http[0].backends[*]}{.serviceName}={.weight}{"\n"}{end}'
+```
+
+The stable and canary weights should be `80` and `20`. Send 100 requests to
+observe the actual responses:
+
+```bash
+for i in $(seq 1 100); do
+  curl --silent --show-error \
+    --header 'Host: rollouts-demo.apisix.local' \
+    http://127.0.0.1:9080/color
+done | sort | uniq -c
+```
+
+Both `blue` and `yellow` should appear, with a distribution close to the
+configured weights. A small sample is not expected to produce an exact 80/20
+split.
+
+## Abort and recover
+
+Abort the rollout while it is paused:
+
+```bash
+kubectl argo rollouts abort rollout-apisix-canary
+kubectl wait --for=delete apisixroute/set-header --timeout=60s
+```
+
+Argo Rollouts removes the managed header route and restores the primary route
+to 100% stable traffic. Verify the weights and request result:
+
+```bash
+kubectl get apisixroute rollouts-apisix-route \
+  --output=jsonpath='{range .spec.http[0].backends[*]}{.serviceName}={.weight}{"\n"}{end}'
+
+curl --silent --show-error \
+  --header 'Host: rollouts-demo.apisix.local' \
+  http://127.0.0.1:9080/color
+```
+
+An aborted Rollout remains `Degraded` until its desired state is changed back
+to the stable version. Restore the blue image:
+
+```bash
 kubectl argo rollouts set image rollout-apisix-canary \
-  rollouts-demo=argoproj/rollouts-demo:yellow
+  rollouts-demo=argoproj/rollouts-demo:blue
+kubectl argo rollouts status rollout-apisix-canary --timeout 180s
 ```
 
-During a rollout update, the controller will progress through the steps defined in the Rollout's update strategy. The example rollout sets a 20% traffic weight to the canary, and pauses the rollout indefinitely until user action is taken to unpause/promote the rollout.
+## Integrating with GitOps
 
-You can check ApisixRoute's backend weights by the following command
-```bash
-kubectl describe apisixroute rollouts-apisix-route
+Argo Rollouts owns the backend `weight` fields while a rollout is in progress.
+If Argo CD also manages the `ApisixRoute`, configure it to ignore those fields
+to prevent sync operations from replacing the active weights:
 
-......
-Spec:
-  Http:
-    Backends:
-      Service Name:  rollout-apisix-canary-stable
-      Service Port:  80
-      Weight:        80
-      Service Name:  rollout-apisix-canary-canary
-      Service Port:  80
-      Weight:        20
-......
+```yaml
+spec:
+  ignoreDifferences:
+    - group: apisix.apache.org
+      kind: ApisixRoute
+      jqPathExpressions:
+        - .spec.http[].backends[].weight
+  syncPolicy:
+    syncOptions:
+      - RespectIgnoreDifferences=true
 ```
-The `rollout-apisix-canary-canary` service gets 20% traffic through the Apache APISIX.
 
-You can check SetHeader ApisixRoute's match by the following command
+The example omits initial weights from Git for the same reason.
+
+## Troubleshooting
+
+### The `set-header` route is not created
+
+Check the Rollouts controller events and logs:
+
 ```bash
-kubectl describe apisixroute set-header
+kubectl describe rollout rollout-apisix-canary
+kubectl logs --namespace argo-rollouts deployment/argo-rollouts
+```
 
-......
-Spec:
-  Http:
-    Backends:
-      Service Name:  rollout-apisix-canary-canary
-      Service Port:  80
-      Weight:        100
-    Match:
-      Exprs:
-        Op:  Equal
-        Subject:
-          Name:   trace
-          Scope:  Header
-        Value:    debug
-......
+An `apisixroutes ... is forbidden` message means the controller ServiceAccount
+cannot create or delete managed routes. Run the `kubectl auth can-i` checks from
+the installation section and update custom RBAC if either returns `no`.
+
+### Requests return 404
+
+The example route matches the `rollouts-demo.apisix.local` host. Include
+`Host: rollouts-demo.apisix.local` in local requests or create a DNS record for
+that host.
+
+### The route exists but APISIX does not use it
+
+Confirm that the route uses the `apisix` IngressClass and inspect the Ingress
+Controller:
+
+```bash
+kubectl get ingressclass apisix
+kubectl get apisixroute rollouts-apisix-route --output yaml
+kubectl logs --namespace ingress-apisix \
+  deployment/apisix-ingress-controller
+```
+
+See the APISIX Ingress Controller
+[configuration troubleshooting guide](https://apisix.apache.org/docs/ingress-controller/reference/apisix-ingress-controller/configuration-troubleshoot/)
+for inspecting the translated gateway configuration.
+
+### APISIX returns 502 or 503
+
+Check that both Services have ready endpoints:
+
+```bash
+kubectl get endpoints \
+  rollout-apisix-canary-stable rollout-apisix-canary-canary
+kubectl get pods --selector app=rollout-apisix-canary
+```
+
+## Cleanup
+
+Stop the port-forward process, then delete the example:
+
+```bash
+kubectl delete --kustomize \
+  "https://github.com/argoproj/argo-rollouts//examples/apisix?ref=stable"
+```
+
+To remove the controllers as well:
+
+```bash
+helm uninstall apisix --namespace ingress-apisix
+kubectl delete namespace ingress-apisix
+kubectl delete namespace argo-rollouts
 ```

--- a/docs/features/traffic-management/apisix.md
+++ b/docs/features/traffic-management/apisix.md
@@ -84,12 +84,16 @@ Install Argo Rollouts using the
 
 ```bash
 kubectl create namespace argo-rollouts
-kubectl apply --namespace argo-rollouts \
+kubectl apply --server-side \
+  --namespace argo-rollouts \
   --filename https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml
 
 kubectl wait --namespace argo-rollouts \
   --for=condition=Available deployment/argo-rollouts --timeout=180s
 ```
+
+Server-side apply avoids the client-side `last-applied-configuration` annotation
+size limit for the bundled CRDs.
 
 If you maintain custom controller RBAC, verify the permissions required for
 managed APISIX routes:

--- a/examples/apisix/kustomization.yaml
+++ b/examples/apisix/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - services.yaml
+  - route.yaml
+  - rollout.yaml

--- a/examples/apisix/route.yaml
+++ b/examples/apisix/route.yaml
@@ -3,6 +3,7 @@ kind: ApisixRoute
 metadata:
   name: rollouts-apisix-route
 spec:
+  ingressClassName: apisix
   http:
     - name: rollouts-apisix
       match:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -39780,6 +39780,8 @@ rules:
   - watch
   - get
   - update
+  - create
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -39814,6 +39814,8 @@ rules:
   - watch
   - get
   - update
+  - create
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -234,6 +234,8 @@ rules:
   - watch
   - get
   - update
+  - create
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/manifests/role/argo-rollouts-clusterrole.yaml
+++ b/manifests/role/argo-rollouts-clusterrole.yaml
@@ -241,3 +241,5 @@ rules:
   - watch
   - get
   - update
+  - create
+  - delete

--- a/rollout/trafficrouting/apisix/rbac_test.go
+++ b/rollout/trafficrouting/apisix/rbac_test.go
@@ -18,15 +18,28 @@ func TestAPISIXRouteRBAC(t *testing.T) {
 	require.True(t, ok)
 
 	repositoryRoot := filepath.Join(filepath.Dir(testFile), "..", "..", "..")
-	manifestPaths := []string{
-		filepath.Join(repositoryRoot, "manifests", "role", "argo-rollouts-clusterrole.yaml"),
-		filepath.Join(repositoryRoot, "manifests", "install.yaml"),
-		filepath.Join(repositoryRoot, "manifests", "namespace-install.yaml"),
+	manifestCases := []struct {
+		path         string
+		expectedKind string
+	}{
+		{
+			path:         filepath.Join(repositoryRoot, "manifests", "role", "argo-rollouts-clusterrole.yaml"),
+			expectedKind: "ClusterRole",
+		},
+		{
+			path:         filepath.Join(repositoryRoot, "manifests", "install.yaml"),
+			expectedKind: "ClusterRole",
+		},
+		{
+			path:         filepath.Join(repositoryRoot, "manifests", "namespace-install.yaml"),
+			expectedKind: "Role",
+		},
 	}
 
-	for _, manifestPath := range manifestPaths {
-		t.Run(filepath.Base(manifestPath), func(t *testing.T) {
-			role := readArgoRolloutsRole(t, manifestPath)
+	for _, manifestCase := range manifestCases {
+		t.Run(filepath.Base(manifestCase.path), func(t *testing.T) {
+			role := readArgoRolloutsRole(t, manifestCase.path)
+			assert.Equal(t, manifestCase.expectedKind, role.Kind)
 			assertAPISIXRouteRBAC(t, role.Rules)
 		})
 	}
@@ -56,16 +69,27 @@ func assertAPISIXRouteRBAC(t *testing.T, rules []rbacv1.PolicyRule) {
 
 	var matchingRules []rbacv1.PolicyRule
 	for _, rule := range rules {
-		if assert.ObjectsAreEqual([]string{"apisix.apache.org"}, rule.APIGroups) &&
-			assert.ObjectsAreEqual([]string{"apisixroutes"}, rule.Resources) {
+		if covers(rule.APIGroups, "apisix.apache.org") &&
+			covers(rule.Resources, "apisixroutes") {
 			matchingRules = append(matchingRules, rule)
 		}
 	}
 
 	require.Len(t, matchingRules, 1)
+	assert.Equal(t, []string{"apisix.apache.org"}, matchingRules[0].APIGroups)
+	assert.Equal(t, []string{"apisixroutes"}, matchingRules[0].Resources)
 	assert.Equal(
 		t,
 		[]string{"watch", "get", "update", "create", "delete"},
 		matchingRules[0].Verbs,
 	)
+}
+
+func covers(values []string, target string) bool {
+	for _, value := range values {
+		if value == target || value == "*" {
+			return true
+		}
+	}
+	return false
 }

--- a/rollout/trafficrouting/apisix/rbac_test.go
+++ b/rollout/trafficrouting/apisix/rbac_test.go
@@ -1,0 +1,71 @@
+package apisix
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func TestAPISIXRouteRBAC(t *testing.T) {
+	_, testFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	repositoryRoot := filepath.Join(filepath.Dir(testFile), "..", "..", "..")
+	manifestPaths := []string{
+		filepath.Join(repositoryRoot, "manifests", "role", "argo-rollouts-clusterrole.yaml"),
+		filepath.Join(repositoryRoot, "manifests", "install.yaml"),
+		filepath.Join(repositoryRoot, "manifests", "namespace-install.yaml"),
+	}
+
+	for _, manifestPath := range manifestPaths {
+		t.Run(filepath.Base(manifestPath), func(t *testing.T) {
+			role := readArgoRolloutsRole(t, manifestPath)
+			assertAPISIXRouteRBAC(t, role.Rules)
+		})
+	}
+}
+
+func readArgoRolloutsRole(t *testing.T, manifestPath string) rbacv1.Role {
+	t.Helper()
+
+	manifest, err := os.ReadFile(manifestPath)
+	require.NoError(t, err)
+
+	for _, document := range bytes.Split(manifest, []byte("\n---\n")) {
+		var role rbacv1.Role
+		require.NoError(t, yaml.Unmarshal(document, &role))
+		if (role.Kind == "Role" || role.Kind == "ClusterRole") &&
+			role.Name == "argo-rollouts" {
+			return role
+		}
+	}
+
+	t.Fatalf("argo-rollouts Role or ClusterRole not found in %s", manifestPath)
+	return rbacv1.Role{}
+}
+
+func assertAPISIXRouteRBAC(t *testing.T, rules []rbacv1.PolicyRule) {
+	t.Helper()
+
+	var matchingRules []rbacv1.PolicyRule
+	for _, rule := range rules {
+		if assert.ObjectsAreEqual([]string{"apisix.apache.org"}, rule.APIGroups) &&
+			assert.ObjectsAreEqual([]string{"apisixroutes"}, rule.Resources) {
+			matchingRules = append(matchingRules, rule)
+		}
+	}
+
+	require.Len(t, matchingRules, 1)
+	assert.Equal(
+		t,
+		[]string{"watch", "get", "update", "create", "delete"},
+		matchingRules[0].Verbs,
+	)
+}


### PR DESCRIPTION
## Summary

- grant the Rollouts controller the missing `create` and `delete` verbs for managed `ApisixRoute` resources
- regenerate the standard cluster-scoped and namespace-scoped installation manifests
- add a regression test that checks the source RBAC and both generated install manifests without allowing wildcard or overlapping APISIX route rules
- make the APISIX example deployable and removable with Kustomize
- rewrite the APISIX traffic-routing guide around header routing, weighted traffic, abort/recovery, troubleshooting, and cleanup

## Root cause

`SetHeaderRoute` creates a managed `ApisixRoute` while header matching is active and deletes it when the managed route is removed. The shipped APISIX RBAC rule allowed only `watch`, `get`, and `update`, so the standard controller ServiceAccount could not create the managed route.

The controller already used the dynamic client's `Create` and `Delete` operations. The missing permissions were in the installation RBAC.

## Permission change

The resulting APISIX route rule is exactly:

```yaml
apiGroups:
  - apisix.apache.org
resources:
  - apisixroutes
verbs:
  - watch
  - get
  - update
  - create
  - delete
```

No wildcard, `patch`, other API group, or other resource permission is added. The namespace-scoped installation remains namespace-scoped.

## Reproducible before/after validation

A no-secrets, read-only GitHub-hosted workflow built the Rollouts controller and CLI from exact PR HEAD `2b77a8e3d39f7f006f0699a44a625eb74f53e88c` and exercised the full integration in a new kind cluster. The workflow ran from validation-harness commit `9c1fc7c35a4e3226797bf58b0a185bae2be7d031`; its checkout, build, and runtime assertions explicitly verify the PR HEAD:

- workflow and downloadable evidence: https://github.com/Yilialinn/argo-rollouts/actions/runs/30539570332
- base commit `22276e383a04c85b9bcdc6a108e0578031ed2304`: `create=no`, `delete=no`; the controller reproduced `apisixroutes.apisix.apache.org is forbidden`, and the managed `set-header` route was absent
- PR RBAC: `create=yes`, `delete=yes`; `patch secrets=no`, confirming that unrelated permission was not added
- after reconciliation, the managed `set-header` route existed, was owned by the Rollout, had the exact `trace: debug` match, targeted only the canary Service, and was `Accepted`
- initial traffic: 10/10 ordinary requests returned `blue`
- header stage: 10/10 ordinary requests returned `blue`; 10/10 `trace: debug` requests returned `yellow`
- 20% stage: 500 requests returned 400 `blue`, 100 `yellow`, and 0 unexpected responses
- abort: the main route returned to stable/canary weights `100/0`, the managed header route was deleted, and 100/100 requests returned `blue`
- recovery: after restoring the blue image, the Rollout reached `Healthy`
- cleanup deleted the example Rollout, example route, APISIX namespace, and Rollouts namespace; the kind cluster was then deleted successfully

The expected base failure is asserted explicitly. Business assertions are not retried until they happen to pass, and failures are not hidden with `continue-on-error`.

## Validation environment

| Component | Validated version |
| --- | --- |
| Argo Rollouts source | PR HEAD `2b77a8e3d` on base `22276e383` |
| kind | 0.32.0 |
| Kubernetes | 1.34.8 |
| Go | 1.26.5 |
| Helm | 3.21.3 |
| Kustomize | 5.7.1 |
| Apache APISIX Helm chart | 2.16.0 |
| Apache APISIX | 3.17.0 |
| Apache APISIX Ingress Controller | 2.1.0 |

These are the versions used for one isolated kind functional-validation environment, not minimum compatibility guarantees. The observed 400/100 sample demonstrates both paths and falls within the asserted tolerance; it is not an exact-distribution guarantee. This run also does not make a production performance or stability claim.

## Additional checks

- `go test -mod=mod ./... -count=1`
- `go test -race ./rollout/trafficrouting/apisix -count=1`
- the APISIX RBAC regression test against the source ClusterRole and both generated install manifests
- the upstream Kubernetes 1.32, 1.33, 1.34, and 1.35 e2e jobs and their composite check; the APISIX suite and both APISIX test cases passed without a failed attempt in every matrix entry
- `make manifests`, followed by a clean-tree/zero-diff check
- `make docs`, followed by a clean-tree/zero-diff check
- MkDocs strict build and rendered-page visual inspection
- YAML parsing and local Kustomize rendering
- remote Kustomize rendering from the exact fork commit, byte-for-byte equal to the local render
- `git diff --check`
- external documentation link checks
- independent final review of the complete diff and runtime evidence

The complete repository e2e suite was not run locally. The upstream GitHub Actions e2e matrix and the dedicated clean-cluster APISIX validation provide the remote integration coverage claimed here.

The published e2e report records one failed attempt in an AWS ALB test on Kubernetes 1.32 and one failed attempt in a BlueGreen analysis timing test on Kubernetes 1.35; both passed within the workflow's five-run policy, and their matrix jobs and composite check are green. Neither failure touched the APISIX package, RBAC, manifests, example, or APISIX e2e suite.

## Risk and compatibility

- The RBAC surface expands by two verbs on one namespaced CRD only.
- Managed route creation and deletion remain limited by the controller's existing managed-route and owner-reference logic.
- There is no API, CRD, or traffic-router behavior change.
- The guide records a validated version set and does not claim a new minimum supported version or an exact probabilistic traffic split.

## AI-assisted contribution

LLM/agent tools assisted with research, editing, testing, and review. I reviewed the complete diff and the raw validation evidence, understand the permission and controller paths involved, and take responsibility for all code, tests, documentation, and technical claims in this PR.

## Checklist

- [x] This is a bug fix.
- [x] The PR title is conventional, describes the change, and references the related issue.
- [x] All commits include a DCO sign-off.
- [x] GitHub CI is green for the current HEAD.
- [x] A regression test covers the RBAC change and rejects broader overlapping permissions.
- [ ] The complete repository test suite, including all e2e suites, passed locally.
- [x] I used LLM/AI/Agent tools and am responsible for all code in this PR.
- [x] I understand what the code does and why the permissions are required.
- [x] This changes existing installation RBAC and documentation; it does not add a new API.
- [ ] My organization is listed in `USERS.md` (not applicable to this bug-fix contribution).

Fixes #4185

Refs #3974
