### PR TITLE
fix(controller)!: do not block abort/progressDeadline on traffic routing errors. Fixes #4626

### DIFF
--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -76,7 +76,9 @@ func (c *rolloutContext) rolloutCanary() error {
 		// (experiments, analysis, ReplicaSet scaling, step plugins), and proceed directly to
 		// status sync so conditions and abort/progressDeadline are still evaluated.
 		c.trafficRoutingNotApplied = true
-		c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: "TrafficRoutingError"}, err.Error())
+		// This is the single emission point for TrafficRoutingError events: every error from
+		// reconcileTrafficRouting() funnels through here exactly once per reconcile.
+		c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: "TrafficRoutingError"}, "%s", err.Error())
 		c.log.Warnf("Traffic routing not applied, syncing status before requeue: %v", err)
 		c.enqueueRolloutAfter(c.rollout, defaults.GetRolloutVerifyRetryInterval())
 		return c.syncRolloutStatusCanary()

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -138,6 +138,14 @@ func (c *rolloutContext) reconcileCanaryStableReplicaSet() (bool, error) {
 		// Therefore, we send c.rollout.Status.Canary.Weights so that the stable scaling happens in
 		// a *susbsequent*, follow-up reconciliation, lagging behind the setWeight and service switch.
 		_, desiredStableRSReplicaCount = replicasetutil.CalculateReplicaCountsForTrafficRoutedCanary(c.rollout, c.newRS, c.stableRS, c.rollout.Status.Canary.Weights)
+		// Never scale down the stable ReplicaSet based on weights the traffic provider has not
+		// verified yet (e.g. ALB load balancer weights still propagating): the provider may
+		// still be routing traffic to stable. Scale-up is still allowed.
+		weights := c.rollout.Status.Canary.Weights
+		if weights != nil && weights.Verified != nil && !*weights.Verified && desiredStableRSReplicaCount < *c.stableRS.Spec.Replicas {
+			c.log.Infof("Holding stable ReplicaSet at %d replicas (desired %d): desired traffic weights are not yet verified", *c.stableRS.Spec.Replicas, desiredStableRSReplicaCount)
+			desiredStableRSReplicaCount = *c.stableRS.Spec.Replicas
+		}
 	}
 	scaled, _, err := c.scaleReplicaSetAndRecordEvent(c.stableRS, desiredStableRSReplicaCount)
 	if err != nil {

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -65,7 +65,21 @@ func (c *rolloutContext) rolloutCanary() error {
 	}
 
 	if err := c.reconcileTrafficRouting(); err != nil {
-		return err
+		// A traffic routing error means the desired routing state was not applied this
+		// reconcile, but it must not block the rest of the sync: historically, returning here
+		// meant syncRolloutStatusCanary() -> persistRolloutStatus() never ran, so a rollout
+		// whose router errored persistently (e.g. Istio delaying the DestinationRule switch
+		// because the canary never becomes available, or a misconfigured ingress) could never
+		// time out, turn Degraded, or auto-abort via progressDeadlineAbort (see #4626).
+		// Instead, flag the failure so the current step is not completed and stable is not
+		// promoted, skip the stages that assume traffic is where status says it is
+		// (experiments, analysis, ReplicaSet scaling, step plugins), and proceed directly to
+		// status sync so conditions and abort/progressDeadline are still evaluated.
+		c.trafficRoutingNotApplied = true
+		c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: "TrafficRoutingError"}, err.Error())
+		c.log.Warnf("Traffic routing not applied, syncing status before requeue: %v", err)
+		c.enqueueRolloutAfter(c.rollout, defaults.GetRolloutVerifyRetryInterval())
+		return c.syncRolloutStatusCanary()
 	}
 
 	err = c.reconcileExperiments()
@@ -306,6 +320,13 @@ func (c *rolloutContext) canProceedWithScaleDownAnnotation(oldRSs []*appsv1.Repl
 
 func (c *rolloutContext) completedCurrentCanaryStep() bool {
 	if c.rollout.Spec.Paused {
+		return false
+	}
+	// The traffic router failed to apply (or intentionally deferred) the desired routing state
+	// this reconcile, so the desired traffic weight is not in effect. Advancing the step now
+	// would let the rollout progress with stale routing. Hold the step until the router applies
+	// it on a subsequent reconcile.
+	if c.trafficRoutingNotApplied {
 		return false
 	}
 	currentStep, currentStepIndex := replicasetutil.GetCurrentCanaryStep(c.rollout)

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -2179,3 +2179,69 @@ func TestIsDynamicallyRollingBackToStable(t *testing.T) {
 		})
 	}
 }
