### PR TITLE
fix(dashboard): prevent rollout mutation APIs from hanging. Fixes #4956

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -387,11 +387,8 @@ func (s *ArgoRolloutsServer) AbortRollout(ctx context.Context, q *rollout.AbortR
 	return abort.AbortRollout(rolloutIf, q.GetName())
 }
 
-func (s *ArgoRolloutsServer) getRollout(namespace string, name string) (*v1alpha1.Rollout, error) {
-	rolloutsInformerFactory := rolloutinformers.NewSharedInformerFactoryWithOptions(s.Options.RolloutsClientset, 0, rolloutinformers.WithNamespace(namespace))
-	cache.WaitForCacheSync(s.stopCh, rolloutsInformerFactory.Argoproj().V1alpha1().Rollouts().Informer().HasSynced)
-	rolloutsLister := rolloutsInformerFactory.Argoproj().V1alpha1().Rollouts().Lister().Rollouts(namespace)
-	return rolloutsLister.Get(name)
+func (s *ArgoRolloutsServer) getRollout(ctx context.Context, namespace string, name string) (*v1alpha1.Rollout, error) {
+	return s.Options.RolloutsClientset.ArgoprojV1alpha1().Rollouts(namespace).Get(ctx, name, v1.GetOptions{})
 }
 
 func (s *ArgoRolloutsServer) SetRolloutImage(ctx context.Context, q *rollout.SetImageRequest) (*v1alpha1.Rollout, error) {
@@ -400,7 +397,7 @@ func (s *ArgoRolloutsServer) SetRolloutImage(ctx context.Context, q *rollout.Set
 	if err != nil {
 		return nil, err
 	}
-	return s.getRollout(q.GetNamespace(), q.GetRollout())
+	return s.getRollout(ctx, q.GetNamespace(), q.GetRollout())
 }
 
 func (s *ArgoRolloutsServer) UndoRollout(ctx context.Context, q *rollout.UndoRolloutRequest) (*v1alpha1.Rollout, error) {
@@ -409,7 +406,7 @@ func (s *ArgoRolloutsServer) UndoRollout(ctx context.Context, q *rollout.UndoRol
 	if err != nil {
 		return nil, err
 	}
-	return s.getRollout(q.GetNamespace(), q.GetRollout())
+	return s.getRollout(ctx, q.GetNamespace(), q.GetRollout())
 }
 
 func (s *ArgoRolloutsServer) RetryRollout(ctx context.Context, q *rollout.RetryRolloutRequest) (*v1alpha1.Rollout, error) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -65,7 +65,7 @@ func TestSetRolloutImageReturnsRollout(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.Equal(t, expected.Name, actual.Name)
+	assert.Equal(t, expected, actual)
 }
 
 func TestUndoRolloutReturnsRollout(t *testing.T) {
@@ -78,11 +78,11 @@ func TestUndoRolloutReturnsRollout(t *testing.T) {
 	actual, err := s.UndoRollout(ctx, &rolloutapi.UndoRolloutRequest{
 		Namespace: expected.Namespace,
 		Rollout:   expected.Name,
-		Revision:  31,
+		Revision:  29,
 	})
 
 	require.NoError(t, err)
-	assert.Equal(t, expected.Name, actual.Name)
+	assert.Equal(t, expected, actual)
 }
 
 func TestNewHTTPServer(t *testing.T) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5,9 +5,85 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	rolloutapi "github.com/argoproj/argo-rollouts/pkg/apiclient/rollout"
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/info/testdata"
+	fakeoptions "github.com/argoproj/argo-rollouts/pkg/kubectl-argo-rollouts/options/fake"
 )
+
+func newTestServer(t *testing.T, objects ...runtime.Object) *ArgoRolloutsServer {
+	t.Helper()
+	tf, o := fakeoptions.NewFakeArgoRolloutsOptions(objects...)
+	t.Cleanup(tf.Cleanup)
+	return &ArgoRolloutsServer{
+		Options: ServerOptions{
+			KubeClientset:     o.KubeClient,
+			RolloutsClientset: o.RolloutsClient,
+			DynamicClientset:  o.DynamicClient,
+		},
+	}
+}
+
+func TestGetRollout(t *testing.T) {
+	expected := &v1alpha1.Rollout{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rollout",
+			Namespace: "default",
+		},
+	}
+	s := newTestServer(t, expected)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	actual, err := s.getRollout(ctx, expected.Namespace, expected.Name)
+
+	require.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestSetRolloutImageReturnsRollout(t *testing.T) {
+	objects := testdata.NewCanaryRollout()
+	expected := objects.Rollouts[0]
+	container := expected.Spec.Template.Spec.Containers[0]
+	s := newTestServer(t, objects.AllObjects()...)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	actual, err := s.SetRolloutImage(ctx, &rolloutapi.SetImageRequest{
+		Namespace: expected.Namespace,
+		Rollout:   expected.Name,
+		Container: container.Name,
+		Image:     "quay.io/argoproj/rollouts-demo",
+		Tag:       "updated",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, expected.Name, actual.Name)
+}
+
+func TestUndoRolloutReturnsRollout(t *testing.T) {
+	objects := testdata.NewCanaryRollout()
+	expected := objects.Rollouts[0]
+	s := newTestServer(t, objects.AllObjects()...)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	actual, err := s.UndoRollout(ctx, &rolloutapi.UndoRolloutRequest{
+		Namespace: expected.Namespace,
+		Rollout:   expected.Name,
+		Revision:  31,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, expected.Name, actual.Name)
+}
 
 func TestNewHTTPServer(t *testing.T) {
 	t.Run("server is created with correct address", func(t *testing.T) {


### PR DESCRIPTION
## Summary

* replace the per-request informer cache in `getRollout` with a direct typed client `Get`
* propagate the request context from `UndoRollout` and `SetRolloutImage` to the follow-up read
* add regression tests covering `getRollout` and both affected handlers

## Problem

`getRollout` creates an informer factory and immediately calls `WaitForCacheSync`, but the informer is never started. The cache therefore cannot sync, leaving successful undo and set image requests waiting indefinitely while trying to build their responses.

A one-off read after a mutation does not need a new informer cache. Using the typed client directly also follows the existing single-resource read pattern used elsewhere in the repository and allows request cancellation to propagate.

Fixes #4956

## Testing

* `go test ./server -count=1`
* `go vet ./server`
* `go test ./server -run 'Test(GetRollout|SetRolloutImageReturnsRollout|UndoRolloutReturnsRollout)$' -count=10`

Checklist:

* [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is conventional, states what changed, and suffixes the related issue number.
* [x] I've signed my commits with DCO.
* [x] My targeted builds and tests are green.
* [x] I have written unit tests for my change.
* [x] I have run all repository tests locally (including the flaky ones) and they pass on my workstation.
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR.
* [x] I understand what the code does and WHY/HOW it works in several scenarios.
* [x] This fixes existing dashboard API behavior and does not add new functionality.
* [ ] My organization is added to `USERS.md`.
