### PR TITLE
fix(controller): require missing stable RS before blue-green fast-track on empty selector

### DIFF
--- a/rollout/bluegreen.go
+++ b/rollout/bluegreen.go
@@ -118,7 +118,11 @@ func (c *rolloutContext) isBlueGreenFastTracked(activeSvc *corev1.Service) bool 
 	if c.rollout.Status.PromoteFull {
 		return true
 	}
-	if _, ok := activeSvc.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey]; !ok {
+	if _, ok := activeSvc.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey]; !ok && c.stableRS == nil {
+		// The active service has never had a selector, which only legitimately happens on the very
+		// first rollout (no stable ReplicaSet recorded yet). If a stable ReplicaSet already exists,
+		// a missing/cleared selector indicates the active service was reset by something else, and we
+		// must not treat that as a signal to fast-track (skip pause/analysis) an unrelated new update.
 		return true
 	}
 	if activeSvc.Spec.Selector[v1alpha1.DefaultRolloutUniqueLabelKey] == c.newRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] {

--- a/rollout/bluegreen_test.go
+++ b/rollout/bluegreen_test.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	core "k8s.io/client-go/testing"
@@ -21,6 +22,7 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/annotations"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
 	"github.com/argoproj/argo-rollouts/utils/hash"
+	logutil "github.com/argoproj/argo-rollouts/utils/log"
 	rolloututil "github.com/argoproj/argo-rollouts/utils/rollout"
 	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
@@ -1736,4 +1738,39 @@ func TestBlueGreenAddScaleDownDelay(t *testing.T) {
 	f.run(getKey(r2, t))
 
 	f.verifyPatchedReplicaSet(rs1Patch, 30)
+}
+
+// TestBlueGreenFastTrackRequiresNoStableRS verifies that isBlueGreenFastTracked only treats a
+// missing active-service selector as a signal to fast-track (skip pause/analysis) when there is no
+// stable ReplicaSet yet (a genuine initial deploy). If a stable ReplicaSet already exists, a missing
+// selector (e.g. cleared by something outside the controller) must not fast-track an unrelated new
+// update, since doing so bypasses prePromotionAnalysis and autoPromotionEnabled=false.
+func TestBlueGreenFastTrackRequiresNoStableRS(t *testing.T) {
+	r1 := newBlueGreenRollout("foo", 1, nil, "active", "preview")
+	r2 := bumpVersion(r1)
+
+	stableRS := newReplicaSetWithStatus(r1, 1, 1)
+	newRS := newReplicaSetWithStatus(r2, 1, 1)
+
+	// active service's selector has no rollouts-pod-template-hash entry at all
+	activeSvc := newService("active", 80, map[string]string{}, r2)
+
+	newCtx := func(stableRS *appsv1.ReplicaSet) *rolloutContext {
+		return &rolloutContext{
+			rollout:  r2,
+			newRS:    newRS,
+			stableRS: stableRS,
+			log:      logutil.WithRollout(r2),
+		}
+	}
+
+	t.Run("GenuineInitialDeployIsFastTracked", func(t *testing.T) {
+		ctx := newCtx(nil)
+		assert.True(t, ctx.isBlueGreenFastTracked(activeSvc))
+	})
+
+	t.Run("ExistingStableRSIsNotFastTrackedDespiteEmptySelector", func(t *testing.T) {
+		ctx := newCtx(stableRS)
+		assert.False(t, ctx.isBlueGreenFastTracked(activeSvc))
+	})
 }


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green. Try syncing with master if they are not.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

---
AI assistance: this change was drafted with Claude Code.

Fixes #4750