+
+// TestCanaryStableReplicaSetScaleDownHeldWhileWeightUnverified verifies that the stable
+// ReplicaSet is never scaled down based on traffic weights the provider has not verified yet
+// (weights.verified == false, e.g. ALB load balancer weights still propagating at the end of
+// the rollout): the provider may still be routing traffic to stable. Verified weights, and
+// nil verification (providers that do not implement VerifyWeight), scale down as usual.
+func TestCanaryStableReplicaSetScaleDownHeldWhileWeightUnverified(t *testing.T) {
+	tests := []struct {
+		name           string
+		verified       *bool
+		expectedScaled bool
+	}{
+		{"unverified weights hold stable scale-down", ptr.To[bool](false), false},
+		{"verified weights allow stable scale-down", ptr.To[bool](true), true},
+		{"nil verification allows stable scale-down", nil, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFixture(t)
+			defer f.Close()
+
+			steps := []v1alpha1.CanaryStep{
+				{SetWeight: ptr.To[int32](10)},
+				{Pause: &v1alpha1.RolloutPause{}},
+			}
+			r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](2), intstr.FromInt(1), intstr.FromInt(0))
+			r2 := bumpVersion(r1)
+			r2.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
+			r2.Spec.Strategy.Canary.CanaryService = "canary"
+			r2.Spec.Strategy.Canary.StableService = "stable"
+			r2.Spec.Strategy.Canary.DynamicStableScale = true
+
+			rs1 := newReplicaSetWithStatus(r1, 10, 10)
+			rs2 := newReplicaSetWithStatus(r2, 10, 10)
+			rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+			rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+			canarySvc := newService("canary", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}, r2)
+			stableSvc := newService("stable", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}, r2)
+
+			r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 20, 10, 20, false)
+			// All steps are completed and the full desired weight has been applied, but the
+			// provider has not necessarily verified it yet. With DynamicStableScale the desired
+			// stable count computed from these weights is 0.
+			r2.Status.Canary.Weights = &v1alpha1.TrafficWeights{
+				Canary:   v1alpha1.WeightDestination{Weight: 100, ServiceName: "canary", PodTemplateHash: rs2PodHash},
+				Stable:   v1alpha1.WeightDestination{Weight: 0, ServiceName: "stable", PodTemplateHash: rs1PodHash},
+				Verified: tc.verified,
+			}
+
+			f.kubeobjects = append(f.kubeobjects, rs1, rs2, canarySvc, stableSvc)
+			f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+			f.serviceLister = append(f.serviceLister, canarySvc, stableSvc)
+			f.rolloutLister = append(f.rolloutLister, r2)
+			f.objects = append(f.objects, r2)
+
+			ctrl, _, _ := f.newController(noResyncPeriodFunc)
+			roCtx, err := ctrl.newRolloutContext(r2)
+			assert.NoError(t, err)
+
+			scaled, err := roCtx.reconcileCanaryStableReplicaSet()
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedScaled, scaled,
+				"stable scale-down must only happen when weights are verified or verification is not implemented")
+		})
+	}
+}

