### PR TITLE
fix(controller): limit ephemeral metadata pod listing to active RS

### DIFF
--- a/rollout/ephemeralmetadata.go
+++ b/rollout/ephemeralmetadata.go
@@ -94,11 +94,16 @@ func (c *rolloutContext) reconcileEphemeralMetadata() error {
 	return nil
 }
 
-func replicaSetNeedsPodMetadataSync(modified bool, rs *appsv1.ReplicaSet) bool {
+func replicaSetNeedsPodMetadataSync(modified bool, rs *appsv1.ReplicaSet, podMetadata *v1alpha1.PodTemplateMetadata) bool {
 	if modified {
 		return true
 	}
-	return replicasetutil.ParseExistingPodMetadata(rs) != nil
+	if replicasetutil.ParseExistingPodMetadata(rs) != nil {
+		return true
+	}
+	// Applying metadata to an unchanged RS still requires a pod sync: the template may
+	// already match while individual pods drifted (#4477).
+	return podMetadata != nil
 }
 
 func (c *rolloutContext) syncEphemeralMetadata(ctx context.Context, rs *appsv1.ReplicaSet, podMetadata *v1alpha1.PodTemplateMetadata) error {
@@ -139,7 +144,7 @@ func (c *rolloutContext) syncEphemeralMetadataInternal(ctx context.Context, rs *
 		return nil
 	}
 
-	if !replicaSetNeedsPodMetadataSync(modified, originalRSCopy) {
+	if !replicaSetNeedsPodMetadataSync(modified, originalRSCopy, podMetadata) {
 		return nil
 	}
 

--- a/rollout/ephemeralmetadata.go
+++ b/rollout/ephemeralmetadata.go
@@ -83,9 +83,10 @@ func (c *rolloutContext) reconcileEphemeralMetadata() error {
 		}
 	}
 
-	// Iterate all other ReplicaSets and verify we don't have injected metadata for them
+	// Iterate all other ReplicaSets and verify we don't have injected metadata for them.
+	// Only the RS template needs cleanup; active pods live on newRS/stableRS.
 	for _, rs := range c.otherRSs {
-		err := c.syncEphemeralMetadata(ctx, rs, nil)
+		err := c.syncEphemeralMetadataReplicaSetOnly(ctx, rs, nil)
 		if err != nil {
 			return err
 		}
@@ -93,7 +94,22 @@ func (c *rolloutContext) reconcileEphemeralMetadata() error {
 	return nil
 }
 
+func replicaSetNeedsPodMetadataSync(modified bool, rs *appsv1.ReplicaSet) bool {
+	if modified {
+		return true
+	}
+	return replicasetutil.ParseExistingPodMetadata(rs) != nil
+}
+
 func (c *rolloutContext) syncEphemeralMetadata(ctx context.Context, rs *appsv1.ReplicaSet, podMetadata *v1alpha1.PodTemplateMetadata) error {
+	return c.syncEphemeralMetadataInternal(ctx, rs, podMetadata, true)
+}
+
+func (c *rolloutContext) syncEphemeralMetadataReplicaSetOnly(ctx context.Context, rs *appsv1.ReplicaSet, podMetadata *v1alpha1.PodTemplateMetadata) error {
+	return c.syncEphemeralMetadataInternal(ctx, rs, podMetadata, false)
+}
+
+func (c *rolloutContext) syncEphemeralMetadataInternal(ctx context.Context, rs *appsv1.ReplicaSet, podMetadata *v1alpha1.PodTemplateMetadata, syncPods bool) error {
 	if rs == nil {
 		return nil
 	}
@@ -115,13 +131,20 @@ func (c *rolloutContext) syncEphemeralMetadata(ctx context.Context, rs *appsv1.R
 		c.log.Infof("synced ephemeral metadata %v to ReplicaSet %s", podMetadata, rs.Name)
 	}
 
+	if !syncPods {
+		return nil
+	}
+
 	if isZeroReplicaReplicaSet(rs) {
 		return nil
 	}
 
-	// 2. Sync ephemeral metadata to pods (always do this, even if replicaset wasn't modified so that we handle cases where
-	// the replicaset already had the correct metadata but some pods don't: e.g. a crash/OOM of the controller between the two steps,
-	// or simply a failure to update some pods in a previous attempt)
+	if !replicaSetNeedsPodMetadataSync(modified, originalRSCopy) {
+		return nil
+	}
+
+	// 2. Sync ephemeral metadata to pods when the ReplicaSet was updated or previously had
+	// injected metadata (handles crash/OOM between RS and pod updates, or partial pod sync).
 	pods, err := replicasetutil.GetPodsOwnedByReplicaSet(ctx, c.kubeclientset, rs)
 	if err != nil {
 		return err

--- a/rollout/ephemeralmetadata_test.go
+++ b/rollout/ephemeralmetadata_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/annotations"
+	replicasetutil "github.com/argoproj/argo-rollouts/utils/replicaset"
 )
 
 // TestSyncCanaryEphemeralMetadataInitialRevision verifies when we create a revision 1 ReplicaSet
@@ -652,6 +653,176 @@ func TestSyncEphemeralMetadataSkipsPodListOnZeroReplicaRS(t *testing.T) {
 	}
 
 	err := ctx.syncEphemeralMetadata(context.Background(), rs, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, podListCalls)
+}
+
+func TestSyncEphemeralMetadataSkipsPodListWhenUnchanged(t *testing.T) {
+	testPodHash := "abc123"
+	replicas := int32(3)
+	rs := &v1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stable-rs",
+			Namespace: "default",
+		},
+		Spec: v1.ReplicaSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"rollouts-pod-template-hash": testPodHash,
+				},
+			},
+			Replicas: &replicas,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"role":                       "stable",
+						"rollouts-pod-template-hash": testPodHash,
+					},
+				},
+			},
+		},
+	}
+	stableMetadata := &v1alpha1.PodTemplateMetadata{
+		Labels: map[string]string{"role": "stable"},
+	}
+
+	kubeclient := k8sfake.NewSimpleClientset()
+	podListCalls := 0
+	kubeclient.Fake.PrependReactor("list", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		podListCalls++
+		return true, nil, fmt.Errorf("unexpected pod list")
+	})
+
+	ctx := &rolloutContext{
+		reconcilerBase: reconcilerBase{
+			kubeclientset: kubeclient,
+		},
+		log: logrus.WithField("test", "unchanged"),
+	}
+
+	err := ctx.syncEphemeralMetadata(context.Background(), rs, stableMetadata)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, podListCalls)
+}
+
+func TestSyncEphemeralMetadataListsPodsWhenAnnotationPresent(t *testing.T) {
+	testPodHash := "abc123"
+	testUID := types.UID("rs-uid")
+	replicas := int32(1)
+	rs := &v1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stable-rs",
+			Namespace: "default",
+			UID:       testUID,
+			Annotations: map[string]string{
+				replicasetutil.EphemeralMetadataAnnotation: `{"labels":{"role":"stable"}}`,
+			},
+		},
+		Spec: v1.ReplicaSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"rollouts-pod-template-hash": testPodHash,
+				},
+			},
+			Replicas: &replicas,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"role":                       "stable",
+						"rollouts-pod-template-hash": testPodHash,
+					},
+				},
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stable-pod",
+			Namespace: "default",
+			Labels: map[string]string{
+				"role":                       "stable",
+				"rollouts-pod-template-hash": testPodHash,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "ReplicaSet",
+					Name:       rs.Name,
+					UID:        testUID,
+					Controller: ptr.To(true),
+				},
+			},
+		},
+	}
+	stableMetadata := &v1alpha1.PodTemplateMetadata{
+		Labels: map[string]string{"role": "stable"},
+	}
+
+	kubeclient := k8sfake.NewSimpleClientset(rs, pod)
+	podListCalls := 0
+	kubeclient.Fake.PrependReactor("list", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		podListCalls++
+		return false, nil, nil
+	})
+
+	ctx := &rolloutContext{
+		reconcilerBase: reconcilerBase{
+			kubeclientset:               kubeclient,
+			ephemeralMetadataThreads:    DefaultEphemeralMetadataThreads,
+			ephemeralMetadataPodRetries: DefaultEphemeralMetadataPodRetries,
+		},
+		log: logrus.WithField("test", "annotation"),
+	}
+
+	err := ctx.syncEphemeralMetadata(context.Background(), rs, stableMetadata)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, podListCalls)
+}
+
+func TestSyncEphemeralMetadataReplicaSetOnlySkipsPodListWithReplicas(t *testing.T) {
+	testPodHash := "abc123"
+	replicas := int32(2)
+	rs := &v1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "old-rs",
+			Namespace: "default",
+			Annotations: map[string]string{
+				replicasetutil.EphemeralMetadataAnnotation: `{"labels":{"role":"canary"}}`,
+			},
+		},
+		Spec: v1.ReplicaSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"rollouts-pod-template-hash": testPodHash,
+				},
+			},
+			Replicas: &replicas,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"role":                       "canary",
+						"rollouts-pod-template-hash": testPodHash,
+					},
+				},
+			},
+		},
+	}
+
+	kubeclient := k8sfake.NewSimpleClientset(rs)
+	podListCalls := 0
+	kubeclient.Fake.PrependReactor("list", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		podListCalls++
+		return true, nil, fmt.Errorf("unexpected pod list")
+	})
+
+	ctx := &rolloutContext{
+		reconcilerBase: reconcilerBase{
+			kubeclientset: kubeclient,
+		},
+		log: logrus.WithField("test", "rs-only"),
+	}
+
+	err := ctx.syncEphemeralMetadataReplicaSetOnly(context.Background(), rs, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, podListCalls)
 }

