### PR TITLE
fix(controller): caps canary replicas for an aborted rollout to its Traffic Weight

### DIFF
--- a/utils/replicaset/canary.go
+++ b/utils/replicaset/canary.go
@@ -413,6 +413,22 @@ func CalculateReplicaCountsForTrafficRoutedCanary(rollout *v1alpha1.Rollout, new
 			// This if block makes sure we don't scale down the canary prematurely
 			trafficWeightReplicaCount := trafficWeightToReplicas(rolloutSpecReplica, weights.Canary.Weight, maxWeight)
 			canaryCount = max(trafficWeightReplicaCount, canaryCount)
+			// Cap canaryCount to the capacity already committed to the canary, so that a
+			// shortfall in stable availability (e.g., spec.replicas increase or pod eviction)
+			// cannot cause a fully-drained aborted canary to be scaled back up.
+			// Skip for:
+			//   1. PromoteFull: GetCanaryReplicasOrWeight returns maxWeight on PromoteFull,
+			//     making canaryCount==rolloutSpecReplica; capping at Spec.Replicas==0 would zero it
+			//   2. Rollbacks: same maxWeight path when newRS==stableRS (rollback) or stableRS==nil; cap must not apply in those states
+			//   3. Zero AbortScaleDownDelaySeconds: abortScaleDownDelaySeconds:0 makes UseSetCanaryScale
+			//     return non-nil (GetAbortScaleDownDelaySecondsOrDefault returns nil for explicit 0,
+			//     bypassing the abort early-return), so the explicit setCanaryScale replica count
+			//     must not be capped on the first reconcile when Spec.Replicas is still 0
+			if newRS != nil && newRS.Spec.Replicas != nil && !rollout.Status.PromoteFull &&
+				CheckStableRSExists(newRS, stableRS) && UseSetCanaryScale(rollout) == nil {
+				committedCeiling := max(trafficWeightReplicaCount, *newRS.Spec.Replicas)
+				canaryCount = minValue(canaryCount, committedCeiling)
+			}
 		}
 	}
 	return CheckMinPodsPerReplicaSet(rollout, canaryCount), CheckMinPodsPerReplicaSet(rollout, stableCount)