--- a/rollout/context.go
+++ b/rollout/context.go
@@ -59,6 +59,15 @@ type rolloutContext struct {
 	// annotation at the start of reconciliation (before it may be removed).
 	// Used to detect fast rollbacks where we skip pause/analysis steps.
 	newRSWithinDelay bool
+
+	// trafficRoutingNotApplied indicates the traffic router failed to apply (or intentionally
+	// deferred applying) the desired routing state this reconcile, e.g. an ingress update
+	// error or Istio delaying the DestinationRule switch while a traffic-receiving ReplicaSet
+	// is unavailable. It is treated as a non-fatal condition: reconciliation proceeds to
+	// status sync so abort/progressDeadline handling still runs (see #4626), but the current
+	// canary step must not be considered completed and stable must not be promoted, since the
+	// desired traffic state was never actually applied.
+	trafficRoutingNotApplied bool
 }
 
 func (c *rolloutContext) reconcile() error {

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -1254,6 +1254,19 @@ func (c *rolloutContext) shouldFullPromote(newStatus v1alpha1.RolloutStatus) str
 		if c.pauseContext.IsAborted() {
 			return ""
 		}
+		// The traffic router failed to apply the desired routing state this reconcile, so we
+		// cannot trust that traffic has actually shifted to the canary. Promoting stable now
+		// would let the old stable ReplicaSet scale down while it may still be receiving
+		// traffic. Hold promotion until the router applies the desired state.
+		if c.trafficRoutingNotApplied {
+			return ""
+		}
+		// The desired traffic weight was applied but has not been verified with the underlying
+		// provider yet (e.g. ALB load balancer weights still propagating). This is the canary
+		// equivalent of the blue-green areTargetsVerified() check below.
+		if newStatus.Canary.Weights != nil && newStatus.Canary.Weights.Verified != nil && !*newStatus.Canary.Weights.Verified {
+			return ""
+		}
 		// Block promotion only when canary has fewer available than desired (e.g. still scaling up).
 		// When canary has >= desired (e.g. HPA scaled rollout down so desired=1 but canary still has 2),
 		// allow promotion so rollout can complete and then scale down to desired.

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -343,12 +343,13 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 				logCtx := logutil.WithRollout(c.rollout)
 				logCtx.Info("rollout enqueue due to trafficrouting")
 				c.enqueueRolloutAfter(c.rollout, defaults.GetRolloutVerifyRetryInterval())
-				// At the end of the rollout we need to verify the weight is correct, and return an error if not because we don't want the rest of the
-				// reconcile process to continue. We don't need to do this if we are in the middle of the rollout because the rest of the reconcile
-				// process won't scale down the old replicasets yet due to being in the middle of some steps.
-				if desiredWeight == weightutil.MaxTrafficWeight(c.rollout) && len(c.rollout.Spec.Strategy.Canary.Steps) >= int(*c.rollout.Status.CurrentStepIndex) {
-					return fmt.Errorf("end of rollout, desired weight %d not yet verified", desiredWeight)
-				}
+				// An unverified weight is expected and transient, so hold its consequences
+				// instead of failing the reconcile: step progression is held by
+				// completedCurrentCanaryStep(), and stable promotion and stable scale-down
+				// (which previously made an unverified weight dangerous at the end of the
+				// rollout) are held by shouldFullPromote() and
+				// reconcileCanaryStableReplicaSet(). Failing here would block
+				// abort/progressDeadline evaluation until the weight verified (see #4626).
 			}
 		}
 	}

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -298,7 +298,6 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 		if (c.newRS == nil || c.newRS.Status.AvailableReplicas == 0) &&
 			c.rollout.Status.Canary.Weights != nil && c.rollout.Status.Canary.Weights.Canary.Weight > 0 {
 			if err := reconciler.SetWeight(desiredWeight, weightDestinations...); err != nil {
-				c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: "TrafficRoutingError"}, err.Error())
 				return err
 			}
 		}