--- a/rollout/ephemeralmetadata_test.go
+++ b/rollout/ephemeralmetadata_test.go
@@ -657,12 +657,12 @@ func TestSyncEphemeralMetadataSkipsPodListOnZeroReplicaRS(t *testing.T) {
 	assert.Equal(t, 0, podListCalls)
 }
 
-func TestSyncEphemeralMetadataSkipsPodListWhenUnchanged(t *testing.T) {
+func TestSyncEphemeralMetadataSkipsPodListWhenNothingToSync(t *testing.T) {
 	testPodHash := "abc123"
 	replicas := int32(3)
 	rs := &v1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "stable-rs",
+			Name:      "old-rs",
 			Namespace: "default",
 		},
 		Spec: v1.ReplicaSetSpec{
@@ -675,15 +675,11 @@ func TestSyncEphemeralMetadataSkipsPodListWhenUnchanged(t *testing.T) {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"role":                       "stable",
 						"rollouts-pod-template-hash": testPodHash,
 					},
 				},
 			},
 		},
-	}
-	stableMetadata := &v1alpha1.PodTemplateMetadata{
-		Labels: map[string]string{"role": "stable"},
 	}
 
 	kubeclient := k8sfake.NewSimpleClientset()
@@ -697,10 +693,10 @@ func TestSyncEphemeralMetadataSkipsPodListWhenUnchanged(t *testing.T) {
 		reconcilerBase: reconcilerBase{
 			kubeclientset: kubeclient,
 		},
-		log: logrus.WithField("test", "unchanged"),
+		log: logrus.WithField("test", "nothing-to-sync"),
 	}
 
