### PR TITLE
fix: skip canary steps and fast-promote when spec.replicas is 0

### DIFF
--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -133,6 +133,9 @@ func (c *rolloutContext) reconcileCanaryStableReplicaSet() (bool, error) {
 }
 
 func (c *rolloutContext) reconcileCanaryPause() bool {
+	if c.isZeroReplicaFastTrack() {
+		return false
+	}
 	if c.rollout.Spec.Paused {
 		return false
 	}
@@ -369,6 +372,13 @@ func (c *rolloutContext) syncRolloutStatusCanary() error {
 				// Else if we get here we detected that we are within the rollback window we can skip steps and move back to the active ReplicaSet
 				c.recorder.Eventf(c.rollout, record.EventOptions{EventReason: "SkipSteps"}, "Rollback to active ReplicaSets within RollbackWindow")
 				newStatus.CurrentStepIndex = &stepCount
+			} else if c.isZeroReplicaFastTrack() {
+				if reason := c.shouldFullPromote(newStatus); reason != "" {
+					if err := c.promoteStable(&newStatus, reason); err != nil {
+						return err
+					}
+					return c.persistRolloutStatus(&newStatus)
+				}
 			}
 		}
 		return c.persistRolloutStatus(&newStatus)

--- a/rollout/context.go
+++ b/rollout/context.go
@@ -76,7 +76,7 @@ func (c *rolloutContext) reconcile() error {
 		return err
 	}
 