@@ -310,7 +309,6 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 
 		err = reconciler.SetWeight(desiredWeight, weightDestinations...)
 		if err != nil {
-			c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: "TrafficRoutingError"}, err.Error())
 			return err
 		}
 

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -117,7 +117,8 @@ func TestReconcileTrafficRoutingSetWeightErr(t *testing.T) {
 	assert.Nil(t, patchedRollout.Status.CurrentStepIndex,
 		"SetWeight error must not complete the setWeight step (currentStepIndex must not advance); patched status: %+v", patchedRollout.Status)
 	eventsStr := strings.Join(f.events, " ")
-	assert.Contains(t, eventsStr, "TrafficRoutingError", "SetWeight error must be surfaced as an event")
+	assert.Equal(t, 1, strings.Count(eventsStr, "TrafficRoutingError"),
+		"SetWeight error must be surfaced as exactly one event; events: %v", f.events)
 	assert.NotContains(t, eventsStr, "RolloutStepCompleted", "SetWeight error must not emit a step-completed event")
 }
 

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -264,13 +264,17 @@ func TestReconcileTrafficRoutingVerifyWeightEndOfRollout(t *testing.T) {
 	patchIndex := f.expectPatchRolloutAction(r2)
 	f.run(getKey(r2, t))
 
-	// An unverified weight at the end of the rollout must not fail the reconcile (that would
-	// block abort/progressDeadline evaluation, see #4626), but it must hold stable promotion:
-	// promoting now would let the old stable ReplicaSet scale down while the load balancer may
-	// still be sending it traffic.
+	// An unverified weight at the end of the rollout is expected and transient (e.g. ALB load
+	// balancer weights still propagating), so it must not fail the reconcile (that would block
+	// abort/progressDeadline evaluation, see #4626) and must not emit warning events. It must
+	// however hold stable promotion: promoting now would let the old stable ReplicaSet scale
+	// down while the load balancer may still be sending it traffic.
 	patch := f.getPatchedRollout(patchIndex)
 	assert.NotContains(t, patch, fmt.Sprintf(`"stableRS":"%s"`, rs2PodHash),
 		"stable must not be promoted while the desired weight is unverified; patch: %s", patch)
+	eventsStr := strings.Join(f.events, " ")
+	assert.NotContains(t, eventsStr, "TrafficRoutingError",
+		"an unverified weight at end of rollout is routine and must not emit warning events")
 }
 
 func TestRolloutUseDesiredWeight(t *testing.T) {

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -100,13 +101,88 @@ func newTrafficWeightFixture(t *testing.T) (*fixture, *v1alpha1.Rollout) {
 	return f, r2
 }
 
+// verify that a SetWeight error does not fail the reconcile: status is still synced (so
+// abort/progressDeadline handling can run, see #4626), but the current step is not completed
+// since the desired traffic weight was never applied.
 func TestReconcileTrafficRoutingSetWeightErr(t *testing.T) {
 	f, ro := newTrafficWeightFixture(t)
 	defer f.Close()
 	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
 	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(errors.New("Error message"))
-	f.runExpectError(getKey(ro, t), true)
+	patchIndex := f.expectPatchRolloutAction(ro)
+	f.run(getKey(ro, t))
+
+	patchedRollout := f.getPatchedRolloutAsObject(patchIndex)
+	assert.Nil(t, patchedRollout.Status.CurrentStepIndex,
+		"SetWeight error must not complete the setWeight step (currentStepIndex must not advance); patched status: %+v", patchedRollout.Status)
+	eventsStr := strings.Join(f.events, " ")
+	assert.Contains(t, eventsStr, "TrafficRoutingError", "SetWeight error must be surfaced as an event")
+	assert.NotContains(t, eventsStr, "RolloutStepCompleted", "SetWeight error must not emit a step-completed event")
+}
+
+// TestCanaryProgressDeadlineAbortNotBlockedByTrafficRoutingError reproduces the user-facing
+// symptom of #4626 for any traffic provider: a canary rollout with progressDeadlineAbort
+// enabled, stuck past its progress deadline, must still auto-abort even while the traffic
+// router errors persistently (e.g. Istio delaying the DestinationRule switch because the
+// canary never becomes available, or a misconfigured ingress).
+//
+// Before the fix, any error from reconcileTrafficRouting() caused rolloutCanary() to return
+// before ever reaching syncRolloutStatusCanary() -> persistRolloutStatus() ->
+// evaluateProgressDeadlineAbort(), so the rollout could never time out, turn Degraded, or
+// auto-abort, no matter how long it stayed stuck.
+func TestCanaryProgressDeadlineAbortNotBlockedByTrafficRoutingError(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{{SetWeight: ptr.To[int32](10)}}
+	r1 := newCanaryRollout("foo", 20, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(0))
+	progressDeadlineSeconds := int32(1)
+	r1.Spec.ProgressDeadlineSeconds = &progressDeadlineSeconds
+	r1.Spec.ProgressDeadlineAbort = true
+	r2 := bumpVersion(r1)
+	r2.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
+	r2.Spec.Strategy.Canary.CanaryService = "canary"
+	r2.Spec.Strategy.Canary.StableService = "stable"
+
+	rs1 := newReplicaSetWithStatus(r1, 20, 20)
+	// Canary RS is at its desired replica count for the 10% step (2 of 20), but only 1 of 2 is
+	// available: pods exist but are stuck (e.g. crashlooping). Since nothing here changes
+	// replica counts or increases availability, this reconcile makes no progress, isolating
+	// the "still progressing" guard in evaluateProgressDeadlineAbort from the one we're
+	// actually testing.
+	rs2 := newReplicaSetWithStatus(r2, 2, 1)
+
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	canarySelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}
+	stableSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}
+	canarySvc := newService("canary", 80, canarySelector, r2)
+	stableSvc := newService("stable", 80, stableSelector, r2)
+
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2, canarySvc, stableSvc)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+
+	// availableReplicas=21 and updatedReplicas=2 mirror exactly what this reconcile will
+	// compute from the live ReplicaSets above (20 available on stable + 1 on canary, 2 spec'd
+	// on canary), so the only thing distinguishing "before" from "after" this reconcile is
+	// progress-deadline evaluation.
+	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 21, 2, 22, false)
+	msg := fmt.Sprintf("ReplicaSet %q has timed out progressing.", rs2.Name)
+	progressingTimeoutCond := conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionFalse, conditions.TimedOutReason, msg)
+	conditions.SetRolloutCondition(&r2.Status, *progressingTimeoutCond)
+
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2)
+
+	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(
+		fmt.Errorf("delaying destination rule switch: ReplicaSet %s not fully available", rs2.Name))
+
+	patchIndex := f.expectPatchRolloutAction(r2)
+	f.run(getKey(r2, t))
+
+	f.verifyPatchedRolloutAborted(patchIndex, rs2.Name)
 }
 
 // verify error is not returned when VerifyWeight returns error (so that we can continue reconciling)
