### PR TITLE
docs: explained haproxy support

### DIFF
--- a/docs/features/traffic-management/haproxy.md
+++ b/docs/features/traffic-management/haproxy.md
@@ -1,0 +1,26 @@
+# HAProxy Ingress
+
+With the introduction of the Kubernetes Gateway API it is now possible to use Argo Rollouts with all compliant implementations that support it. The integration is available with the [Argo Rollouts Gateway API plugin](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/) currently hosted in Argo Labs.
+
+!!! note
+
+    There are two projects that call themselves an HAProxy ingress controller. The one described here is the community [HAProxy Ingress](https://haproxy-ingress.github.io/) controller, which is the [Gateway API conformant](https://gateway-api.sigs.k8s.io/implementations/) HAProxy implementation. Gateway API conformance arrived in v0.17. Earlier versions have only partial Gateway API support and will not work with the plugin.
+
+Useful resources:
+
+* [The Gateway API specification](https://gateway-api.sigs.k8s.io/)
+* [Support of the Gateway API in HAProxy Ingress](https://haproxy-ingress.github.io/docs/configuration/gateway-api/)
+* [Argo Rollouts Plugin capabilities](../plugins/)
+* [Plugin for the Gateway API](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi)
+
+The process involves the following steps:
+
+1. Installing the Gateway API CRDs in your cluster
+1. Installing HAProxy Ingress (v0.17 or later) with Gateway API support
+1. Creating a GatewayClass and Gateway resources
+1. Installing Argo Rollouts + gateway API plugin in the cluster
+1. Defining a Rollout that takes advantage of the plugin
+
+Note that HAProxy Ingress does not implement `GRPCRoute` or `UDPRoute`, so the gRPC routing capabilities of the plugin cannot be used with this provider. HAProxy Ingress also runs a single shared HAProxy deployment instead of creating one Service per Gateway, so all Gateway traffic enters through the chart's own `haproxy-ingress` Service.
+
+For a full application that includes all manifests see the [plugin example](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/tree/main/examples/haproxy).

--- a/docs/features/traffic-management/index.md
+++ b/docs/features/traffic-management/index.md
@@ -27,6 +27,7 @@ Argo Rollouts enables traffic management by manipulating the Service Mesh resour
 - [Apache APISIX](apisix.md)
 - [Google Cloud](google-cloud.md)
 - [Gateway API](plugins.md)
+- [HAProxy Ingress](haproxy.md)
 - [Istio](istio.md)
 - [Kong Ingress](kong.md)
 - [Nginx Ingress Controller](nginx.md)

--- a/docs/features/traffic-management/plugins.md
+++ b/docs/features/traffic-management/plugins.md
@@ -97,7 +97,7 @@ If you have created a plugin, please submit a PR to add it to this list.
 
 ### [Gateway API](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/)
 
-- Provide support for Gateway API, which includes Kuma, Traefix, cilium, Contour, GloodMesh, HAProxy, and [many others](https://gateway-api.sigs.k8s.io/implementations/#implementation-status).
+- Provide support for Gateway API, which includes Traefik, Cilium, Gloo Gateway, kgateway, HAProxy, and [many others](https://gateway-api.sigs.k8s.io/implementations/#implementation-status).
 
 ### [Gloo Edge](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-glooedge)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
   - APISIX: features/traffic-management/apisix.md
   - AWS ALB: features/traffic-management/alb.md
   - Google Cloud: features/traffic-management/google-cloud.md
+  - HAProxy: features/traffic-management/haproxy.md
   - Istio: features/traffic-management/istio.md
   - Kong: features/traffic-management/kong.md
   - NGINX: features/traffic-management/nginx.md


### PR DESCRIPTION
Haproxy 0.17 alpha version now supports the Gateway API

This means that Argo Rollouts can take advantage of it right away.

Full example is here https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/tree/main/examples/haproxy

Closes https://github.com/argoproj/argo-rollouts/issues/1106

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [ ] I understand what the code does and WHY/HOW it works in several scenarios
* [ ] I know if my code is just adding new functionality or changing old functionality for existing users
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).