-	if isScalingEvent {
+	if isScalingEvent && !c.needsZeroReplicaFastTrackReconcile() {
 		return c.syncReplicasOnly()
 	}
 

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -1219,6 +1219,19 @@ func (c *rolloutContext) isZeroReplicaFastTrack() bool {
 	return c.rollout.Spec.Replicas != nil && *c.rollout.Spec.Replicas == 0
 }
 
+// needsZeroReplicaFastTrackReconcile returns true when a full canary reconcile is required
+// instead of syncReplicasOnly. Scaling to zero mid-rollout must still skip pause steps and
+// promote the new version as stable.
+func (c *rolloutContext) needsZeroReplicaFastTrackReconcile() bool {
+	if !c.isZeroReplicaFastTrack() || c.rollout.Spec.Strategy.Canary == nil {
+		return false
+	}
+	if c.newRS == nil || c.rollout.Status.StableRS == "" {
+		return false
+	}
+	return c.rollout.Status.StableRS != replicasetutil.GetPodTemplateHash(c.newRS)
+}
+
 func (c *rolloutContext) isRollbackWithinWindow() bool {
 	if c.newRS == nil || c.stableRS == nil {
 		return false

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -1213,6 +1213,12 @@ func (c *rolloutContext) isFastRollback() bool {
 
 }
 
+// isZeroReplicaFastTrack returns true when spec.replicas is explicitly set to 0.
+// With no pods to validate, canary steps should be skipped and the new version promoted as stable.
+func (c *rolloutContext) isZeroReplicaFastTrack() bool {
+	return c.rollout.Spec.Replicas != nil && *c.rollout.Spec.Replicas == 0
+}
+
 func (c *rolloutContext) isRollbackWithinWindow() bool {
 	if c.newRS == nil || c.stableRS == nil {
 		return false
@@ -1253,6 +1259,10 @@ func (c *rolloutContext) shouldFullPromote(newStatus v1alpha1.RolloutStatus) str
 	} else if c.rollout.Spec.Strategy.Canary != nil {
 		if c.pauseContext.IsAborted() {
 			return ""
+		}
+		if c.isZeroReplicaFastTrack() && c.newRS != nil && c.rollout.Status.StableRS != "" &&
+			c.rollout.Status.StableRS != replicasetutil.GetPodTemplateHash(c.newRS) {
+			return "Zero replicas - skipping canary steps"
 		}
 		// Block promotion only when canary has fewer available than desired (e.g. still scaling up).
 		// When canary has >= desired (e.g. HPA scaled rollout down so desired=1 but canary still has 2),

--- a/rollout/sync_test.go
+++ b/rollout/sync_test.go
@@ -467,6 +467,54 @@ func TestCanaryZeroReplicasSkipSteps(t *testing.T) {
 	assert.False(t, patchedRollout.Status.ControllerPause)
 }
 
+// TestCanaryZeroReplicasScaleDownDuringPause verifies scaling to 0 mid-rollout while paused
+// skips the pause and promotes, even when isScalingEvent would normally short-circuit to syncReplicasOnly.
+func TestCanaryZeroReplicasScaleDownDuringPause(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{
+		{
+			SetWeight: int32Ptr(25),
+		},
+		{
+			Pause: &v1alpha1.RolloutPause{},
+		},
+	}
+
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
+	rs1 := newReplicaSetWithStatus(r1, 10, 10)
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+
+	r2 := bumpVersion(r1)
+	rs2 := newReplicaSetWithStatus(r2, 1, 1)
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+
+	r2.Spec.Replicas = ptr.To[int32](0)
+	// Stale desired-replicas annotations trigger isScalingEvent.
+	rs1.Annotations[annotations.DesiredReplicasAnnotation] = "10"
+	rs2.Annotations[annotations.DesiredReplicasAnnotation] = "10"
+
+	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 11, 1, 11, true)
+	r2.Status.CurrentStepIndex = ptr.To[int32](1)
+	r2.Status.CurrentPodHash = rs2PodHash
+
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2)
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+
+	f.expectUpdateReplicaSetAction(rs1)
+	patchedRolloutIndex := f.expectPatchRolloutAction(r2)
+	f.run(getKey(r2, t))
+
+	patchedRollout := f.getPatchedRolloutAsObject(patchedRolloutIndex)
+	assert.Equal(t, int32(len(steps)), *patchedRollout.Status.CurrentStepIndex)
+	assert.Equal(t, rs2PodHash, patchedRollout.Status.StableRS)
+	assert.False(t, patchedRollout.Status.ControllerPause)
+	assert.Nil(t, patchedRollout.Status.PauseConditions)
+}
+
 // TesBlueGreenPromoteFull verifies skip pause, analysis when promote full is set for a blue-green rollout
 func TestBlueGreenPromoteFull(t *testing.T) {
 	f := newFixture(t)

--- a/rollout/sync_test.go
+++ b/rollout/sync_test.go
@@ -420,6 +420,53 @@ func TestCanaryPromoteFull(t *testing.T) {
 	assert.False(t, patchedRollout.Status.PromoteFull)
 }
 
+// TestCanaryZeroReplicasSkipSteps verifies canary steps are skipped when spec.replicas is 0
+func TestCanaryZeroReplicasSkipSteps(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{
+		{
+			SetWeight: int32Ptr(25),
+		},
+		{
+			Pause: &v1alpha1.RolloutPause{},
+		},
+		{
+			SetWeight: int32Ptr(100),
+		},
+	}
+
+	r1 := newCanaryRollout("foo", 0, nil, steps, int32Ptr(0), intstr.FromInt(1), intstr.FromInt(0))
+	rs1 := newReplicaSetWithStatus(r1, 0, 0)
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	r1.Status.StableRS = rs1PodHash
+	r2 := bumpVersion(r1)
+	r2.Annotations[annotations.RevisionAnnotation] = "1"
+	rs2 := newReplicaSetWithStatus(r2, 0, 0)
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2)
+	f.kubeobjects = append(f.kubeobjects, rs1)
+	f.replicaSetLister = append(f.replicaSetLister, rs1)
+
+	createdRS2Index := f.expectCreateReplicaSetAction(rs2) // sync 1: create new ReplicaSet (size 0)
+	f.expectUpdateRolloutAction(r2)                        // sync 1: update rollout revision
+	f.expectUpdateRolloutStatusAction(r2)                  // sync 1: update rollout conditions
+	f.expectGetRolloutAction(r2)                           // re-seed between syncs
+	patchedRolloutIndex := f.expectPatchRolloutAction(r2)  // sync 2: promote and patch status
+	f.runWithSyncs(getKey(r2, t), 2)
+
+	createdRS2 := f.getCreatedReplicaSet(createdRS2Index)
+	assert.Equal(t, int32(0), *createdRS2.Spec.Replicas)
+
+	patchedRollout := f.getPatchedRolloutAsObject(patchedRolloutIndex)
+	assert.Equal(t, int32(len(steps)), *patchedRollout.Status.CurrentStepIndex)
+	assert.Equal(t, rs2PodHash, patchedRollout.Status.StableRS)
+	assert.False(t, patchedRollout.Status.ControllerPause)
+}
+
 // TesBlueGreenPromoteFull verifies skip pause, analysis when promote full is set for a blue-green rollout
 func TestBlueGreenPromoteFull(t *testing.T) {
 	f := newFixture(t)
@@ -683,6 +730,43 @@ func Test_shouldFullPromote(t *testing.T) {
 
 	result = ctx.shouldFullPromote(newStatus)
 	assert.Equal(t, result, "Rollback within window")
+}
+
+func TestShouldFullPromoteZeroReplicas(t *testing.T) {
+	stableRS := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: "stablehash"},
+		},
+	}
+	newRS := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: "newhash"},
+		},
+	}
+	ctx := &rolloutContext{
+		stableRS: stableRS,
+		newRS:    newRS,
+		rollout: &v1alpha1.Rollout{
+			Spec: v1alpha1.RolloutSpec{
+				Replicas: ptr.To[int32](0),
+				Strategy: v1alpha1.RolloutStrategy{
+					Canary: &v1alpha1.CanaryStrategy{
+						Steps: []v1alpha1.CanaryStep{{SetWeight: ptr.To[int32](25)}},
+					},
+				},
+			},
+			Status: v1alpha1.RolloutStatus{
+				StableRS:         "stablehash",
+				CurrentPodHash:   "newhash",
+				CurrentStepIndex: ptr.To[int32](0),
+			},
+		},
+	}
+	ctx.pauseContext = &pauseContext{rollout: ctx.rollout}
+	ctx.log = logutil.WithRollout(ctx.rollout)
+
+	result := ctx.shouldFullPromote(v1alpha1.RolloutStatus{})
+	assert.Equal(t, "Zero replicas - skipping canary steps", result)
 }
 
 func TestShouldFullPromoteWithReplicaProgressThreshold(t *testing.T) {

--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -381,7 +381,11 @@ func CalculateReplicaCountsForTrafficRoutedCanary(rollout *v1alpha1.Rollout, new
 	maxWeight := weightutil.MaxTrafficWeight(rollout)
 	if setCanaryScaleReplicas != nil {
 		// a canary count was explicitly set
-		canaryCount = *setCanaryScaleReplicas
+		if rolloutSpecReplica == 0 {
+			canaryCount = 0
+		} else {
+			canaryCount = *setCanaryScaleReplicas
+		}
 	} else {
 		canaryCount = CheckMinPodsPerReplicaSet(rollout, trafficWeightToReplicas(rolloutSpecReplica, desiredWeight, maxWeight))
 	}

--- a/utils/replicaset/canary_test.go
+++ b/utils/replicaset/canary_test.go
@@ -486,6 +486,19 @@ func TestCalculateReplicaCountsForCanary(t *testing.T) {
 			trafficRouting:             &v1alpha1.RolloutTrafficRouting{},
 		},
 		{
+			name: "Ignore setCanaryScale.replicas when spec.replicas is 0",
+
+			rolloutSpecReplicas:    0,
+			stableSpecReplica:      0,
+			stableAvailableReplica: 0,
+
+			expectedStableReplicaCount: 0,
+			expectedCanaryReplicaCount: 0,
+			setWeight:                  100,
+			setCanaryScale:             newSetCanaryScale(intPnt(1), nil, false),
+			trafficRouting:             &v1alpha1.RolloutTrafficRouting{},
+		},
+		{
 			name: "Use setCanaryScale.weight for canary replicas when specified with trafficRouting (and ignore setWeight)",
 
 			rolloutSpecReplicas:    4,


### PR DESCRIPTION
## Summary
When a canary Rollout has `spec.replicas: 0` and a new version is deployed, the controller now skips canary steps and immediately promotes the new ReplicaSet as stable. Previously, percentage-based steps were no-ops but explicit steps still ran — notably `pause` could suspend the rollout indefinitely, and `setCanaryScale.replicas` could spawn unexpected pods (e.g. scaling to 1 while the rollout was scaled down).
This matches the expected behavior for scaled-down workloads: with no pods to validate, canary progression adds no value. The new version becomes stable so that traffic routing (VirtualServices, Services, etc.) is already pointed at the correct hash when replicas are scaled back up.
## Changes
- **`shouldFullPromote`**: when `spec.replicas == 0` and an update is in progress, promote immediately with reason `"Zero replicas - skipping canary steps"`
- **`reconcileCanaryPause`**: skip pause steps at zero replicas
- **`CalculateReplicaCountsForTrafficRoutedCanary`**: ignore explicit `setCanaryScale.replicas` when `spec.replicas == 0`
- **Template-change path**: promote in the same reconcile when the pod-template-change fast path fires at zero replicas
Only applies when `spec.replicas` is explicitly set to `0` (not nil/default).


Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [ ] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [ ] I understand what the code does and WHY/HOW it works in several scenarios
* [ ] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).