@@ -185,7 +261,16 @@ func TestReconcileTrafficRoutingVerifyWeightEndOfRollout(t *testing.T) {
 	})
 	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
 	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](false), nil)
-	f.runExpectError(getKey(r2, t), true)
+	patchIndex := f.expectPatchRolloutAction(r2)
+	f.run(getKey(r2, t))
+
+	// An unverified weight at the end of the rollout must not fail the reconcile (that would
+	// block abort/progressDeadline evaluation, see #4626), but it must hold stable promotion:
+	// promoting now would let the old stable ReplicaSet scale down while the load balancer may
+	// still be sending it traffic.
+	patch := f.getPatchedRollout(patchIndex)
+	assert.NotContains(t, patch, fmt.Sprintf(`"stableRS":"%s"`, rs2PodHash),
+		"stable must not be promoted while the desired weight is unverified; patch: %s", patch)
 }
 
 func TestRolloutUseDesiredWeight(t *testing.T) {
@@ -1947,8 +2032,9 @@ func TestNewRolloutResetsWeightBeforeUpdatingHash(t *testing.T) {
 }
 
 // TestTrafficRoutingErrorsWhenNewCanaryHasNoReplicas verifies that errors from
-// SetWeight and RemoveManagedRoutes are properly propagated when the new canary
-// has no available replicas.
+// SetWeight and RemoveManagedRoutes when the new canary has no available replicas
+// do not fail the reconcile (status is still synced so abort/progressDeadline
+// handling can run, see #4626), but hold the current step.
 func TestTrafficRoutingErrorsWhenNewCanaryHasNoReplicas(t *testing.T) {
 	const (
 		canaryService = "myservice-canary"
@@ -2027,9 +2113,17 @@ func TestTrafficRoutingErrorsWhenNewCanaryHasNoReplicas(t *testing.T) {
 			f.fakeTrafficRouting.On("RemoveManagedRoutes").Return(tc.removeManagedRoutesErr)
 			f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](true), nil)
 
-			f.runExpectError(getKey(r2, t), true)
+			patchIndex := f.expectPatchRolloutAction(r2)
+			f.run(getKey(r2, t))
 
 			f.fakeTrafficRouting.AssertCalled(t, tc.expectedCall, mock.Anything, mock.Anything)
+			patchedRollout := f.getPatchedRolloutAsObject(patchIndex)
+			if patchedRollout.Status.CurrentStepIndex != nil {
+				assert.Equal(t, int32(0), *patchedRollout.Status.CurrentStepIndex,
+					"traffic routing error must not complete the current step")
+			}
+			eventsStr := strings.Join(f.events, " ")
+			assert.Contains(t, eventsStr, "TrafficRoutingError", "traffic routing error must be surfaced as an event")
 		})
 	}
 }