--- a/utils/replicaset/canary_test.go
+++ b/utils/replicaset/canary_test.go
@@ -1994,7 +1994,7 @@ func TestAbortedCanaryNotScaledUpOnStableAvailabilityGap(t *testing.T) {
 		{SetWeight: pointer.Int32Ptr(10)},
 		{SetWeight: pointer.Int32Ptr(20)},
 		{SetWeight: pointer.Int32Ptr(50)},
-		{SetWeight: pointer.Int32Ptr(100)}
+		{SetWeight: pointer.Int32Ptr(100)},
 	}
 
 	tests := []struct {
@@ -2061,7 +2061,7 @@ func TestAbortedCanaryNotScaledUpOnStableAvailabilityGap(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			rollout := makeRollout(test.rolloutReplicas, test.steps)
+			rollout := newAbortedRollout(test.rolloutReplicas, test.steps)
 			stableRS := newRS("stable", test.stableSpecReplicas, test.availableStableReplicas)
 			canaryRS := newRS("canary", test.canarySpecReplicas, test.availableCanaryReplicas)
 			weights := v1alpha1.TrafficWeights{
@@ -2078,7 +2078,7 @@ func TestAbortedCanaryNotScaledUpOnStableAvailabilityGap(t *testing.T) {
 	// GetCanaryReplicasOrWeight returns (nil, maxWeight) when PromoteFull is set, making
 	// canaryCount == rolloutSpecReplica. Capping at newRS.Spec.Replicas==0 would zero it out.
 	t.Run("promote-full while aborted is not capped at drained canary size", func(t *testing.T) {
-		rollout := makeRollout(10, steps)
+		rollout := newAbortedRollout(10, steps)
 		rollout.Status.PromoteFull = true
 		stableRS := newRS("stable", 10, 8) // stable lagging
 		canaryRS := newRS("canary", 0, 0)  // fully drained

--- a/utils/replicaset/canary_test.go
+++ b/utils/replicaset/canary_test.go
@@ -1972,3 +1972,165 @@ func TestGetDesiredCanaryWeightOnAbortWithScaleDownDelay(t *testing.T) {
 		assert.Equal(t, int32(10), stableRSReplicaCount)
 	})
 }
+
+// TestAbortedCanaryNotScaledUpOnStableAvailabilityGap is a regression test for a bug
+// where a fully-drained aborted canary RS was scaled back up whenever stable.availableReplicas
+// fell below spec.replicas (e.g. after an HPA scale-up, pod eviction, or node loss).
+// GetDesiredCanaryWeight infers the canary's expected size as
+// rolloutSpecReplica - stableRS.AvailableReplicas; when the shortfall has any cause other
+// than the canary still holding those replicas the resulting non-zero weight propagates to
+// CalculateReplicaCountsForTrafficRoutedCanary and the aborted RS is scaled up (Issue #4973).
+func TestAbortedCanaryNotScaledUpOnStableAvailabilityGap(t *testing.T) {
+	newAbortedRollout := func(specReplicas int32, steps []v1alpha1.CanaryStep) *v1alpha1.Rollout {
+		r := newRollout(specReplicas, 100, intstr.FromInt(0), intstr.FromInt(1), "canary", "stable", nil, &v1alpha1.RolloutTrafficRouting{})
+		r.Spec.Strategy.Canary.DynamicStableScale = true
+		r.Spec.Strategy.Canary.Steps = steps
+		r.Status.Abort = true
+		return r
+	}
+
+	steps := []v1alpha1.CanaryStep{
+		{SetWeight: pointer.Int32Ptr(5)},
+		{SetWeight: pointer.Int32Ptr(10)},
+		{SetWeight: pointer.Int32Ptr(20)},
+		{SetWeight: pointer.Int32Ptr(50)},
+		{SetWeight: pointer.Int32Ptr(100)}
+	}
+
+	tests := []struct {
+		name                    string
+		rolloutReplicas         int32
+		stableSpecReplicas      int32
+		availableStableReplicas int32
+		canarySpecReplicas      int32
+		availableCanaryReplicas int32
+		canaryWeight            int32
+		stableWeight            int32
+		steps                   []v1alpha1.CanaryStep
+		expectedCanaryReplicas  int32
+		expectedStableReplicas  int32
+	}{
+		{
+			// spec.replicas increased from 10 → 12 via HPA; stable has 12 spec but only 10
+			// available while new pods pass readiness. Canary is fully drained (0 replicas,
+			// 0% traffic). The 2-pod gap must not resurrect the canary.
+			name:                    "canary drained to 0 should not scale up when spec.replicas increases and stable lags",
+			rolloutReplicas:         12,
+			stableSpecReplicas:      12,
+			availableStableReplicas: 10,
+			canarySpecReplicas:      0,
+			availableCanaryReplicas: 0,
+			canaryWeight:            0,
+			stableWeight:            100,
+			steps:                   steps,
+			expectedCanaryReplicas:  0,
+			expectedStableReplicas:  12,
+		},
+		{
+			// spec.replicas unchanged at 10; 3 stable pods evicted and not yet replaced.
+			// Canary fully drained. The 3-pod availability dip must not resurrect the canary.
+			name:                    "canary drained to 0 should not scale up when stable availability dips due to eviction",
+			rolloutReplicas:         10,
+			stableSpecReplicas:      10,
+			availableStableReplicas: 7,
+			canarySpecReplicas:      0,
+			availableCanaryReplicas: 0,
+			canaryWeight:            0,
+			stableWeight:            100,
+			steps:                   steps,
+			expectedCanaryReplicas:  0,
+			expectedStableReplicas:  10,
+		},
+		{
+			// Sanity-check: during an active abort where canary still carries 50% traffic the
+			// progressive drain behaviour is unchanged — canary stays at the traffic-required
+			// level and stable scales up to absorb the coming shift.
+			name:                    "active abort drain is not affected by the ceiling cap",
+			rolloutReplicas:         10,
+			stableSpecReplicas:      5,
+			availableStableReplicas: 5,
+			canarySpecReplicas:      5,
+			availableCanaryReplicas: 5,
+			canaryWeight:            50,
+			stableWeight:            50,
+			steps:                   []v1alpha1.CanaryStep{{SetWeight: pointer.Int32Ptr(10)}, {SetWeight: pointer.Int32Ptr(50)}},
+			expectedCanaryReplicas:  5,
+			expectedStableReplicas:  9,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rollout := makeRollout(test.rolloutReplicas, test.steps)
+			stableRS := newRS("stable", test.stableSpecReplicas, test.availableStableReplicas)
+			canaryRS := newRS("canary", test.canarySpecReplicas, test.availableCanaryReplicas)
+			weights := v1alpha1.TrafficWeights{
+				Canary: v1alpha1.WeightDestination{Weight: test.canaryWeight},
+				Stable: v1alpha1.WeightDestination{Weight: test.stableWeight},
+			}
+			canaryCount, stableCount := CalculateReplicaCountsForTrafficRoutedCanary(rollout, canaryRS, stableRS, &weights)
+			assert.Equal(t, test.expectedCanaryReplicas, canaryCount, "canary replica count")
+			assert.Equal(t, test.expectedStableReplicas, stableCount, "stable replica count")
+		})
+	}
+
+	// Guard: !rollout.Status.PromoteFull
+	// GetCanaryReplicasOrWeight returns (nil, maxWeight) when PromoteFull is set, making
+	// canaryCount == rolloutSpecReplica. Capping at newRS.Spec.Replicas==0 would zero it out.
+	t.Run("promote-full while aborted is not capped at drained canary size", func(t *testing.T) {
+		rollout := makeRollout(10, steps)
+		rollout.Status.PromoteFull = true
+		stableRS := newRS("stable", 10, 8) // stable lagging
+		canaryRS := newRS("canary", 0, 0)  // fully drained
+		weights := v1alpha1.TrafficWeights{
+			Canary: v1alpha1.WeightDestination{Weight: 0},
+			Stable: v1alpha1.WeightDestination{Weight: 100},
+		}
+		canaryCount, stableCount := CalculateReplicaCountsForTrafficRoutedCanary(rollout, canaryRS, stableRS, &weights)
+		assert.Equal(t, int32(10), canaryCount, "canary replica count")
+		assert.Equal(t, int32(10), stableCount, "stable replica count")
+	})
+
+	// Guard: CheckStableRSExists(newRS, stableRS)
+	// Returns false when newRS.Name == stableRS.Name (rollback onto the stable pod hash).
+	// GetCanaryReplicasOrWeight likewise returns maxWeight when CurrentPodHash == StableRS,
+	// so canaryCount == rolloutSpecReplica. The cap must not apply here.
+	t.Run("rollback onto stable pod hash is not capped at 0", func(t *testing.T) {
+		// Both currentPodHash and stableRS are "stable" → rollback / no separate canary.
+		rollout := newRollout(10, 100, intstr.FromInt(0), intstr.FromInt(1), "stable", "stable", nil, &v1alpha1.RolloutTrafficRouting{})
+		rollout.Spec.Strategy.Canary.DynamicStableScale = true
+		rollout.Spec.Strategy.Canary.Steps = steps
+		rollout.Status.Abort = true
+		stableRS := newRS("stable", 10, 8)
+		canaryRS := newRS("stable", 0, 0) // same name → CheckStableRSExists returns false
+		weights := v1alpha1.TrafficWeights{
+			Canary: v1alpha1.WeightDestination{Weight: 0},
+			Stable: v1alpha1.WeightDestination{Weight: 100},
+		}
+		canaryCount, stableCount := CalculateReplicaCountsForTrafficRoutedCanary(rollout, canaryRS, stableRS, &weights)
+		assert.Equal(t, int32(10), canaryCount, "canary replica count")
+		assert.Equal(t, int32(10), stableCount, "stable replica count")
+	})
+
+	// Guard: UseSetCanaryScale(rollout) == nil
+	// abortScaleDownDelaySeconds:0 causes GetAbortScaleDownDelaySecondsOrDefault to return
+	// (nil, true), so UseSetCanaryScale does NOT early-return nil during abort and the explicit
+	// setCanaryScale replica count is honoured. If the cap were applied on the first reconcile
+	// (when newRS.Spec.Replicas is still 0), it would override that explicit instruction.
+	t.Run("abortScaleDownDelaySeconds:0 with setCanaryScale keeps canary scaled up", func(t *testing.T) {
+		scs := newSetCanaryScale(pointer.Int32Ptr(1), nil, false)
+		rollout := newRollout(10, 100, intstr.FromInt(0), intstr.FromInt(1), "canary", "stable", scs, &v1alpha1.RolloutTrafficRouting{})
+		rollout.Spec.Strategy.Canary.DynamicStableScale = true
+		rollout.Status.Abort = true
+		rollout.Spec.Strategy.Canary.AbortScaleDownDelaySeconds = pointer.Int32Ptr(0)
+		stableRS := newRS("stable", 10, 10)
+		canaryRS := newRS("canary", 0, 0) // not yet scaled up on first reconcile
+		weights := v1alpha1.TrafficWeights{
+			Canary: v1alpha1.WeightDestination{Weight: 0},
+			Stable: v1alpha1.WeightDestination{Weight: 100},
+		}
+		canaryCount, stableCount := CalculateReplicaCountsForTrafficRoutedCanary(rollout, canaryRS, stableRS, &weights)
+		assert.Equal(t, int32(1), canaryCount, "canary replica count")
+		assert.Equal(t, int32(10), stableCount, "stable replica count")
+	})
+}


### PR DESCRIPTION
Fixes: #4973 

Checklist:
* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green. Try syncing with master if they are not. 
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).

 ## Summary

An aborted rollout that uses `dynamicStableScale: true` prematurely scales up the canary replicaset on any scaleup of rollout.Spec.Replicas(scaled due to HPA/Keda, or manually).

## Root cause
`GetDesiredCanaryWeight` in utils/replicaset/canary.go infers the canary's size from the stable ReplicaSet's shortfall:
```
expectedCanaryReplicas := rolloutSpecReplica - stableRS.Status.AvailableReplicas
canaryReplicas := max(expectedCanaryReplicas, newRS.Status.AvailableReplicas)
// walk steps in reverse, return the first setWeight whose replica-equivalent is below canaryReplicas
```
This assumes the only reason stable is below spec.replicas is that the canary still holds those replicas. That assumption breaks whenever the shortfall has any other cause. The resulting non-zero weight is converted back to a replica count and the aborted ReplicaSet is scaled to it.

Worked example, spec.replicas 10 → 12, steps [5, 10, 20, 50, 100], stable at 10 available, canary at 0:

expectedCanaryReplicas = 12 - 10 = 2
canaryReplicas = max(2, 0) = 2
reverse scan: 100 -> 12 , 50 -> 6, 20 -> 3, 10 -> 2, 5 -> 1 < 2 -> weight 5
canary replicas = ceil(5% × 12) = 1
It reverts once stable reports 11 available: the gap becomes 1, no step qualifies, weight returns to 0, canary back to 0.
A large scale-up or a significant availability dip can therefore resurrect most of an aborted ReplicaSet.

## Fix

`utils/replicaset/canary.go`: In `CalculateReplicaCountsForTrafficRoutedCanary`, when `dynamicStableScale` is enabled, add a ceiling cap of its assigned traffic weight and add checks to skip the cases where we need to scale the canary above its traffic boundry, such as full-promote, rollback & when `abortScaleDownDelaySeconds` is set to 0.

  Compared to the progressive abort behaviour (#4035): Abort with
  `dynamicStableScale` reverse scans the canary steps finding the canary replica count for the previous step and progressively making it to 0. But it also leads to re-evaluation of these steps for an aborted rollout(canary: 0) resulting in the scaleup of aborted canary. This PR instead caps the canary scale up to its traffic distribution and preserves the progressive scale down of canary pods during an abort.

  ## Testing

  - New unit test `TestAbortedCanaryNotScaledUpOnStableAvailabilityGap`: fails on master with
    the scaleup of canary replicas, passes with the fix. No-delay and zero-delay behavior pinned.
  - `go test ./rollout/... ./utils/replicaset/...` passes unchanged.