### PR TITLE
fix(controller): expire stale scale-down-deadline to stop reconcile loop. Fixes #4971

### DIFF
--- a/rollout/controller_test.go
+++ b/rollout/controller_test.go
@@ -1466,6 +1466,10 @@ func TestRequeueStuckRollout(t *testing.T) {
 		rollout            *v1alpha1.Rollout
 		requeueImmediately bool
 		noRequeue          bool
+		// otherRSScaleDownDeadlineOffset, when non-nil, causes an "other" ReplicaSet (neither
+		// newRS nor stableRS) to be created and attached to the rollout, annotated with a
+		// scale-down-deadline computed as timeutil.MetaNow() + the offset.
+		otherRSScaleDownDeadlineOffset *time.Duration
 	}{
 		{
 			name:      "No Progressing Condition",
@@ -1496,6 +1500,16 @@ func TestRequeueStuckRollout(t *testing.T) {
 			name:    "More than a second",
 			rollout: rollout(conditions.ReplicaSetUpdatedReason, false, false, ptr.To[int32](20)),
 		},
+		{
+			// A live scale-down-deadline on an orphaned ("other") ReplicaSet means the rollout
+			// is still waiting for that RS to scale down, so requeueStuckRollout must not
+			// requeue the rollout for a progress-deadline check. See
+			// https://github.com/argoproj/argo-rollouts/issues/4971
+			name:                           "Other RS with live scale-down deadline blocks requeue",
+			rollout:                        rollout(conditions.ReplicaSetUpdatedReason, false, false, ptr.To[int32](10)),
+			otherRSScaleDownDeadlineOffset: ptr.To(time.Hour),
+			noRequeue:                      true,
+		},
 	}
 	for i := range tests {
 		test := tests[i]
@@ -1503,6 +1517,14 @@ func TestRequeueStuckRollout(t *testing.T) {
 			savedRollout := test.rollout.DeepCopy()
 			f := newFixture(t)
 			defer f.Close()
+			if test.otherRSScaleDownDeadlineOffset != nil {
+				otherRS := newReplicaSet(test.rollout, 1)
+				otherRS.Name = test.rollout.Name + "-other"
+				otherRS.Labels[v1alpha1.DefaultRolloutUniqueLabelKey] = "orphanedhash"
+				otherRS.Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey] = timeutil.MetaNow().Add(*test.otherRSScaleDownDeadlineOffset).UTC().Format(time.RFC3339)
+				f.kubeobjects = append(f.kubeobjects, otherRS)
+				f.replicaSetLister = append(f.replicaSetLister, otherRS)
+			}
 			c, _, _ := f.newController(noResyncPeriodFunc)
 			f.client.PrependReactor("*", "rollouts", func(action core.Action) (bool, runtime.Object, error) {
 				savedRollout.DeepCopyInto(test.rollout)

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -807,13 +807,16 @@ func isIndefiniteStep(r *v1alpha1.Rollout) bool {
 	return pausedCondTrue
 }
 
-// isWaitingForReplicaSetScaleDown returns whether or not the rollout still has other replica sets with a scale down deadline annotation
+// isWaitingForReplicaSetScaleDown returns whether or not the rollout still has other replica sets waiting on a scale down delay which has not yet elapsed
 func isWaitingForReplicaSetScaleDown(r *v1alpha1.Rollout, newRS, stableRS *appsv1.ReplicaSet, allRSs []*appsv1.ReplicaSet) bool {
 	otherRSs := replicasetutil.GetOtherRSs(r, newRS, stableRS, allRSs)
 
 	for _, rs := range otherRSs {
 		if replicasetutil.HasScaleDownDeadline(rs) {
-			return true
+			remainingTime, err := replicasetutil.GetTimeRemainingBeforeScaleDownDeadline(rs)
+			if err == nil && remainingTime != nil {
+				return true
+			}
 		}
 	}
 
@@ -1088,7 +1091,11 @@ func (c *rolloutContext) requeueStuckRollout(newStatus v1alpha1.RolloutStatus) t
 	}
 	// No need to estimate progress if the rollout is complete or already timed out.
 	isPaused := len(c.rollout.Status.PauseConditions) > 0 || c.rollout.Spec.Paused
-	if conditions.RolloutHealthy(c.rollout, &newStatus) || currentCond.Reason == conditions.TimedOutReason || isPaused || c.rollout.Status.Abort || isIndefiniteStep(c.rollout) {
+	// isWaitingForReplicaSetScaleDown is included here to keep this guard list consistent with the
+	// one used by calculateRolloutConditions when deciding to mark the rollout as timed out. Without
+	// it, a rollout that is legitimately waiting for another ReplicaSet to scale down would still be
+	// requeued for a progress check.
+	if conditions.RolloutHealthy(c.rollout, &newStatus) || currentCond.Reason == conditions.TimedOutReason || isPaused || c.rollout.Status.Abort || isIndefiniteStep(c.rollout) || isWaitingForReplicaSetScaleDown(c.rollout, c.newRS, c.stableRS, c.allRSs) {
 		return time.Duration(-1)
 	}
 	// If there is no sign of progress at this point then there is a high chance that the

--- a/rollout/sync_test.go
+++ b/rollout/sync_test.go
@@ -949,3 +949,90 @@ func TestIsScalingEventMissMatchedDesiredOldReplicas(t *testing.T) {
 	assert.Equal(t, int32(13), roStatus.Status.ReadyReplicas)
 	assert.Equal(t, int32(0), roStatus.Status.UpdatedReplicas)
 }
+
+// TestIsWaitingForReplicaSetScaleDown verifies that isWaitingForReplicaSetScaleDown only reports
+// that the rollout is waiting for a replicaset scale down when an "other" (neither new nor stable)
+// ReplicaSet carries a scale-down-deadline annotation whose deadline has not yet passed. An expired
+// or malformed deadline must not latch this to true forever, and annotations on the new/stable RS
+// themselves must never count. See https://github.com/argoproj/argo-rollouts/issues/4971
+func TestIsWaitingForReplicaSetScaleDown(t *testing.T) {
+	r := newCanaryRollout("foo", 1, nil, nil, nil, intstr.FromInt(0), intstr.FromInt(1))
+
+	newRS := rs("foo-new", 1, nil, timeutil.MetaNow(), nil)
+	stableRS := rs("foo-stable", 1, nil, timeutil.MetaNow(), nil)
+
+	otherRSWithDeadline := func(deadline string) *appsv1.ReplicaSet {
+		other := rs("foo-other", 1, nil, timeutil.MetaNow(), nil)
+		other.Annotations[v1alpha1.DefaultReplicaSetScaleDownDeadlineAnnotationKey] = deadline
+		return other
+	}
+
+	futureDeadline := timeutil.MetaNow().Add(time.Hour).UTC().Format(time.RFC3339)
+	pastDeadline := timeutil.MetaNow().Add(-time.Hour).UTC().Format(time.RFC3339)
+	malformedDeadline := "not-a-valid-timestamp"
+
+	tests := []struct {
+		name     string
+		newRS    *appsv1.ReplicaSet
+		stableRS *appsv1.ReplicaSet
+		allRSs   []*appsv1.ReplicaSet
+		expected bool
+	}{
+		{
+			name:     "other RS with a future (live) scale-down deadline",
+			newRS:    newRS,
+			stableRS: stableRS,
+			allRSs:   []*appsv1.ReplicaSet{newRS, stableRS, otherRSWithDeadline(futureDeadline)},
+			expected: true,
+		},
+		{
+			name:     "other RS with an expired scale-down deadline must not block progress forever",
+			newRS:    newRS,
+			stableRS: stableRS,
+			allRSs:   []*appsv1.ReplicaSet{newRS, stableRS, otherRSWithDeadline(pastDeadline)},
+			expected: false,
+		},
+		{
+			name:     "other RS with a malformed scale-down deadline fails open",
+			newRS:    newRS,
+			stableRS: stableRS,
+			allRSs:   []*appsv1.ReplicaSet{newRS, stableRS, otherRSWithDeadline(malformedDeadline)},
+			expected: false,
+		},
+		{
+			name:     "other RS without any scale-down deadline annotation",
+			newRS:    newRS,
+			stableRS: stableRS,
+			allRSs:   []*appsv1.ReplicaSet{newRS, stableRS, rs("foo-other", 1, nil, timeutil.MetaNow(), nil)},
+			expected: false,
+		},
+		{
+			name:     "no other RSs present",
+			newRS:    newRS,
+			stableRS: stableRS,
+			allRSs:   []*appsv1.ReplicaSet{newRS, stableRS},
+			expected: false,
+		},
+		{
+			name:     "a future deadline on the newRS itself does not count as an other RS",
+			newRS:    otherRSWithDeadline(futureDeadline),
+			stableRS: stableRS,
+			allRSs:   []*appsv1.ReplicaSet{otherRSWithDeadline(futureDeadline), stableRS},
+			expected: false,
+		},
+		{
+			name:     "a future deadline on the stableRS itself does not count as an other RS",
+			newRS:    newRS,
+			stableRS: otherRSWithDeadline(futureDeadline),
+			allRSs:   []*appsv1.ReplicaSet{newRS, otherRSWithDeadline(futureDeadline)},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := isWaitingForReplicaSetScaleDown(r, test.newRS, test.stableRS, test.allRSs)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
A `scale-down-deadline` annotation left on an orphaned ReplicaSet never stops counting, because `HasScaleDownDeadline` only checks that the annotation is non-empty and never compares it to the clock. A deadline that expired still counts exactly as a live one, which should not be true. An expired scale down deadline means that the rollout will not be requed again so it should not trigger the reconciliation loop.

Currently the behavior keeps `isWaitingForReplicaSetScaleDown` permanently true, which suppresses the progress-deadline timeout, so `TimedOutReason` is never written and the `Progressing` condition's `lastUpdateTime` freezes. `requeueStuckRollout` does not consult the same guard, so it re-enqueues the Rollout with a never ending reconcilation loop.

Two changes:

- `isWaitingForReplicaSetScaleDown` now reports "still waiting" only while the deadline is in the future and ignores a deadline that has already been achieved.
- `requeueStuckRollout` now includes that guard in its early return, matching the guard list already used when marking the Rollout as timed out.


Verified on minikube against v1.8.3 with four affected Rollouts: loop reconciles dropped from 563/s to 0, controller CPU from 500m (at its limit) to 4m, and all four correctly moved to `ProgressDeadlineExceeded`. The stale annotations were left in place, so this is a behaviour fix rather than a cleanup.

Fixes #4971

**Note on behaviour change**

This fix makes stuck Rollouts start telling the truth, and two knock-on effects are worth knowing about:

- A Rollout that used to sit on `Progressing` forever will now go `Degraded` with `ProgressDeadlineExceeded`. That is the correct state, since it was already broken, but anything watching the phase (alerts, dashboards, Argo CD health) will start seeing `Degraded` where it saw `Progressing` before.
- If `spec.progressDeadlineAbort: true`, that Rollout will now actually abort, which scales the canary down and the stable back up. The stale annotation used to stop the abort from ever firing (see #4626). This only affects users who set that flag, which is off by default.

Nothing else changes. The code that decides when a ReplicaSet scales down is untouched: this fix only changes when the controller decides a Rollout has run out of time.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green. Try syncing with master if they are not.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

Note: PR generated with the help of Claude Code. However, I'm responsible for every proposed change here. All of this has been manually validated by me.