--- a/test/e2e/istio/istio-subset-split-progress-deadline-abort.yaml
+++ b/test/e2e/istio/istio-subset-split-progress-deadline-abort.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-subset-split-pda
+spec:
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app: istio-subset-split-pda
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: istio-subset-split-pda-vsvc
+spec:
+  hosts:
+  - istio-subset-split-pda
+  http:
+  - name: primary
+    route:
+    - destination:
+        host: istio-subset-split-pda
+        subset: stable
+      weight: 100
+    - destination:
+        host: istio-subset-split-pda
+        subset: canary
+      weight: 0
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: istio-subset-split-pda-destrule
+spec:
+  host: istio-subset-split-pda
+  subsets:
+  - name: stable
+    labels:
+      app: istio-subset-split-pda
+  - name: canary
+    labels:
+      app: istio-subset-split-pda
+
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: istio-subset-split-pda
+spec:
+  strategy:
+    canary:
+      trafficRouting:
+        istio:
+          virtualService:
+            name: istio-subset-split-pda-vsvc
+            routes:
+            - primary
+          destinationRule:
+            name: istio-subset-split-pda-destrule
+            canarySubsetName: canary
+            stableSubsetName: stable
+      steps:
+      - setWeight: 10
+      - pause: {}
+  selector:
+    matchLabels:
+      app: istio-subset-split-pda
+  template:
+    metadata:
+      labels:
+        app: istio-subset-split-pda
+    spec:
+      containers:
+      - name: istio-subset-split-pda
+        image: nginx:1.19-alpine
+        ports:
+        - name: http
+          containerPort: 80
+          protocol: TCP
+        resources:
+          requests:
+            memory: 16Mi
+            cpu: 5m

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -294,6 +294,48 @@ func (s *IstioSuite) TestIstioSubsetSplitSingleRoute() {
 		ExpectRevisionPodCount("1", 1) // don't scale down old replicaset since it will be within scaleDownDelay
 }
 
