### PR TITLE
fix: clear loading state when namespace has zero rollouts

### DIFF
--- a/ui/src/app/components/rollouts-home/rollouts-home.tsx
+++ b/ui/src/app/components/rollouts-home/rollouts-home.tsx
@@ -144,7 +144,7 @@ export const RolloutsHome = () => {
                         <FontAwesomeIcon icon={faCircleNotch} spin={true} style={{marginRight: '5px'}} />
                         Loading...
                     </div>
-                ) : (rollouts || []).length > 0 ? (
+                ) : (loading === false && (rollouts || []).length === 0) ? (
                     <React.Fragment>
                         {filters.displayMode === 'table' && <RolloutsTable rollouts={filteredRollouts} onFavoriteChange={handleFavoriteChange} favorites={favorites} />}
                         {filters.displayMode !== 'table' && <RolloutsGrid rollouts={filteredRollouts} onFavoriteChange={handleFavoriteChange} favorites={favorites} />}

--- a/ui/src/app/shared/services/rollout.ts
+++ b/ui/src/app/shared/services/rollout.ts
@@ -38,7 +38,11 @@ export const useWatchRollouts = (): ListState<RolloutInfo> => {
     const streamUrl = getApiBasePath() + RolloutServiceApiFetchParamCreator().rolloutServiceWatchRolloutInfos(namespaceCtx.namespace).url;
 
     const init = useRollouts();
-    const loading = useLoading(init);
+    const [initLoaded, setInitLoaded] = React.useState(false);
+    React.useEffect(() => {
+        setInitLoaded(true);
+    }, [init]);
+    const loading = useLoading(init) && !initLoaded;
 
     const [rollouts, setRollouts] = React.useState(init);
     const liveList = useWatchList<RolloutInfo, RolloutRolloutWatchEvent>(streamUrl, findRollout, getRollout, rollouts);


### PR DESCRIPTION
useLoading() only clears loading when list.length > 0, so a namespace with no rollouts keeps the spinner forever since the watch endpoint has nothing to emit. The initial list request succeeds and returns zero items, but the UI stays stuck on Loading... indefinitely.

Fix: track whether the initial fetch completed and clear loading once it does, regardless of item count. The existing empty state will then render correctly.

Fixes #4888