-	err := ctx.syncEphemeralMetadata(context.Background(), rs, stableMetadata)
+	err := ctx.syncEphemeralMetadata(context.Background(), rs, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, podListCalls)
 }


### PR DESCRIPTION
## Summary

After #4477, `reconcileEphemeralMetadata()` performs a live apiserver Pod List for every ReplicaSet it touches on every reconcile — including rollouts with no ephemeral metadata configured and ~40 zero-replica historical ReplicaSets. On rollouts with large revision histories (`revisionHistoryLimit: 40`), this produced ~41 silent Pod List calls per reconcile and drove p90 reconciliation time from ~250ms to ~10s.

This change adds guards to limit pod listing to cases that require it, while preserving #4477 crash-recovery behavior (RS template already correct but individual pods drifted).

### Changes

- **Skip entirely when metadata is not configured** — if `canaryMetadata`/`stableMetadata` (or blue-green equivalents) are all nil, return immediately with no RS iteration or pod lists.
- **RS-template-only cleanup for `otherRSs`** — historical ReplicaSets get stale ephemeral labels removed from their pod template if needed, but never trigger a Pod List. Running pods only exist on `newRS`/`stableRS`.
- **Skip pod list on zero-replica ReplicaSets** — no pods to sync when `spec.replicas == 0`.
- **Skip pod list when there is nothing to sync** — when clearing metadata (`podMetadata == nil`), the RS was not modified, and it has no `rollout.argoproj.io/ephemeral-metadata` annotation.
- **Preserve #4477 pod drift recovery** — still list and patch pods on active RSes when applying metadata (`podMetadata != nil`), even if the RS template is already correct, or when the ephemeral-metadata annotation is present (partial sync after controller restart).

### Expected API calls per reconcile

| Rollout | Before | After |
|---------|--------|-------|
| No ephemeral metadata (sharded rollouts) | ~41 Pod Lists | **0** |
| Ephemeral metadata, steady state | ~41 Pod Lists | **1** (active RS only) |
| Ephemeral metadata, canary upgrade | ~42 Pod Lists | **2** (newRS + stableRS) |
| Clearing metadata on old RSes | ~41 Pod Lists | **0** pod lists on otherRSs |

## Test plan

- [x] `TestReconcileEphemeralMetadataSkipsWhenNotConfigured`
- [x] `TestSyncEphemeralMetadataSkipsPodListOnZeroReplicaRS`
- [x] `TestSyncEphemeralMetadataSkipsPodListWhenNothingToSync`
- [x] `TestSyncEphemeralMetadataReplicaSetOnlySkipsPodListWithReplicas`
- [x] `TestSyncEphemeralMetadataListsPodsWhenAnnotationPresent`
- [x] `TestSyncCanaryEphemeralMetadataReplicaSetAlreadyPatched` — RS template correct, pod drifted (#4477)
- [x] `TestSyncBlueGreenEphemeralMetadataReplicaSetAlreadyPatched` — RS template correct, pod drifted (#4477)
- [x] Existing ephemeral metadata tests pass
- [ ] Deploy and confirm p90 reconciliation time drops for rollouts without ephemeral metadata
- [ ] Confirm rollouts with `canaryMetadata`/`stableMetadata` still apply labels during canary upgrades