+// TestIstioSubsetSplitProgressDeadlineAbortWithUnavailableCanary reproduces #4626: with
+// subset-level traffic routing (no canary/stable services), the Istio reconciler intentionally
+// delays the DestinationRule switch while the canary ReplicaSet is unavailable and reports it
+// as an error on every reconcile. That error must not block progressDeadline evaluation: a
+// canary whose pods can never become available must still time out, turn Degraded, and
+// auto-abort when progressDeadlineAbort is set. Before the fix, the rollout stayed Progressing
+// indefinitely (this test times out waiting for Degraded).
+func (s *IstioSuite) TestIstioSubsetSplitProgressDeadlineAbortWithUnavailableCanary() {
+	s.Given().
+		RolloutObjects("@istio/istio-subset-split-progress-deadline-abort.yaml").
+		When().
+		ApplyManifests().
+		WaitForRolloutStatus("Healthy").
+		PatchSpec(`
+spec:
+  progressDeadlineAbort: true
+  progressDeadlineSeconds: 10
+  template:
+    spec:
+      containers:
+      - name: istio-subset-split-pda
+        image: nginx:1.19-alpine-argo-error
+        command: null`).
+		WaitForRolloutStatus("Degraded").
+		Sleep(3*time.Second).
+		Then().
+		ExpectRollout("Abort=True", func(r *v1alpha1.Rollout) bool {
+			return r.Status.Abort
+		}).
+		Assert(func(t *fixtures.Then) {
+			// traffic must never have shifted to the unavailable canary
+			vsvc := t.GetVirtualService()
+			assert.Equal(s.T(), int64(100), vsvc.Spec.HTTP[0].Route[0].Weight)
+			assert.Equal(s.T(), int64(0), vsvc.Spec.HTTP[0].Route[1].Weight)
+
+			// stable subset must still point at the stable ReplicaSet
+			rs1 := t.GetReplicaSetByRevision("1")
+			destrule := t.GetDestinationRule()
+			assert.Equal(s.T(), rs1.Spec.Template.Labels[v1alpha1.DefaultRolloutUniqueLabelKey], destrule.Spec.Subsets[0].Labels[v1alpha1.DefaultRolloutUniqueLabelKey])
+		})
+}
+
 func (s *IstioSuite) TestIstioAbortUpdate() {
 	s.Given().
 		RolloutObjects("@istio/istio-host-split.yaml").


### PR DESCRIPTION
## Summary

Any error returned by `reconcileTrafficRouting()` short-circuits `rolloutCanary()` before it reaches `syncRolloutStatusCanary()` → `persistRolloutStatus()`, which is where `evaluateProgressDeadlineAbort()`, the `Progressing`-condition timeout evaluation, and `requeueStuckRollout()` live. A rollout whose traffic router errors *persistently* can therefore never time out, turn `Degraded`, or auto-abort — the controller retries the same reconcile forever and the rollout stays `Progressing` until manual intervention.

This is not Istio-specific. Any provider that can produce a persistent error is affected:

- **Istio**: subset-level routing intentionally delays the DestinationRule switch while a traffic-receiving ReplicaSet is unavailable and returns it as an error (#4626 — hit three times in production, once requiring a controller restart). This is the third recurrence of this symptom: introduced by #3602, fixed by #4299, reintroduced by #4612 (each time trading it against the rollback weight-ordering bug).
- **Nginx / Ambassador / APISIX / Traefik / plugins**: a missing or misconfigured ingress/route makes `SetWeight` fail every reconcile with the same result.
- **ALB**: mid-rollout `VerifyWeight=false` behaves correctly (holds the step, keeps reconciling), but at end-of-rollout an unverified weight is converted into a fatal error, blocking abort at the final step.

## Fix

Rather than distinguishing "expected" provider errors case-by-case (the approach in #4823, see discussion there), treat *all* traffic routing errors as non-fatal for status synchronization:

1. **`rollout/canary.go`**: on `reconcileTrafficRouting()` error, record `trafficRoutingNotApplied` on the `rolloutContext`, emit a `TrafficRoutingError` event, requeue after the verify retry interval, and proceed directly to `syncRolloutStatusCanary()`. The stages that assume traffic is where status says it is (experiments, analysis, ReplicaSet scaling, step plugins) are still skipped, exactly as before.
2. **`rollout/canary.go` `completedCurrentCanaryStep()`**: hold the current step while the desired routing state was not applied, so `currentStepIndex` cannot advance with stale routing.
3. **`rollout/sync.go` `shouldFullPromote()`**: hold stable promotion while routing was not applied or the desired weight is unverified (the canary equivalent of the blue-green `areTargetsVerified()` check), so the old stable ReplicaSet cannot scale down via promotion while the load balancer may still be sending it traffic.
4. **`rollout/trafficrouting.go`**: remove the end-of-rollout fatal error for an unverified weight. With the gates above it was redundant for promotion safety, and absorbing it would have emitted a `TrafficRoutingError` warning event on every reconcile of a routine verification window (e.g. ALB weights propagating for 30-60s at the end of every rollout). `VerifyWeight=false` now behaves identically mid-rollout and at end-of-rollout: log, requeue after the verify retry interval, keep reconciling.
5. **`rollout/canary.go` `reconcileCanaryStableReplicaSet()`**: never scale the stable ReplicaSet *down* based on weights the provider has not verified yet. The removed error was implicitly preventing this hazard for `dynamicStableScale` (unverified weights can now be persisted to status); it is now handled explicitly at the point of the dangerous decision. Scale-up is unaffected, as are providers that do not implement `VerifyWeight` (`verified == nil`).

The #4612 ordering guarantee (never `SetWeight` while the DestinationRule switch is pending) is untouched: it is enforced *inside* `reconcileTrafficRouting()` by the early return after `UpdateHash()`, which still happens; `status.canary.weights` also keeps reflecting only actually-applied weights.

Behavior while a traffic router errors persistently:

| | before | after |
|---|---|---|
| step index advances | no (reconcile aborted) | no (explicit guard) |
| stable promotion / old-RS scale-down | no | no (explicit guard) |
| progressDeadline / abort evaluated | **never** | every reconcile |
| `Progressing` → `TimedOut`, phase `Degraded` | **never** | on deadline expiry |
| error visibility | controller log only | `TrafficRoutingError` event + log |

## Note on PromoteFull with unverified weights (ALB / plugins)

One intentional tightening: `shouldFullPromote()` now holds promotion while `weights.verified == false` regardless of how promotion was requested. On master, a `PromoteFull` under `dynamicStableScale` with a partially-available canary computes `desiredWeight < max`, so the old end-of-rollout error (which only fired at `desiredWeight == max`) did not fire — master could promote stable and begin scaling it down while the load balancer had not verified the shift. The branch waits for verification (10s requeue cycles) before promoting. Only ALB and plugins implementing `VerifyWeight` are affected; providers returning `nil` verification are untouched.

## Note on PromoteFull / rollback-window step index

`syncRolloutStatusCanary()` jumps `currentStepIndex` to N/N for `PromoteFull` and rollback-within-window without consulting the guarded `completedCurrentCanaryStep()`, so during a router error the rollout can display all steps complete while traffic never shifted. This is intentional: the step index has never meant "traffic is in effect" (these branches already set it optimistically before `SetWeight(100)` on master's non-error path — the actual traffic position lives in `status.canary.weights`, which only updates on successful `SetWeight`), and all traffic-affecting consequences (stable promotion, old-RS scale-down) remain held by the gates above. Guarding the jump would make an explicit promote-full silently no-op during router errors; instead the intent is queued and takes effect on the first successful reconcile — on master, a promote-full during a persistent router error never took effect at all.

## Behavior change note

This intentionally changes behavior for **all** traffic providers: rollouts that previously sat `Progressing` forever on a persistently failing router will now time out, go `Degraded`, and auto-abort when `progressDeadlineAbort: true` is set. That is what `progressDeadlineSeconds` is documented to do, but it deserves a release note. Because of the provider-wide blast radius this is proposed for master only, not for backport; #4823 remains the scoped, cherry-pickable fix for release-1.9 if desired.

## Testing

- New: `TestCanaryProgressDeadlineAbortNotBlockedByTrafficRoutingError` reproduces the #4626 symptom end-to-end at the controller level with a plain (non-sentinel) router error: a canary rollout with `progressDeadlineAbort: true`, stuck past its deadline, must still auto-abort. Verified to fail with the fix reverted.
- Updated: `TestReconcileTrafficRoutingSetWeightErr` and `TestTrafficRoutingErrorsWhenNewCanaryHasNoReplicas` now pin the new contract: no reconcile error, `TrafficRoutingError` event emitted, step not completed.
- Updated: `TestReconcileTrafficRoutingVerifyWeightEndOfRollout` now asserts stable is **not** promoted and no warning event is emitted while the desired weight is unverified (previously it asserted the reconcile errored).
- New: `TestCanaryStableReplicaSetScaleDownHeldWhileWeightUnverified` pins the stable scale-down hold: unverified weights hold the scale-down, verified or nil (provider without verification) weights scale down as usual. Verified to fail with the guard removed.
- New e2e: `TestIstioSubsetSplitProgressDeadlineAbortWithUnavailableCanary` (Istio suite) reproduces #4626 end-to-end on a live cluster: subset-level routing, canary image that can never pull, `progressDeadlineAbort: true`. Verified both ways against a running controller: passes with this fix; against a pre-fix (master) controller it fails with `timeout waiting for condition status=Degraded` — the rollout stays `Progressing` indefinitely.
- `go build ./...`, `go test ./rollout/... ./utils/...` (0 failures), `go vet ./rollout/...` pass locally.

## Related

- Fixes #4626; same symptom as #4128. Alternative to #4823 (per-provider sentinel), generalizing the discussion there with @kostis-codefresh about not letting provider semantics bleed into generic code — with this change no provider needs a special error contract at all.

---

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green. Try syncing with master if they are not.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] I have run all tests locally (including the flaky ones) and they pass on my workstation — `./rollout/...` and `./utils/...` unit suites pass locally; e2e suites rely on CI.
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users — this changes error handling for all traffic providers; see behavior change note above.
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
