### PR TITLE
fix(controller): skip unnecessary ephemeral metadata pod listing

### DIFF
--- a/rollout/ephemeralmetadata.go
+++ b/rollout/ephemeralmetadata.go
@@ -25,8 +25,32 @@ const DefaultEphemeralMetadataPodRetries = 3
 // DefaultEphemeralMetadataRetryBackoff is the base duration for exponential backoff between retry attempts
 const DefaultEphemeralMetadataRetryBackoff = 100 * time.Millisecond
 
+func hasEphemeralMetadataConfigured(rollout *v1alpha1.Rollout) bool {
+	if rollout.Spec.Strategy.Canary != nil {
+		return rollout.Spec.Strategy.Canary.CanaryMetadata != nil || rollout.Spec.Strategy.Canary.StableMetadata != nil
+	}
+	if rollout.Spec.Strategy.BlueGreen != nil {
+		return rollout.Spec.Strategy.BlueGreen.PreviewMetadata != nil || rollout.Spec.Strategy.BlueGreen.ActiveMetadata != nil
+	}
+	return false
+}
+
+func isZeroReplicaReplicaSet(rs *appsv1.ReplicaSet) bool {
+	if rs == nil {
+		return true
+	}
+	if rs.Spec.Replicas != nil && *rs.Spec.Replicas == 0 {
+		return true
+	}
+	return false
+}
+
 // reconcileEphemeralMetadata syncs canary/stable ephemeral metadata to ReplicaSets and pods
 func (c *rolloutContext) reconcileEphemeralMetadata() error {
+	if !hasEphemeralMetadataConfigured(c.rollout) {
+		return nil
+	}
+
 	ctx := context.TODO()
 	var newMetadata, stableMetadata *v1alpha1.PodTemplateMetadata
 	if c.rollout.Spec.Strategy.Canary != nil {
@@ -89,6 +113,10 @@ func (c *rolloutContext) syncEphemeralMetadata(ctx context.Context, rs *appsv1.R
 			return fmt.Errorf("failed to sync ephemeral metadata: %w", err)
 		}
 		c.log.Infof("synced ephemeral metadata %v to ReplicaSet %s", podMetadata, rs.Name)
+	}
+
+	if isZeroReplicaReplicaSet(rs) {
+		return nil
 	}
 
 	// 2. Sync ephemeral metadata to pods (always do this, even if replicaset wasn't modified so that we handle cases where

--- a/rollout/ephemeralmetadata_test.go
+++ b/rollout/ephemeralmetadata_test.go
@@ -566,3 +566,92 @@ func TestSyncEphemeralMetadata(t *testing.T) {
 	}
 	assert.Equal(t, expectedLabels, updatedPod.Labels)
 }
+
+func TestReconcileEphemeralMetadataSkipsWhenNotConfigured(t *testing.T) {
+	selector := &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}
+	zero := int32(0)
+	otherRS := &v1.ReplicaSet{
+		Spec: v1.ReplicaSetSpec{
+			Selector: selector,
+			Replicas: &zero,
+		},
+	}
+	kubeclient := k8sfake.NewSimpleClientset()
+	podListCalls := 0
+	kubeclient.Fake.PrependReactor("list", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		podListCalls++
+		return true, nil, fmt.Errorf("unexpected pod list")
+	})
+
+	mockContext := &rolloutContext{
+		reconcilerBase: reconcilerBase{
+			kubeclientset: kubeclient,
+		},
+		rollout: &v1alpha1.Rollout{
+			Spec: v1alpha1.RolloutSpec{
+				Strategy: v1alpha1.RolloutStrategy{
+					Canary: &v1alpha1.CanaryStrategy{},
+				},
+			},
+			Status: v1alpha1.RolloutStatus{
+				StableRS: "stable-hash",
+			},
+		},
+		newRS: &v1.ReplicaSet{
+			Spec: v1.ReplicaSetSpec{
+				Selector: selector,
+				Replicas: ptr.To[int32](3),
+			},
+		},
+		otherRSs: []*v1.ReplicaSet{otherRS},
+	}
+
+	err := mockContext.reconcileEphemeralMetadata()
+	assert.NoError(t, err)
+	assert.Equal(t, 0, podListCalls)
+}
+
+func TestSyncEphemeralMetadataSkipsPodListOnZeroReplicaRS(t *testing.T) {
+	testPodHash := "abc123"
+	zero := int32(0)
+	rs := &v1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "old-rs",
+			Namespace: "default",
+		},
+		Spec: v1.ReplicaSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"rollouts-pod-template-hash": testPodHash,
+				},
+			},
+			Replicas: &zero,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"role":                       "canary",
+						"rollouts-pod-template-hash": testPodHash,
+					},
+				},
+			},
+		},
+	}
+
+	kubeclient := k8sfake.NewSimpleClientset()
+	podListCalls := 0
+	kubeclient.Fake.PrependReactor("list", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		podListCalls++
+		return true, nil, fmt.Errorf("unexpected pod list")
+	})
+
+	ctx := &rolloutContext{
+		reconcilerBase: reconcilerBase{
+			kubeclientset: kubeclient,
+		},
+		log: logrus.WithField("test", "zero-replica"),
+	}
+
+	err := ctx.syncEphemeralMetadata(context.Background(), rs, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, podListCalls)
+}


### PR DESCRIPTION
## Summary

After #4477, `reconcileEphemeralMetadata()` always performs a live Pod List for every ReplicaSet it touches — including rollouts with no ephemeral metadata configured and zero-replica historical ReplicaSets.

For rollouts with a large revision history (e.g. `revisionHistoryLimit: 40`), this means ~41 apiserver List calls per reconcile with no corresponding log output when nothing needs updating. In production this drove p90 reconciliation time from ~250ms to ~10s on rollouts that do not use ephemeral metadata at all.

This change adds two guards:

- **Skip ephemeral metadata reconciliation entirely** when neither canary nor blue-green ephemeral metadata is configured (`CanaryMetadata`/`StableMetadata` or `PreviewMetadata`/`ActiveMetadata` are all nil).
- **Skip pod listing on zero-replica ReplicaSets** when metadata is configured. RS template cleanup still runs if needed; only the live Pod List is skipped since there are no pods to sync.

Rollouts that actively use ephemeral metadata are unchanged for their running ReplicaSets.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [ ] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [ ] I understand what the code does and WHY/HOW it works in several scenarios
* [ ] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).