### PR TITLE
refactor(controller): reconcile pipeline with guaranteed status sync (canary + blue-green). Fixes #4626

### DIFF
--- a/docs/features/specification.md
+++ b/docs/features/specification.md
@@ -479,10 +479,8 @@ spec:
       # are created the number of stable pods stays the same. 
       dynamicStableScale: false
 
-  # Stage conditions (canary):
-  # - TrafficRoutingApplied: True when the traffic router applied the desired routing state
-  # - ServicesReconciled: True when stable/canary (and ping-pong) Service selectors reconciled
-  # - ReconcileSucceeded: catch-all True when the remaining reconcile steps succeed; False on failure
+  # ReconcileSucceeded: True when the reconcile pipeline applied all changes; False on failure.
+  # Reasons distinguish the failure: TrafficRoutingError, ServiceUpdateError, ReconciliationError.
 
 status:
   pauseConditions:

--- a/docs/features/specification.md
+++ b/docs/features/specification.md
@@ -479,6 +479,11 @@ spec:
       # are created the number of stable pods stays the same. 
       dynamicStableScale: false
 
+  # Actuation stage conditions (canary):
+  # - TrafficRoutingApplied: True when the traffic router applied the desired routing state
+  # - ServicesReconciled: True when stable/canary (and ping-pong) Service selectors reconciled
+  # - ActuationSucceeded: catch-all True when other actuation stages succeed; False on failure
+
 status:
   pauseConditions:
     - reason: StepPause

--- a/docs/features/specification.md
+++ b/docs/features/specification.md
@@ -479,8 +479,9 @@ spec:
       # are created the number of stable pods stays the same. 
       dynamicStableScale: false
 
-  # ReconcileSucceeded: True when the reconcile pipeline applied all changes; False on failure.
-  # Reasons distinguish the failure: TrafficRoutingError, ServiceUpdateError, ReconciliationError.
+  # ReconcileSucceeded: True when reconcile work completed without error; False on failure.
+  # Reasons: TrafficRoutingError, ServiceUpdateError, ReconciliationError.
+  # Other failures use InvalidSpec, Progressing, or ReplicaFailure.
 
 status:
   pauseConditions:

--- a/docs/features/specification.md
+++ b/docs/features/specification.md
@@ -479,10 +479,10 @@ spec:
       # are created the number of stable pods stays the same. 
       dynamicStableScale: false
 
-  # Actuation stage conditions (canary):
+  # Stage conditions (canary):
   # - TrafficRoutingApplied: True when the traffic router applied the desired routing state
   # - ServicesReconciled: True when stable/canary (and ping-pong) Service selectors reconciled
-  # - ActuationSucceeded: catch-all True when other actuation stages succeed; False on failure
+  # - ReconcileSucceeded: catch-all True when the remaining reconcile steps succeed; False on failure
 
 status:
   pauseConditions:

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -1322,6 +1322,15 @@ const (
 	// RolloutHealthy means that rollout is in a completed state and is healthy. Which means that all the pods have been updated
 	// and are passing their health checks and are ready to serve traffic.
 	RolloutHealthy RolloutConditionType = "Healthy"
+	// RolloutTrafficRoutingApplied means the traffic router last applied (True) or failed /
+	// intentionally deferred applying (False) the desired routing state.
+	RolloutTrafficRoutingApplied RolloutConditionType = "TrafficRoutingApplied"
+	// RolloutServicesReconciled means the stable/canary (and ping-pong) Service selectors
+	// last reconciled successfully (True) or failed (False).
+	RolloutServicesReconciled RolloutConditionType = "ServicesReconciled"
+	// RolloutActuationSucceeded is a catch-all: False when any actuation stage without a
+	// dedicated condition failed during the last reconcile.
+	RolloutActuationSucceeded RolloutConditionType = "ActuationSucceeded"
 )
 
 // RolloutCondition describes the state of a rollout at a certain point.

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -1322,9 +1322,11 @@ const (
 	// RolloutHealthy means that rollout is in a completed state and is healthy. Which means that all the pods have been updated
 	// and are passing their health checks and are ready to serve traffic.
 	RolloutHealthy RolloutConditionType = "Healthy"
-	// RolloutReconcileSucceeded means the last reconcile that applies cluster changes succeeded (True)
-	// or failed (False). The reason distinguishes failure category (e.g. TrafficRoutingError,
-	// ServiceUpdateError, ReconciliationError).
+	// RolloutReconcileSucceeded indicates the controller completed its reconcile work without error
+	// on the last pass (True), or hit an error that prevents safe progression (False). The reason
+	// distinguishes failure category (e.g. TrafficRoutingError, ServiceUpdateError,
+	// ReconciliationError). Other failure modes use separate conditions (InvalidSpec, Progressing,
+	// ReplicaFailure).
 	RolloutReconcileSucceeded RolloutConditionType = "ReconcileSucceeded"
 )
 

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -1328,9 +1328,10 @@ const (
 	// RolloutServicesReconciled means the stable/canary (and ping-pong) Service selectors
 	// last reconciled successfully (True) or failed (False).
 	RolloutServicesReconciled RolloutConditionType = "ServicesReconciled"
-	// RolloutActuationSucceeded is a catch-all: False when any actuation stage without a
-	// dedicated condition failed during the last reconcile.
-	RolloutActuationSucceeded RolloutConditionType = "ActuationSucceeded"
+	// RolloutReconcileSucceeded is a catch-all: False when any part of the reconcile that applies
+	// changes to the cluster (ReplicaSet sync, scaling, experiments, analysis, pod metadata, step
+	// plugins) failed during the last reconcile without a more specific condition.
+	RolloutReconcileSucceeded RolloutConditionType = "ReconcileSucceeded"
 )
 
 // RolloutCondition describes the state of a rollout at a certain point.

--- a/pkg/apis/rollouts/v1alpha1/types.go
+++ b/pkg/apis/rollouts/v1alpha1/types.go
@@ -1322,15 +1322,9 @@ const (
 	// RolloutHealthy means that rollout is in a completed state and is healthy. Which means that all the pods have been updated
 	// and are passing their health checks and are ready to serve traffic.
 	RolloutHealthy RolloutConditionType = "Healthy"
-	// RolloutTrafficRoutingApplied means the traffic router last applied (True) or failed /
-	// intentionally deferred applying (False) the desired routing state.
-	RolloutTrafficRoutingApplied RolloutConditionType = "TrafficRoutingApplied"
-	// RolloutServicesReconciled means the stable/canary (and ping-pong) Service selectors
-	// last reconciled successfully (True) or failed (False).
-	RolloutServicesReconciled RolloutConditionType = "ServicesReconciled"
-	// RolloutReconcileSucceeded is a catch-all: False when any part of the reconcile that applies
-	// changes to the cluster (ReplicaSet sync, scaling, experiments, analysis, pod metadata, step
-	// plugins) failed during the last reconcile without a more specific condition.
+	// RolloutReconcileSucceeded means the last reconcile that applies cluster changes succeeded (True)
+	// or failed (False). The reason distinguishes failure category (e.g. TrafficRoutingError,
+	// ServiceUpdateError, ReconciliationError).
 	RolloutReconcileSucceeded RolloutConditionType = "ReconcileSucceeded"
 )
 

--- a/rollout/bluegreen.go
+++ b/rollout/bluegreen.go
@@ -77,7 +77,10 @@ func (c *rolloutContext) reconcileBlueGreen(previewSvc, activeSvc *corev1.Servic
 		return err
 	}
 
-	return c.reconcileEphemeralMetadata()
+	// Cosmetic steps run last so a failure (e.g. RBAC denying old-ReplicaSet deletion) cannot
+	// block the service switch or scaling; both always run and their errors still propagate for
+	// workqueue backoff (mirrors the canary stageContinueWithError semantics).
+	return errors.Join(c.reconcileEphemeralMetadata(), c.reconcileRevisionHistoryLimit(c.otherRSs))
 }
 
 func (c *rolloutContext) reconcileBlueGreenStableReplicaSet() error {
@@ -110,9 +113,6 @@ func (c *rolloutContext) reconcileBlueGreenReplicaSets(activeSvc *corev1.Service
 	// Scale down old non-active, non-stable replicasets, if we can.
 	_, err = c.reconcileOtherReplicaSets()
 	if err != nil {
-		return err
-	}
-	if err := c.reconcileRevisionHistoryLimit(c.otherRSs); err != nil {
 		return err
 	}
 	return nil

--- a/rollout/bluegreen.go
+++ b/rollout/bluegreen.go
@@ -17,7 +17,7 @@ import (
 )
 
 // rolloutBlueGreen implements the logic for rolling a new replica set. Status is synced, exactly
-// once, even when an actuation step fails: syncRolloutStatusBlueGreen is where
+// once, even when reconcileBlueGreen fails: syncRolloutStatusBlueGreen is where
 // progressDeadline/abort evaluation lives, and skipping it is how a rollout gets wedged in
 // Progressing forever (#4626) — mirroring rolloutCanary. The only exceptions are the
 // prerequisites (service lookup and ReplicaSet sync), without which a meaningful status cannot
@@ -35,14 +35,15 @@ func (c *rolloutContext) rolloutBlueGreen() error {
 	}
 	c.newRS = newRS
 
-	actuationErr := c.reconcileBlueGreen(previewSvc, activeSvc)
+	reconcileErr := c.reconcileBlueGreen(previewSvc, activeSvc)
 	// errors.Join so As/Is-based checks (e.g. k8serrors.IsNotFound) still see through the
 	// combined error; it returns nil when both errors are nil.
-	return errors.Join(actuationErr, c.syncRolloutStatusBlueGreen(previewSvc, activeSvc))
+	return errors.Join(reconcileErr, c.syncRolloutStatusBlueGreen(previewSvc, activeSvc))
 }
 
-// reconcileBlueGreen performs the actuation steps of the blue-green strategy. An error stops
-// actuation but is surfaced only after the status sync runs (see rolloutBlueGreen).
+// reconcileBlueGreen applies the desired blue-green state (ReplicaSets, services, analysis) to
+// the cluster. An error stops further changes but is surfaced only after the status sync runs
+// (see rolloutBlueGreen).
 func (c *rolloutContext) reconcileBlueGreen(previewSvc, activeSvc *corev1.Service) error {
 	// This must happen right after the new replicaset is created
 	if err := c.reconcilePreviewService(previewSvc); err != nil {

--- a/rollout/bluegreen.go
+++ b/rollout/bluegreen.go
@@ -17,11 +17,10 @@ import (
 )
 
 // rolloutBlueGreen implements the logic for rolling a new replica set. Status is synced, exactly
-// once, even when reconcileBlueGreen fails: syncRolloutStatusBlueGreen is where
-// progressDeadline/abort evaluation lives, and skipping it is how a rollout gets wedged in
-// Progressing forever (#4626) — mirroring rolloutCanary. The only exceptions are the
-// prerequisites (service lookup and ReplicaSet sync), without which a meaningful status cannot
-// be computed.
+// once, even when a stage fails: syncRolloutStatusBlueGreen is where progressDeadline/abort
+// evaluation lives, and skipping it is how a rollout gets wedged in Progressing forever (#4626)
+// — mirroring rolloutCanary. The only exceptions are the prerequisites (service lookup and
+// ReplicaSet sync), without which a meaningful status cannot be computed.
 func (c *rolloutContext) rolloutBlueGreen() error {
 	previewSvc, activeSvc, err := c.getPreviewAndActiveServices()
 	if err != nil {
@@ -35,52 +34,14 @@ func (c *rolloutContext) rolloutBlueGreen() error {
 	}
 	c.newRS = newRS
 
-	reconcileErr := c.reconcileBlueGreen(previewSvc, activeSvc)
-	// errors.Join so As/Is-based checks (e.g. k8serrors.IsNotFound) still see through the
-	// combined error; it returns nil when both errors are nil.
-	return errors.Join(reconcileErr, c.syncRolloutStatusBlueGreen(previewSvc, activeSvc))
-}
-
-// reconcileBlueGreen applies the desired blue-green state (ReplicaSets, services, analysis) to
-// the cluster. An error stops further changes but is surfaced only after the status sync runs
-// (see rolloutBlueGreen).
-func (c *rolloutContext) reconcileBlueGreen(previewSvc, activeSvc *corev1.Service) error {
-	// This must happen right after the new replicaset is created
-	if err := c.reconcilePreviewService(previewSvc); err != nil {
-		return err
+	stageErr := c.runBlueGreenStages(previewSvc, activeSvc)
+	if stageErr != nil {
+		c.ensureReconcileFailureCondition(stageErr)
 	}
-
-	if replicasetutil.CheckPodSpecChange(c.rollout, c.newRS) {
-		// A pod template change is handled entirely by the status sync.
-		return nil
+	if c.skipStatusSync {
+		return stageErr
 	}
-
-	if _, err := c.podRestarter.Reconcile(c); err != nil {
-		return err
-	}
-
-	if err := c.reconcileBlueGreenReplicaSets(activeSvc); err != nil {
-		return err
-	}
-
-	c.reconcileBlueGreenPause(activeSvc, previewSvc)
-
-	if err := c.reconcileActiveService(activeSvc); err != nil {
-		return err
-	}
-
-	if err := c.awsVerifyTargetGroups(activeSvc); err != nil {
-		return err
-	}
-
-	if err := c.reconcileAnalysisRuns(); err != nil {
-		return err
-	}
-
-	// Cosmetic steps run last so a failure (e.g. RBAC denying old-ReplicaSet deletion) cannot
-	// block the service switch or scaling; both always run and their errors still propagate for
-	// workqueue backoff (mirrors the canary stageContinueWithError semantics).
-	return errors.Join(c.reconcileEphemeralMetadata(), c.reconcileRevisionHistoryLimit(c.otherRSs))
+	return errors.Join(stageErr, c.syncRolloutStatusBlueGreen(previewSvc, activeSvc))
 }
 
 func (c *rolloutContext) reconcileBlueGreenStableReplicaSet() error {

--- a/rollout/bluegreen.go
+++ b/rollout/bluegreen.go
@@ -1,6 +1,7 @@
 package rollout
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -15,60 +16,67 @@ import (
 	serviceutil "github.com/argoproj/argo-rollouts/utils/service"
 )
 
-// rolloutBlueGreen implements the logic for rolling a new replica set.
+// rolloutBlueGreen implements the logic for rolling a new replica set. Status is synced, exactly
+// once, even when an actuation step fails: syncRolloutStatusBlueGreen is where
+// progressDeadline/abort evaluation lives, and skipping it is how a rollout gets wedged in
+// Progressing forever (#4626) — mirroring rolloutCanary. The only exceptions are the
+// prerequisites (service lookup and ReplicaSet sync), without which a meaningful status cannot
+// be computed.
 func (c *rolloutContext) rolloutBlueGreen() error {
 	previewSvc, activeSvc, err := c.getPreviewAndActiveServices()
 	if err != nil {
 		return err
 	}
-	c.newRS, err = c.getAllReplicaSetsAndSyncRevision()
+	newRS, err := c.getAllReplicaSetsAndSyncRevision()
 	if err != nil {
+		// Leave c.newRS untouched and skip the status sync: a status computed from a nil/stale
+		// newRS would persist corrupted values.
 		return fmt.Errorf("failed to getAllReplicaSetsAndSyncRevision in rolloutBlueGreen create true: %w", err)
 	}
+	c.newRS = newRS
 
+	actuationErr := c.reconcileBlueGreen(previewSvc, activeSvc)
+	// errors.Join so As/Is-based checks (e.g. k8serrors.IsNotFound) still see through the
+	// combined error; it returns nil when both errors are nil.
+	return errors.Join(actuationErr, c.syncRolloutStatusBlueGreen(previewSvc, activeSvc))
+}
+
+// reconcileBlueGreen performs the actuation steps of the blue-green strategy. An error stops
+// actuation but is surfaced only after the status sync runs (see rolloutBlueGreen).
+func (c *rolloutContext) reconcileBlueGreen(previewSvc, activeSvc *corev1.Service) error {
 	// This must happen right after the new replicaset is created
-	err = c.reconcilePreviewService(previewSvc)
-	if err != nil {
+	if err := c.reconcilePreviewService(previewSvc); err != nil {
 		return err
 	}
 
 	if replicasetutil.CheckPodSpecChange(c.rollout, c.newRS) {
-		return c.syncRolloutStatusBlueGreen(previewSvc, activeSvc)
+		// A pod template change is handled entirely by the status sync.
+		return nil
 	}
 
-	_, err = c.podRestarter.Reconcile(c)
-	if err != nil {
+	if _, err := c.podRestarter.Reconcile(c); err != nil {
 		return err
 	}
 
-	err = c.reconcileBlueGreenReplicaSets(activeSvc)
-	if err != nil {
+	if err := c.reconcileBlueGreenReplicaSets(activeSvc); err != nil {
 		return err
 	}
 
 	c.reconcileBlueGreenPause(activeSvc, previewSvc)
 
-	err = c.reconcileActiveService(activeSvc)
-	if err != nil {
+	if err := c.reconcileActiveService(activeSvc); err != nil {
 		return err
 	}
 
-	err = c.awsVerifyTargetGroups(activeSvc)
-	if err != nil {
+	if err := c.awsVerifyTargetGroups(activeSvc); err != nil {
 		return err
 	}
 
-	err = c.reconcileAnalysisRuns()
-	if err != nil {
+	if err := c.reconcileAnalysisRuns(); err != nil {
 		return err
 	}
 
-	err = c.reconcileEphemeralMetadata()
-	if err != nil {
-		return err
-	}
-
-	return c.syncRolloutStatusBlueGreen(previewSvc, activeSvc)
+	return c.reconcileEphemeralMetadata()
 }
 
 func (c *rolloutContext) reconcileBlueGreenStableReplicaSet() error {

--- a/rollout/bluegreen_test.go
+++ b/rollout/bluegreen_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	core "k8s.io/client-go/testing"
 	"k8s.io/utils/ptr"
 
@@ -1736,4 +1737,55 @@ func TestBlueGreenAddScaleDownDelay(t *testing.T) {
 	f.run(getKey(r2, t))
 
 	f.verifyPatchedReplicaSet(rs1Patch, 30)
+}
+
+// TestBlueGreenProgressDeadlineAbortNotBlockedByActuationError reproduces the user-facing
+// symptom of #4626 for the blue-green strategy: a rollout with progressDeadlineAbort enabled,
+// stuck past its progress deadline, must still auto-abort even while an actuation step (here
+// the preview service update) errors persistently — the status sync must not be skipped.
+func TestBlueGreenProgressDeadlineAbortNotBlockedByActuationError(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	r1 := newBlueGreenRollout("foo", 2, nil, "active", "preview")
+	progressDeadlineSeconds := int32(1)
+	r1.Spec.ProgressDeadlineSeconds = &progressDeadlineSeconds
+	r1.Spec.ProgressDeadlineAbort = true
+	r1.Spec.Strategy.BlueGreen.AutoPromotionEnabled = ptr.To[bool](false)
+	r2 := bumpVersion(r1)
+
+	rs1 := newReplicaSetWithStatus(r1, 2, 2)
+	rs2 := newReplicaSetWithStatus(r2, 2, 1)
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+
+	// Status must match the observed state (stale preview selector, replica counts) so the
+	// reconcile does not register as "making progress", which would defer the deadline abort.
+	r2 = updateBlueGreenRolloutStatus(r2, rs1PodHash, rs1PodHash, rs1PodHash, 3, 2, 4, 4, false, true, false)
+	msg := fmt.Sprintf("ReplicaSet %q has timed out progressing.", rs2.Name)
+	progressingTimeoutCond := conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionFalse, conditions.TimedOutReason, msg)
+	conditions.SetRolloutCondition(&r2.Status, *progressingTimeoutCond)
+
+	activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}
+	activeSvc := newService("active", 80, activeSelector, r2)
+	// stale preview selector forces a service patch, which the reactor below fails persistently
+	previewSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}
+	previewSvc := newService("preview", 80, previewSelector, r2)
+
+	f.objects = append(f.objects, r2)
+	f.kubeobjects = append(f.kubeobjects, activeSvc, previewSvc, rs1, rs2)
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+	f.serviceLister = append(f.serviceLister, activeSvc, previewSvc)
+
+	c, i, k8sI := f.newController(noResyncPeriodFunc)
+	f.kubeclient.PrependReactor("patch", "services", func(action core.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("admission webhook denied service update")
+	})
+
+	_ = f.expectPatchServiceAction(previewSvc, rs2PodHash)
+	patchIndex := f.expectPatchRolloutAction(r2)
+	f.runController(getKey(r2, t), true, true, c, i, k8sI)
+
+	f.verifyPatchedRolloutAborted(patchIndex, rs2.Name)
 }

--- a/rollout/bluegreen_test.go
+++ b/rollout/bluegreen_test.go
@@ -1789,3 +1789,48 @@ func TestBlueGreenProgressDeadlineAbortNotBlockedByApplyError(t *testing.T) {
 
 	f.verifyPatchedRolloutAborted(patchIndex, rs2.Name)
 }
+
+// TestBlueGreenRevisionHistoryFailureDoesNotBlockServiceSwitch verifies cosmetic cleanup
+// failures cannot block the active service switch: revision-history deletion runs after the
+// service reconcile, so a denied ReplicaSet deletion still surfaces as a reconcile error but
+// the switch (and the rest of the pass) completes.
+func TestBlueGreenRevisionHistoryFailureDoesNotBlockServiceSwitch(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	r1 := newBlueGreenRollout("foo", 2, ptr.To[int32](0), "active", "preview")
+	r2 := bumpVersion(r1)
+	r3 := bumpVersion(r2)
+
+	rs1 := newReplicaSetWithStatus(r1, 0, 0) // scaled-down old revision: deletion candidate
+	rs2 := newReplicaSetWithStatus(r2, 2, 2) // stable / currently active
+	rs3 := newReplicaSetWithStatus(r3, 2, 2) // new, fully available
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs3PodHash := rs3.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+
+	r3 = updateBlueGreenRolloutStatus(r3, rs3PodHash, rs2PodHash, rs2PodHash, 4, 2, 4, 4, false, true, false)
+
+	activeSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}
+	activeSvc := newService("active", 80, activeSelector, r3)
+	previewSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs3PodHash}
+	previewSvc := newService("preview", 80, previewSelector, r3)
+
+	f.objects = append(f.objects, r3)
+	f.kubeobjects = append(f.kubeobjects, activeSvc, previewSvc, rs1, rs2, rs3)
+	f.rolloutLister = append(f.rolloutLister, r3)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2, rs3)
+	f.serviceLister = append(f.serviceLister, activeSvc, previewSvc)
+
+	c, i, k8sI := f.newController(noResyncPeriodFunc)
+	f.kubeclient.PrependReactor("delete", "replicasets", func(action core.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("rbac denied replicaset deletion")
+	})
+
+	servicePatchIndex := f.expectPatchServiceAction(activeSvc, rs3PodHash)
+	_ = f.expectDeleteReplicaSetAction(rs1)
+	_ = f.expectPatchRolloutAction(r3)
+	f.runController(getKey(r3, t), true, true, c, i, k8sI)
+
+	// active service must still switch to the new ReplicaSet despite the cleanup failure
+	f.verifyPatchedService(servicePatchIndex, rs3PodHash, "")
+}

--- a/rollout/bluegreen_test.go
+++ b/rollout/bluegreen_test.go
@@ -1739,11 +1739,11 @@ func TestBlueGreenAddScaleDownDelay(t *testing.T) {
 	f.verifyPatchedReplicaSet(rs1Patch, 30)
 }
 
-// TestBlueGreenProgressDeadlineAbortNotBlockedByActuationError reproduces the user-facing
+// TestBlueGreenProgressDeadlineAbortNotBlockedByApplyError reproduces the user-facing
 // symptom of #4626 for the blue-green strategy: a rollout with progressDeadlineAbort enabled,
-// stuck past its progress deadline, must still auto-abort even while an actuation step (here
+// stuck past its progress deadline, must still auto-abort even while a step that applies changes (here
 // the preview service update) errors persistently — the status sync must not be skipped.
-func TestBlueGreenProgressDeadlineAbortNotBlockedByActuationError(t *testing.T) {
+func TestBlueGreenProgressDeadlineAbortNotBlockedByApplyError(t *testing.T) {
 	f := newFixture(t)
 	defer f.Close()
 

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -250,9 +250,8 @@ func (c *rolloutContext) completedCurrentCanaryStep() bool {
 	if c.rollout.Spec.Paused {
 		return false
 	}
-	// Some stage failed this reconcile, so the cluster may not match the state about
-	// to be persisted. Advancing the step now would let the rollout progress with stale routing,
-	// service selectors, or replica counts (#3602-class hazard).
+	// ReconcileSucceeded=False this pass: advancing now risks persisting state the cluster does not
+	// match (#3602-class hazard).
 	if c.anyStageConditionFalse() {
 		return false
 	}

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/utils/ptr"
@@ -25,9 +26,7 @@ import (
 func (c *rolloutContext) rolloutCanary() error {
 	stageErr := c.runCanaryStages()
 	if stageErr != nil {
-		// Actuation did not fully apply the desired state this pass. Progression gates
-		// (completedCurrentCanaryStep, shouldFullPromote) must hold.
-		c.actuationDeferred = true
+		c.ensureActuationFailureCondition(stageErr)
 	}
 	if c.skipStatusSync {
 		// Only the pod-restart early exit sets this; see runCanaryStages.
@@ -80,14 +79,17 @@ func (c *rolloutContext) runCanaryStages() error {
 	}
 
 	if err := c.reconcilePingAndPongService(); err != nil {
+		c.setStageCondition(v1alpha1.RolloutServicesReconciled, corev1.ConditionFalse, conditions.ServiceUpdateErrorReason, err.Error())
 		return err
 	}
 
 	if err := c.reconcileStableAndCanaryService(); err != nil {
+		c.setStageCondition(v1alpha1.RolloutServicesReconciled, corev1.ConditionFalse, conditions.ServiceUpdateErrorReason, err.Error())
 		return err
 	}
 
 	if err := c.reconcileTrafficRouting(); err != nil {
+		c.setStageCondition(v1alpha1.RolloutTrafficRoutingApplied, corev1.ConditionFalse, conditions.TrafficRoutingErrorReason, err.Error())
 		return err
 	}
 
@@ -342,7 +344,7 @@ func (c *rolloutContext) completedCurrentCanaryStep() bool {
 	// Some actuation stage failed this reconcile, so the cluster may not match the state about
 	// to be persisted. Advancing the step now would let the rollout progress with stale routing,
 	// service selectors, or replica counts (#3602-class hazard).
-	if c.actuationDeferred {
+	if c.anyStageConditionFalse() {
 		return false
 	}
 	currentStep, currentStepIndex := replicasetutil.GetCurrentCanaryStep(c.rollout)

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -19,8 +19,8 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/weightutil"
 )
 
-// rolloutCanary is the top-level canary reconcile. Status is synced, exactly once, even when an
-// actuation stage fails: syncRolloutStatusCanary is where progressDeadline/abort evaluation and
+// rolloutCanary is the top-level canary reconcile. Status is synced, exactly once, even when a
+// stage fails: syncRolloutStatusCanary is where progressDeadline/abort evaluation and
 // condition/phase calculation live, and skipping it is how a rollout gets wedged in Progressing
 // forever (#4626). The only exceptions are the pod-restart early exit and ReplicaSet-sync
 // failures (stageFatalNoStatus), where c.newRS is unreliable and a status computed from it
@@ -250,7 +250,7 @@ func (c *rolloutContext) completedCurrentCanaryStep() bool {
 	if c.rollout.Spec.Paused {
 		return false
 	}
-	// Some actuation stage failed this reconcile, so the cluster may not match the state about
+	// Some stage failed this reconcile, so the cluster may not match the state about
 	// to be persisted. Advancing the step now would let the rollout progress with stale routing,
 	// service selectors, or replica counts (#3602-class hazard).
 	if c.anyStageConditionFalse() {

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -18,10 +18,12 @@ import (
 	rolloututil "github.com/argoproj/argo-rollouts/utils/rollout"
 )
 
-// rolloutCanary is the top-level canary reconcile. Status is ALWAYS synced, exactly once, even
-// when an actuation stage fails: syncRolloutStatusCanary is where progressDeadline/abort
-// evaluation and condition/phase calculation live, and skipping it is how a rollout gets wedged
-// in Progressing forever (#4626).
+// rolloutCanary is the top-level canary reconcile. Status is synced, exactly once, even when an
+// actuation stage fails: syncRolloutStatusCanary is where progressDeadline/abort evaluation and
+// condition/phase calculation live, and skipping it is how a rollout gets wedged in Progressing
+// forever (#4626). The only exceptions are the pod-restart early exit and ReplicaSet-sync
+// failures (stageFatalNoStatus), where c.newRS is unreliable and a status computed from it
+// would persist corrupted values.
 func (c *rolloutContext) rolloutCanary() error {
 	stageErr := c.runCanaryStages()
 	if stageErr != nil {

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -6,6 +6,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
@@ -17,14 +18,35 @@ import (
 	rolloututil "github.com/argoproj/argo-rollouts/utils/rollout"
 )
 
+// rolloutCanary is the top-level canary reconcile. Status is ALWAYS synced, exactly once, even
+// when an actuation stage fails: syncRolloutStatusCanary is where progressDeadline/abort
+// evaluation and condition/phase calculation live, and skipping it is how a rollout gets wedged
+// in Progressing forever (#4626).
 func (c *rolloutContext) rolloutCanary() error {
+	stageErr := c.runCanaryStages()
+	if stageErr != nil {
+		// Actuation did not fully apply the desired state this pass. Progression gates
+		// (completedCurrentCanaryStep, shouldFullPromote) must hold.
+		c.actuationDeferred = true
+	}
+	if c.skipStatusSync {
+		// Only the pod-restart early exit sets this; see runCanaryStages.
+		return stageErr
+	}
+	return kerrors.NewAggregate([]error{stageErr, c.syncRolloutStatusCanary()})
+}
+
+// runCanaryStages performs actuation only. It must not call syncRolloutStatusCanary; return nil
+// to fall through to the status sync in rolloutCanary, or set c.skipStatusSync for the restart
+// early-exit.
+func (c *rolloutContext) runCanaryStages() error {
 	var err error
 	if replicasetutil.PodTemplateOrStepsChanged(c.rollout, c.newRS) {
 		c.newRS, err = c.getAllReplicaSetsAndSyncRevision()
 		if err != nil {
 			return fmt.Errorf("failed to getAllReplicaSetsAndSyncRevision in rolloutCanary with PodTemplateOrStepsChanged: %w", err)
 		}
-		return c.syncRolloutStatusCanary()
+		return nil
 	}
 
 	c.newRS, err = c.getAllReplicaSetsAndSyncRevision()
@@ -44,6 +66,7 @@ func (c *rolloutContext) rolloutCanary() error {
 		// so that the *next* reconciliation will have an accurate availability count to calculate
 		// the safe number of pods to scale down for the update.
 		c.log.Infof("Finished reconciliation due to %d restarted pods", restarted)
+		c.skipStatusSync = true
 		return nil
 	}
 
@@ -76,7 +99,7 @@ func (c *rolloutContext) rolloutCanary() error {
 	err = c.reconcileAnalysisRuns()
 	if c.pauseContext.HasAddPause() {
 		c.log.Info("Detected pause due to inconclusive AnalysisRun")
-		return c.syncRolloutStatusCanary()
+		return nil
 	}
 	if err != nil {
 		return err
@@ -88,13 +111,13 @@ func (c *rolloutContext) rolloutCanary() error {
 	}
 	if noScalingOccurred {
 		c.log.Info("Not finished reconciling ReplicaSets")
-		return c.syncRolloutStatusCanary()
+		return nil
 	}
 
 	stillReconciling := c.reconcileCanaryPause()
 	if stillReconciling {
 		c.log.Infof("Not finished reconciling Canary Pause")
-		return c.syncRolloutStatusCanary()
+		return nil
 	}
 
 	err = c.stepPluginContext.reconcile(c)
@@ -102,7 +125,7 @@ func (c *rolloutContext) rolloutCanary() error {
 		return err
 	}
 
-	return c.syncRolloutStatusCanary()
+	return nil
 }
 
 func (c *rolloutContext) reconcileCanaryStableReplicaSet() (bool, error) {
@@ -124,6 +147,14 @@ func (c *rolloutContext) reconcileCanaryStableReplicaSet() (bool, error) {
 		// Therefore, we send c.rollout.Status.Canary.Weights so that the stable scaling happens in
 		// a *susbsequent*, follow-up reconciliation, lagging behind the setWeight and service switch.
 		_, desiredStableRSReplicaCount = replicasetutil.CalculateReplicaCountsForTrafficRoutedCanary(c.rollout, c.newRS, c.stableRS, c.rollout.Status.Canary.Weights)
+		// Never scale down the stable ReplicaSet based on weights the traffic provider has not
+		// verified yet (e.g. ALB load balancer weights still propagating): the provider may
+		// still be routing traffic to stable. Scale-up is still allowed.
+		weights := c.rollout.Status.Canary.Weights
+		if weights != nil && weights.Verified != nil && !*weights.Verified && desiredStableRSReplicaCount < *c.stableRS.Spec.Replicas {
+			c.log.Infof("Holding stable ReplicaSet at %d replicas (desired %d): desired traffic weights are not yet verified", *c.stableRS.Spec.Replicas, desiredStableRSReplicaCount)
+			desiredStableRSReplicaCount = *c.stableRS.Spec.Replicas
+		}
 	}
 	scaled, _, err := c.scaleReplicaSetAndRecordEvent(c.stableRS, desiredStableRSReplicaCount)
 	if err != nil {
@@ -306,6 +337,12 @@ func (c *rolloutContext) canProceedWithScaleDownAnnotation(oldRSs []*appsv1.Repl
 
 func (c *rolloutContext) completedCurrentCanaryStep() bool {
 	if c.rollout.Spec.Paused {
+		return false
+	}
+	// Some actuation stage failed this reconcile, so the cluster may not match the state about
+	// to be persisted. Advancing the step now would let the rollout progress with stale routing,
+	// service selectors, or replica counts (#3602-class hazard).
+	if c.actuationDeferred {
 		return false
 	}
 	currentStep, currentStepIndex := replicasetutil.GetCurrentCanaryStep(c.rollout)

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/utils/ptr"
@@ -33,101 +32,6 @@ func (c *rolloutContext) rolloutCanary() error {
 		return stageErr
 	}
 	return kerrors.NewAggregate([]error{stageErr, c.syncRolloutStatusCanary()})
-}
-
-// runCanaryStages performs actuation only. It must not call syncRolloutStatusCanary; return nil
-// to fall through to the status sync in rolloutCanary, or set c.skipStatusSync for the restart
-// early-exit.
-func (c *rolloutContext) runCanaryStages() error {
-	var err error
-	if replicasetutil.PodTemplateOrStepsChanged(c.rollout, c.newRS) {
-		c.newRS, err = c.getAllReplicaSetsAndSyncRevision()
-		if err != nil {
-			return fmt.Errorf("failed to getAllReplicaSetsAndSyncRevision in rolloutCanary with PodTemplateOrStepsChanged: %w", err)
-		}
-		return nil
-	}
-
-	c.newRS, err = c.getAllReplicaSetsAndSyncRevision()
-	if err != nil {
-		return fmt.Errorf("failed to getAllReplicaSetsAndSyncRevision in rolloutCanary create true: %w", err)
-	}
-
-	restarted, err := c.podRestarter.Reconcile(c)
-	if err != nil {
-		return err
-	}
-	if restarted > 0 {
-		// If we restarted any pods, we can no longer trust the current availability counts of our
-		// ReplicaSets, since those counts do not factor in the unavailability of pods we just
-		// restarted. We would cause downtime if we continue the reconciliation and *also* scale
-		// down a ReplicaSet (e.g. because of a canary update scaling). Therefore, we return early,
-		// so that the *next* reconciliation will have an accurate availability count to calculate
-		// the safe number of pods to scale down for the update.
-		c.log.Infof("Finished reconciliation due to %d restarted pods", restarted)
-		c.skipStatusSync = true
-		return nil
-	}
-
-	err = c.reconcileEphemeralMetadata()
-	if err != nil {
-		return err
-	}
-
-	if err := c.reconcileRevisionHistoryLimit(c.otherRSs); err != nil {
-		return err
-	}
-
-	if err := c.reconcilePingAndPongService(); err != nil {
-		c.setStageCondition(v1alpha1.RolloutServicesReconciled, corev1.ConditionFalse, conditions.ServiceUpdateErrorReason, err.Error())
-		return err
-	}
-
-	if err := c.reconcileStableAndCanaryService(); err != nil {
-		c.setStageCondition(v1alpha1.RolloutServicesReconciled, corev1.ConditionFalse, conditions.ServiceUpdateErrorReason, err.Error())
-		return err
-	}
-
-	if err := c.reconcileTrafficRouting(); err != nil {
-		c.setStageCondition(v1alpha1.RolloutTrafficRoutingApplied, corev1.ConditionFalse, conditions.TrafficRoutingErrorReason, err.Error())
-		return err
-	}
-
-	err = c.reconcileExperiments()
-	if err != nil {
-		return err
-	}
-
-	err = c.reconcileAnalysisRuns()
-	if c.pauseContext.HasAddPause() {
-		c.log.Info("Detected pause due to inconclusive AnalysisRun")
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-
-	noScalingOccurred, err := c.reconcileCanaryReplicaSets()
-	if err != nil {
-		return err
-	}
-	if noScalingOccurred {
-		c.log.Info("Not finished reconciling ReplicaSets")
-		return nil
-	}
-
-	stillReconciling := c.reconcileCanaryPause()
-	if stillReconciling {
-		c.log.Infof("Not finished reconciling Canary Pause")
-		return nil
-	}
-
-	err = c.stepPluginContext.reconcile(c)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (c *rolloutContext) reconcileCanaryStableReplicaSet() (bool, error) {

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -1,12 +1,12 @@
 package rollout
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
@@ -16,6 +16,7 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/record"
 	replicasetutil "github.com/argoproj/argo-rollouts/utils/replicaset"
 	rolloututil "github.com/argoproj/argo-rollouts/utils/rollout"
+	"github.com/argoproj/argo-rollouts/utils/weightutil"
 )
 
 // rolloutCanary is the top-level canary reconcile. Status is synced, exactly once, even when an
@@ -30,10 +31,13 @@ func (c *rolloutContext) rolloutCanary() error {
 		c.ensureActuationFailureCondition(stageErr)
 	}
 	if c.skipStatusSync {
-		// Only the pod-restart early exit sets this; see runCanaryStages.
+		// Pod-restart early exit and ReplicaSet-sync failures set this; see runCanaryStages.
 		return stageErr
 	}
-	return kerrors.NewAggregate([]error{stageErr, c.syncRolloutStatusCanary()})
+	// errors.Join (rather than kerrors.NewAggregate) so that errors.As/Is-based checks like
+	// k8serrors.IsNotFound still see through the combined error in processNextWorkItem; the
+	// apimachinery aggregate implements Is but not Unwrap/As. Join returns nil when both are nil.
+	return errors.Join(stageErr, c.syncRolloutStatusCanary())
 }
 
 func (c *rolloutContext) reconcileCanaryStableReplicaSet() (bool, error) {
@@ -58,8 +62,7 @@ func (c *rolloutContext) reconcileCanaryStableReplicaSet() (bool, error) {
 		// Never scale down the stable ReplicaSet based on weights the traffic provider has not
 		// verified yet (e.g. ALB load balancer weights still propagating): the provider may
 		// still be routing traffic to stable. Scale-up is still allowed.
-		weights := c.rollout.Status.Canary.Weights
-		if weights != nil && weights.Verified != nil && !*weights.Verified && desiredStableRSReplicaCount < *c.stableRS.Spec.Replicas {
+		if weightutil.VerificationPending(c.rollout.Status.Canary.Weights) && desiredStableRSReplicaCount < *c.stableRS.Spec.Replicas {
 			c.log.Infof("Holding stable ReplicaSet at %d replicas (desired %d): desired traffic weights are not yet verified", *c.stableRS.Spec.Replicas, desiredStableRSReplicaCount)
 			desiredStableRSReplicaCount = *c.stableRS.Spec.Replicas
 		}
@@ -266,7 +269,7 @@ func (c *rolloutContext) completedCurrentCanaryStep() bool {
 		if !replicasetutil.AtDesiredReplicaCountsForCanary(c.rollout, c.newRS, c.stableRS, c.otherRSs, c.newStatus.Canary.Weights) {
 			return false
 		}
-		if c.newStatus.Canary.Weights != nil && c.newStatus.Canary.Weights.Verified != nil && !*c.newStatus.Canary.Weights.Verified {
+		if weightutil.VerificationPending(c.newStatus.Canary.Weights) {
 			// we haven't yet verified the target weight after the setWeight
 			return false
 		}

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -28,7 +28,7 @@ import (
 func (c *rolloutContext) rolloutCanary() error {
 	stageErr := c.runCanaryStages()
 	if stageErr != nil {
-		c.ensureActuationFailureCondition(stageErr)
+		c.ensureReconcileFailureCondition(stageErr)
 	}
 	if c.skipStatusSync {
 		// Pod-restart early exit and ReplicaSet-sync failures set this; see runCanaryStages.

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -23,7 +23,7 @@ import (
 // stage fails: syncRolloutStatusCanary is where progressDeadline/abort evaluation and
 // condition/phase calculation live, and skipping it is how a rollout gets wedged in Progressing
 // forever (#4626). The only exceptions are the pod-restart early exit and ReplicaSet-sync
-// failures (stageFatalNoStatus), where c.newRS is unreliable and a status computed from it
+// failures (stageStopNoStatus with err), where c.newRS is unreliable and a status computed from it
 // would persist corrupted values.
 func (c *rolloutContext) rolloutCanary() error {
 	stageErr := c.runCanaryStages()
@@ -31,7 +31,7 @@ func (c *rolloutContext) rolloutCanary() error {
 		c.ensureReconcileFailureCondition(stageErr)
 	}
 	if c.skipStatusSync {
-		// Pod-restart early exit and ReplicaSet-sync failures set this; see runCanaryStages.
+		// Pod-restart early exit and ReplicaSet-sync failures set this; see runStages.
 		return stageErr
 	}
 	// errors.Join (rather than kerrors.NewAggregate) so that errors.As/Is-based checks like

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -2,6 +2,7 @@ package rollout
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"testing"
@@ -14,9 +15,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	k8sinformers "k8s.io/client-go/informers"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
@@ -2178,4 +2181,156 @@ func TestIsDynamicallyRollingBackToStable(t *testing.T) {
 			assert.Equal(t, tc.expectedResult, rbToStable)
 		})
 	}
+}
+
+// TestCanaryStableReplicaSetScaleDownHeldWhileWeightUnverified verifies that the stable
+// ReplicaSet is never scaled down based on traffic weights the provider has not verified yet.
+func TestCanaryStableReplicaSetScaleDownHeldWhileWeightUnverified(t *testing.T) {
+	tests := []struct {
+		name           string
+		verified       *bool
+		expectedScaled bool
+	}{
+		{"unverified weights hold stable scale-down", ptr.To[bool](false), false},
+		{"verified weights allow stable scale-down", ptr.To[bool](true), true},
+		{"nil verification allows stable scale-down", nil, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFixture(t)
+			defer f.Close()
+
+			steps := []v1alpha1.CanaryStep{
+				{SetWeight: ptr.To[int32](10)},
+				{Pause: &v1alpha1.RolloutPause{}},
+			}
+			r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](2), intstr.FromInt(1), intstr.FromInt(0))
+			r2 := bumpVersion(r1)
+			r2.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
+			r2.Spec.Strategy.Canary.CanaryService = "canary"
+			r2.Spec.Strategy.Canary.StableService = "stable"
+			r2.Spec.Strategy.Canary.DynamicStableScale = true
+
+			rs1 := newReplicaSetWithStatus(r1, 10, 10)
+			rs2 := newReplicaSetWithStatus(r2, 10, 10)
+			rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+			rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+			canarySvc := newService("canary", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}, r2)
+			stableSvc := newService("stable", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}, r2)
+
+			r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 20, 10, 20, false)
+			r2.Status.Canary.Weights = &v1alpha1.TrafficWeights{
+				Canary:   v1alpha1.WeightDestination{Weight: 100, ServiceName: "canary", PodTemplateHash: rs2PodHash},
+				Stable:   v1alpha1.WeightDestination{Weight: 0, ServiceName: "stable", PodTemplateHash: rs1PodHash},
+				Verified: tc.verified,
+			}
+
+			f.kubeobjects = append(f.kubeobjects, rs1, rs2, canarySvc, stableSvc)
+			f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+			f.serviceLister = append(f.serviceLister, canarySvc, stableSvc)
+			f.rolloutLister = append(f.rolloutLister, r2)
+			f.objects = append(f.objects, r2)
+
+			ctrl, _, _ := f.newController(noResyncPeriodFunc)
+			roCtx, err := ctrl.newRolloutContext(r2)
+			assert.NoError(t, err)
+
+			scaled, err := roCtx.reconcileCanaryStableReplicaSet()
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedScaled, scaled,
+				"stable scale-down must only happen when weights are verified or verification is not implemented")
+		})
+	}
+}
+
+// TestCanaryStatusSyncedDespiteStageError verifies actuation stage failures still sync status,
+// hold step progression, and return an error for workqueue backoff.
+func TestCanaryStatusSyncedDespiteStageError(t *testing.T) {
+	t.Run("traffic routing SetWeight error", func(t *testing.T) {
+		f, ro := newTrafficWeightFixture(t)
+		defer f.Close()
+		f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+		f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(errors.New("routing failed"))
+		patchIndex := f.expectPatchRolloutAction(ro)
+		f.runExpectError(getKey(ro, t), true)
+		patchedRollout := f.getPatchedRolloutAsObject(patchIndex)
+		assert.Nil(t, patchedRollout.Status.CurrentStepIndex)
+		rs2PodHash := ro.Status.CurrentPodHash
+		assert.NotContains(t, f.getPatchedRollout(patchIndex), fmt.Sprintf(`"stableRS":"%s"`, rs2PodHash),
+			"must not promote stable to the canary ReplicaSet")
+	})
+
+	t.Run("invalid step analysis template", func(t *testing.T) {
+		f := newFixture(t)
+		defer f.Close()
+
+		at := analysisTemplate("bad-template")
+		at.Spec.Metrics = append(at.Spec.Metrics, at.Spec.Metrics[0])
+		f.analysisTemplateLister = append(f.analysisTemplateLister, at)
+
+		steps := []v1alpha1.CanaryStep{{
+			SetWeight: ptr.To[int32](10),
+			Analysis: &v1alpha1.RolloutAnalysis{
+				Templates: []v1alpha1.AnalysisTemplateRef{{TemplateName: "bad-template"}},
+			},
+		}}
+		r := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(0), intstr.FromInt(1))
+		rs := newReplicaSetWithStatus(r, 10, 10)
+		r.Status.StableRS = rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+		f.rolloutLister = append(f.rolloutLister, r)
+		f.objects = append(f.objects, r, at)
+		f.kubeobjects = append(f.kubeobjects, rs)
+		f.replicaSetLister = append(f.replicaSetLister, rs)
+
+		patchIndex := f.expectPatchRolloutAction(r)
+		f.runExpectError(getKey(r, t), true)
+		patchedRollout := f.getPatchedRolloutAsObject(patchIndex)
+		if patchedRollout.Status.CurrentStepIndex != nil {
+			assert.Equal(t, int32(0), *patchedRollout.Status.CurrentStepIndex)
+		}
+	})
+}
+
+// TestCanaryProgressDeadlineAbortDespiteServiceError verifies progressDeadlineAbort still runs
+// when a service selector switch fails persistently.
+func TestCanaryProgressDeadlineAbortDespiteServiceError(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{{SetWeight: ptr.To[int32](10)}}
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(0))
+	progressDeadlineSeconds := int32(1)
+	r1.Spec.ProgressDeadlineSeconds = &progressDeadlineSeconds
+	r1.Spec.ProgressDeadlineAbort = true
+	r1.Spec.Strategy.Canary.StableService = "stable"
+	r1.Spec.Strategy.Canary.CanaryService = "canary"
+	r2 := bumpVersion(r1)
+
+	rs1 := newReplicaSetWithStatus(r1, 10, 10)
+	rs2 := newReplicaSetWithStatus(r2, 1, 1)
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	canarySvc := newService("canary", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}, r2)
+	stableSvc := newService("stable", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}, r2)
+
+	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 11, 1, 11, false)
+	msg := fmt.Sprintf("ReplicaSet %q has timed out progressing.", rs2.Name)
+	progressingTimeoutCond := conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionFalse, conditions.TimedOutReason, msg)
+	conditions.SetRolloutCondition(&r2.Status, *progressingTimeoutCond)
+
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2, canarySvc, stableSvc)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+	f.serviceLister = append(f.serviceLister, canarySvc, stableSvc)
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2)
+
+	_ = f.expectPatchServiceAction(canarySvc, rs2PodHash)
+	patchIndex := f.expectPatchRolloutAction(r2)
+	c, i, k8sI := f.newController(noResyncPeriodFunc)
+	f.kubeclient.Fake.PrependReactor("patch", "services", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("admission webhook denied service update")
+	})
+	f.runController(getKey(r2, t), true, true, c, i, k8sI)
+	f.verifyPatchedRolloutAborted(patchIndex, rs2.Name)
 }

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -2253,7 +2253,7 @@ func TestCanaryStatusSyncedDespiteStageError(t *testing.T) {
 		f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(errors.New("routing failed"))
 		patchIndex := f.expectPatchRolloutAction(ro)
-		f.run(getKey(ro, t))
+		f.runExpectError(getKey(ro, t), true)
 		patchedRollout := f.getPatchedRolloutAsObject(patchIndex)
 		assert.Nil(t, patchedRollout.Status.CurrentStepIndex)
 		rs2PodHash := ro.Status.CurrentPodHash

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -2253,7 +2253,7 @@ func TestCanaryStatusSyncedDespiteStageError(t *testing.T) {
 		f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(errors.New("routing failed"))
 		patchIndex := f.expectPatchRolloutAction(ro)
-		f.runExpectError(getKey(ro, t), true)
+		f.run(getKey(ro, t))
 		patchedRollout := f.getPatchedRolloutAsObject(patchIndex)
 		assert.Nil(t, patchedRollout.Status.CurrentStepIndex)
 		rs2PodHash := ro.Status.CurrentPodHash

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -2243,7 +2243,7 @@ func TestCanaryStableReplicaSetScaleDownHeldWhileWeightUnverified(t *testing.T) 
 	}
 }
 
-// TestCanaryStatusSyncedDespiteStageError verifies actuation stage failures still sync status,
+// TestCanaryStatusSyncedDespiteStageError verifies stage failures still sync status,
 // hold step progression, and return an error for workqueue backoff.
 func TestCanaryStatusSyncedDespiteStageError(t *testing.T) {
 	t.Run("traffic routing SetWeight error", func(t *testing.T) {

--- a/rollout/context.go
+++ b/rollout/context.go
@@ -60,14 +60,14 @@ type rolloutContext struct {
 	// Used to detect fast rollbacks where we skip pause/analysis steps.
 	newRSWithinDelay bool
 
-	// actuationDeferred is set when any actuation stage errored this reconcile, meaning the
-	// cluster may not match the state about to be persisted. While set, the current canary step
-	// must not complete and stable must not be promoted. Superseded by per-stage conditions in
-	// a follow-up phase.
-	actuationDeferred bool
 	// skipStatusSync preserves the historical pod-restart early exit, which intentionally ends
 	// the pass without a status sync (see rolloutCanary).
 	skipStatusSync bool
+
+	// stageConditions collects conditions produced by actuation stages during this reconcile.
+	// Merged into newStatus by mergeStageConditions; read by progression gates via
+	// stageConditionFalse.
+	stageConditions map[v1alpha1.RolloutConditionType]v1alpha1.RolloutCondition
 }
 
 func (c *rolloutContext) reconcile() error {

--- a/rollout/context.go
+++ b/rollout/context.go
@@ -3,6 +3,7 @@ package rollout
 import (
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	analysisutil "github.com/argoproj/argo-rollouts/utils/analysis"
@@ -60,13 +61,12 @@ type rolloutContext struct {
 	// Used to detect fast rollbacks where we skip pause/analysis steps.
 	newRSWithinDelay bool
 
-	// skipStatusSync ends the pass without a status sync. Set by the historical pod-restart
-	// early exit and by ReplicaSet-sync failures (stageFatalNoStatus), where c.newRS is
-	// unreliable and a status computed from it would persist corrupted values (see
-	// rolloutCanary and runCanaryStages).
+	// skipStatusSync ends the pass without a status sync. Set by the pod-restart early exit and
+	// by ReplicaSet-sync failures (stageStopNoStatus with err), where c.newRS is unreliable and
+	// a status computed from it would persist corrupted values (see rolloutCanary and runStages).
 	skipStatusSync bool
 
-	// stageConditions collects conditions produced by the canary stages during this reconcile.
+	// stageConditions collects conditions produced by reconcile stages during this reconcile.
 	// Merged into newStatus by mergeStageConditions; read by progression gates via
 	// stageConditionFalse.
 	stageConditions map[v1alpha1.RolloutConditionType]v1alpha1.RolloutCondition
@@ -75,6 +75,10 @@ type rolloutContext struct {
 	// completion without error this reconcile. mergeStageConditions only lets a previously-False
 	// stage condition recover to True when its owner actually succeeded this pass.
 	stageSuccesses map[v1alpha1.RolloutConditionType]bool
+
+	// blueGreenPreviewSvc and blueGreenActiveSvc are set for the duration of runBlueGreenStages.
+	blueGreenPreviewSvc *corev1.Service
+	blueGreenActiveSvc  *corev1.Service
 }
 
 func (c *rolloutContext) reconcile() error {

--- a/rollout/context.go
+++ b/rollout/context.go
@@ -66,14 +66,14 @@ type rolloutContext struct {
 	// a status computed from it would persist corrupted values (see rolloutCanary and runStages).
 	skipStatusSync bool
 
-	// stageConditions collects conditions produced by reconcile stages during this reconcile.
-	// Merged into newStatus by mergeStageConditions; read by progression gates via
+	// stageConditions holds the in-memory ReconcileSucceeded condition when reconcile work fails
+	// this pass. Merged into newStatus by mergeStageConditions; read by progression gates via
 	// stageConditionFalse.
 	stageConditions map[v1alpha1.RolloutConditionType]v1alpha1.RolloutCondition
 
-	// stageSuccesses records, per tracked stage condition type, that the owning stage(s) ran to
-	// completion without error this reconcile. mergeStageConditions only lets a previously-False
-	// stage condition recover to True when its owner actually succeeded this pass.
+	// stageSuccesses records that reconcile work completed without error this pass.
+	// mergeStageConditions only lets a previously-False ReconcileSucceeded recover to True when
+	// stageSuccesses is set.
 	stageSuccesses map[v1alpha1.RolloutConditionType]bool
 
 	// blueGreenPreviewSvc and blueGreenActiveSvc are set for the duration of runBlueGreenStages.

--- a/rollout/context.go
+++ b/rollout/context.go
@@ -60,14 +60,21 @@ type rolloutContext struct {
 	// Used to detect fast rollbacks where we skip pause/analysis steps.
 	newRSWithinDelay bool
 
-	// skipStatusSync preserves the historical pod-restart early exit, which intentionally ends
-	// the pass without a status sync (see rolloutCanary).
+	// skipStatusSync ends the pass without a status sync. Set by the historical pod-restart
+	// early exit and by ReplicaSet-sync failures (stageFatalNoStatus), where c.newRS is
+	// unreliable and a status computed from it would persist corrupted values (see
+	// rolloutCanary and runCanaryStages).
 	skipStatusSync bool
 
 	// stageConditions collects conditions produced by actuation stages during this reconcile.
 	// Merged into newStatus by mergeStageConditions; read by progression gates via
 	// stageConditionFalse.
 	stageConditions map[v1alpha1.RolloutConditionType]v1alpha1.RolloutCondition
+
+	// stageSuccesses records, per tracked stage condition type, that the owning stage(s) ran to
+	// completion without error this reconcile. mergeStageConditions only lets a previously-False
+	// stage condition recover to True when its owner actually succeeded this pass.
+	stageSuccesses map[v1alpha1.RolloutConditionType]bool
 }
 
 func (c *rolloutContext) reconcile() error {

--- a/rollout/context.go
+++ b/rollout/context.go
@@ -59,6 +59,15 @@ type rolloutContext struct {
 	// annotation at the start of reconciliation (before it may be removed).
 	// Used to detect fast rollbacks where we skip pause/analysis steps.
 	newRSWithinDelay bool
+
+	// actuationDeferred is set when any actuation stage errored this reconcile, meaning the
+	// cluster may not match the state about to be persisted. While set, the current canary step
+	// must not complete and stable must not be promoted. Superseded by per-stage conditions in
+	// a follow-up phase.
+	actuationDeferred bool
+	// skipStatusSync preserves the historical pod-restart early exit, which intentionally ends
+	// the pass without a status sync (see rolloutCanary).
+	skipStatusSync bool
 }
 
 func (c *rolloutContext) reconcile() error {

--- a/rollout/context.go
+++ b/rollout/context.go
@@ -66,7 +66,7 @@ type rolloutContext struct {
 	// rolloutCanary and runCanaryStages).
 	skipStatusSync bool
 
-	// stageConditions collects conditions produced by actuation stages during this reconcile.
+	// stageConditions collects conditions produced by the canary stages during this reconcile.
 	// Merged into newStatus by mergeStageConditions; read by progression gates via
 	// stageConditionFalse.
 	stageConditions map[v1alpha1.RolloutConditionType]v1alpha1.RolloutCondition

--- a/rollout/controller.go
+++ b/rollout/controller.go
@@ -469,16 +469,18 @@ func (c *Controller) syncHandler(ctx context.Context, key string) error {
 	}
 
 	err = roCtx.reconcile()
-	if err != nil {
-		logCtx.Errorf("roCtx.reconcile err %v", err)
-		// return an err here so that we do not update the informer cache with a "bad" rollout object, for the case when
-		// we get an error during reconciliation but c.newRollout still gets updated this can happen in syncReplicaSetRevision
-		// https://github.com/argoproj/argo-rollouts/issues/2522#issuecomment-1492181154 I also believe there are other cases
-		// that newRollout can get updated while we get an error during reconciliation
-		return err
-	}
+	// Record the ResourceVersion even when reconcile returned an error: a stage failure is
+	// routinely joined with a successful status patch (rolloutCanary/rolloutBlueGreen return
+	// errors.Join(stageErr, syncRolloutStatus(...))), and newRollout.ResourceVersion comes from
+	// a write the API server accepted. Skipping the Record here would let the quick workqueue
+	// retry pass the IsCacheStale check with the pre-patch rollout and reconcile off stale
+	// status (CurrentStepIndex, weights, conditions).
 	if roCtx.newRollout != nil {
 		c.rolloutVersionTracker.Record(key, roCtx.newRollout.ResourceVersion)
+	}
+	if err != nil {
+		logCtx.Errorf("roCtx.reconcile err %v", err)
+		return err
 	}
 	return nil
 }

--- a/rollout/service.go
+++ b/rollout/service.go
@@ -141,6 +141,10 @@ func (c *rolloutContext) awsVerifyTargetGroups(svc *corev1.Service) error {
 	// find all TargetGroupBindings in the namespace which reference the service name + port
 	tgBindings, err := aws.GetTargetGroupBindingsByService(ctx, c.dynamicclientset, *svc)
 	if err != nil {
+		// Mark verification as attempted-and-failed so promotion gates (areTargetsVerified)
+		// hold: the reconcile now always falls through to the status sync, and a nil
+		// targetsVerified would read as "verified".
+		c.targetsVerified = ptr.To[bool](false)
 		return err
 	}
 	if len(tgBindings) == 0 {

--- a/rollout/stageconditions.go
+++ b/rollout/stageconditions.go
@@ -1,0 +1,86 @@
+package rollout
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/argoproj/argo-rollouts/utils/conditions"
+)
+
+const maxStageConditionMessageLen = 256
+
+var trackedStageConditionTypes = []v1alpha1.RolloutConditionType{
+	v1alpha1.RolloutTrafficRoutingApplied,
+	v1alpha1.RolloutServicesReconciled,
+	v1alpha1.RolloutActuationSucceeded,
+}
+
+func truncateStageConditionMessage(message string) string {
+	if len(message) <= maxStageConditionMessageLen {
+		return message
+	}
+	return message[:maxStageConditionMessageLen]
+}
+
+func (c *rolloutContext) setStageCondition(condType v1alpha1.RolloutConditionType, status corev1.ConditionStatus, reason, message string) {
+	if c.stageConditions == nil {
+		c.stageConditions = make(map[v1alpha1.RolloutConditionType]v1alpha1.RolloutCondition)
+	}
+	c.stageConditions[condType] = *conditions.NewRolloutCondition(condType, status, reason, truncateStageConditionMessage(message))
+}
+
+// stageConditionFalse reports whether condType was recorded False THIS reconcile. Gates must key
+// off current-pass failures, not stale persisted conditions.
+func (c *rolloutContext) stageConditionFalse(condType v1alpha1.RolloutConditionType) bool {
+	if c.stageConditions == nil {
+		return false
+	}
+	cond, ok := c.stageConditions[condType]
+	return ok && cond.Status == corev1.ConditionFalse
+}
+
+func (c *rolloutContext) anyStageConditionFalse() bool {
+	for _, condType := range trackedStageConditionTypes {
+		if c.stageConditionFalse(condType) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *rolloutContext) ensureActuationFailureCondition(err error) {
+	for _, condType := range trackedStageConditionTypes {
+		if c.stageConditionFalse(condType) {
+			return
+		}
+	}
+	c.setStageCondition(v1alpha1.RolloutActuationSucceeded, corev1.ConditionFalse, conditions.ActuationErrorReason, err.Error())
+}
+
+func (c *rolloutContext) mergeStageConditions(newStatus *v1alpha1.RolloutStatus) {
+	if c.rollout.Spec.Strategy.Canary == nil {
+		return
+	}
+	trafficRoutingConfigured := c.rollout.Spec.Strategy.Canary.TrafficRouting != nil
+
+	for _, condType := range trackedStageConditionTypes {
+		if condType == v1alpha1.RolloutTrafficRoutingApplied && !trafficRoutingConfigured {
+			conditions.RemoveRolloutCondition(newStatus, condType)
+			continue
+		}
+
+		if cond, ok := c.stageConditions[condType]; ok {
+			conditions.SetRolloutCondition(newStatus, cond)
+			continue
+		}
+
+		prevCond := conditions.GetRolloutCondition(c.rollout.Status, condType)
+		if prevCond != nil && prevCond.Status == corev1.ConditionFalse {
+			reason := conditions.StageConditionAppliedReason
+			if condType == v1alpha1.RolloutServicesReconciled {
+				reason = conditions.StageConditionReconciledReason
+			}
+			conditions.SetRolloutCondition(newStatus, *conditions.NewRolloutCondition(condType, corev1.ConditionTrue, reason, ""))
+		}
+	}
+}

--- a/rollout/stageconditions.go
+++ b/rollout/stageconditions.go
@@ -29,6 +29,16 @@ func (c *rolloutContext) setStageCondition(condType v1alpha1.RolloutConditionTyp
 	c.stageConditions[condType] = *conditions.NewRolloutCondition(condType, status, reason, truncateStageConditionMessage(message))
 }
 
+// markStageSucceeded records that the stage(s) reporting under condType ran to completion without
+// error this reconcile, making a previously-False condition eligible to recover to True in
+// mergeStageConditions.
+func (c *rolloutContext) markStageSucceeded(condType v1alpha1.RolloutConditionType) {
+	if c.stageSuccesses == nil {
+		c.stageSuccesses = make(map[v1alpha1.RolloutConditionType]bool)
+	}
+	c.stageSuccesses[condType] = true
+}
+
 // stageConditionFalse reports whether condType was recorded False THIS reconcile. Gates must key
 // off current-pass failures, not stale persisted conditions.
 func (c *rolloutContext) stageConditionFalse(condType v1alpha1.RolloutConditionType) bool {
@@ -74,8 +84,13 @@ func (c *rolloutContext) mergeStageConditions(newStatus *v1alpha1.RolloutStatus)
 			continue
 		}
 
+		// A previously-False condition may only recover to True when the owning stage(s)
+		// actually re-ran and succeeded this pass. A reconcile that never reached the stage
+		// (an earlier stage stopped or failed the pipeline, or a scaling-only pass that runs
+		// no stages at all) must leave the condition untouched rather than report a recovery
+		// that never happened.
 		prevCond := conditions.GetRolloutCondition(c.rollout.Status, condType)
-		if prevCond != nil && prevCond.Status == corev1.ConditionFalse {
+		if prevCond != nil && prevCond.Status == corev1.ConditionFalse && c.stageSuccesses[condType] {
 			reason := conditions.StageConditionAppliedReason
 			if condType == v1alpha1.RolloutServicesReconciled {
 				reason = conditions.StageConditionReconciledReason

--- a/rollout/stageconditions.go
+++ b/rollout/stageconditions.go
@@ -76,16 +76,7 @@ func (c *rolloutContext) ensureReconcileFailureCondition(err error) {
 }
 
 func (c *rolloutContext) mergeStageConditions(newStatus *v1alpha1.RolloutStatus) {
-	if c.rollout.Spec.Strategy.Canary == nil {
-		// Stage conditions are only produced by the canary pipeline. Remove any leftovers so a
-		// strategy migration (canary -> blueGreen) does not freeze a stale False condition into
-		// status forever.
-		for _, condType := range trackedStageConditionTypes {
-			conditions.RemoveRolloutCondition(newStatus, condType)
-		}
-		return
-	}
-	trafficRoutingConfigured := c.rollout.Spec.Strategy.Canary.TrafficRouting != nil
+	trafficRoutingConfigured := c.rollout.Spec.Strategy.Canary != nil && c.rollout.Spec.Strategy.Canary.TrafficRouting != nil
 
 	for _, condType := range trackedStageConditionTypes {
 		if condType == v1alpha1.RolloutTrafficRoutingApplied && !trafficRoutingConfigured {

--- a/rollout/stageconditions.go
+++ b/rollout/stageconditions.go
@@ -31,9 +31,8 @@ func (c *rolloutContext) setStageCondition(condType v1alpha1.RolloutConditionTyp
 	c.stageConditions[condType] = *conditions.NewRolloutCondition(condType, status, reason, truncateStageConditionMessage(message))
 }
 
-// markStageSucceeded records that the full stage pipeline ran to completion without error this
-// reconcile, making a previously-False ReconcileSucceeded eligible to recover to True in
-// mergeStageConditions.
+// markStageSucceeded records that reconcile work completed without error this pass, making a
+// previously-False ReconcileSucceeded eligible to recover to True in mergeStageConditions.
 func (c *rolloutContext) markStageSucceeded() {
 	if c.stageSuccesses == nil {
 		c.stageSuccesses = make(map[v1alpha1.RolloutConditionType]bool)
@@ -41,8 +40,8 @@ func (c *rolloutContext) markStageSucceeded() {
 	c.stageSuccesses[v1alpha1.RolloutReconcileSucceeded] = true
 }
 
-// stageConditionFalse reports whether ReconcileSucceeded was recorded False THIS reconcile.
-// Gates must key off current-pass failures, not stale persisted conditions.
+// stageConditionFalse reports whether ReconcileSucceeded was recorded False this pass.
+// Progression gates key off current-pass failures, not stale persisted conditions.
 func (c *rolloutContext) stageConditionFalse() bool {
 	if c.stageConditions == nil {
 		return false
@@ -69,9 +68,8 @@ func (c *rolloutContext) mergeStageConditions(newStatus *v1alpha1.RolloutStatus)
 		return
 	}
 
-	// A previously-False condition may only recover to True when the full pipeline actually
-	// completed without error this pass. A reconcile that stopped or failed early must leave
-	// the condition untouched rather than report a recovery that never happened.
+	// A previously-False condition may only recover to True when reconcile work completed without
+	// error this pass. Early exits (e.g. waiting for scaling) leave the condition unchanged.
 	prevCond := conditions.GetRolloutCondition(c.rollout.Status, condType)
 	if prevCond != nil && prevCond.Status == corev1.ConditionFalse && c.stageSuccesses[condType] {
 		conditions.SetRolloutCondition(newStatus, *conditions.NewRolloutCondition(

--- a/rollout/stageconditions.go
+++ b/rollout/stageconditions.go
@@ -11,12 +11,6 @@ import (
 
 const maxStageConditionMessageLen = 256
 
-var trackedStageConditionTypes = []v1alpha1.RolloutConditionType{
-	v1alpha1.RolloutTrafficRoutingApplied,
-	v1alpha1.RolloutServicesReconciled,
-	v1alpha1.RolloutReconcileSucceeded,
-}
-
 func truncateStageConditionMessage(message string) string {
 	if len(message) <= maxStageConditionMessageLen {
 		return message
@@ -37,70 +31,50 @@ func (c *rolloutContext) setStageCondition(condType v1alpha1.RolloutConditionTyp
 	c.stageConditions[condType] = *conditions.NewRolloutCondition(condType, status, reason, truncateStageConditionMessage(message))
 }
 
-// markStageSucceeded records that the stage(s) reporting under condType ran to completion without
-// error this reconcile, making a previously-False condition eligible to recover to True in
+// markStageSucceeded records that the full stage pipeline ran to completion without error this
+// reconcile, making a previously-False ReconcileSucceeded eligible to recover to True in
 // mergeStageConditions.
-func (c *rolloutContext) markStageSucceeded(condType v1alpha1.RolloutConditionType) {
+func (c *rolloutContext) markStageSucceeded() {
 	if c.stageSuccesses == nil {
 		c.stageSuccesses = make(map[v1alpha1.RolloutConditionType]bool)
 	}
-	c.stageSuccesses[condType] = true
+	c.stageSuccesses[v1alpha1.RolloutReconcileSucceeded] = true
 }
 
-// stageConditionFalse reports whether condType was recorded False THIS reconcile. Gates must key
-// off current-pass failures, not stale persisted conditions.
-func (c *rolloutContext) stageConditionFalse(condType v1alpha1.RolloutConditionType) bool {
+// stageConditionFalse reports whether ReconcileSucceeded was recorded False THIS reconcile.
+// Gates must key off current-pass failures, not stale persisted conditions.
+func (c *rolloutContext) stageConditionFalse() bool {
 	if c.stageConditions == nil {
 		return false
 	}
-	cond, ok := c.stageConditions[condType]
+	cond, ok := c.stageConditions[v1alpha1.RolloutReconcileSucceeded]
 	return ok && cond.Status == corev1.ConditionFalse
 }
 
 func (c *rolloutContext) anyStageConditionFalse() bool {
-	for _, condType := range trackedStageConditionTypes {
-		if c.stageConditionFalse(condType) {
-			return true
-		}
-	}
-	return false
+	return c.stageConditionFalse()
 }
 
 func (c *rolloutContext) ensureReconcileFailureCondition(err error) {
-	for _, condType := range trackedStageConditionTypes {
-		if c.stageConditionFalse(condType) {
-			return
-		}
+	if c.stageConditionFalse() {
+		return
 	}
 	c.setStageCondition(v1alpha1.RolloutReconcileSucceeded, corev1.ConditionFalse, conditions.RolloutReconciliationErrorReason, err.Error())
 }
 
 func (c *rolloutContext) mergeStageConditions(newStatus *v1alpha1.RolloutStatus) {
-	trafficRoutingConfigured := c.rollout.Spec.Strategy.Canary != nil && c.rollout.Spec.Strategy.Canary.TrafficRouting != nil
+	condType := v1alpha1.RolloutReconcileSucceeded
+	if cond, ok := c.stageConditions[condType]; ok {
+		conditions.SetRolloutCondition(newStatus, cond)
+		return
+	}
 
-	for _, condType := range trackedStageConditionTypes {
-		if condType == v1alpha1.RolloutTrafficRoutingApplied && !trafficRoutingConfigured {
-			conditions.RemoveRolloutCondition(newStatus, condType)
-			continue
-		}
-
-		if cond, ok := c.stageConditions[condType]; ok {
-			conditions.SetRolloutCondition(newStatus, cond)
-			continue
-		}
-
-		// A previously-False condition may only recover to True when the owning stage(s)
-		// actually re-ran and succeeded this pass. A reconcile that never reached the stage
-		// (an earlier stage stopped or failed the pipeline, or a scaling-only pass that runs
-		// no stages at all) must leave the condition untouched rather than report a recovery
-		// that never happened.
-		prevCond := conditions.GetRolloutCondition(c.rollout.Status, condType)
-		if prevCond != nil && prevCond.Status == corev1.ConditionFalse && c.stageSuccesses[condType] {
-			reason := conditions.StageConditionAppliedReason
-			if condType == v1alpha1.RolloutServicesReconciled {
-				reason = conditions.StageConditionReconciledReason
-			}
-			conditions.SetRolloutCondition(newStatus, *conditions.NewRolloutCondition(condType, corev1.ConditionTrue, reason, ""))
-		}
+	// A previously-False condition may only recover to True when the full pipeline actually
+	// completed without error this pass. A reconcile that stopped or failed early must leave
+	// the condition untouched rather than report a recovery that never happened.
+	prevCond := conditions.GetRolloutCondition(c.rollout.Status, condType)
+	if prevCond != nil && prevCond.Status == corev1.ConditionFalse && c.stageSuccesses[condType] {
+		conditions.SetRolloutCondition(newStatus, *conditions.NewRolloutCondition(
+			condType, corev1.ConditionTrue, conditions.StageConditionAppliedReason, ""))
 	}
 }

--- a/rollout/stageconditions.go
+++ b/rollout/stageconditions.go
@@ -14,7 +14,7 @@ const maxStageConditionMessageLen = 256
 var trackedStageConditionTypes = []v1alpha1.RolloutConditionType{
 	v1alpha1.RolloutTrafficRoutingApplied,
 	v1alpha1.RolloutServicesReconciled,
-	v1alpha1.RolloutActuationSucceeded,
+	v1alpha1.RolloutReconcileSucceeded,
 }
 
 func truncateStageConditionMessage(message string) string {
@@ -66,13 +66,13 @@ func (c *rolloutContext) anyStageConditionFalse() bool {
 	return false
 }
 
-func (c *rolloutContext) ensureActuationFailureCondition(err error) {
+func (c *rolloutContext) ensureReconcileFailureCondition(err error) {
 	for _, condType := range trackedStageConditionTypes {
 		if c.stageConditionFalse(condType) {
 			return
 		}
 	}
-	c.setStageCondition(v1alpha1.RolloutActuationSucceeded, corev1.ConditionFalse, conditions.ActuationErrorReason, err.Error())
+	c.setStageCondition(v1alpha1.RolloutReconcileSucceeded, corev1.ConditionFalse, conditions.RolloutReconciliationErrorReason, err.Error())
 }
 
 func (c *rolloutContext) mergeStageConditions(newStatus *v1alpha1.RolloutStatus) {

--- a/rollout/stageconditions.go
+++ b/rollout/stageconditions.go
@@ -1,6 +1,8 @@
 package rollout
 
 import (
+	"unicode/utf8"
+
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
@@ -19,7 +21,13 @@ func truncateStageConditionMessage(message string) string {
 	if len(message) <= maxStageConditionMessageLen {
 		return message
 	}
-	return message[:maxStageConditionMessageLen]
+	// Back up to a rune boundary so the cut never splits a multi-byte UTF-8 character, which
+	// would persist an invalid-UTF-8 condition message.
+	cut := maxStageConditionMessageLen
+	for cut > 0 && !utf8.RuneStart(message[cut]) {
+		cut--
+	}
+	return message[:cut]
 }
 
 func (c *rolloutContext) setStageCondition(condType v1alpha1.RolloutConditionType, status corev1.ConditionStatus, reason, message string) {
@@ -69,6 +77,12 @@ func (c *rolloutContext) ensureActuationFailureCondition(err error) {
 
 func (c *rolloutContext) mergeStageConditions(newStatus *v1alpha1.RolloutStatus) {
 	if c.rollout.Spec.Strategy.Canary == nil {
+		// Stage conditions are only produced by the canary pipeline. Remove any leftovers so a
+		// strategy migration (canary -> blueGreen) does not freeze a stale False condition into
+		// status forever.
+		for _, condType := range trackedStageConditionTypes {
+			conditions.RemoveRolloutCondition(newStatus, condType)
+		}
 		return
 	}
 	trafficRoutingConfigured := c.rollout.Spec.Strategy.Canary.TrafficRouting != nil

--- a/rollout/stageconditions_test.go
+++ b/rollout/stageconditions_test.go
@@ -95,6 +95,49 @@ func TestPromotionHeldWhileStageConditionFalse(t *testing.T) {
 	assert.NotContains(t, f.getPatchedRollout(patchIndex), fmt.Sprintf(`"stableRS":"%s"`, rs2PodHash))
 }
 
+// TestPromoteFullHeldEmitsEvent verifies that a user-requested full promotion (promote --full)
+// held by the unverified-weights safety gate emits an event explaining why the forced promotion
+// did not take effect.
+func TestPromoteFullHeldEmitsEvent(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{{SetWeight: ptr.To[int32](10)}, {Pause: &v1alpha1.RolloutPause{}}}
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](2), intstr.FromInt(1), intstr.FromInt(0))
+	r2 := bumpVersion(r1)
+	r2.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
+	r2.Spec.Strategy.Canary.CanaryService = "canary"
+	r2.Spec.Strategy.Canary.StableService = "stable"
+
+	rs1 := newReplicaSetWithStatus(r1, 10, 10)
+	rs2 := newReplicaSetWithStatus(r2, 10, 10)
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	canarySvc := newService("canary", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}, r2)
+	stableSvc := newService("stable", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}, r2)
+
+	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 10, 0, 10, false)
+	r2.Status.PromoteFull = true
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2, canarySvc, stableSvc)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2)
+
+	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](false), nil)
+	f.fakeTrafficRouting.On("RemoveManagedRoutes").Return(nil)
+
+	patchIndex := f.expectPatchRolloutAction(r2)
+	f.run(getKey(r2, t))
+	assert.NotContains(t, f.getPatchedRollout(patchIndex), fmt.Sprintf(`"stableRS":"%s"`, rs2PodHash),
+		"unverified weights must still hold the forced promotion")
+	assert.Contains(t, strings.Join(f.events, " "), conditions.PromoteFullHeldReason,
+		"the held promotion must be surfaced to the operator via an event")
+}
+
 // TestStageConditionRecoveryRequiresStageSuccess verifies that a previously-False stage condition
 // only flips back to True when the owning stage actually re-ran and succeeded this reconcile —
 // a pass that never reached the stage must not report a recovery that never happened.

--- a/rollout/stageconditions_test.go
+++ b/rollout/stageconditions_test.go
@@ -236,21 +236,30 @@ func TestConditionMessageTruncatedOnRuneBoundary(t *testing.T) {
 	assert.Equal(t, maxStageConditionMessageLen-1, len(truncated))
 }
 
-// TestStageConditionsRemovedOnStrategyMigration verifies that a stale stage condition left over
-// from a canary strategy is removed once the rollout is migrated to blueGreen, instead of
-// reporting a reconcile failure forever on a healthy blue-green rollout.
-func TestStageConditionsRemovedOnStrategyMigration(t *testing.T) {
+// TestStageConditionsOnStrategyMigration verifies canary-only stage conditions are handled when
+// a rollout is migrated to blue-green: TrafficRoutingApplied is removed as inapplicable, and a
+// stale ServicesReconciled=False recovers once the blue-green service stages succeed.
+func TestStageConditionsOnStrategyMigration(t *testing.T) {
 	ro := newCanaryRollout("foo", 1, nil, nil, nil, intstr.FromInt(1), intstr.FromInt(0))
 	ro.Spec.Strategy.Canary = nil
 	ro.Spec.Strategy.BlueGreen = &v1alpha1.BlueGreenStrategy{}
 	conditions.SetRolloutCondition(&ro.Status, *conditions.NewRolloutCondition(
 		v1alpha1.RolloutServicesReconciled, corev1.ConditionFalse, conditions.ServiceUpdateErrorReason, "service update failed"))
+	conditions.SetRolloutCondition(&ro.Status, *conditions.NewRolloutCondition(
+		v1alpha1.RolloutTrafficRoutingApplied, corev1.ConditionFalse, conditions.TrafficRoutingErrorReason, "routing failed"))
 
 	ctx := &rolloutContext{rollout: ro}
 	newStatus := ro.Status.DeepCopy()
 	ctx.mergeStageConditions(newStatus)
-	assert.Nil(t, conditions.GetRolloutCondition(*newStatus, v1alpha1.RolloutServicesReconciled),
-		"stage conditions must not survive a strategy migration away from canary")
+	assert.Nil(t, conditions.GetRolloutCondition(*newStatus, v1alpha1.RolloutTrafficRoutingApplied),
+		"TrafficRoutingApplied must not apply to blue-green")
+
+	ctx.markStageSucceeded(v1alpha1.RolloutServicesReconciled)
+	ctx.mergeStageConditions(newStatus)
+	servicesCond := conditions.GetRolloutCondition(*newStatus, v1alpha1.RolloutServicesReconciled)
+	assert.NotNil(t, servicesCond)
+	assert.Equal(t, corev1.ConditionTrue, servicesCond.Status,
+		"ServicesReconciled must recover once blue-green service stages succeed")
 }
 
 func TestConditionNoChurnOnRepeatedError(t *testing.T) {

--- a/rollout/stageconditions_test.go
+++ b/rollout/stageconditions_test.go
@@ -221,8 +221,8 @@ func TestStageConditionNotRecoveredWhenPipelineStopsEarly(t *testing.T) {
 func TestConditionMessageTruncated(t *testing.T) {
 	ctx := &rolloutContext{}
 	longMsg := strings.Repeat("x", maxStageConditionMessageLen+10)
-	ctx.setStageCondition(v1alpha1.RolloutActuationSucceeded, corev1.ConditionFalse, conditions.ActuationErrorReason, longMsg)
-	cond := ctx.stageConditions[v1alpha1.RolloutActuationSucceeded]
+	ctx.setStageCondition(v1alpha1.RolloutReconcileSucceeded, corev1.ConditionFalse, conditions.RolloutReconciliationErrorReason, longMsg)
+	cond := ctx.stageConditions[v1alpha1.RolloutReconcileSucceeded]
 	assert.Len(t, cond.Message, maxStageConditionMessageLen)
 }
 

--- a/rollout/stageconditions_test.go
+++ b/rollout/stageconditions_test.go
@@ -24,7 +24,7 @@ func TestStageConditionsMergedIntoStatus(t *testing.T) {
 	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(errors.New("routing failed"))
 
 	patchIndex := f.expectPatchRolloutAction(ro)
-	f.runExpectError(getKey(ro, t), true)
+	f.run(getKey(ro, t))
 	patched := f.getPatchedRolloutAsObject(patchIndex)
 	cond := conditions.GetRolloutCondition(patched.Status, v1alpha1.RolloutTrafficRoutingApplied)
 	assert.NotNil(t, cond)
@@ -53,7 +53,7 @@ func TestStepHeldWhileStageConditionFalse(t *testing.T) {
 	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(errors.New("routing failed"))
 
 	patchIndex := f.expectPatchRolloutAction(ro)
-	f.runExpectError(getKey(ro, t), true)
+	f.run(getKey(ro, t))
 	patched := f.getPatchedRolloutAsObject(patchIndex)
 	assert.Nil(t, patched.Status.CurrentStepIndex)
 }

--- a/rollout/stageconditions_test.go
+++ b/rollout/stageconditions_test.go
@@ -29,7 +29,7 @@ func TestStageConditionsMergedIntoStatus(t *testing.T) {
 	patchIndex := f.expectPatchRolloutAction(ro)
 	f.runExpectError(getKey(ro, t), true)
 	patched := f.getPatchedRolloutAsObject(patchIndex)
-	cond := conditions.GetRolloutCondition(patched.Status, v1alpha1.RolloutTrafficRoutingApplied)
+	cond := conditions.GetRolloutCondition(patched.Status, v1alpha1.RolloutReconcileSucceeded)
 	assert.NotNil(t, cond)
 	assert.Equal(t, corev1.ConditionFalse, cond.Status)
 	assert.Equal(t, conditions.TrafficRoutingErrorReason, cond.Reason)
@@ -44,8 +44,6 @@ func TestStageConditionsMergedIntoStatus(t *testing.T) {
 	f2.replicaSetLister = append(f2.replicaSetLister, rs)
 	patchIndex = f2.expectPatchRolloutAction(basic)
 	f2.run(getKey(basic, t))
-	patchedBasic := f2.getPatchedRolloutAsObject(patchIndex)
-	assert.Nil(t, conditions.GetRolloutCondition(patchedBasic.Status, v1alpha1.RolloutTrafficRoutingApplied))
 }
 
 func TestStepHeldWhileStageConditionFalse(t *testing.T) {
@@ -146,30 +144,29 @@ func TestStageConditionRecoveryRequiresStageSuccess(t *testing.T) {
 	ro := newCanaryRollout("foo", 1, nil, nil, nil, intstr.FromInt(1), intstr.FromInt(0))
 	ro.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
 	conditions.SetRolloutCondition(&ro.Status, *conditions.NewRolloutCondition(
-		v1alpha1.RolloutTrafficRoutingApplied, corev1.ConditionFalse, conditions.TrafficRoutingErrorReason, "routing failed"))
+		v1alpha1.RolloutReconcileSucceeded, corev1.ConditionFalse, conditions.TrafficRoutingErrorReason, "routing failed"))
 
 	ctx := &rolloutContext{rollout: ro}
 	newStatus := ro.Status.DeepCopy()
 
-	// The trafficRouting stage did not run this pass (e.g. an earlier stage stopped the
-	// pipeline, or a scaling-only pass ran no stages): the condition must stay False.
+	// The full pipeline did not complete this pass: the condition must stay False.
 	ctx.mergeStageConditions(newStatus)
-	cond := conditions.GetRolloutCondition(*newStatus, v1alpha1.RolloutTrafficRoutingApplied)
+	cond := conditions.GetRolloutCondition(*newStatus, v1alpha1.RolloutReconcileSucceeded)
 	assert.NotNil(t, cond)
-	assert.Equal(t, corev1.ConditionFalse, cond.Status, "a stage that did not run must not report recovery")
+	assert.Equal(t, corev1.ConditionFalse, cond.Status, "a pass that did not finish must not report recovery")
 
-	// Once the owning stage actually re-runs and succeeds, the condition recovers.
-	ctx.markStageSucceeded(v1alpha1.RolloutTrafficRoutingApplied)
+	// Once the full pipeline completes without error, the condition recovers.
+	ctx.markStageSucceeded()
 	ctx.mergeStageConditions(newStatus)
-	cond = conditions.GetRolloutCondition(*newStatus, v1alpha1.RolloutTrafficRoutingApplied)
+	cond = conditions.GetRolloutCondition(*newStatus, v1alpha1.RolloutReconcileSucceeded)
 	assert.NotNil(t, cond)
 	assert.Equal(t, corev1.ConditionTrue, cond.Status)
 	assert.Equal(t, conditions.StageConditionAppliedReason, cond.Reason)
 }
 
 // TestStageConditionNotRecoveredWhenPipelineStopsEarly is the end-to-end variant: a services
-// failure aborts the pipeline before the trafficRouting stage runs, so a pre-existing
-// TrafficRoutingApplied=False must survive the status sync unchanged instead of flipping True.
+// failure aborts the pipeline before traffic routing runs, so ReconcileSucceeded stays False
+// with the service failure reason instead of reporting recovery.
 func TestStageConditionNotRecoveredWhenPipelineStopsEarly(t *testing.T) {
 	f := newFixture(t)
 	defer f.Close()
@@ -190,7 +187,7 @@ func TestStageConditionNotRecoveredWhenPipelineStopsEarly(t *testing.T) {
 
 	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 11, 1, 11, false)
 	conditions.SetRolloutCondition(&r2.Status, *conditions.NewRolloutCondition(
-		v1alpha1.RolloutTrafficRoutingApplied, corev1.ConditionFalse, conditions.TrafficRoutingErrorReason, "routing failed"))
+		v1alpha1.RolloutReconcileSucceeded, corev1.ConditionFalse, conditions.TrafficRoutingErrorReason, "routing failed"))
 	f.kubeobjects = append(f.kubeobjects, rs1, rs2, canarySvc, stableSvc)
 	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
 	f.serviceLister = append(f.serviceLister, canarySvc, stableSvc)
@@ -208,14 +205,10 @@ func TestStageConditionNotRecoveredWhenPipelineStopsEarly(t *testing.T) {
 	f.runController(getKey(r2, t), true, true, c, i, k8sI)
 
 	patched := f.getPatchedRolloutAsObject(patchIndex)
-	servicesCond := conditions.GetRolloutCondition(patched.Status, v1alpha1.RolloutServicesReconciled)
-	assert.NotNil(t, servicesCond)
-	assert.Equal(t, corev1.ConditionFalse, servicesCond.Status)
-	trCond := conditions.GetRolloutCondition(patched.Status, v1alpha1.RolloutTrafficRoutingApplied)
-	if trCond != nil {
-		assert.Equal(t, corev1.ConditionFalse, trCond.Status,
-			"trafficRouting stage never ran this pass; its condition must not report recovery")
-	}
+	cond := conditions.GetRolloutCondition(patched.Status, v1alpha1.RolloutReconcileSucceeded)
+	assert.NotNil(t, cond)
+	assert.Equal(t, corev1.ConditionFalse, cond.Status)
+	assert.Equal(t, conditions.ServiceUpdateErrorReason, cond.Reason)
 }
 
 func TestConditionMessageTruncated(t *testing.T) {
@@ -236,41 +229,36 @@ func TestConditionMessageTruncatedOnRuneBoundary(t *testing.T) {
 	assert.Equal(t, maxStageConditionMessageLen-1, len(truncated))
 }
 
-// TestStageConditionsOnStrategyMigration verifies canary-only stage conditions are handled when
-// a rollout is migrated to blue-green: TrafficRoutingApplied is removed as inapplicable, and a
-// stale ServicesReconciled=False recovers once the blue-green service stages succeed.
-func TestStageConditionsOnStrategyMigration(t *testing.T) {
+// TestReconcileSucceededRecoversAfterPipelineSuccess verifies a stale
+// ReconcileSucceeded=False recovers to True once the full pipeline succeeds.
+func TestReconcileSucceededRecoversAfterPipelineSuccess(t *testing.T) {
 	ro := newCanaryRollout("foo", 1, nil, nil, nil, intstr.FromInt(1), intstr.FromInt(0))
-	ro.Spec.Strategy.Canary = nil
-	ro.Spec.Strategy.BlueGreen = &v1alpha1.BlueGreenStrategy{}
 	conditions.SetRolloutCondition(&ro.Status, *conditions.NewRolloutCondition(
-		v1alpha1.RolloutServicesReconciled, corev1.ConditionFalse, conditions.ServiceUpdateErrorReason, "service update failed"))
-	conditions.SetRolloutCondition(&ro.Status, *conditions.NewRolloutCondition(
-		v1alpha1.RolloutTrafficRoutingApplied, corev1.ConditionFalse, conditions.TrafficRoutingErrorReason, "routing failed"))
+		v1alpha1.RolloutReconcileSucceeded, corev1.ConditionFalse, conditions.ServiceUpdateErrorReason, "service update failed"))
 
 	ctx := &rolloutContext{rollout: ro}
 	newStatus := ro.Status.DeepCopy()
 	ctx.mergeStageConditions(newStatus)
-	assert.Nil(t, conditions.GetRolloutCondition(*newStatus, v1alpha1.RolloutTrafficRoutingApplied),
-		"TrafficRoutingApplied must not apply to blue-green")
+	cond := conditions.GetRolloutCondition(*newStatus, v1alpha1.RolloutReconcileSucceeded)
+	assert.NotNil(t, cond)
+	assert.Equal(t, corev1.ConditionFalse, cond.Status)
 
-	ctx.markStageSucceeded(v1alpha1.RolloutServicesReconciled)
+	ctx.markStageSucceeded()
 	ctx.mergeStageConditions(newStatus)
-	servicesCond := conditions.GetRolloutCondition(*newStatus, v1alpha1.RolloutServicesReconciled)
-	assert.NotNil(t, servicesCond)
-	assert.Equal(t, corev1.ConditionTrue, servicesCond.Status,
-		"ServicesReconciled must recover once blue-green service stages succeed")
+	cond = conditions.GetRolloutCondition(*newStatus, v1alpha1.RolloutReconcileSucceeded)
+	assert.NotNil(t, cond)
+	assert.Equal(t, corev1.ConditionTrue, cond.Status)
 }
 
 func TestConditionNoChurnOnRepeatedError(t *testing.T) {
 	status := v1alpha1.RolloutStatus{}
-	cond := *conditions.NewRolloutCondition(v1alpha1.RolloutTrafficRoutingApplied, corev1.ConditionFalse, conditions.TrafficRoutingErrorReason, "same error")
+	cond := *conditions.NewRolloutCondition(v1alpha1.RolloutReconcileSucceeded, corev1.ConditionFalse, conditions.TrafficRoutingErrorReason, "same error")
 	firstTransition := cond.LastTransitionTime
 	conditions.SetRolloutCondition(&status, cond)
 
-	repeated := *conditions.NewRolloutCondition(v1alpha1.RolloutTrafficRoutingApplied, corev1.ConditionFalse, conditions.TrafficRoutingErrorReason, "same error with different suffix")
+	repeated := *conditions.NewRolloutCondition(v1alpha1.RolloutReconcileSucceeded, corev1.ConditionFalse, conditions.TrafficRoutingErrorReason, "same error with different suffix")
 	updated := conditions.SetRolloutCondition(&status, repeated)
 	assert.False(t, updated)
-	persisted := conditions.GetRolloutCondition(status, v1alpha1.RolloutTrafficRoutingApplied)
+	persisted := conditions.GetRolloutCondition(status, v1alpha1.RolloutReconcileSucceeded)
 	assert.Equal(t, firstTransition, persisted.LastTransitionTime)
 }

--- a/rollout/stageconditions_test.go
+++ b/rollout/stageconditions_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -26,7 +27,7 @@ func TestStageConditionsMergedIntoStatus(t *testing.T) {
 	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(errors.New("routing failed"))
 
 	patchIndex := f.expectPatchRolloutAction(ro)
-	f.run(getKey(ro, t))
+	f.runExpectError(getKey(ro, t), true)
 	patched := f.getPatchedRolloutAsObject(patchIndex)
 	cond := conditions.GetRolloutCondition(patched.Status, v1alpha1.RolloutTrafficRoutingApplied)
 	assert.NotNil(t, cond)
@@ -55,7 +56,7 @@ func TestStepHeldWhileStageConditionFalse(t *testing.T) {
 	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(errors.New("routing failed"))
 
 	patchIndex := f.expectPatchRolloutAction(ro)
-	f.run(getKey(ro, t))
+	f.runExpectError(getKey(ro, t), true)
 	patched := f.getPatchedRolloutAsObject(patchIndex)
 	assert.Nil(t, patched.Status.CurrentStepIndex)
 }
@@ -223,6 +224,33 @@ func TestConditionMessageTruncated(t *testing.T) {
 	ctx.setStageCondition(v1alpha1.RolloutActuationSucceeded, corev1.ConditionFalse, conditions.ActuationErrorReason, longMsg)
 	cond := ctx.stageConditions[v1alpha1.RolloutActuationSucceeded]
 	assert.Len(t, cond.Message, maxStageConditionMessageLen)
+}
+
+func TestConditionMessageTruncatedOnRuneBoundary(t *testing.T) {
+	// Place a multi-byte rune straddling the truncation limit; the cut must back up to a rune
+	// boundary instead of persisting invalid UTF-8.
+	msg := strings.Repeat("x", maxStageConditionMessageLen-1) + "日本語のエラー"
+	truncated := truncateStageConditionMessage(msg)
+	assert.LessOrEqual(t, len(truncated), maxStageConditionMessageLen)
+	assert.True(t, utf8.ValidString(truncated), "truncated message must remain valid UTF-8")
+	assert.Equal(t, maxStageConditionMessageLen-1, len(truncated))
+}
+
+// TestStageConditionsRemovedOnStrategyMigration verifies that a stale stage condition left over
+// from a canary strategy is removed once the rollout is migrated to blueGreen, instead of
+// reporting an actuation failure forever on a healthy blue-green rollout.
+func TestStageConditionsRemovedOnStrategyMigration(t *testing.T) {
+	ro := newCanaryRollout("foo", 1, nil, nil, nil, intstr.FromInt(1), intstr.FromInt(0))
+	ro.Spec.Strategy.Canary = nil
+	ro.Spec.Strategy.BlueGreen = &v1alpha1.BlueGreenStrategy{}
+	conditions.SetRolloutCondition(&ro.Status, *conditions.NewRolloutCondition(
+		v1alpha1.RolloutServicesReconciled, corev1.ConditionFalse, conditions.ServiceUpdateErrorReason, "service update failed"))
+
+	ctx := &rolloutContext{rollout: ro}
+	newStatus := ro.Status.DeepCopy()
+	ctx.mergeStageConditions(newStatus)
+	assert.Nil(t, conditions.GetRolloutCondition(*newStatus, v1alpha1.RolloutServicesReconciled),
+		"stage conditions must not survive a strategy migration away from canary")
 }
 
 func TestConditionNoChurnOnRepeatedError(t *testing.T) {

--- a/rollout/stageconditions_test.go
+++ b/rollout/stageconditions_test.go
@@ -238,7 +238,7 @@ func TestConditionMessageTruncatedOnRuneBoundary(t *testing.T) {
 
 // TestStageConditionsRemovedOnStrategyMigration verifies that a stale stage condition left over
 // from a canary strategy is removed once the rollout is migrated to blueGreen, instead of
-// reporting an actuation failure forever on a healthy blue-green rollout.
+// reporting a reconcile failure forever on a healthy blue-green rollout.
 func TestStageConditionsRemovedOnStrategyMigration(t *testing.T) {
 	ro := newCanaryRollout("foo", 1, nil, nil, nil, intstr.FromInt(1), intstr.FromInt(0))
 	ro.Spec.Strategy.Canary = nil

--- a/rollout/stageconditions_test.go
+++ b/rollout/stageconditions_test.go
@@ -1,0 +1,115 @@
+package rollout
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/argoproj/argo-rollouts/utils/conditions"
+)
+
+func TestStageConditionsMergedIntoStatus(t *testing.T) {
+	f, ro := newTrafficWeightFixture(t)
+	defer f.Close()
+	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(errors.New("routing failed"))
+
+	patchIndex := f.expectPatchRolloutAction(ro)
+	f.runExpectError(getKey(ro, t), true)
+	patched := f.getPatchedRolloutAsObject(patchIndex)
+	cond := conditions.GetRolloutCondition(patched.Status, v1alpha1.RolloutTrafficRoutingApplied)
+	assert.NotNil(t, cond)
+	assert.Equal(t, corev1.ConditionFalse, cond.Status)
+	assert.Equal(t, conditions.TrafficRoutingErrorReason, cond.Reason)
+
+	basic := newCanaryRollout("basic", 1, nil, nil, nil, intstr.FromInt(1), intstr.FromInt(0))
+	rs := newReplicaSetWithStatus(basic, 1, 1)
+	f2 := newFixture(t)
+	defer f2.Close()
+	f2.rolloutLister = append(f2.rolloutLister, basic)
+	f2.objects = append(f2.objects, basic)
+	f2.kubeobjects = append(f2.kubeobjects, rs)
+	f2.replicaSetLister = append(f2.replicaSetLister, rs)
+	patchIndex = f2.expectPatchRolloutAction(basic)
+	f2.run(getKey(basic, t))
+	patchedBasic := f2.getPatchedRolloutAsObject(patchIndex)
+	assert.Nil(t, conditions.GetRolloutCondition(patchedBasic.Status, v1alpha1.RolloutTrafficRoutingApplied))
+}
+
+func TestStepHeldWhileStageConditionFalse(t *testing.T) {
+	f, ro := newTrafficWeightFixture(t)
+	defer f.Close()
+	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(errors.New("routing failed"))
+
+	patchIndex := f.expectPatchRolloutAction(ro)
+	f.runExpectError(getKey(ro, t), true)
+	patched := f.getPatchedRolloutAsObject(patchIndex)
+	assert.Nil(t, patched.Status.CurrentStepIndex)
+}
+
+func TestPromotionHeldWhileStageConditionFalse(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{{SetWeight: ptr.To[int32](10)}, {Pause: &v1alpha1.RolloutPause{}}}
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](2), intstr.FromInt(1), intstr.FromInt(0))
+	r2 := bumpVersion(r1)
+	r2.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
+	r2.Spec.Strategy.Canary.CanaryService = "canary"
+	r2.Spec.Strategy.Canary.StableService = "stable"
+
+	rs1 := newReplicaSetWithStatus(r1, 10, 10)
+	rs2 := newReplicaSetWithStatus(r2, 10, 10)
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	canarySvc := newService("canary", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}, r2)
+	stableSvc := newService("stable", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}, r2)
+
+	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 10, 0, 10, false)
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2, canarySvc, stableSvc)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2)
+
+	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
+	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](false), nil)
+
+	patchIndex := f.expectPatchRolloutAction(r2)
+	f.run(getKey(r2, t))
+	assert.NotContains(t, f.getPatchedRollout(patchIndex), fmt.Sprintf(`"stableRS":"%s"`, rs2PodHash))
+}
+
+func TestConditionMessageTruncated(t *testing.T) {
+	ctx := &rolloutContext{}
+	longMsg := strings.Repeat("x", maxStageConditionMessageLen+10)
+	ctx.setStageCondition(v1alpha1.RolloutActuationSucceeded, corev1.ConditionFalse, conditions.ActuationErrorReason, longMsg)
+	cond := ctx.stageConditions[v1alpha1.RolloutActuationSucceeded]
+	assert.Len(t, cond.Message, maxStageConditionMessageLen)
+}
+
+func TestConditionNoChurnOnRepeatedError(t *testing.T) {
+	status := v1alpha1.RolloutStatus{}
+	cond := *conditions.NewRolloutCondition(v1alpha1.RolloutTrafficRoutingApplied, corev1.ConditionFalse, conditions.TrafficRoutingErrorReason, "same error")
+	firstTransition := cond.LastTransitionTime
+	conditions.SetRolloutCondition(&status, cond)
+
+	repeated := *conditions.NewRolloutCondition(v1alpha1.RolloutTrafficRoutingApplied, corev1.ConditionFalse, conditions.TrafficRoutingErrorReason, "same error with different suffix")
+	updated := conditions.SetRolloutCondition(&status, repeated)
+	assert.False(t, updated)
+	persisted := conditions.GetRolloutCondition(status, v1alpha1.RolloutTrafficRoutingApplied)
+	assert.Equal(t, firstTransition, persisted.LastTransitionTime)
+}

--- a/rollout/stageconditions_test.go
+++ b/rollout/stageconditions_test.go
@@ -42,7 +42,7 @@ func TestStageConditionsMergedIntoStatus(t *testing.T) {
 	f2.objects = append(f2.objects, basic)
 	f2.kubeobjects = append(f2.kubeobjects, rs)
 	f2.replicaSetLister = append(f2.replicaSetLister, rs)
-	patchIndex = f2.expectPatchRolloutAction(basic)
+	f2.expectPatchRolloutAction(basic)
 	f2.run(getKey(basic, t))
 }
 

--- a/rollout/stageconditions_test.go
+++ b/rollout/stageconditions_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
@@ -91,6 +93,85 @@ func TestPromotionHeldWhileStageConditionFalse(t *testing.T) {
 	patchIndex := f.expectPatchRolloutAction(r2)
 	f.run(getKey(r2, t))
 	assert.NotContains(t, f.getPatchedRollout(patchIndex), fmt.Sprintf(`"stableRS":"%s"`, rs2PodHash))
+}
+
+// TestStageConditionRecoveryRequiresStageSuccess verifies that a previously-False stage condition
+// only flips back to True when the owning stage actually re-ran and succeeded this reconcile —
+// a pass that never reached the stage must not report a recovery that never happened.
+func TestStageConditionRecoveryRequiresStageSuccess(t *testing.T) {
+	ro := newCanaryRollout("foo", 1, nil, nil, nil, intstr.FromInt(1), intstr.FromInt(0))
+	ro.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
+	conditions.SetRolloutCondition(&ro.Status, *conditions.NewRolloutCondition(
+		v1alpha1.RolloutTrafficRoutingApplied, corev1.ConditionFalse, conditions.TrafficRoutingErrorReason, "routing failed"))
+
+	ctx := &rolloutContext{rollout: ro}
+	newStatus := ro.Status.DeepCopy()
+
+	// The trafficRouting stage did not run this pass (e.g. an earlier stage stopped the
+	// pipeline, or a scaling-only pass ran no stages): the condition must stay False.
+	ctx.mergeStageConditions(newStatus)
+	cond := conditions.GetRolloutCondition(*newStatus, v1alpha1.RolloutTrafficRoutingApplied)
+	assert.NotNil(t, cond)
+	assert.Equal(t, corev1.ConditionFalse, cond.Status, "a stage that did not run must not report recovery")
+
+	// Once the owning stage actually re-runs and succeeds, the condition recovers.
+	ctx.markStageSucceeded(v1alpha1.RolloutTrafficRoutingApplied)
+	ctx.mergeStageConditions(newStatus)
+	cond = conditions.GetRolloutCondition(*newStatus, v1alpha1.RolloutTrafficRoutingApplied)
+	assert.NotNil(t, cond)
+	assert.Equal(t, corev1.ConditionTrue, cond.Status)
+	assert.Equal(t, conditions.StageConditionAppliedReason, cond.Reason)
+}
+
+// TestStageConditionNotRecoveredWhenPipelineStopsEarly is the end-to-end variant: a services
+// failure aborts the pipeline before the trafficRouting stage runs, so a pre-existing
+// TrafficRoutingApplied=False must survive the status sync unchanged instead of flipping True.
+func TestStageConditionNotRecoveredWhenPipelineStopsEarly(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{{SetWeight: ptr.To[int32](10)}}
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(0))
+	r2 := bumpVersion(r1)
+	r2.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
+	r2.Spec.Strategy.Canary.StableService = "stable"
+	r2.Spec.Strategy.Canary.CanaryService = "canary"
+
+	rs1 := newReplicaSetWithStatus(r1, 10, 10)
+	rs2 := newReplicaSetWithStatus(r2, 1, 1)
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	canarySvc := newService("canary", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}, r2)
+	stableSvc := newService("stable", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}, r2)
+
+	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 11, 1, 11, false)
+	conditions.SetRolloutCondition(&r2.Status, *conditions.NewRolloutCondition(
+		v1alpha1.RolloutTrafficRoutingApplied, corev1.ConditionFalse, conditions.TrafficRoutingErrorReason, "routing failed"))
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2, canarySvc, stableSvc)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+	f.serviceLister = append(f.serviceLister, canarySvc, stableSvc)
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2)
+
+	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+	c, i, k8sI := f.newController(noResyncPeriodFunc)
+	f.kubeclient.Fake.PrependReactor("patch", "services", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("admission webhook denied service update")
+	})
+
+	_ = f.expectPatchServiceAction(canarySvc, rs2PodHash)
+	patchIndex := f.expectPatchRolloutAction(r2)
+	f.runController(getKey(r2, t), true, true, c, i, k8sI)
+
+	patched := f.getPatchedRolloutAsObject(patchIndex)
+	servicesCond := conditions.GetRolloutCondition(patched.Status, v1alpha1.RolloutServicesReconciled)
+	assert.NotNil(t, servicesCond)
+	assert.Equal(t, corev1.ConditionFalse, servicesCond.Status)
+	trCond := conditions.GetRolloutCondition(patched.Status, v1alpha1.RolloutTrafficRoutingApplied)
+	if trCond != nil {
+		assert.Equal(t, corev1.ConditionFalse, trCond.Status,
+			"trafficRouting stage never ran this pass; its condition must not report recovery")
+	}
 }
 
 func TestConditionMessageTruncated(t *testing.T) {

--- a/rollout/stages.go
+++ b/rollout/stages.go
@@ -17,17 +17,17 @@ type stageOutcome int
 const (
 	// stageContinue: proceed to the next stage.
 	stageContinue stageOutcome = iota
-	// stageContinueWithError: a cosmetic stage failed; record the condition, keep actuating
-	// (nothing downstream depends on it for traffic safety), and surface the error after the
-	// status sync for workqueue backoff. Step progression still holds via the condition gates.
+	// stageContinueWithError: a cosmetic stage failed; record the condition, keep running the
+	// remaining stages (nothing downstream depends on it for traffic safety), and surface the
+	// error after the status sync for workqueue backoff. Step progression still holds via the condition gates.
 	stageContinueWithError
-	// stageStop: stop actuating, fall through to status sync. NOT an error.
+	// stageStop: stop applying changes, fall through to status sync. NOT an error.
 	stageStop
 	// stageStopNoStatus: stop without status sync (pod-restart early exit only).
 	stageStopNoStatus
-	// stageFatal: stop actuating, still status-sync, and return the error for workqueue backoff.
+	// stageFatal: stop applying changes, still status-sync, and return the error for workqueue backoff.
 	stageFatal
-	// stageFatalNoStatus: stop actuating, skip status sync, and return the error for workqueue
+	// stageFatalNoStatus: stop applying changes, skip status sync, and return the error for workqueue
 	// backoff. Reserved for ReplicaSet-sync failures that leave c.newRS unreliable: a status
 	// computed from a nil/stale newRS would persist corrupted values (e.g. clear abort state and
 	// record a CurrentPodHash for a ReplicaSet that was never created).
@@ -72,7 +72,7 @@ func (c *rolloutContext) runCanaryStages() error {
 			c.recordStageFailure(res)
 			errs = append(errs, res.err)
 		case stageStop:
-			c.log.Infof("stage %s: stopping actuation, proceeding to status sync", s.name)
+			c.log.Infof("stage %s: stopping further changes, proceeding to status sync", s.name)
 			return errors.Join(errs...)
 		case stageStopNoStatus:
 			c.skipStatusSync = true
@@ -88,7 +88,7 @@ func (c *rolloutContext) runCanaryStages() error {
 		}
 	}
 	if len(errs) == 0 {
-		// Every stage ran without failure, so the catch-all actuation condition is allowed to
+		// Every stage ran without failure, so the catch-all ReconcileSucceeded condition is allowed to
 		// recover to True in mergeStageConditions.
 		c.markStageSucceeded(v1alpha1.RolloutReconcileSucceeded)
 	}

--- a/rollout/stages.go
+++ b/rollout/stages.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
-	"github.com/argoproj/argo-rollouts/utils/defaults"
 	"github.com/argoproj/argo-rollouts/utils/record"
 	replicasetutil "github.com/argoproj/argo-rollouts/utils/replicaset"
 )
@@ -21,9 +20,6 @@ const (
 	stageStop
 	// stageStopNoStatus: stop without status sync (pod-restart early exit only).
 	stageStopNoStatus
-	// stageHold: desired state not applied; record condition, hold progression,
-	// continue to status sync. Not returned as a reconcile error.
-	stageHold
 	// stageFatal: stop actuating, still status-sync, and return the error for workqueue backoff.
 	stageFatal
 	// stageFatalNoStatus: stop actuating, skip status sync, and return the error for workqueue
@@ -75,7 +71,7 @@ func (c *rolloutContext) runCanaryStages() error {
 		case stageFatalNoStatus:
 			c.skipStatusSync = true
 			return res.err
-		case stageHold, stageFatal:
+		case stageFatal:
 			condType := res.condition
 			if condType == "" {
 				condType = v1alpha1.RolloutActuationSucceeded
@@ -85,10 +81,12 @@ func (c *rolloutContext) runCanaryStages() error {
 				reason = conditions.ActuationErrorReason
 			}
 			c.setStageCondition(condType, corev1.ConditionFalse, reason, res.err.Error())
-			c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: reason}, "%s", res.err.Error())
-			if res.outcome == stageHold {
-				c.enqueueRolloutAfter(c.rollout, defaults.GetRolloutVerifyRetryInterval())
-				return nil
+			// A persistently failing stage retries on workqueue backoff; emit the warning event
+			// only when the condition actually transitions (new failure or changed reason), not
+			// on every retry pass.
+			prevCond := conditions.GetRolloutCondition(c.rollout.Status, condType)
+			if prevCond == nil || prevCond.Status != corev1.ConditionFalse || prevCond.Reason != reason {
+				c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: reason}, "%s", res.err.Error())
 			}
 			return res.err
 		}
@@ -187,7 +185,7 @@ func canaryStageStableCanaryService(c *rolloutContext) stageResult {
 func canaryStageTrafficRouting(c *rolloutContext) stageResult {
 	if err := c.reconcileTrafficRouting(); err != nil {
 		return stageResult{
-			outcome:   stageHold,
+			outcome:   stageFatal,
 			err:       err,
 			condition: v1alpha1.RolloutTrafficRoutingApplied,
 			reason:    conditions.TrafficRoutingErrorReason,

--- a/rollout/stages.go
+++ b/rollout/stages.go
@@ -26,6 +26,11 @@ const (
 	stageHold
 	// stageFatal: stop actuating, still status-sync, and return the error for workqueue backoff.
 	stageFatal
+	// stageFatalNoStatus: stop actuating, skip status sync, and return the error for workqueue
+	// backoff. Reserved for ReplicaSet-sync failures that leave c.newRS unreliable: a status
+	// computed from a nil/stale newRS would persist corrupted values (e.g. clear abort state and
+	// record a CurrentPodHash for a ReplicaSet that was never created).
+	stageFatalNoStatus
 )
 
 type stageResult struct {
@@ -67,6 +72,9 @@ func (c *rolloutContext) runCanaryStages() error {
 		case stageStopNoStatus:
 			c.skipStatusSync = true
 			return nil
+		case stageFatalNoStatus:
+			c.skipStatusSync = true
+			return res.err
 		case stageHold, stageFatal:
 			condType := res.condition
 			if condType == "" {
@@ -85,6 +93,9 @@ func (c *rolloutContext) runCanaryStages() error {
 			return res.err
 		}
 	}
+	// Every stage ran without failure, so the catch-all actuation condition is allowed to
+	// recover to True in mergeStageConditions.
+	c.markStageSucceeded(v1alpha1.RolloutActuationSucceeded)
 	return nil
 }
 
@@ -92,26 +103,31 @@ func canaryStageSyncRevisionOnChange(c *rolloutContext) stageResult {
 	if !replicasetutil.PodTemplateOrStepsChanged(c.rollout, c.newRS) {
 		return stageResult{outcome: stageContinue}
 	}
-	var err error
-	c.newRS, err = c.getAllReplicaSetsAndSyncRevision()
+	newRS, err := c.getAllReplicaSetsAndSyncRevision()
 	if err != nil {
+		// Leave c.newRS untouched and skip the status sync: syncing now would evaluate
+		// PodTemplateOrStepsChanged against a nil newRS and persist a reset status (cleared
+		// abort/pause state, phantom CurrentPodHash) for a ReplicaSet that was never synced.
 		return stageResult{
-			outcome: stageFatal,
+			outcome: stageFatalNoStatus,
 			err:     fmt.Errorf("failed to getAllReplicaSetsAndSyncRevision in rolloutCanary with PodTemplateOrStepsChanged: %w", err),
 		}
 	}
+	c.newRS = newRS
 	return stageResult{outcome: stageStop}
 }
 
 func canaryStageSyncReplicaSets(c *rolloutContext) stageResult {
-	var err error
-	c.newRS, err = c.getAllReplicaSetsAndSyncRevision()
+	newRS, err := c.getAllReplicaSetsAndSyncRevision()
 	if err != nil {
+		// Leave c.newRS untouched and skip the status sync: syncing now would compute replica
+		// counts from a nil newRS (e.g. UpdatedReplicas flapping to 0 on a transient API error).
 		return stageResult{
-			outcome: stageFatal,
+			outcome: stageFatalNoStatus,
 			err:     fmt.Errorf("failed to getAllReplicaSetsAndSyncRevision in rolloutCanary create true: %w", err),
 		}
 	}
+	c.newRS = newRS
 	return stageResult{outcome: stageContinue}
 }
 
@@ -162,6 +178,9 @@ func canaryStageStableCanaryService(c *rolloutContext) stageResult {
 			reason:    conditions.ServiceUpdateErrorReason,
 		}
 	}
+	// pingPongService runs before this stage and any failure there aborts the pipeline, so both
+	// owners of the ServicesReconciled condition succeeded this pass.
+	c.markStageSucceeded(v1alpha1.RolloutServicesReconciled)
 	return stageResult{outcome: stageContinue}
 }
 
@@ -174,6 +193,7 @@ func canaryStageTrafficRouting(c *rolloutContext) stageResult {
 			reason:    conditions.TrafficRoutingErrorReason,
 		}
 	}
+	c.markStageSucceeded(v1alpha1.RolloutTrafficRoutingApplied)
 	return stageResult{outcome: stageContinue}
 }
 

--- a/rollout/stages.go
+++ b/rollout/stages.go
@@ -31,10 +31,9 @@ const (
 )
 
 type stageResult struct {
-	outcome   stageOutcome
-	err       error
-	condition v1alpha1.RolloutConditionType
-	reason    string
+	outcome stageOutcome
+	err     error
+	reason  string
 }
 
 type strategyStage struct {
@@ -113,7 +112,7 @@ func (c *rolloutContext) runStages(stages []strategyStage) error {
 	if len(errs) == 0 {
 		// Every stage ran without failure, so the catch-all ReconcileSucceeded condition is allowed to
 		// recover to True in mergeStageConditions.
-		c.markStageSucceeded(v1alpha1.RolloutReconcileSucceeded)
+		c.markStageSucceeded()
 	}
 	return errors.Join(errs...)
 }
@@ -122,16 +121,12 @@ func (c *rolloutContext) runStages(stages []strategyStage) error {
 // persistently failing stage retries on workqueue backoff; the event is emitted only when the
 // condition actually transitions (new failure or changed reason), not on every retry pass.
 func (c *rolloutContext) recordStageFailure(res stageResult) {
-	condType := res.condition
-	if condType == "" {
-		condType = v1alpha1.RolloutReconcileSucceeded
-	}
 	reason := res.reason
 	if reason == "" {
 		reason = conditions.RolloutReconciliationErrorReason
 	}
-	c.setStageCondition(condType, corev1.ConditionFalse, reason, res.err.Error())
-	prevCond := conditions.GetRolloutCondition(c.rollout.Status, condType)
+	c.setStageCondition(v1alpha1.RolloutReconcileSucceeded, corev1.ConditionFalse, reason, res.err.Error())
+	prevCond := conditions.GetRolloutCondition(c.rollout.Status, v1alpha1.RolloutReconcileSucceeded)
 	if prevCond == nil || prevCond.Status != corev1.ConditionFalse || prevCond.Reason != reason {
 		c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: reason}, "%s", res.err.Error())
 	}
@@ -200,10 +195,9 @@ func canaryStageRevisionHistory(c *rolloutContext) stageResult {
 func canaryStagePingPongService(c *rolloutContext) stageResult {
 	if err := c.reconcilePingAndPongService(); err != nil {
 		return stageResult{
-			outcome:   stageStop,
-			err:       err,
-			condition: v1alpha1.RolloutServicesReconciled,
-			reason:    conditions.ServiceUpdateErrorReason,
+			outcome: stageStop,
+			err:     err,
+			reason:  conditions.ServiceUpdateErrorReason,
 		}
 	}
 	return stageResult{outcome: stageContinue}
@@ -212,28 +206,22 @@ func canaryStagePingPongService(c *rolloutContext) stageResult {
 func canaryStageStableCanaryService(c *rolloutContext) stageResult {
 	if err := c.reconcileStableAndCanaryService(); err != nil {
 		return stageResult{
-			outcome:   stageStop,
-			err:       err,
-			condition: v1alpha1.RolloutServicesReconciled,
-			reason:    conditions.ServiceUpdateErrorReason,
+			outcome: stageStop,
+			err:     err,
+			reason:  conditions.ServiceUpdateErrorReason,
 		}
 	}
-	// pingPongService runs before this stage and any failure there aborts the pipeline, so both
-	// owners of the ServicesReconciled condition succeeded this pass.
-	c.markStageSucceeded(v1alpha1.RolloutServicesReconciled)
 	return stageResult{outcome: stageContinue}
 }
 
 func canaryStageTrafficRouting(c *rolloutContext) stageResult {
 	if err := c.reconcileTrafficRouting(); err != nil {
 		return stageResult{
-			outcome:   stageStop,
-			err:       err,
-			condition: v1alpha1.RolloutTrafficRoutingApplied,
-			reason:    conditions.TrafficRoutingErrorReason,
+			outcome: stageStop,
+			err:     err,
+			reason:  conditions.TrafficRoutingErrorReason,
 		}
 	}
-	c.markStageSucceeded(v1alpha1.RolloutTrafficRoutingApplied)
 	return stageResult{outcome: stageContinue}
 }
 
@@ -287,10 +275,9 @@ func blueGreenStagePreviewService(c *rolloutContext) stageResult {
 	// This must happen right after the new replicaset is created.
 	if err := c.reconcilePreviewService(c.blueGreenPreviewSvc); err != nil {
 		return stageResult{
-			outcome:   stageStop,
-			err:       err,
-			condition: v1alpha1.RolloutServicesReconciled,
-			reason:    conditions.ServiceUpdateErrorReason,
+			outcome: stageStop,
+			err:     err,
+			reason:  conditions.ServiceUpdateErrorReason,
 		}
 	}
 	return stageResult{outcome: stageContinue}
@@ -326,15 +313,11 @@ func blueGreenStagePause(c *rolloutContext) stageResult {
 func blueGreenStageActiveService(c *rolloutContext) stageResult {
 	if err := c.reconcileActiveService(c.blueGreenActiveSvc); err != nil {
 		return stageResult{
-			outcome:   stageStop,
-			err:       err,
-			condition: v1alpha1.RolloutServicesReconciled,
-			reason:    conditions.ServiceUpdateErrorReason,
+			outcome: stageStop,
+			err:     err,
+			reason:  conditions.ServiceUpdateErrorReason,
 		}
 	}
-	// previewService runs before this stage and any failure there aborts the pipeline, so both
-	// owners of the ServicesReconciled condition succeeded this pass.
-	c.markStageSucceeded(v1alpha1.RolloutServicesReconciled)
 	return stageResult{outcome: stageContinue}
 }
 

--- a/rollout/stages.go
+++ b/rollout/stages.go
@@ -110,16 +110,14 @@ func (c *rolloutContext) runStages(stages []strategyStage) error {
 		}
 	}
 	if len(errs) == 0 {
-		// Every stage ran without failure, so the catch-all ReconcileSucceeded condition is allowed to
-		// recover to True in mergeStageConditions.
+		// Reconcile work completed without error; ReconcileSucceeded may recover to True.
 		c.markStageSucceeded()
 	}
 	return errors.Join(errs...)
 }
 
-// recordStageFailure records the failing stage's condition and emits a warning event. A
-// persistently failing stage retries on workqueue backoff; the event is emitted only when the
-// condition actually transitions (new failure or changed reason), not on every retry pass.
+// recordStageFailure sets ReconcileSucceeded=False and emits a warning event. The event is emitted
+// only when the condition transitions (new failure or changed reason), not on every retry.
 func (c *rolloutContext) recordStageFailure(res stageResult) {
 	reason := res.reason
 	if reason == "" {

--- a/rollout/stages.go
+++ b/rollout/stages.go
@@ -21,17 +21,13 @@ const (
 	// remaining stages (nothing downstream depends on it for traffic safety), and surface the
 	// error after the status sync for workqueue backoff. Step progression still holds via the condition gates.
 	stageContinueWithError
-	// stageStop: stop applying changes, fall through to status sync. NOT an error.
+	// stageStop: halt the pipeline and fall through to status sync. When err is set, the failure
+	// is recorded, returned for workqueue backoff, and status still syncs (#4626).
 	stageStop
-	// stageStopNoStatus: stop without status sync (pod-restart early exit only).
+	// stageStopNoStatus: halt without status sync. Used for the pod-restart early exit (no err)
+	// and ReplicaSet-sync failures (err set), where c.newRS is unreliable and a status computed
+	// from it would persist corrupted values.
 	stageStopNoStatus
-	// stageFatal: stop applying changes, still status-sync, and return the error for workqueue backoff.
-	stageFatal
-	// stageFatalNoStatus: stop applying changes, skip status sync, and return the error for workqueue
-	// backoff. Reserved for ReplicaSet-sync failures that leave c.newRS unreliable: a status
-	// computed from a nil/stale newRS would persist corrupted values (e.g. clear abort state and
-	// record a CurrentPodHash for a ReplicaSet that was never created).
-	stageFatalNoStatus
 )
 
 type stageResult struct {
@@ -41,12 +37,12 @@ type stageResult struct {
 	reason    string
 }
 
-type canaryStage struct {
+type strategyStage struct {
 	name string
 	run  func(c *rolloutContext) stageResult
 }
 
-var canaryStages = []canaryStage{
+var canaryStages = []strategyStage{
 	{"syncRevisionOnChange", canaryStageSyncRevisionOnChange},
 	{"syncReplicaSets", canaryStageSyncReplicaSets},
 	{"podRestart", canaryStagePodRestart},
@@ -62,9 +58,36 @@ var canaryStages = []canaryStage{
 	{"stepPlugins", canaryStageStepPlugins},
 }
 
+var blueGreenStages = []strategyStage{
+	{"previewService", blueGreenStagePreviewService},
+	{"podTemplateChange", blueGreenStagePodTemplateChange},
+	{"podRestart", blueGreenStagePodRestart},
+	{"replicaSets", blueGreenStageReplicaSets},
+	{"pause", blueGreenStagePause},
+	{"activeService", blueGreenStageActiveService},
+	{"targetGroups", blueGreenStageTargetGroups},
+	{"analysis", blueGreenStageAnalysis},
+	{"ephemeralMetadata", blueGreenStageEphemeralMetadata},
+	{"revisionHistory", blueGreenStageRevisionHistory},
+}
+
 func (c *rolloutContext) runCanaryStages() error {
+	return c.runStages(canaryStages)
+}
+
+func (c *rolloutContext) runBlueGreenStages(previewSvc, activeSvc *corev1.Service) error {
+	c.blueGreenPreviewSvc = previewSvc
+	c.blueGreenActiveSvc = activeSvc
+	defer func() {
+		c.blueGreenPreviewSvc = nil
+		c.blueGreenActiveSvc = nil
+	}()
+	return c.runStages(blueGreenStages)
+}
+
+func (c *rolloutContext) runStages(stages []strategyStage) error {
 	var errs []error
-	for _, s := range canaryStages {
+	for _, s := range stages {
 		res := s.run(c)
 		switch res.outcome {
 		case stageContinue:
@@ -72,18 +95,18 @@ func (c *rolloutContext) runCanaryStages() error {
 			c.recordStageFailure(res)
 			errs = append(errs, res.err)
 		case stageStop:
-			c.log.Infof("stage %s: stopping further changes, proceeding to status sync", s.name)
+			if res.err != nil {
+				c.recordStageFailure(res)
+				errs = append(errs, res.err)
+			} else {
+				c.log.Infof("stage %s: stopping further changes, proceeding to status sync", s.name)
+			}
 			return errors.Join(errs...)
 		case stageStopNoStatus:
 			c.skipStatusSync = true
-			return errors.Join(errs...)
-		case stageFatalNoStatus:
-			c.skipStatusSync = true
-			errs = append(errs, res.err)
-			return errors.Join(errs...)
-		case stageFatal:
-			c.recordStageFailure(res)
-			errs = append(errs, res.err)
+			if res.err != nil {
+				errs = append(errs, res.err)
+			}
 			return errors.Join(errs...)
 		}
 	}
@@ -124,7 +147,7 @@ func canaryStageSyncRevisionOnChange(c *rolloutContext) stageResult {
 		// PodTemplateOrStepsChanged against a nil newRS and persist a reset status (cleared
 		// abort/pause state, phantom CurrentPodHash) for a ReplicaSet that was never synced.
 		return stageResult{
-			outcome: stageFatalNoStatus,
+			outcome: stageStopNoStatus,
 			err:     fmt.Errorf("failed to getAllReplicaSetsAndSyncRevision in rolloutCanary with PodTemplateOrStepsChanged: %w", err),
 		}
 	}
@@ -138,7 +161,7 @@ func canaryStageSyncReplicaSets(c *rolloutContext) stageResult {
 		// Leave c.newRS untouched and skip the status sync: syncing now would compute replica
 		// counts from a nil newRS (e.g. UpdatedReplicas flapping to 0 on a transient API error).
 		return stageResult{
-			outcome: stageFatalNoStatus,
+			outcome: stageStopNoStatus,
 			err:     fmt.Errorf("failed to getAllReplicaSetsAndSyncRevision in rolloutCanary create true: %w", err),
 		}
 	}
@@ -149,7 +172,7 @@ func canaryStageSyncReplicaSets(c *rolloutContext) stageResult {
 func canaryStagePodRestart(c *rolloutContext) stageResult {
 	restarted, err := c.podRestarter.Reconcile(c)
 	if err != nil {
-		return stageResult{outcome: stageFatal, err: err}
+		return stageResult{outcome: stageStop, err: err}
 	}
 	if restarted > 0 {
 		c.log.Infof("Finished reconciliation due to %d restarted pods", restarted)
@@ -177,7 +200,7 @@ func canaryStageRevisionHistory(c *rolloutContext) stageResult {
 func canaryStagePingPongService(c *rolloutContext) stageResult {
 	if err := c.reconcilePingAndPongService(); err != nil {
 		return stageResult{
-			outcome:   stageFatal,
+			outcome:   stageStop,
 			err:       err,
 			condition: v1alpha1.RolloutServicesReconciled,
 			reason:    conditions.ServiceUpdateErrorReason,
@@ -189,7 +212,7 @@ func canaryStagePingPongService(c *rolloutContext) stageResult {
 func canaryStageStableCanaryService(c *rolloutContext) stageResult {
 	if err := c.reconcileStableAndCanaryService(); err != nil {
 		return stageResult{
-			outcome:   stageFatal,
+			outcome:   stageStop,
 			err:       err,
 			condition: v1alpha1.RolloutServicesReconciled,
 			reason:    conditions.ServiceUpdateErrorReason,
@@ -204,7 +227,7 @@ func canaryStageStableCanaryService(c *rolloutContext) stageResult {
 func canaryStageTrafficRouting(c *rolloutContext) stageResult {
 	if err := c.reconcileTrafficRouting(); err != nil {
 		return stageResult{
-			outcome:   stageFatal,
+			outcome:   stageStop,
 			err:       err,
 			condition: v1alpha1.RolloutTrafficRoutingApplied,
 			reason:    conditions.TrafficRoutingErrorReason,
@@ -216,7 +239,7 @@ func canaryStageTrafficRouting(c *rolloutContext) stageResult {
 
 func canaryStageExperiments(c *rolloutContext) stageResult {
 	if err := c.reconcileExperiments(); err != nil {
-		return stageResult{outcome: stageFatal, err: err}
+		return stageResult{outcome: stageStop, err: err}
 	}
 	return stageResult{outcome: stageContinue}
 }
@@ -228,7 +251,7 @@ func canaryStageAnalysis(c *rolloutContext) stageResult {
 		return stageResult{outcome: stageStop}
 	}
 	if err != nil {
-		return stageResult{outcome: stageFatal, err: err}
+		return stageResult{outcome: stageStop, err: err}
 	}
 	return stageResult{outcome: stageContinue}
 }
@@ -236,7 +259,7 @@ func canaryStageAnalysis(c *rolloutContext) stageResult {
 func canaryStageReplicaSetScaling(c *rolloutContext) stageResult {
 	noScalingOccurred, err := c.reconcileCanaryReplicaSets()
 	if err != nil {
-		return stageResult{outcome: stageFatal, err: err}
+		return stageResult{outcome: stageStop, err: err}
 	}
 	if noScalingOccurred {
 		c.log.Info("Not finished reconciling ReplicaSets")
@@ -255,7 +278,92 @@ func canaryStageCanaryPause(c *rolloutContext) stageResult {
 
 func canaryStageStepPlugins(c *rolloutContext) stageResult {
 	if err := c.stepPluginContext.reconcile(c); err != nil {
-		return stageResult{outcome: stageFatal, err: err}
+		return stageResult{outcome: stageStop, err: err}
+	}
+	return stageResult{outcome: stageContinue}
+}
+
+func blueGreenStagePreviewService(c *rolloutContext) stageResult {
+	// This must happen right after the new replicaset is created.
+	if err := c.reconcilePreviewService(c.blueGreenPreviewSvc); err != nil {
+		return stageResult{
+			outcome:   stageStop,
+			err:       err,
+			condition: v1alpha1.RolloutServicesReconciled,
+			reason:    conditions.ServiceUpdateErrorReason,
+		}
+	}
+	return stageResult{outcome: stageContinue}
+}
+
+func blueGreenStagePodTemplateChange(c *rolloutContext) stageResult {
+	if replicasetutil.CheckPodSpecChange(c.rollout, c.newRS) {
+		// A pod template change is handled entirely by the status sync.
+		return stageResult{outcome: stageStop}
+	}
+	return stageResult{outcome: stageContinue}
+}
+
+func blueGreenStagePodRestart(c *rolloutContext) stageResult {
+	if _, err := c.podRestarter.Reconcile(c); err != nil {
+		return stageResult{outcome: stageStop, err: err}
+	}
+	return stageResult{outcome: stageContinue}
+}
+
+func blueGreenStageReplicaSets(c *rolloutContext) stageResult {
+	if err := c.reconcileBlueGreenReplicaSets(c.blueGreenActiveSvc); err != nil {
+		return stageResult{outcome: stageStop, err: err}
+	}
+	return stageResult{outcome: stageContinue}
+}
+
+func blueGreenStagePause(c *rolloutContext) stageResult {
+	c.reconcileBlueGreenPause(c.blueGreenActiveSvc, c.blueGreenPreviewSvc)
+	return stageResult{outcome: stageContinue}
+}
+
+func blueGreenStageActiveService(c *rolloutContext) stageResult {
+	if err := c.reconcileActiveService(c.blueGreenActiveSvc); err != nil {
+		return stageResult{
+			outcome:   stageStop,
+			err:       err,
+			condition: v1alpha1.RolloutServicesReconciled,
+			reason:    conditions.ServiceUpdateErrorReason,
+		}
+	}
+	// previewService runs before this stage and any failure there aborts the pipeline, so both
+	// owners of the ServicesReconciled condition succeeded this pass.
+	c.markStageSucceeded(v1alpha1.RolloutServicesReconciled)
+	return stageResult{outcome: stageContinue}
+}
+
+func blueGreenStageTargetGroups(c *rolloutContext) stageResult {
+	if err := c.awsVerifyTargetGroups(c.blueGreenActiveSvc); err != nil {
+		return stageResult{outcome: stageStop, err: err}
+	}
+	return stageResult{outcome: stageContinue}
+}
+
+func blueGreenStageAnalysis(c *rolloutContext) stageResult {
+	if err := c.reconcileAnalysisRuns(); err != nil {
+		return stageResult{outcome: stageStop, err: err}
+	}
+	return stageResult{outcome: stageContinue}
+}
+
+func blueGreenStageEphemeralMetadata(c *rolloutContext) stageResult {
+	if err := c.reconcileEphemeralMetadata(); err != nil {
+		// Cosmetic: pod metadata labeling must not block the service switch or scaling this pass.
+		return stageResult{outcome: stageContinueWithError, err: err}
+	}
+	return stageResult{outcome: stageContinue}
+}
+
+func blueGreenStageRevisionHistory(c *rolloutContext) stageResult {
+	if err := c.reconcileRevisionHistoryLimit(c.otherRSs); err != nil {
+		// Cosmetic: old-revision cleanup must not block the service switch or scaling this pass.
+		return stageResult{outcome: stageContinueWithError, err: err}
 	}
 	return stageResult{outcome: stageContinue}
 }

--- a/rollout/stages.go
+++ b/rollout/stages.go
@@ -1,0 +1,224 @@
+package rollout
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/argoproj/argo-rollouts/utils/conditions"
+	"github.com/argoproj/argo-rollouts/utils/defaults"
+	"github.com/argoproj/argo-rollouts/utils/record"
+	replicasetutil "github.com/argoproj/argo-rollouts/utils/replicaset"
+)
+
+type stageOutcome int
+
+const (
+	// stageContinue: proceed to the next stage.
+	stageContinue stageOutcome = iota
+	// stageStop: stop actuating, fall through to status sync. NOT an error.
+	stageStop
+	// stageStopNoStatus: stop without status sync (pod-restart early exit only).
+	stageStopNoStatus
+	// stageHold: desired state not applied; record condition, hold progression,
+	// continue to status sync. Not returned as a reconcile error.
+	stageHold
+	// stageFatal: stop actuating, still status-sync, and return the error for workqueue backoff.
+	stageFatal
+)
+
+type stageResult struct {
+	outcome   stageOutcome
+	err       error
+	condition v1alpha1.RolloutConditionType
+	reason    string
+}
+
+type canaryStage struct {
+	name string
+	run  func(c *rolloutContext) stageResult
+}
+
+var canaryStages = []canaryStage{
+	{"syncRevisionOnChange", canaryStageSyncRevisionOnChange},
+	{"syncReplicaSets", canaryStageSyncReplicaSets},
+	{"podRestart", canaryStagePodRestart},
+	{"ephemeralMetadata", canaryStageEphemeralMetadata},
+	{"revisionHistory", canaryStageRevisionHistory},
+	{"pingPongService", canaryStagePingPongService},
+	{"stableCanaryService", canaryStageStableCanaryService},
+	{"trafficRouting", canaryStageTrafficRouting},
+	{"experiments", canaryStageExperiments},
+	{"analysis", canaryStageAnalysis},
+	{"replicaSetScaling", canaryStageReplicaSetScaling},
+	{"canaryPause", canaryStageCanaryPause},
+	{"stepPlugins", canaryStageStepPlugins},
+}
+
+func (c *rolloutContext) runCanaryStages() error {
+	for _, s := range canaryStages {
+		res := s.run(c)
+		switch res.outcome {
+		case stageContinue:
+		case stageStop:
+			c.log.Infof("stage %s: stopping actuation, proceeding to status sync", s.name)
+			return nil
+		case stageStopNoStatus:
+			c.skipStatusSync = true
+			return nil
+		case stageHold, stageFatal:
+			condType := res.condition
+			if condType == "" {
+				condType = v1alpha1.RolloutActuationSucceeded
+			}
+			reason := res.reason
+			if reason == "" {
+				reason = conditions.ActuationErrorReason
+			}
+			c.setStageCondition(condType, corev1.ConditionFalse, reason, res.err.Error())
+			c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: reason}, "%s", res.err.Error())
+			if res.outcome == stageHold {
+				c.enqueueRolloutAfter(c.rollout, defaults.GetRolloutVerifyRetryInterval())
+				return nil
+			}
+			return res.err
+		}
+	}
+	return nil
+}
+
+func canaryStageSyncRevisionOnChange(c *rolloutContext) stageResult {
+	if !replicasetutil.PodTemplateOrStepsChanged(c.rollout, c.newRS) {
+		return stageResult{outcome: stageContinue}
+	}
+	var err error
+	c.newRS, err = c.getAllReplicaSetsAndSyncRevision()
+	if err != nil {
+		return stageResult{
+			outcome: stageFatal,
+			err:     fmt.Errorf("failed to getAllReplicaSetsAndSyncRevision in rolloutCanary with PodTemplateOrStepsChanged: %w", err),
+		}
+	}
+	return stageResult{outcome: stageStop}
+}
+
+func canaryStageSyncReplicaSets(c *rolloutContext) stageResult {
+	var err error
+	c.newRS, err = c.getAllReplicaSetsAndSyncRevision()
+	if err != nil {
+		return stageResult{
+			outcome: stageFatal,
+			err:     fmt.Errorf("failed to getAllReplicaSetsAndSyncRevision in rolloutCanary create true: %w", err),
+		}
+	}
+	return stageResult{outcome: stageContinue}
+}
+
+func canaryStagePodRestart(c *rolloutContext) stageResult {
+	restarted, err := c.podRestarter.Reconcile(c)
+	if err != nil {
+		return stageResult{outcome: stageFatal, err: err}
+	}
+	if restarted > 0 {
+		c.log.Infof("Finished reconciliation due to %d restarted pods", restarted)
+		return stageResult{outcome: stageStopNoStatus}
+	}
+	return stageResult{outcome: stageContinue}
+}
+
+func canaryStageEphemeralMetadata(c *rolloutContext) stageResult {
+	if err := c.reconcileEphemeralMetadata(); err != nil {
+		return stageResult{outcome: stageFatal, err: err}
+	}
+	return stageResult{outcome: stageContinue}
+}
+
+func canaryStageRevisionHistory(c *rolloutContext) stageResult {
+	if err := c.reconcileRevisionHistoryLimit(c.otherRSs); err != nil {
+		return stageResult{outcome: stageFatal, err: err}
+	}
+	return stageResult{outcome: stageContinue}
+}
+
+func canaryStagePingPongService(c *rolloutContext) stageResult {
+	if err := c.reconcilePingAndPongService(); err != nil {
+		return stageResult{
+			outcome:   stageFatal,
+			err:       err,
+			condition: v1alpha1.RolloutServicesReconciled,
+			reason:    conditions.ServiceUpdateErrorReason,
+		}
+	}
+	return stageResult{outcome: stageContinue}
+}
+
+func canaryStageStableCanaryService(c *rolloutContext) stageResult {
+	if err := c.reconcileStableAndCanaryService(); err != nil {
+		return stageResult{
+			outcome:   stageFatal,
+			err:       err,
+			condition: v1alpha1.RolloutServicesReconciled,
+			reason:    conditions.ServiceUpdateErrorReason,
+		}
+	}
+	return stageResult{outcome: stageContinue}
+}
+
+func canaryStageTrafficRouting(c *rolloutContext) stageResult {
+	if err := c.reconcileTrafficRouting(); err != nil {
+		return stageResult{
+			outcome:   stageHold,
+			err:       err,
+			condition: v1alpha1.RolloutTrafficRoutingApplied,
+			reason:    conditions.TrafficRoutingErrorReason,
+		}
+	}
+	return stageResult{outcome: stageContinue}
+}
+
+func canaryStageExperiments(c *rolloutContext) stageResult {
+	if err := c.reconcileExperiments(); err != nil {
+		return stageResult{outcome: stageFatal, err: err}
+	}
+	return stageResult{outcome: stageContinue}
+}
+
+func canaryStageAnalysis(c *rolloutContext) stageResult {
+	err := c.reconcileAnalysisRuns()
+	if c.pauseContext.HasAddPause() {
+		c.log.Info("Detected pause due to inconclusive AnalysisRun")
+		return stageResult{outcome: stageStop}
+	}
+	if err != nil {
+		return stageResult{outcome: stageFatal, err: err}
+	}
+	return stageResult{outcome: stageContinue}
+}
+
+func canaryStageReplicaSetScaling(c *rolloutContext) stageResult {
+	noScalingOccurred, err := c.reconcileCanaryReplicaSets()
+	if err != nil {
+		return stageResult{outcome: stageFatal, err: err}
+	}
+	if noScalingOccurred {
+		c.log.Info("Not finished reconciling ReplicaSets")
+		return stageResult{outcome: stageStop}
+	}
+	return stageResult{outcome: stageContinue}
+}
+
+func canaryStageCanaryPause(c *rolloutContext) stageResult {
+	if c.reconcileCanaryPause() {
+		c.log.Infof("Not finished reconciling Canary Pause")
+		return stageResult{outcome: stageStop}
+	}
+	return stageResult{outcome: stageContinue}
+}
+
+func canaryStageStepPlugins(c *rolloutContext) stageResult {
+	if err := c.stepPluginContext.reconcile(c); err != nil {
+		return stageResult{outcome: stageFatal, err: err}
+	}
+	return stageResult{outcome: stageContinue}
+}

--- a/rollout/stages.go
+++ b/rollout/stages.go
@@ -1,6 +1,7 @@
 package rollout
 
 import (
+	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -16,6 +17,10 @@ type stageOutcome int
 const (
 	// stageContinue: proceed to the next stage.
 	stageContinue stageOutcome = iota
+	// stageContinueWithError: a cosmetic stage failed; record the condition, keep actuating
+	// (nothing downstream depends on it for traffic safety), and surface the error after the
+	// status sync for workqueue backoff. Step progression still holds via the condition gates.
+	stageContinueWithError
 	// stageStop: stop actuating, fall through to status sync. NOT an error.
 	stageStop
 	// stageStopNoStatus: stop without status sync (pod-restart early exit only).
@@ -58,43 +63,55 @@ var canaryStages = []canaryStage{
 }
 
 func (c *rolloutContext) runCanaryStages() error {
+	var errs []error
 	for _, s := range canaryStages {
 		res := s.run(c)
 		switch res.outcome {
 		case stageContinue:
+		case stageContinueWithError:
+			c.recordStageFailure(res)
+			errs = append(errs, res.err)
 		case stageStop:
 			c.log.Infof("stage %s: stopping actuation, proceeding to status sync", s.name)
-			return nil
+			return errors.Join(errs...)
 		case stageStopNoStatus:
 			c.skipStatusSync = true
-			return nil
+			return errors.Join(errs...)
 		case stageFatalNoStatus:
 			c.skipStatusSync = true
-			return res.err
+			errs = append(errs, res.err)
+			return errors.Join(errs...)
 		case stageFatal:
-			condType := res.condition
-			if condType == "" {
-				condType = v1alpha1.RolloutActuationSucceeded
-			}
-			reason := res.reason
-			if reason == "" {
-				reason = conditions.ActuationErrorReason
-			}
-			c.setStageCondition(condType, corev1.ConditionFalse, reason, res.err.Error())
-			// A persistently failing stage retries on workqueue backoff; emit the warning event
-			// only when the condition actually transitions (new failure or changed reason), not
-			// on every retry pass.
-			prevCond := conditions.GetRolloutCondition(c.rollout.Status, condType)
-			if prevCond == nil || prevCond.Status != corev1.ConditionFalse || prevCond.Reason != reason {
-				c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: reason}, "%s", res.err.Error())
-			}
-			return res.err
+			c.recordStageFailure(res)
+			errs = append(errs, res.err)
+			return errors.Join(errs...)
 		}
 	}
-	// Every stage ran without failure, so the catch-all actuation condition is allowed to
-	// recover to True in mergeStageConditions.
-	c.markStageSucceeded(v1alpha1.RolloutActuationSucceeded)
-	return nil
+	if len(errs) == 0 {
+		// Every stage ran without failure, so the catch-all actuation condition is allowed to
+		// recover to True in mergeStageConditions.
+		c.markStageSucceeded(v1alpha1.RolloutActuationSucceeded)
+	}
+	return errors.Join(errs...)
+}
+
+// recordStageFailure records the failing stage's condition and emits a warning event. A
+// persistently failing stage retries on workqueue backoff; the event is emitted only when the
+// condition actually transitions (new failure or changed reason), not on every retry pass.
+func (c *rolloutContext) recordStageFailure(res stageResult) {
+	condType := res.condition
+	if condType == "" {
+		condType = v1alpha1.RolloutActuationSucceeded
+	}
+	reason := res.reason
+	if reason == "" {
+		reason = conditions.ActuationErrorReason
+	}
+	c.setStageCondition(condType, corev1.ConditionFalse, reason, res.err.Error())
+	prevCond := conditions.GetRolloutCondition(c.rollout.Status, condType)
+	if prevCond == nil || prevCond.Status != corev1.ConditionFalse || prevCond.Reason != reason {
+		c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: reason}, "%s", res.err.Error())
+	}
 }
 
 func canaryStageSyncRevisionOnChange(c *rolloutContext) stageResult {
@@ -143,14 +160,16 @@ func canaryStagePodRestart(c *rolloutContext) stageResult {
 
 func canaryStageEphemeralMetadata(c *rolloutContext) stageResult {
 	if err := c.reconcileEphemeralMetadata(); err != nil {
-		return stageResult{outcome: stageFatal, err: err}
+		// Cosmetic: pod metadata labeling must not block services/traffic/scaling this pass.
+		return stageResult{outcome: stageContinueWithError, err: err}
 	}
 	return stageResult{outcome: stageContinue}
 }
 
 func canaryStageRevisionHistory(c *rolloutContext) stageResult {
 	if err := c.reconcileRevisionHistoryLimit(c.otherRSs); err != nil {
-		return stageResult{outcome: stageFatal, err: err}
+		// Cosmetic: old-revision cleanup must not block services/traffic/scaling this pass.
+		return stageResult{outcome: stageContinueWithError, err: err}
 	}
 	return stageResult{outcome: stageContinue}
 }

--- a/rollout/stages.go
+++ b/rollout/stages.go
@@ -90,7 +90,7 @@ func (c *rolloutContext) runCanaryStages() error {
 	if len(errs) == 0 {
 		// Every stage ran without failure, so the catch-all actuation condition is allowed to
 		// recover to True in mergeStageConditions.
-		c.markStageSucceeded(v1alpha1.RolloutActuationSucceeded)
+		c.markStageSucceeded(v1alpha1.RolloutReconcileSucceeded)
 	}
 	return errors.Join(errs...)
 }
@@ -101,11 +101,11 @@ func (c *rolloutContext) runCanaryStages() error {
 func (c *rolloutContext) recordStageFailure(res stageResult) {
 	condType := res.condition
 	if condType == "" {
-		condType = v1alpha1.RolloutActuationSucceeded
+		condType = v1alpha1.RolloutReconcileSucceeded
 	}
 	reason := res.reason
 	if reason == "" {
-		reason = conditions.ActuationErrorReason
+		reason = conditions.RolloutReconciliationErrorReason
 	}
 	c.setStageCondition(condType, corev1.ConditionFalse, reason, res.err.Error())
 	prevCond := conditions.GetRolloutCondition(c.rollout.Status, condType)

--- a/rollout/stages_test.go
+++ b/rollout/stages_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/annotations"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
+	logutil "github.com/argoproj/argo-rollouts/utils/log"
+	"github.com/argoproj/argo-rollouts/utils/record"
 )
 
 func TestCanaryStageTableMatchesLegacyOrder(t *testing.T) {
@@ -162,6 +164,58 @@ func TestCanaryStageSyncFailurePreservesNewRS(t *testing.T) {
 	assert.NotNil(t, roCtx.newRS, "newRS must not be clobbered by a failed ReplicaSet sync")
 }
 
+// TestStageContinueWithErrorKeepsActuating verifies the stageContinueWithError plumbing: a
+// cosmetic stage failure records its condition and keeps the pipeline running (services, traffic
+// routing, and scaling still actuate this pass), while the error is still returned for workqueue
+// backoff — including when a later stage stops the pipeline normally.
+func TestStageContinueWithErrorKeepsActuating(t *testing.T) {
+	orig := canaryStages
+	defer func() { canaryStages = orig }()
+	cosmeticErr := errors.New("revision history cleanup failed")
+
+	t.Run("later stages still run and the error is returned", func(t *testing.T) {
+		laterStageRan := false
+		canaryStages = []canaryStage{
+			{"cosmetic", func(c *rolloutContext) stageResult {
+				return stageResult{outcome: stageContinueWithError, err: cosmeticErr}
+			}},
+			{"later", func(c *rolloutContext) stageResult {
+				laterStageRan = true
+				return stageResult{outcome: stageContinue}
+			}},
+		}
+		ctx := &rolloutContext{
+			rollout:        &v1alpha1.Rollout{},
+			reconcilerBase: reconcilerBase{recorder: record.NewFakeEventRecorder()},
+		}
+		err := ctx.runCanaryStages()
+		assert.True(t, laterStageRan, "a cosmetic failure must not stop actuation")
+		assert.ErrorIs(t, err, cosmeticErr)
+		cond := ctx.stageConditions[v1alpha1.RolloutActuationSucceeded]
+		assert.Equal(t, corev1.ConditionFalse, cond.Status)
+		assert.False(t, ctx.stageSuccesses[v1alpha1.RolloutActuationSucceeded],
+			"a pass with a cosmetic failure must not mark actuation as recovered")
+	})
+
+	t.Run("error survives a later stageStop", func(t *testing.T) {
+		canaryStages = []canaryStage{
+			{"cosmetic", func(c *rolloutContext) stageResult {
+				return stageResult{outcome: stageContinueWithError, err: cosmeticErr}
+			}},
+			{"pause", func(c *rolloutContext) stageResult {
+				return stageResult{outcome: stageStop}
+			}},
+		}
+		ctx := &rolloutContext{
+			rollout:        &v1alpha1.Rollout{},
+			log:            logutil.WithRollout(&v1alpha1.Rollout{}),
+			reconcilerBase: reconcilerBase{recorder: record.NewFakeEventRecorder()},
+		}
+		err := ctx.runCanaryStages()
+		assert.ErrorIs(t, err, cosmeticErr, "a cosmetic failure must not be swallowed by a later normal stop")
+	})
+}
+
 // TestStageFatalNoStatusSkipsStatusSync verifies the stageFatalNoStatus plumbing: the error is
 // returned for workqueue backoff and the status sync is skipped entirely.
 func TestStageFatalNoStatusSkipsStatusSync(t *testing.T) {
@@ -176,6 +230,6 @@ func TestStageFatalNoStatusSkipsStatusSync(t *testing.T) {
 	// would dereference nil members and panic.
 	ctx := &rolloutContext{}
 	err := ctx.rolloutCanary()
-	assert.Equal(t, boom, err)
+	assert.ErrorIs(t, err, boom)
 	assert.True(t, ctx.skipStatusSync)
 }

--- a/rollout/stages_test.go
+++ b/rollout/stages_test.go
@@ -164,11 +164,11 @@ func TestCanaryStageSyncFailurePreservesNewRS(t *testing.T) {
 	assert.NotNil(t, roCtx.newRS, "newRS must not be clobbered by a failed ReplicaSet sync")
 }
 
-// TestStageContinueWithErrorKeepsActuating verifies the stageContinueWithError plumbing: a
+// TestStageContinueWithErrorKeepsApplying verifies the stageContinueWithError plumbing: a
 // cosmetic stage failure records its condition and keeps the pipeline running (services, traffic
-// routing, and scaling still actuate this pass), while the error is still returned for workqueue
+// routing, and scaling still run this pass), while the error is still returned for workqueue
 // backoff — including when a later stage stops the pipeline normally.
-func TestStageContinueWithErrorKeepsActuating(t *testing.T) {
+func TestStageContinueWithErrorKeepsApplying(t *testing.T) {
 	orig := canaryStages
 	defer func() { canaryStages = orig }()
 	cosmeticErr := errors.New("revision history cleanup failed")
@@ -189,12 +189,12 @@ func TestStageContinueWithErrorKeepsActuating(t *testing.T) {
 			reconcilerBase: reconcilerBase{recorder: record.NewFakeEventRecorder()},
 		}
 		err := ctx.runCanaryStages()
-		assert.True(t, laterStageRan, "a cosmetic failure must not stop actuation")
+		assert.True(t, laterStageRan, "a cosmetic failure must not stop the remaining stages")
 		assert.ErrorIs(t, err, cosmeticErr)
 		cond := ctx.stageConditions[v1alpha1.RolloutReconcileSucceeded]
 		assert.Equal(t, corev1.ConditionFalse, cond.Status)
 		assert.False(t, ctx.stageSuccesses[v1alpha1.RolloutReconcileSucceeded],
-			"a pass with a cosmetic failure must not mark actuation as recovered")
+			"a pass with a cosmetic failure must not mark ReconcileSucceeded as recovered")
 	})
 
 	t.Run("error survives a later stageStop", func(t *testing.T) {

--- a/rollout/stages_test.go
+++ b/rollout/stages_test.go
@@ -73,7 +73,7 @@ func TestCanaryStagePipelineSemantics(t *testing.T) {
 		assert.Equal(t, corev1.ConditionFalse, cond.Status)
 	})
 
-	t.Run("stageFatal returns error and does not requeue on hold interval", func(t *testing.T) {
+	t.Run("stageStop with error returns error and does not requeue on hold interval", func(t *testing.T) {
 		f := newFixture(t)
 		defer f.Close()
 
@@ -120,7 +120,7 @@ func TestCanaryStagePipelineSemantics(t *testing.T) {
 }
 
 // TestCanaryStageSyncFailurePreservesNewRS verifies that a failed getAllReplicaSetsAndSyncRevision
-// does not clobber c.newRS to nil and skips the status sync (stageFatalNoStatus): a status
+// does not clobber c.newRS to nil and skips the status sync (stageStopNoStatus with err): a status
 // computed from a nil newRS would reset abort/pause state and record a phantom CurrentPodHash on
 // a template change, or flap UpdatedReplicas to 0 on a transient API error.
 func TestCanaryStageSyncFailurePreservesNewRS(t *testing.T) {
@@ -154,12 +154,12 @@ func TestCanaryStageSyncFailurePreservesNewRS(t *testing.T) {
 	assert.NoError(t, err)
 
 	res := canaryStageSyncRevisionOnChange(roCtx)
-	assert.Equal(t, stageFatalNoStatus, res.outcome)
+	assert.Equal(t, stageStopNoStatus, res.outcome)
 	assert.Error(t, res.err)
 	assert.NotNil(t, roCtx.newRS, "newRS must not be clobbered by a failed ReplicaSet sync")
 
 	res = canaryStageSyncReplicaSets(roCtx)
-	assert.Equal(t, stageFatalNoStatus, res.outcome)
+	assert.Equal(t, stageStopNoStatus, res.outcome)
 	assert.Error(t, res.err)
 	assert.NotNil(t, roCtx.newRS, "newRS must not be clobbered by a failed ReplicaSet sync")
 }
@@ -175,7 +175,7 @@ func TestStageContinueWithErrorKeepsApplying(t *testing.T) {
 
 	t.Run("later stages still run and the error is returned", func(t *testing.T) {
 		laterStageRan := false
-		canaryStages = []canaryStage{
+		canaryStages = []strategyStage{
 			{"cosmetic", func(c *rolloutContext) stageResult {
 				return stageResult{outcome: stageContinueWithError, err: cosmeticErr}
 			}},
@@ -198,7 +198,7 @@ func TestStageContinueWithErrorKeepsApplying(t *testing.T) {
 	})
 
 	t.Run("error survives a later stageStop", func(t *testing.T) {
-		canaryStages = []canaryStage{
+		canaryStages = []strategyStage{
 			{"cosmetic", func(c *rolloutContext) stageResult {
 				return stageResult{outcome: stageContinueWithError, err: cosmeticErr}
 			}},
@@ -216,14 +216,61 @@ func TestStageContinueWithErrorKeepsApplying(t *testing.T) {
 	})
 }
 
-// TestStageFatalNoStatusSkipsStatusSync verifies the stageFatalNoStatus plumbing: the error is
+// TestBlueGreenStageTableMatchesLegacyOrder guards against accidental reordering of the
+// blue-green reconcile pipeline.
+func TestBlueGreenStageTableMatchesLegacyOrder(t *testing.T) {
+	expected := []string{
+		"previewService",
+		"podTemplateChange",
+		"podRestart",
+		"replicaSets",
+		"pause",
+		"activeService",
+		"targetGroups",
+		"analysis",
+		"ephemeralMetadata",
+		"revisionHistory",
+	}
+	names := make([]string, len(blueGreenStages))
+	for i, stage := range blueGreenStages {
+		names[i] = stage.name
+	}
+	assert.Equal(t, expected, names)
+}
+
+// TestBlueGreenStageContinueWithErrorKeepsApplying verifies cosmetic stage failures on blue-green
+// still allow the remaining stages in the pipeline to run.
+func TestBlueGreenStageContinueWithErrorKeepsApplying(t *testing.T) {
+	orig := blueGreenStages
+	defer func() { blueGreenStages = orig }()
+	cosmeticErr := errors.New("revision history cleanup failed")
+	laterStageRan := false
+	blueGreenStages = []strategyStage{
+		{"cosmetic", func(c *rolloutContext) stageResult {
+			return stageResult{outcome: stageContinueWithError, err: cosmeticErr}
+		}},
+		{"later", func(c *rolloutContext) stageResult {
+			laterStageRan = true
+			return stageResult{outcome: stageContinue}
+		}},
+	}
+	ctx := &rolloutContext{
+		rollout:        &v1alpha1.Rollout{},
+		reconcilerBase: reconcilerBase{recorder: record.NewFakeEventRecorder()},
+	}
+	err := ctx.runBlueGreenStages(nil, nil)
+	assert.True(t, laterStageRan)
+	assert.ErrorIs(t, err, cosmeticErr)
+}
+
+// TestStageStopNoStatusSkipsStatusSync verifies stageStopNoStatus with err: the error is
 // returned for workqueue backoff and the status sync is skipped entirely.
-func TestStageFatalNoStatusSkipsStatusSync(t *testing.T) {
+func TestStageStopNoStatusSkipsStatusSync(t *testing.T) {
 	orig := canaryStages
 	defer func() { canaryStages = orig }()
 	boom := errors.New("replicaset sync failed")
-	canaryStages = []canaryStage{{name: "boom", run: func(c *rolloutContext) stageResult {
-		return stageResult{outcome: stageFatalNoStatus, err: boom}
+	canaryStages = []strategyStage{{name: "boom", run: func(c *rolloutContext) stageResult {
+		return stageResult{outcome: stageStopNoStatus, err: boom}
 	}}}
 
 	// A bare context suffices: if the status sync were not skipped, syncRolloutStatusCanary

--- a/rollout/stages_test.go
+++ b/rollout/stages_test.go
@@ -68,9 +68,10 @@ func TestCanaryStagePipelineSemantics(t *testing.T) {
 		assert.False(t, enqueued)
 
 		patched := f.getPatchedRolloutAsObject(patchIndex)
-		cond := conditions.GetRolloutCondition(patched.Status, v1alpha1.RolloutTrafficRoutingApplied)
+		cond := conditions.GetRolloutCondition(patched.Status, v1alpha1.RolloutReconcileSucceeded)
 		assert.NotNil(t, cond)
 		assert.Equal(t, corev1.ConditionFalse, cond.Status)
+		assert.Equal(t, conditions.TrafficRoutingErrorReason, cond.Reason)
 	})
 
 	t.Run("stageStop with error returns error and does not requeue on hold interval", func(t *testing.T) {
@@ -113,9 +114,10 @@ func TestCanaryStagePipelineSemantics(t *testing.T) {
 		f.runController(getKey(r2, t), true, true, c, i, k8sI)
 		assert.False(t, enqueued)
 		patched := f.getPatchedRolloutAsObject(patchIndex)
-		cond := conditions.GetRolloutCondition(patched.Status, v1alpha1.RolloutServicesReconciled)
+		cond := conditions.GetRolloutCondition(patched.Status, v1alpha1.RolloutReconcileSucceeded)
 		assert.NotNil(t, cond)
 		assert.Equal(t, corev1.ConditionFalse, cond.Status)
+		assert.Equal(t, conditions.ServiceUpdateErrorReason, cond.Reason)
 	})
 }
 

--- a/rollout/stages_test.go
+++ b/rollout/stages_test.go
@@ -1,6 +1,7 @@
 package rollout
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/argoproj/argo-rollouts/utils/annotations"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
 )
@@ -110,4 +112,68 @@ func TestCanaryStagePipelineSemantics(t *testing.T) {
 		assert.NotNil(t, cond)
 		assert.Equal(t, corev1.ConditionFalse, cond.Status)
 	})
+}
+
+// TestCanaryStageSyncFailurePreservesNewRS verifies that a failed getAllReplicaSetsAndSyncRevision
+// does not clobber c.newRS to nil and skips the status sync (stageFatalNoStatus): a status
+// computed from a nil newRS would reset abort/pause state and record a phantom CurrentPodHash on
+// a template change, or flap UpdatedReplicas to 0 on a transient API error.
+func TestCanaryStageSyncFailurePreservesNewRS(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{{SetWeight: ptr.To[int32](10)}, {Pause: &v1alpha1.RolloutPause{}}}
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(0))
+	r2 := bumpVersion(r1)
+
+	rs1 := newReplicaSetWithStatus(r1, 10, 10)
+	rs2 := newReplicaSetWithStatus(r2, 1, 1)
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	// Force syncReplicaSetRevision down the updateReplicaSet path so the injected failure hits.
+	rs2.Annotations[annotations.RevisionAnnotation] = "1"
+
+	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 11, 1, 11, false)
+	// Simulate a pod template change whose status sync has not happened yet.
+	r2.Status.CurrentPodHash = rs1PodHash
+
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2)
+
+	f.kubeclient.PrependReactor("update", "replicasets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("api server unavailable")
+	})
+
+	ctrl, _, _ := f.newController(noResyncPeriodFunc)
+	roCtx, err := ctrl.newRolloutContext(r2)
+	assert.NoError(t, err)
+
+	res := canaryStageSyncRevisionOnChange(roCtx)
+	assert.Equal(t, stageFatalNoStatus, res.outcome)
+	assert.Error(t, res.err)
+	assert.NotNil(t, roCtx.newRS, "newRS must not be clobbered by a failed ReplicaSet sync")
+
+	res = canaryStageSyncReplicaSets(roCtx)
+	assert.Equal(t, stageFatalNoStatus, res.outcome)
+	assert.Error(t, res.err)
+	assert.NotNil(t, roCtx.newRS, "newRS must not be clobbered by a failed ReplicaSet sync")
+}
+
+// TestStageFatalNoStatusSkipsStatusSync verifies the stageFatalNoStatus plumbing: the error is
+// returned for workqueue backoff and the status sync is skipped entirely.
+func TestStageFatalNoStatusSkipsStatusSync(t *testing.T) {
+	orig := canaryStages
+	defer func() { canaryStages = orig }()
+	boom := errors.New("replicaset sync failed")
+	canaryStages = []canaryStage{{name: "boom", run: func(c *rolloutContext) stageResult {
+		return stageResult{outcome: stageFatalNoStatus, err: boom}
+	}}}
+
+	// A bare context suffices: if the status sync were not skipped, syncRolloutStatusCanary
+	// would dereference nil members and panic.
+	ctx := &rolloutContext{}
+	err := ctx.rolloutCanary()
+	assert.Equal(t, boom, err)
+	assert.True(t, ctx.skipStatusSync)
 }

--- a/rollout/stages_test.go
+++ b/rollout/stages_test.go
@@ -44,7 +44,7 @@ func TestCanaryStageTableMatchesLegacyOrder(t *testing.T) {
 }
 
 func TestCanaryStagePipelineSemantics(t *testing.T) {
-	t.Run("stageHold swallows error and requeues", func(t *testing.T) {
+	t.Run("trafficRouting error returns error and still syncs status", func(t *testing.T) {
 		f, ro := newTrafficWeightFixture(t)
 		defer f.Close()
 		f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
@@ -54,13 +54,16 @@ func TestCanaryStagePipelineSemantics(t *testing.T) {
 		enqueued := false
 		c, i, k8sI := f.newController(noResyncPeriodFunc)
 		c.enqueueRolloutAfter = func(obj any, duration time.Duration) {
-			enqueued = true
-			assert.Equal(t, defaults.GetRolloutVerifyRetryInterval(), duration)
+			if duration == defaults.GetRolloutVerifyRetryInterval() {
+				enqueued = true
+			}
 		}
 
 		patchIndex := f.expectPatchRolloutAction(ro)
-		f.runController(getKey(ro, t), true, false, c, i, k8sI)
-		assert.True(t, enqueued)
+		// The error must propagate for workqueue backoff and error metrics; retry pacing comes
+		// from the rate-limited requeue, not a fixed verify-interval requeue.
+		f.runController(getKey(ro, t), true, true, c, i, k8sI)
+		assert.False(t, enqueued)
 
 		patched := f.getPatchedRolloutAsObject(patchIndex)
 		cond := conditions.GetRolloutCondition(patched.Status, v1alpha1.RolloutTrafficRoutingApplied)

--- a/rollout/stages_test.go
+++ b/rollout/stages_test.go
@@ -191,9 +191,9 @@ func TestStageContinueWithErrorKeepsActuating(t *testing.T) {
 		err := ctx.runCanaryStages()
 		assert.True(t, laterStageRan, "a cosmetic failure must not stop actuation")
 		assert.ErrorIs(t, err, cosmeticErr)
-		cond := ctx.stageConditions[v1alpha1.RolloutActuationSucceeded]
+		cond := ctx.stageConditions[v1alpha1.RolloutReconcileSucceeded]
 		assert.Equal(t, corev1.ConditionFalse, cond.Status)
-		assert.False(t, ctx.stageSuccesses[v1alpha1.RolloutActuationSucceeded],
+		assert.False(t, ctx.stageSuccesses[v1alpha1.RolloutReconcileSucceeded],
 			"a pass with a cosmetic failure must not mark actuation as recovered")
 	})
 

--- a/rollout/stages_test.go
+++ b/rollout/stages_test.go
@@ -141,11 +141,10 @@ func TestCanaryStageSyncFailurePreservesNewRS(t *testing.T) {
 	f.rolloutLister = append(f.rolloutLister, r2)
 	f.objects = append(f.objects, r2)
 
+	ctrl, _, _ := f.newController(noResyncPeriodFunc)
 	f.kubeclient.PrependReactor("update", "replicasets", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, fmt.Errorf("api server unavailable")
 	})
-
-	ctrl, _, _ := f.newController(noResyncPeriodFunc)
 	roCtx, err := ctrl.newRolloutContext(r2)
 	assert.NoError(t, err)
 

--- a/rollout/stages_test.go
+++ b/rollout/stages_test.go
@@ -1,0 +1,113 @@
+package rollout
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/utils/ptr"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/argoproj/argo-rollouts/utils/conditions"
+	"github.com/argoproj/argo-rollouts/utils/defaults"
+)
+
+func TestCanaryStageTableMatchesLegacyOrder(t *testing.T) {
+	expected := []string{
+		"syncRevisionOnChange",
+		"syncReplicaSets",
+		"podRestart",
+		"ephemeralMetadata",
+		"revisionHistory",
+		"pingPongService",
+		"stableCanaryService",
+		"trafficRouting",
+		"experiments",
+		"analysis",
+		"replicaSetScaling",
+		"canaryPause",
+		"stepPlugins",
+	}
+	names := make([]string, len(canaryStages))
+	for i, stage := range canaryStages {
+		names[i] = stage.name
+	}
+	assert.Equal(t, expected, names)
+}
+
+func TestCanaryStagePipelineSemantics(t *testing.T) {
+	t.Run("stageHold swallows error and requeues", func(t *testing.T) {
+		f, ro := newTrafficWeightFixture(t)
+		defer f.Close()
+		f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+		f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(assert.AnError)
+
+		enqueued := false
+		c, i, k8sI := f.newController(noResyncPeriodFunc)
+		c.enqueueRolloutAfter = func(obj any, duration time.Duration) {
+			enqueued = true
+			assert.Equal(t, defaults.GetRolloutVerifyRetryInterval(), duration)
+		}
+
+		patchIndex := f.expectPatchRolloutAction(ro)
+		f.runController(getKey(ro, t), true, false, c, i, k8sI)
+		assert.True(t, enqueued)
+
+		patched := f.getPatchedRolloutAsObject(patchIndex)
+		cond := conditions.GetRolloutCondition(patched.Status, v1alpha1.RolloutTrafficRoutingApplied)
+		assert.NotNil(t, cond)
+		assert.Equal(t, corev1.ConditionFalse, cond.Status)
+	})
+
+	t.Run("stageFatal returns error and does not requeue on hold interval", func(t *testing.T) {
+		f := newFixture(t)
+		defer f.Close()
+
+		steps := []v1alpha1.CanaryStep{{SetWeight: ptr.To[int32](10)}}
+		r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(0))
+		r2 := bumpVersion(r1)
+		r2.Spec.Strategy.Canary.StableService = "stable"
+		r2.Spec.Strategy.Canary.CanaryService = "canary"
+
+		rs1 := newReplicaSetWithStatus(r1, 10, 10)
+		rs2 := newReplicaSetWithStatus(r2, 1, 1)
+		rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+		rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+		canarySvc := newService("canary", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}, r2)
+		stableSvc := newService("stable", 80, map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}, r2)
+
+		r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 11, 1, 11, false)
+		f.kubeobjects = append(f.kubeobjects, rs1, rs2, canarySvc, stableSvc)
+		f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+		f.serviceLister = append(f.serviceLister, canarySvc, stableSvc)
+		f.rolloutLister = append(f.rolloutLister, r2)
+		f.objects = append(f.objects, r2)
+
+		enqueued := false
+		c, i, k8sI := f.newController(noResyncPeriodFunc)
+		c.enqueueRolloutAfter = func(obj any, duration time.Duration) {
+			if duration == defaults.GetRolloutVerifyRetryInterval() {
+				enqueued = true
+			}
+		}
+		f.kubeclient.Fake.PrependReactor("patch", "services", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, fmt.Errorf("admission webhook denied service update")
+		})
+
+		_ = f.expectPatchServiceAction(canarySvc, rs2PodHash)
+		patchIndex := f.expectPatchRolloutAction(r2)
+		f.runController(getKey(r2, t), true, true, c, i, k8sI)
+		assert.False(t, enqueued)
+		patched := f.getPatchedRolloutAsObject(patchIndex)
+		cond := conditions.GetRolloutCondition(patched.Status, v1alpha1.RolloutServicesReconciled)
+		assert.NotNil(t, cond)
+		assert.Equal(t, corev1.ConditionFalse, cond.Status)
+	})
+}

--- a/rollout/stepplugin.go
+++ b/rollout/stepplugin.go
@@ -167,7 +167,7 @@ func (spc *stepPluginContext) updateStatus(status *v1alpha1.RolloutStatus) {
 
 func (spc *stepPluginContext) isStepPluginCompleted(stepIndex int32, _ *v1alpha1.PluginStep) bool {
 	// Controller-side plugin errors (resolver/RPC failures) surface through the stage pipeline
-	// as an ReconcileSucceeded=False condition, which already holds step progression via the
+	// as ReconcileSucceeded=False, which already holds step progression via the
 	// anyStageConditionFalse gate in completedCurrentCanaryStep.
 	runStatus := spc.findCurrentStepStatus(stepIndex, v1alpha1.StepPluginOperationRun)
 	if runStatus != nil && runStatus.Disabled {

--- a/rollout/stepplugin.go
+++ b/rollout/stepplugin.go
@@ -15,8 +15,7 @@ import (
 )
 
 var (
-	defaultControllerErrorBackoff = time.Second * 30
-	defaultBackoffDelay           = time.Second * 5
+	defaultBackoffDelay = time.Second * 5
 )
 
 type stepPluginContext struct {
@@ -24,7 +23,6 @@ type stepPluginContext struct {
 	log      *log.Entry
 
 	stepPluginStatuses []v1alpha1.StepPluginStatus
-	hasError           bool
 }
 
 func (spc *stepPluginContext) reconcile(c *rolloutContext) error {
@@ -46,11 +44,11 @@ func (spc *stepPluginContext) reconcile(c *rolloutContext) error {
 
 			stepPlugin, err := spc.resolver.Resolve(pluginStatus.Index, *pluginStep.Plugin, c.log)
 			if err != nil {
-				return spc.handleError(c, fmt.Errorf("could not create step plugin at index %d : %w", pluginStatus.Index, err))
+				return fmt.Errorf("could not create step plugin at index %d : %w", pluginStatus.Index, err)
 			}
 			status, err := stepPlugin.Abort(rollout)
 			if err != nil {
-				return spc.handleError(c, fmt.Errorf("failed to abort plugin: %w", err))
+				return fmt.Errorf("failed to abort plugin: %w", err)
 			}
 			phaseTransition := spc.updateStepPluginStatus(status)
 			if phaseTransition {
@@ -74,12 +72,12 @@ func (spc *stepPluginContext) reconcile(c *rolloutContext) error {
 
 		stepPlugin, err := spc.resolver.Resolve(*stepIndex, *pluginStep.Plugin, c.log)
 		if err != nil {
-			return spc.handleError(c, fmt.Errorf("could not create step plugin at index %d : %w", *stepIndex, err))
+			return fmt.Errorf("could not create step plugin at index %d : %w", *stepIndex, err)
 		}
 
 		status, err := stepPlugin.Terminate(rollout)
 		if err != nil {
-			return spc.handleError(c, fmt.Errorf("failed to terminate plugin: %w", err))
+			return fmt.Errorf("failed to terminate plugin: %w", err)
 		}
 
 		phaseTransition := spc.updateStepPluginStatus(status)
@@ -105,11 +103,11 @@ func (spc *stepPluginContext) reconcile(c *rolloutContext) error {
 
 	stepPlugin, err := spc.resolver.Resolve(*currentStepIndex, *currentStep.Plugin, c.log)
 	if err != nil {
-		return spc.handleError(c, fmt.Errorf("could not create step plugin at index %d : %w", *currentStepIndex, err))
+		return fmt.Errorf("could not create step plugin at index %d : %w", *currentStepIndex, err)
 	}
 	status, err := stepPlugin.Run(rollout)
 	if err != nil {
-		return spc.handleError(c, fmt.Errorf("failed to run plugin: %w", err))
+		return fmt.Errorf("failed to run plugin: %w", err)
 	}
 
 	phaseTransition := spc.updateStepPluginStatus(status)
@@ -124,7 +122,7 @@ func (spc *stepPluginContext) reconcile(c *rolloutContext) error {
 	if status.Phase == v1alpha1.StepPluginPhaseRunning || status.Phase == v1alpha1.StepPluginPhaseError {
 		backoff, err := status.Backoff.Duration()
 		if err != nil {
-			return spc.handleError(c, fmt.Errorf("failed to parse backoff duration: %w", err))
+			return fmt.Errorf("failed to parse backoff duration: %w", err)
 		}
 
 		// Get the remaining time until the backoff + a little buffer
@@ -137,19 +135,6 @@ func (spc *stepPluginContext) reconcile(c *rolloutContext) error {
 	if status.Phase == v1alpha1.StepPluginPhaseFailed {
 		c.pauseContext.AddAbort(fmt.Sprintf("Step Plugin %d (%s) failed: %s", status.Index+1, status.Name, status.Message))
 	}
-
-	return nil
-}
-
-// handleError handles any error that should not cause the rollout reconciliation to fail
-func (spc *stepPluginContext) handleError(c *rolloutContext, e error) error {
-	spc.hasError = true
-
-	msg := fmt.Sprintf(conditions.RolloutReconciliationErrorMessage, e.Error())
-	c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: conditions.RolloutReconciliationErrorReason}, msg)
-
-	c.log.Debugf("queueing up rollout in %s because of transient error", defaultControllerErrorBackoff)
-	c.enqueueRolloutAfter(c.rollout, defaultControllerErrorBackoff)
 
 	return nil
 }
@@ -181,11 +166,9 @@ func (spc *stepPluginContext) updateStatus(status *v1alpha1.RolloutStatus) {
 }
 
 func (spc *stepPluginContext) isStepPluginCompleted(stepIndex int32, _ *v1alpha1.PluginStep) bool {
-	if spc.hasError {
-		// If there was a transient error during the reconcile, we should retry
-		return false
-	}
-
+	// Controller-side plugin errors (resolver/RPC failures) surface through the stage pipeline
+	// as an ActuationSucceeded=False condition, which already holds step progression via the
+	// anyStageConditionFalse gate in completedCurrentCanaryStep.
 	runStatus := spc.findCurrentStepStatus(stepIndex, v1alpha1.StepPluginOperationRun)
 	if runStatus != nil && runStatus.Disabled {
 		return true

--- a/rollout/stepplugin.go
+++ b/rollout/stepplugin.go
@@ -167,7 +167,7 @@ func (spc *stepPluginContext) updateStatus(status *v1alpha1.RolloutStatus) {
 
 func (spc *stepPluginContext) isStepPluginCompleted(stepIndex int32, _ *v1alpha1.PluginStep) bool {
 	// Controller-side plugin errors (resolver/RPC failures) surface through the stage pipeline
-	// as an ActuationSucceeded=False condition, which already holds step progression via the
+	// as an ReconcileSucceeded=False condition, which already holds step progression via the
 	// anyStageConditionFalse gate in completedCurrentCanaryStep.
 	runStatus := spc.findCurrentStepStatus(stepIndex, v1alpha1.StepPluginOperationRun)
 	if runStatus != nil && runStatus.Disabled {

--- a/rollout/stepplugin_test.go
+++ b/rollout/stepplugin_test.go
@@ -71,18 +71,12 @@ func Test_stepPluginContext_reconcile_ReconciliationError(t *testing.T) {
 
 	stepPluginResolver.On("Resolve", mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("test error"))
 
-	var requeuedAfter time.Duration
-	roCtx.enqueueRolloutAfter = func(obj any, duration time.Duration) {
-		requeuedAfter = duration
-	}
-
 	err := roCtx.stepPluginContext.reconcile(roCtx)
 
-	require.NoError(t, err)
+	// Controller-side plugin errors propagate through the stage pipeline: the condition and
+	// event are recorded there, and the workqueue provides retry backoff.
+	require.ErrorContains(t, err, "test error")
 	assert.Equal(t, roCtx.rollout.Status.Canary.StepPluginStatuses, roCtx.stepPluginContext.stepPluginStatuses)
-	assert.Equal(t, defaultControllerErrorBackoff, requeuedAfter)
-	assert.True(t, roCtx.stepPluginContext.hasError)
-
 }
 
 func Test_stepPluginContext_reconcile_SuccessfulReconciliation(t *testing.T) {
@@ -452,20 +446,13 @@ func Test_stepPluginContext_reconcile_FullyPromoted(t *testing.T) {
 			},
 		}
 
-		var requeuedAfter time.Duration
-		roCtx.enqueueRolloutAfter = func(obj any, duration time.Duration) {
-			requeuedAfter = duration
-		}
-
 		stepPluginMock.On("Terminate", mock.Anything).Return(nil, fmt.Errorf("error"))
 
 		err := roCtx.stepPluginContext.reconcile(roCtx)
 
-		require.NoError(t, err)
+		require.ErrorContains(t, err, "failed to terminate plugin")
 		require.Len(t, roCtx.stepPluginContext.stepPluginStatuses, 1)
 		assert.Equal(t, roCtx.rollout.Status.Canary.StepPluginStatuses, roCtx.stepPluginContext.stepPluginStatuses)
-		assert.Equal(t, defaultControllerErrorBackoff, requeuedAfter)
-		assert.True(t, roCtx.stepPluginContext.hasError)
 	})
 }
 
@@ -632,22 +619,15 @@ func Test_stepPluginContext_reconcile_Aborted(t *testing.T) {
 			},
 		}
 
-		var requeuedAfter time.Duration
-		roCtx.enqueueRolloutAfter = func(obj any, duration time.Duration) {
-			requeuedAfter = duration
-		}
-
 		stepPluginMock := mocks.NewStepPlugin(t)
 		stepPluginResolver.On("Resolve", int32(0), mock.Anything, mock.Anything).Return(stepPluginMock, nil)
 		stepPluginMock.On("Abort", mock.Anything).Return(nil, fmt.Errorf("error"))
 
 		err := roCtx.stepPluginContext.reconcile(roCtx)
 
-		require.NoError(t, err)
+		require.ErrorContains(t, err, "failed to abort plugin")
 		require.Len(t, roCtx.stepPluginContext.stepPluginStatuses, 1)
 		assert.Equal(t, roCtx.rollout.Status.Canary.StepPluginStatuses, roCtx.stepPluginContext.stepPluginStatuses)
-		assert.Equal(t, defaultControllerErrorBackoff, requeuedAfter)
-		assert.True(t, roCtx.stepPluginContext.hasError)
 	})
 }
 
@@ -741,7 +721,7 @@ func Test_stepPluginContext_reconcile_Retry_After_Abort(t *testing.T) {
 }
 
 func Test_stepPluginContext_isStepPluginCompleted(t *testing.T) {
-	newRolloutContext := func(statuses []*v1alpha1.StepPluginStatus, hasError bool) *rolloutContext {
+	newRolloutContext := func(statuses []*v1alpha1.StepPluginStatus) *rolloutContext {
 		r := newStepPluginRollout()
 		logCtx := logutil.WithRollout(r)
 		roCtx := &rolloutContext{
@@ -755,7 +735,6 @@ func Test_stepPluginContext_isStepPluginCompleted(t *testing.T) {
 		for _, s := range statuses {
 			roCtx.stepPluginContext.stepPluginStatuses = append(roCtx.stepPluginContext.stepPluginStatuses, *s)
 		}
-		roCtx.stepPluginContext.hasError = hasError
 		return roCtx
 	}
 
@@ -763,7 +742,6 @@ func Test_stepPluginContext_isStepPluginCompleted(t *testing.T) {
 		name     string
 		statuses []*v1alpha1.StepPluginStatus
 		index    int32
-		hasError bool
 		want     bool
 	}{
 		{
@@ -779,15 +757,6 @@ func Test_stepPluginContext_isStepPluginCompleted(t *testing.T) {
 			},
 			index: 0,
 			want:  true,
-		},
-		{
-			name: "With transient error",
-			statuses: []*v1alpha1.StepPluginStatus{
-				{Index: 0, Operation: v1alpha1.StepPluginOperationRun, Phase: v1alpha1.StepPluginPhaseSuccessful},
-			},
-			index:    0,
-			hasError: true,
-			want:     false,
 		},
 		{
 			name: "Phase is failed",
@@ -850,7 +819,7 @@ func Test_stepPluginContext_isStepPluginCompleted(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := newRolloutContext(tt.statuses, tt.hasError)
+			c := newRolloutContext(tt.statuses)
 			if got := c.stepPluginContext.isStepPluginCompleted(tt.index, c.rollout.Spec.Strategy.Canary.Steps[tt.index].Plugin); got != tt.want {
 				t.Errorf("rolloutContext.isStepPluginCompleted() = %v, want %v", got, tt.want)
 			}

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -1246,6 +1246,16 @@ func (c *rolloutContext) isRollbackWithinWindow() bool {
 	return false
 }
 
+// warnPromoteFullHeld surfaces why a user-requested full promotion (promote --full) is being
+// held by a safety gate. Without this, the forced promotion silently never happens and the
+// operator has no signal explaining why their escape hatch did nothing.
+func (c *rolloutContext) warnPromoteFullHeld(reason string) {
+	if !c.rollout.Status.PromoteFull {
+		return
+	}
+	c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: conditions.PromoteFullHeldReason}, "Full promotion is held: %s", reason)
+}
+
 // shouldFullPromote returns a reason string explaining why a rollout should fully promote, marking
 // the desired ReplicaSet as stable. Returns empty string if the rollout is in middle of update
 func (c *rolloutContext) shouldFullPromote(newStatus v1alpha1.RolloutStatus) string {
@@ -1258,12 +1268,14 @@ func (c *rolloutContext) shouldFullPromote(newStatus v1alpha1.RolloutStatus) str
 		}
 		// Some actuation stage failed this reconcile; hold promotion until the cluster catches up.
 		if c.anyStageConditionFalse() {
+			c.warnPromoteFullHeld("an actuation stage failed during this reconciliation")
 			return ""
 		}
 		// The desired traffic weight was applied but has not been verified with the underlying
 		// provider yet (e.g. ALB load balancer weights still propagating). This is the canary
 		// equivalent of the blue-green areTargetsVerified() check below.
 		if newStatus.Canary.Weights != nil && newStatus.Canary.Weights.Verified != nil && !*newStatus.Canary.Weights.Verified {
+			c.warnPromoteFullHeld("desired traffic weights have not been verified by the traffic provider")
 			return ""
 		}
 		// Block promotion only when canary has fewer available than desired (e.g. still scaling up).

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -857,6 +857,8 @@ func (c *rolloutContext) evaluateProgressDeadlineAbort(newStatus *v1alpha1.Rollo
 }
 
 func (c *rolloutContext) calculateRolloutConditions(newStatus *v1alpha1.RolloutStatus) {
+	c.mergeStageConditions(newStatus)
+
 	isPaused := len(newStatus.PauseConditions) > 0 || c.rollout.Spec.Paused
 	isAborted := c.pauseContext.IsAborted()
 
@@ -1255,7 +1257,7 @@ func (c *rolloutContext) shouldFullPromote(newStatus v1alpha1.RolloutStatus) str
 			return ""
 		}
 		// Some actuation stage failed this reconcile; hold promotion until the cluster catches up.
-		if c.actuationDeferred {
+		if c.anyStageConditionFalse() {
 			return ""
 		}
 		// The desired traffic weight was applied but has not been verified with the underlying

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -1267,9 +1267,9 @@ func (c *rolloutContext) shouldFullPromote(newStatus v1alpha1.RolloutStatus) str
 		if c.pauseContext.IsAborted() {
 			return ""
 		}
-		// Some actuation stage failed this reconcile; hold promotion until the cluster catches up.
+		// Some stage failed this reconcile; hold promotion until the cluster catches up.
 		if c.anyStageConditionFalse() {
-			c.warnPromoteFullHeld("an actuation stage failed during this reconciliation")
+			c.warnPromoteFullHeld("a stage failed to apply changes during this reconciliation")
 			return ""
 		}
 		// The desired traffic weight was applied but has not been verified with the underlying

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -30,6 +30,7 @@ import (
 	replicasetutil "github.com/argoproj/argo-rollouts/utils/replicaset"
 	rolloututil "github.com/argoproj/argo-rollouts/utils/rollout"
 	timeutil "github.com/argoproj/argo-rollouts/utils/time"
+	"github.com/argoproj/argo-rollouts/utils/weightutil"
 )
 
 // getAllReplicaSetsAndSyncRevision returns all the replica sets for the provided rollout (new and all old), with new RS's and rollout's revision updated.
@@ -1274,7 +1275,7 @@ func (c *rolloutContext) shouldFullPromote(newStatus v1alpha1.RolloutStatus) str
 		// The desired traffic weight was applied but has not been verified with the underlying
 		// provider yet (e.g. ALB load balancer weights still propagating). This is the canary
 		// equivalent of the blue-green areTargetsVerified() check below.
-		if newStatus.Canary.Weights != nil && newStatus.Canary.Weights.Verified != nil && !*newStatus.Canary.Weights.Verified {
+		if weightutil.VerificationPending(newStatus.Canary.Weights) {
 			c.warnPromoteFullHeld("desired traffic weights have not been verified by the traffic provider")
 			return ""
 		}

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -1267,7 +1267,7 @@ func (c *rolloutContext) shouldFullPromote(newStatus v1alpha1.RolloutStatus) str
 		if c.pauseContext.IsAborted() {
 			return ""
 		}
-		// Some stage failed this reconcile; hold promotion until the cluster catches up.
+		// ReconcileSucceeded=False this pass; hold promotion.
 		if c.anyStageConditionFalse() {
 			c.warnPromoteFullHeld("a stage failed to apply changes during this reconciliation")
 			return ""

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -1254,6 +1254,16 @@ func (c *rolloutContext) shouldFullPromote(newStatus v1alpha1.RolloutStatus) str
 		if c.pauseContext.IsAborted() {
 			return ""
 		}
+		// Some actuation stage failed this reconcile; hold promotion until the cluster catches up.
+		if c.actuationDeferred {
+			return ""
+		}
+		// The desired traffic weight was applied but has not been verified with the underlying
+		// provider yet (e.g. ALB load balancer weights still propagating). This is the canary
+		// equivalent of the blue-green areTargetsVerified() check below.
+		if newStatus.Canary.Weights != nil && newStatus.Canary.Weights.Verified != nil && !*newStatus.Canary.Weights.Verified {
+			return ""
+		}
 		// Block promotion only when canary has fewer available than desired (e.g. still scaling up).
 		// When canary has >= desired (e.g. HPA scaled rollout down so desired=1 but canary still has 2),
 		// allow promotion so rollout can complete and then scale down to desired.

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -1317,6 +1317,10 @@ func (c *rolloutContext) shouldFullPromote(newStatus v1alpha1.RolloutStatus) str
 			// active selector is pointing to desired RS, but we have not verify the target group yet
 			return ""
 		}
+		if c.anyStageConditionFalse() {
+			c.warnPromoteFullHeld("a stage failed to apply changes during this reconciliation")
+			return ""
+		}
 		if c.rollout.Status.PromoteFull {
 			return "Full promotion requested"
 		}

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -343,12 +343,11 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 				logCtx := logutil.WithRollout(c.rollout)
 				logCtx.Info("rollout enqueue due to trafficrouting")
 				c.enqueueRolloutAfter(c.rollout, defaults.GetRolloutVerifyRetryInterval())
-				// At the end of the rollout we need to verify the weight is correct, and return an error if not because we don't want the rest of the
-				// reconcile process to continue. We don't need to do this if we are in the middle of the rollout because the rest of the reconcile
-				// process won't scale down the old replicasets yet due to being in the middle of some steps.
-				if desiredWeight == weightutil.MaxTrafficWeight(c.rollout) && len(c.rollout.Spec.Strategy.Canary.Steps) >= int(*c.rollout.Status.CurrentStepIndex) {
-					return fmt.Errorf("end of rollout, desired weight %d not yet verified", desiredWeight)
-				}
+				// An unverified weight is expected and transient, so hold its consequences instead
+				// of failing the reconcile: step progression is held by completedCurrentCanaryStep(),
+				// and stable promotion and stable scale-down are held by shouldFullPromote() and
+				// reconcileCanaryStableReplicaSet(). Failing here would block abort/progressDeadline
+				// evaluation until the weight verified (see #4626).
 			}
 		}
 	}

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -298,7 +298,6 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 		if (c.newRS == nil || c.newRS.Status.AvailableReplicas == 0) &&
 			c.rollout.Status.Canary.Weights != nil && c.rollout.Status.Canary.Weights.Canary.Weight > 0 {
 			if err := reconciler.SetWeight(desiredWeight, weightDestinations...); err != nil {
-				c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: "TrafficRoutingError"}, err.Error())
 				return err
 			}
 		}
@@ -310,7 +309,6 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 
 		err = reconciler.SetWeight(desiredWeight, weightDestinations...)
 		if err != nil {
-			c.recorder.Warnf(c.rollout, record.EventOptions{EventReason: "TrafficRoutingError"}, err.Error())
 			return err
 		}
 

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -112,7 +112,11 @@ func TestReconcileTrafficRoutingSetWeightErr(t *testing.T) {
 
 	patchedRollout := f.getPatchedRolloutAsObject(patchIndex)
 	assert.Nil(t, patchedRollout.Status.CurrentStepIndex,
-		"SetWeight error must not complete the setWeight step (currentStepIndex must not advance)")
+		"SetWeight error must not complete the setWeight step (currentStepIndex must not advance); patched status: %+v", patchedRollout.Status)
+	eventsStr := strings.Join(f.events, " ")
+	assert.Equal(t, 1, strings.Count(eventsStr, "TrafficRoutingError"),
+		"SetWeight error must be surfaced as exactly one event; events: %v", f.events)
+	assert.NotContains(t, eventsStr, "RolloutStepCompleted", "SetWeight error must not emit a step-completed event")
 }
 
 // TestCanaryProgressDeadlineAbortNotBlockedByTrafficRoutingError reproduces the user-facing
@@ -2104,6 +2108,8 @@ func TestTrafficRoutingErrorsWhenNewCanaryHasNoReplicas(t *testing.T) {
 				assert.Equal(t, int32(0), *patchedRollout.Status.CurrentStepIndex,
 					"traffic routing error must not complete the current step")
 			}
+			eventsStr := strings.Join(f.events, " ")
+			assert.Contains(t, eventsStr, "TrafficRoutingError", "traffic routing error must be surfaced as an event")
 		})
 	}
 }

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -108,7 +108,7 @@ func TestReconcileTrafficRoutingSetWeightErr(t *testing.T) {
 	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(errors.New("Error message"))
 	patchIndex := f.expectPatchRolloutAction(ro)
-	f.run(getKey(ro, t))
+	f.runExpectError(getKey(ro, t), true)
 
 	patchedRollout := f.getPatchedRolloutAsObject(patchIndex)
 	assert.Nil(t, patchedRollout.Status.CurrentStepIndex,
@@ -163,7 +163,7 @@ func TestCanaryProgressDeadlineAbortNotBlockedByTrafficRoutingError(t *testing.T
 		fmt.Errorf("delaying destination rule switch: ReplicaSet %s not fully available", rs2.Name))
 
 	patchIndex := f.expectPatchRolloutAction(r2)
-	f.run(getKey(r2, t))
+	f.runExpectError(getKey(r2, t), true)
 
 	f.verifyPatchedRolloutAborted(patchIndex, rs2.Name)
 }
@@ -2100,7 +2100,7 @@ func TestTrafficRoutingErrorsWhenNewCanaryHasNoReplicas(t *testing.T) {
 			f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](true), nil)
 
 			patchIndex := f.expectPatchRolloutAction(r2)
-			f.run(getKey(r2, t))
+			f.runExpectError(getKey(r2, t), true)
 
 			f.fakeTrafficRouting.AssertCalled(t, tc.expectedCall, mock.Anything, mock.Anything)
 			patchedRollout := f.getPatchedRolloutAsObject(patchIndex)
@@ -2240,7 +2240,9 @@ spec:
 	f.reseedRolloutMutator = func(ro *v1alpha1.Rollout) {
 		ro.Status.CurrentStepIndex = &stepCount
 	}
-	f.allowErrorOnLastSync = false
+	// The delayed destination-rule switch surfaces as a reconcile error on the second sync
+	// (traffic-routing errors propagate for workqueue backoff instead of being swallowed).
+	f.allowErrorOnLastSync = true
 
 	prevLog := log.StandardLogger().Out
 	defer log.SetOutput(prevLog)

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -108,7 +108,7 @@ func TestReconcileTrafficRoutingSetWeightErr(t *testing.T) {
 	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(errors.New("Error message"))
 	patchIndex := f.expectPatchRolloutAction(ro)
-	f.runExpectError(getKey(ro, t), true)
+	f.run(getKey(ro, t))
 
 	patchedRollout := f.getPatchedRolloutAsObject(patchIndex)
 	assert.Nil(t, patchedRollout.Status.CurrentStepIndex,
@@ -159,7 +159,7 @@ func TestCanaryProgressDeadlineAbortNotBlockedByTrafficRoutingError(t *testing.T
 		fmt.Errorf("delaying destination rule switch: ReplicaSet %s not fully available", rs2.Name))
 
 	patchIndex := f.expectPatchRolloutAction(r2)
-	f.runExpectError(getKey(r2, t), true)
+	f.run(getKey(r2, t))
 
 	f.verifyPatchedRolloutAborted(patchIndex, rs2.Name)
 }
@@ -2096,7 +2096,7 @@ func TestTrafficRoutingErrorsWhenNewCanaryHasNoReplicas(t *testing.T) {
 			f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](true), nil)
 
 			patchIndex := f.expectPatchRolloutAction(r2)
-			f.runExpectError(getKey(r2, t), true)
+			f.run(getKey(r2, t))
 
 			f.fakeTrafficRouting.AssertCalled(t, tc.expectedCall, mock.Anything, mock.Anything)
 			patchedRollout := f.getPatchedRolloutAsObject(patchIndex)
@@ -2234,7 +2234,7 @@ spec:
 	f.reseedRolloutMutator = func(ro *v1alpha1.Rollout) {
 		ro.Status.CurrentStepIndex = &stepCount
 	}
-	f.allowErrorOnLastSync = true // sync 2 returns "delaying destination rule switch" and does not complete
+	f.allowErrorOnLastSync = false
 
 	prevLog := log.StandardLogger().Out
 	defer log.SetOutput(prevLog)

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/dynamic/dynamicinformer"
@@ -28,6 +29,7 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/rollout/mocks"
 	"github.com/argoproj/argo-rollouts/rollout/trafficrouting/alb"
+	"github.com/argoproj/argo-rollouts/utils/conditions"
 	apisixMocks "github.com/argoproj/argo-rollouts/rollout/trafficrouting/apisix/mocks"
 	"github.com/argoproj/argo-rollouts/rollout/trafficrouting/appmesh"
 	"github.com/argoproj/argo-rollouts/rollout/trafficrouting/istio"
@@ -36,7 +38,6 @@ import (
 	"github.com/argoproj/argo-rollouts/rollout/trafficrouting/traefik"
 	traefikMocks "github.com/argoproj/argo-rollouts/rollout/trafficrouting/traefik/mocks"
 	testutil "github.com/argoproj/argo-rollouts/test/util"
-	"github.com/argoproj/argo-rollouts/utils/conditions"
 	ingressutil "github.com/argoproj/argo-rollouts/utils/ingress"
 	istioutil "github.com/argoproj/argo-rollouts/utils/istio"
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
@@ -106,7 +107,61 @@ func TestReconcileTrafficRoutingSetWeightErr(t *testing.T) {
 	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
 	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	f.fakeTrafficRouting.On("SetWeight", mock.Anything, mock.Anything).Return(errors.New("Error message"))
+	patchIndex := f.expectPatchRolloutAction(ro)
 	f.runExpectError(getKey(ro, t), true)
+
+	patchedRollout := f.getPatchedRolloutAsObject(patchIndex)
+	assert.Nil(t, patchedRollout.Status.CurrentStepIndex,
+		"SetWeight error must not complete the setWeight step (currentStepIndex must not advance)")
+}
+
+// TestCanaryProgressDeadlineAbortNotBlockedByTrafficRoutingError reproduces the user-facing
+// symptom of #4626 for any traffic provider: a canary rollout with progressDeadlineAbort
+// enabled, stuck past its progress deadline, must still auto-abort even while the traffic
+// router errors persistently.
+func TestCanaryProgressDeadlineAbortNotBlockedByTrafficRoutingError(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{{SetWeight: ptr.To[int32](10)}}
+	r1 := newCanaryRollout("foo", 20, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(0))
+	progressDeadlineSeconds := int32(1)
+	r1.Spec.ProgressDeadlineSeconds = &progressDeadlineSeconds
+	r1.Spec.ProgressDeadlineAbort = true
+	r2 := bumpVersion(r1)
+	r2.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{}
+	r2.Spec.Strategy.Canary.CanaryService = "canary"
+	r2.Spec.Strategy.Canary.StableService = "stable"
+
+	rs1 := newReplicaSetWithStatus(r1, 20, 20)
+	rs2 := newReplicaSetWithStatus(r2, 2, 1)
+
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs2PodHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	canarySelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs2PodHash}
+	stableSelector := map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: rs1PodHash}
+	canarySvc := newService("canary", 80, canarySelector, r2)
+	stableSvc := newService("stable", 80, stableSelector, r2)
+
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2, canarySvc, stableSvc)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+
+	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 21, 2, 22, false)
+	msg := fmt.Sprintf("ReplicaSet %q has timed out progressing.", rs2.Name)
+	progressingTimeoutCond := conditions.NewRolloutCondition(v1alpha1.RolloutProgressing, corev1.ConditionFalse, conditions.TimedOutReason, msg)
+	conditions.SetRolloutCondition(&r2.Status, *progressingTimeoutCond)
+
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2)
+
+	f.fakeTrafficRouting = newUnmockedFakeTrafficRoutingReconciler()
+	f.fakeTrafficRouting.On("UpdateHash", mock.Anything, mock.Anything, mock.Anything).Return(
+		fmt.Errorf("delaying destination rule switch: ReplicaSet %s not fully available", rs2.Name))
+
+	patchIndex := f.expectPatchRolloutAction(r2)
+	f.runExpectError(getKey(r2, t), true)
+
+	f.verifyPatchedRolloutAborted(patchIndex, rs2.Name)
 }
 
 // verify error is not returned when VerifyWeight returns error (so that we can continue reconciling)
@@ -185,7 +240,20 @@ func TestReconcileTrafficRoutingVerifyWeightEndOfRollout(t *testing.T) {
 	})
 	f.fakeTrafficRouting.On("SetHeaderRoute", mock.Anything, mock.Anything).Return(nil)
 	f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](false), nil)
-	f.runExpectError(getKey(r2, t), true)
+	patchIndex := f.expectPatchRolloutAction(r2)
+	f.run(getKey(r2, t))
+
+	// An unverified weight at the end of the rollout is expected and transient (e.g. ALB load
+	// balancer weights still propagating), so it must not fail the reconcile (that would block
+	// abort/progressDeadline evaluation, see #4626) and must not emit warning events. It must
+	// however hold stable promotion: promoting now would let the old stable ReplicaSet scale
+	// down while the load balancer may still be sending it traffic.
+	patch := f.getPatchedRollout(patchIndex)
+	assert.NotContains(t, patch, fmt.Sprintf(`"stableRS":"%s"`, rs2PodHash),
+		"stable must not be promoted while the desired weight is unverified; patch: %s", patch)
+	eventsStr := strings.Join(f.events, " ")
+	assert.NotContains(t, eventsStr, "TrafficRoutingError",
+		"an unverified weight at end of rollout is routine and must not emit warning events")
 }
 
 func TestRolloutUseDesiredWeight(t *testing.T) {
@@ -2027,9 +2095,15 @@ func TestTrafficRoutingErrorsWhenNewCanaryHasNoReplicas(t *testing.T) {
 			f.fakeTrafficRouting.On("RemoveManagedRoutes").Return(tc.removeManagedRoutesErr)
 			f.fakeTrafficRouting.On("VerifyWeight", mock.Anything).Return(ptr.To[bool](true), nil)
 
+			patchIndex := f.expectPatchRolloutAction(r2)
 			f.runExpectError(getKey(r2, t), true)
 
 			f.fakeTrafficRouting.AssertCalled(t, tc.expectedCall, mock.Anything, mock.Anything)
+			patchedRollout := f.getPatchedRolloutAsObject(patchIndex)
+			if patchedRollout.Status.CurrentStepIndex != nil {
+				assert.Equal(t, int32(0), *patchedRollout.Status.CurrentStepIndex,
+					"traffic routing error must not complete the current step")
+			}
 		})
 	}
 }

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -2224,7 +2224,7 @@ spec:
 	f.expectUpdateRolloutAction(r6)
 	f.expectPatchRolloutAction(r6)
 	f.expectGetRolloutAction(r6) // re-seed between syncs
-	// Sync 2 returns error "delaying destination rule switch" and does not complete, so we do NOT expect update rs6 or second patch.
+	f.expectPatchRolloutAction(r6) // sync 2: status sync despite delaying destination rule switch error
 
 	assert.Nil(t, f.fakeTrafficRouting, "test must use real Istio reconciler (fakeTrafficRouting=nil)")
 

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/rollout/mocks"
 	"github.com/argoproj/argo-rollouts/rollout/trafficrouting/alb"
-	"github.com/argoproj/argo-rollouts/utils/conditions"
 	apisixMocks "github.com/argoproj/argo-rollouts/rollout/trafficrouting/apisix/mocks"
 	"github.com/argoproj/argo-rollouts/rollout/trafficrouting/appmesh"
 	"github.com/argoproj/argo-rollouts/rollout/trafficrouting/istio"
@@ -38,6 +37,7 @@ import (
 	"github.com/argoproj/argo-rollouts/rollout/trafficrouting/traefik"
 	traefikMocks "github.com/argoproj/argo-rollouts/rollout/trafficrouting/traefik/mocks"
 	testutil "github.com/argoproj/argo-rollouts/test/util"
+	"github.com/argoproj/argo-rollouts/utils/conditions"
 	ingressutil "github.com/argoproj/argo-rollouts/utils/ingress"
 	istioutil "github.com/argoproj/argo-rollouts/utils/istio"
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
@@ -2223,7 +2223,7 @@ spec:
 	f.expectUpdateReplicaSetAction(rs3)
 	f.expectUpdateRolloutAction(r6)
 	f.expectPatchRolloutAction(r6)
-	f.expectGetRolloutAction(r6) // re-seed between syncs
+	f.expectGetRolloutAction(r6)   // re-seed between syncs
 	f.expectPatchRolloutAction(r6) // sync 2: status sync despite delaying destination rule switch error
 
 	assert.Nil(t, f.fakeTrafficRouting, "test must use real Istio reconciler (fakeTrafficRouting=nil)")

--- a/test/e2e/istio/istio-subset-split-progress-deadline-abort.yaml
+++ b/test/e2e/istio/istio-subset-split-progress-deadline-abort.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-subset-split-pda
+spec:
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app: istio-subset-split-pda
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: istio-subset-split-pda-vsvc
+spec:
+  hosts:
+  - istio-subset-split-pda
+  http:
+  - name: primary
+    route:
+    - destination:
+        host: istio-subset-split-pda
+        subset: stable
+      weight: 100
+    - destination:
+        host: istio-subset-split-pda
+        subset: canary
+      weight: 0
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: istio-subset-split-pda-destrule
+spec:
+  host: istio-subset-split-pda
+  subsets:
+  - name: stable
+    labels:
+      app: istio-subset-split-pda
+  - name: canary
+    labels:
+      app: istio-subset-split-pda
+
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: istio-subset-split-pda
+spec:
+  strategy:
+    canary:
+      trafficRouting:
+        istio:
+          virtualService:
+            name: istio-subset-split-pda-vsvc
+            routes:
+            - primary
+          destinationRule:
+            name: istio-subset-split-pda-destrule
+            canarySubsetName: canary
+            stableSubsetName: stable
+      steps:
+      - setWeight: 10
+      - pause: {}
+  selector:
+    matchLabels:
+      app: istio-subset-split-pda
+  template:
+    metadata:
+      labels:
+        app: istio-subset-split-pda
+    spec:
+      containers:
+      - name: istio-subset-split-pda
+        image: nginx:1.19-alpine
+        ports:
+        - name: http
+          containerPort: 80
+          protocol: TCP
+        resources:
+          requests:
+            memory: 16Mi
+            cpu: 5m

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -545,6 +545,48 @@ func (s *IstioSuite) TestIstioPingPongUpdate() {
 		})
 }
 
+// TestIstioSubsetSplitProgressDeadlineAbortWithUnavailableCanary reproduces #4626: with
+// subset-level traffic routing (no canary/stable services), the Istio reconciler intentionally
+// delays the DestinationRule switch while the canary ReplicaSet is unavailable and reports it
+// as an error on every reconcile. That error must not block progressDeadline evaluation: a
+// canary whose pods can never become available must still time out, turn Degraded, and
+// auto-abort when progressDeadlineAbort is set. Before the fix, the rollout stayed Progressing
+// indefinitely (this test times out waiting for Degraded).
+func (s *IstioSuite) TestIstioSubsetSplitProgressDeadlineAbortWithUnavailableCanary() {
+	s.Given().
+		RolloutObjects("@istio/istio-subset-split-progress-deadline-abort.yaml").
+		When().
+		ApplyManifests().
+		WaitForRolloutStatus("Healthy").
+		PatchSpec(`
+spec:
+  progressDeadlineAbort: true
+  progressDeadlineSeconds: 10
+  template:
+    spec:
+      containers:
+      - name: istio-subset-split-pda
+        image: nginx:1.19-alpine-argo-error
+        command: null`).
+		WaitForRolloutStatus("Degraded").
+		Sleep(3 * time.Second).
+		Then().
+		ExpectRollout("Abort=True", func(r *v1alpha1.Rollout) bool {
+			return r.Status.Abort
+		}).
+		Assert(func(t *fixtures.Then) {
+			// traffic must never have shifted to the unavailable canary
+			vsvc := t.GetVirtualService()
+			assert.Equal(s.T(), int64(100), vsvc.Spec.HTTP[0].Route[0].Weight)
+			assert.Equal(s.T(), int64(0), vsvc.Spec.HTTP[0].Route[1].Weight)
+
+			// stable subset must still point at the stable ReplicaSet
+			rs1 := t.GetReplicaSetByRevision("1")
+			destrule := t.GetDestinationRule()
+			assert.Equal(s.T(), rs1.Spec.Template.Labels[v1alpha1.DefaultRolloutUniqueLabelKey], destrule.Spec.Subsets[0].Labels[v1alpha1.DefaultRolloutUniqueLabelKey])
+		})
+}
+
 func (s *IstioSuite) TestIstioSubsetSplitInStableDownscaleAfterCanaryAbort() {
 	s.Given().
 		RolloutObjects("@istio/istio-subset-split-in-stable-downscale-after-canary-abort.yaml").

--- a/utils/conditions/conditions.go
+++ b/utils/conditions/conditions.go
@@ -189,17 +189,15 @@ const (
 
 	RolloutAddedToInformerReason = "RolloutAddedToInformer"
 
-	// TrafficRoutingErrorReason is recorded on TrafficRoutingApplied=False when SetWeight or
+	// TrafficRoutingErrorReason is recorded on ReconcileSucceeded=False when SetWeight or
 	// related routing operations fail.
 	TrafficRoutingErrorReason = "TrafficRoutingError"
 	// TrafficRoutingDeferredReason is recorded when routing is intentionally deferred.
 	TrafficRoutingDeferredReason = "TrafficRoutingDeferred"
-	// ServiceUpdateErrorReason is recorded on ServicesReconciled=False when a Service update fails.
+	// ServiceUpdateErrorReason is recorded on ReconcileSucceeded=False when a Service update fails.
 	ServiceUpdateErrorReason = "ServiceUpdateError"
-	// StageConditionAppliedReason is recorded when a stage condition recovers to True.
+	// StageConditionAppliedReason is recorded when ReconcileSucceeded recovers to True.
 	StageConditionAppliedReason = "Applied"
-	// StageConditionReconciledReason is recorded when ServicesReconciled recovers to True.
-	StageConditionReconciledReason = "Reconciled"
 	// PromoteFullHeldReason is emitted when a user-requested full promotion (promote --full)
 	// is being held by a safety gate instead of taking effect.
 	PromoteFullHeldReason = "PromoteFullHeld"

--- a/utils/conditions/conditions.go
+++ b/utils/conditions/conditions.go
@@ -134,7 +134,7 @@ const (
 	RolloutExperimentFailedMessage = "Experiment '%s' owned by the Rollout '%q' has timed out."
 
 	// RolloutReconciliationErrorReason is recorded on ReconcileSucceeded=False (and as the event
-	// reason) when a reconcile step without a more specific condition fails, preventing progress.
+	// reason) for reconcile failures without a more specific reason.
 	RolloutReconciliationErrorReason = "ReconciliationError"
 	// RolloutReconciliationErrorMessage is added in a rollout when the reconciliation returns an error preventing progress
 	RolloutReconciliationErrorMessage = "Reconciliation failed with error: %v"
@@ -189,12 +189,11 @@ const (
 
 	RolloutAddedToInformerReason = "RolloutAddedToInformer"
 
-	// TrafficRoutingErrorReason is recorded on ReconcileSucceeded=False when SetWeight or
-	// related routing operations fail.
+	// TrafficRoutingErrorReason is recorded on ReconcileSucceeded=False when traffic routing fails.
 	TrafficRoutingErrorReason = "TrafficRoutingError"
 	// TrafficRoutingDeferredReason is recorded when routing is intentionally deferred.
 	TrafficRoutingDeferredReason = "TrafficRoutingDeferred"
-	// ServiceUpdateErrorReason is recorded on ReconcileSucceeded=False when a Service update fails.
+	// ServiceUpdateErrorReason is recorded on ReconcileSucceeded=False when a service update fails.
 	ServiceUpdateErrorReason = "ServiceUpdateError"
 	// StageConditionAppliedReason is recorded when ReconcileSucceeded recovers to True.
 	StageConditionAppliedReason = "Applied"

--- a/utils/conditions/conditions.go
+++ b/utils/conditions/conditions.go
@@ -133,7 +133,8 @@ const (
 	// RolloutExperimentFailedMessage is added in a rollout when the experiment owned by a rollout fails to show any progress
 	RolloutExperimentFailedMessage = "Experiment '%s' owned by the Rollout '%q' has timed out."
 
-	// RolloutReconciliationErrorReason is added in a rollout when the reconciliation returns an error preventing progress
+	// RolloutReconciliationErrorReason is recorded on ReconcileSucceeded=False (and as the event
+	// reason) when a reconcile step without a more specific condition fails, preventing progress.
 	RolloutReconciliationErrorReason = "ReconciliationError"
 	// RolloutReconciliationErrorMessage is added in a rollout when the reconciliation returns an error preventing progress
 	RolloutReconciliationErrorMessage = "Reconciliation failed with error: %v"
@@ -195,8 +196,6 @@ const (
 	TrafficRoutingDeferredReason = "TrafficRoutingDeferred"
 	// ServiceUpdateErrorReason is recorded on ServicesReconciled=False when a Service update fails.
 	ServiceUpdateErrorReason = "ServiceUpdateError"
-	// ActuationErrorReason is recorded on ActuationSucceeded=False for generic actuation failures.
-	ActuationErrorReason = "ActuationError"
 	// StageConditionAppliedReason is recorded when a stage condition recovers to True.
 	StageConditionAppliedReason = "Applied"
 	// StageConditionReconciledReason is recorded when ServicesReconciled recovers to True.

--- a/utils/conditions/conditions.go
+++ b/utils/conditions/conditions.go
@@ -201,6 +201,9 @@ const (
 	StageConditionAppliedReason = "Applied"
 	// StageConditionReconciledReason is recorded when ServicesReconciled recovers to True.
 	StageConditionReconciledReason = "Reconciled"
+	// PromoteFullHeldReason is emitted when a user-requested full promotion (promote --full)
+	// is being held by a safety gate instead of taking effect.
+	PromoteFullHeldReason = "PromoteFullHeld"
 )
 
 // NewRolloutCondition creates a new rollout condition.

--- a/utils/conditions/conditions.go
+++ b/utils/conditions/conditions.go
@@ -187,6 +187,20 @@ const (
 	LoadBalancerNotFoundMessage = "Failed to find load balancer: %s"
 
 	RolloutAddedToInformerReason = "RolloutAddedToInformer"
+
+	// TrafficRoutingErrorReason is recorded on TrafficRoutingApplied=False when SetWeight or
+	// related routing operations fail.
+	TrafficRoutingErrorReason = "TrafficRoutingError"
+	// TrafficRoutingDeferredReason is recorded when routing is intentionally deferred.
+	TrafficRoutingDeferredReason = "TrafficRoutingDeferred"
+	// ServiceUpdateErrorReason is recorded on ServicesReconciled=False when a Service update fails.
+	ServiceUpdateErrorReason = "ServiceUpdateError"
+	// ActuationErrorReason is recorded on ActuationSucceeded=False for generic actuation failures.
+	ActuationErrorReason = "ActuationError"
+	// StageConditionAppliedReason is recorded when a stage condition recovers to True.
+	StageConditionAppliedReason = "Applied"
+	// StageConditionReconciledReason is recorded when ServicesReconciled recovers to True.
+	StageConditionReconciledReason = "Reconciled"
 )
 
 // NewRolloutCondition creates a new rollout condition.

--- a/utils/evaluate/evaluate.go
+++ b/utils/evaluate/evaluate.go
@@ -267,7 +267,7 @@ func isNil(in any) (out bool) {
 	}
 
 	switch reflect.TypeOf(in).Kind() {
-	case reflect.Ptr, reflect.Map, reflect.Array, reflect.Chan, reflect.Slice:
+	case reflect.Pointer, reflect.Map, reflect.Array, reflect.Chan, reflect.Slice:
 		out = reflect.ValueOf(in).IsNil()
 	}
 
@@ -281,7 +281,7 @@ func valueFromPointer(in any) (out any) {
 		return
 	}
 
-	if reflect.TypeOf(in).Kind() != reflect.Ptr {
+	if reflect.TypeOf(in).Kind() != reflect.Pointer {
 		out = in
 		return
 	}

--- a/utils/weightutil/weight.go
+++ b/utils/weightutil/weight.go
@@ -4,6 +4,15 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 )
 
+// VerificationPending reports whether recorded traffic weights were applied but the traffic
+// provider has not yet verified them (Verified explicitly false, e.g. ALB load balancer weights
+// still propagating). While pending, serving capacity must not be reduced and promotion must not
+// proceed: the provider may still be routing traffic according to the previous weights. A nil
+// weights or nil Verified (verification not implemented or not applicable) is not pending.
+func VerificationPending(weights *v1alpha1.TrafficWeights) bool {
+	return weights != nil && weights.Verified != nil && !*weights.Verified
+}
+
 func MaxTrafficWeight(ro *v1alpha1.Rollout) int32 {
 	maxWeight := int32(100)
 	if ro.Spec.Strategy.Canary != nil && ro.Spec.Strategy.Canary.TrafficRouting != nil && ro.Spec.Strategy.Canary.TrafficRouting.MaxTrafficWeight != nil {


### PR DESCRIPTION
## Summary

- **Phase 1:** Guarantee `syncRolloutStatusCanary()` runs after every canary reconcile pass so `evaluateProgressDeadlineAbort`, progress deadline timeout, and `requeueStuckRollout` cannot be skipped when a stage errors (#4626). Ports #4962's weight-verification safety (stable scale-down hold, `shouldFullPromote` verified-weight check, end-of-rollout unverified-weight handling). The only exceptions are ReplicaSet-sync failures (`stageFatalNoStatus`), where `c.newRS` is unreliable and a status computed from it would persist corrupted values (e.g. clear abort state or record a pod hash for a ReplicaSet that was never created).
- **Phase 2:** Replace per-pass deferral flags with persisted rollout conditions (`TrafficRoutingApplied`, `ServicesReconciled`, `ReconcileSucceeded`) merged during status sync; progression gates read current-pass stage condition state. A previously-False condition only recovers to True when its owning stage actually re-ran and succeeded — a pass that stopped before the stage leaves it untouched rather than reporting a phantom recovery.
- **Phase 3:** Replace the hand-rolled canary stage chain with a declarative stage table + executor. All stage failures record their condition, complete the status sync, and then return the error for workqueue backoff — so persistent failures show up in reconcile-error metrics and retry with exponential backoff instead of a fixed-interval requeue. Warning events for stage failures are emitted only when the condition transitions, not on every retry pass.
- **Phase 4:** Extend the guaranteed status sync to blue-green: the apply steps move to `reconcileBlueGreen()` and `syncRolloutStatusBlueGreen()` always runs afterward, closing the same #4626 wedge class for the blue-green strategy (covered by `TestBlueGreenProgressDeadlineAbortNotBlockedByApplyError`). `awsVerifyTargetGroups` now marks verification attempted-and-failed when listing TargetGroupBindings errors, so the promotion gate cannot read a failed verification as verified.

Additional hardening from review:

- `promote --full` remains held while traffic weights are unverified or a stage failed this pass (the provider may still be routing traffic to stable); a `PromoteFullHeld` warning event now tells the operator why the forced promotion did not take effect.
- Combined stage/status errors use `errors.Join` instead of `kerrors.NewAggregate`, so `errors.As`-based checks (`k8serrors.IsNotFound` in the workqueue handler) keep working.
- Stage conditions are removed when a rollout migrates from canary to blueGreen instead of freezing a stale False condition into status forever.
- Stage condition messages truncate on a UTF-8 rune boundary.
- The unverified-weights predicate is centralized in `weightutil.VerificationPending`.
- Cosmetic stage failures (`ephemeralMetadata`, `revisionHistory`) use a new `stageContinueWithError` outcome: they record `ReconcileSucceeded=False` and still surface the error, but no longer stop the remaining stages — services, traffic routing, and scaling still run. Blue-green gets the same treatment by ordering: both cosmetic steps run last in `reconcileBlueGreen`, so a denied ReplicaSet deletion can no longer block the active service switch (previously `reconcileRevisionHistoryLimit` ran before the service reconcile).
- Step plugin controller-side errors (resolver/RPC failures) drop their private `hasError` side channel (swallowed error, fixed 30s requeue, per-pass `ReconciliationError` events) and flow through the stage pipeline like every other failure: `ReconcileSucceeded=False` condition, transition-gated event, workqueue backoff, error metrics. Plugin-protocol phases (`StepPluginPhaseError` backoff, `StepPluginPhaseFailed` abort) are unchanged.

Supersedes #4962 — same #4626 fix, generalized to all canary stages and to blue-green.

## Behavior changes (release note)

1. Rollouts stuck on a **persistently failing** reconcile step (traffic router, service update, target group verification, analysis, etc.) now evaluate `progressDeadlineAbort` every reconcile and can time out / auto-abort when `progressDeadlineAbort: true`. Previously they could stay `Progressing` forever. This applies to **both canary and blue-green**.
2. Traffic-routing failures now surface as reconcile errors: they count in reconcile-error metrics and retry with workqueue exponential backoff (previously a fixed ~10s requeue with no error reported). Alerting on controller error rates will now see these failures; retry cadence against a persistently failing provider backs off instead of hammering it.
3. Canary rollouts gain three status conditions that surface reconcile failures: `TrafficRoutingApplied`, `ServicesReconciled`, and `ReconcileSucceeded`. They appear on failure and flip back to True when the failing stage recovers.
4. `kubectl argo rollouts promote --full` is held while desired traffic weights are unverified by the provider or a stage failed during the current reconcile; a `PromoteFullHeld` warning event is emitted so the hold is visible.
5. Failures in cosmetic stages (ephemeral pod metadata labeling, revision-history cleanup) no longer block the rest of the reconcile pass, for **both canary and blue-green**: services, traffic routing/active-service switching, and scaling still reconcile while the failure is surfaced as a reconcile error (and, on canary, via the `ReconcileSucceeded` condition). Step progression still holds on canary until the stage recovers. Scaling-only passes no longer prune blue-green revision history (matching canary).
6. Step plugin controller-side errors (plugin resolution or RPC failures) now surface as reconcile errors with exponential backoff and the `ReconcileSucceeded` condition, instead of a fixed 30s requeue with a `ReconciliationError` event on every pass. Plugin-reported phases and their configured backoff behave as before.
