### PR TITLE
fix(trafficrouting): stop degraded stable RS from permanently blocking subset DestinationRule switch

### DIFF
--- a/rollout/trafficrouting/istio/istio.go
+++ b/rollout/trafficrouting/istio/istio.go
@@ -386,16 +386,18 @@ func (r *Reconciler) shouldDelayDestinationRuleUpdate(canaryHash, stableHash str
 	if r.rollout.Spec.Strategy.Canary.CanaryService != "" || r.rollout.Spec.Strategy.Canary.StableService != "" {
 		return false, ""
 	}
-	abortOrDynamicRollbackToStable := rolloututil.AbortOrDynamicRollbackToStable(r.rollout, r.replicaSets, stableHash)
+	requiredHash := canaryHash
+	if rolloututil.AbortOrDynamicRollbackToStable(r.rollout, r.replicaSets, stableHash) {
+		requiredHash = stableHash
+	}
+	// Only require availability from the direction of the switch: canary during forward
+	// progress, stable during abort/rollback. The caller checks stable capacity before UpdateHash.
 	for _, rs := range r.replicaSets {
 		if *rs.Spec.Replicas == 0 {
 			continue
 		}
 		rsHash := rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
-		if rsHash == "" || (rsHash != stableHash && rsHash != canaryHash) {
-			continue
-		}
-		if abortOrDynamicRollbackToStable && rsHash == canaryHash {
+		if rsHash == "" || rsHash != requiredHash {
 			continue
 		}
 		if !replicasetutil.IsReplicaSetAvailable(rs) {

--- a/rollout/trafficrouting/istio/istio_test.go
+++ b/rollout/trafficrouting/istio/istio_test.go
@@ -3474,6 +3474,21 @@ spec:
 		assert.Equal(t, "update", actions[0].GetVerb())
 	})
 
+	t.Run("healthy canary proceeds when stable ReplicaSet is unavailable", func(t *testing.T) {
+		ro := createRollout(false)
+		obj := createDestinationRuleObj()
+		client := testutil.NewFakeDynamicClient(obj)
+
+		stableRS := createUnavailableReplicaSet(ro, "stable123")
+		canaryRS := createAvailableReplicaSet(ro, "canary456")
+		r := setupReconciler(ro, client, []*appsv1.ReplicaSet{stableRS, canaryRS})
+
+		err := r.UpdateHash("canary456", "stable123")
+		assert.NoError(t, err)
+		assert.Len(t, client.Actions(), 1)
+		assert.Equal(t, "update", client.Actions()[0].GetVerb())
+	})
+
 	t.Run("works correctly during abort scenarios", func(t *testing.T) {
 		ro := createRollout(true) // Aborted rollout
 		obj := createDestinationRuleObj()
@@ -3549,7 +3564,19 @@ func TestShouldDelayDestinationRuleUpdate(t *testing.T) {
 		assert.Equal(t, "rs-canary456", rsName)
 	})
 
-	t.Run("unavailable stable RS delays", func(t *testing.T) {
+	t.Run("unavailable stable RS does not delay healthy canary progression", func(t *testing.T) {
+		stableRS := createUnavailableRS("stable123", 1)
+		canaryRS := createAvailableRS("canary456", 1)
+		r.replicaSets = []*appsv1.ReplicaSet{stableRS, canaryRS}
+
+		shouldDelay, rsName := r.shouldDelayDestinationRuleUpdate("canary456", "stable123")
+		assert.False(t, shouldDelay)
+		assert.Empty(t, rsName)
+	})
+
+	t.Run("unavailable stable RS still delays abort to stable", func(t *testing.T) {
+		ro.Status.Abort = true
+		t.Cleanup(func() { ro.Status.Abort = false })
 		stableRS := createUnavailableRS("stable123", 1)
 		canaryRS := createAvailableRS("canary456", 1)
 		r.replicaSets = []*appsv1.ReplicaSet{stableRS, canaryRS}


### PR DESCRIPTION
## Problem

Fixes #4839.

For **subset-based** Istio DestinationRule routing (no `canaryService`/`stableService` set), `shouldDelayDestinationRuleUpdate()` required *both* the canary-hash and stable-hash ReplicaSets to be available before allowing the DestinationRule subset switch.

If the **stable** ReplicaSet became degraded (crashlooping pods, `ImagePullBackOff`, failing readiness probes) while a canary revision was progressing, the delay never cleared — there was no self-recovery. Since `UpdateHash()` runs before `SetWeight()` each reconcile, the traffic split got stuck at whatever weight was last applied: the rollout could neither advance toward the healthy canary nor fall back to 100% stable. The only workaround was manually forcing the stable hash to the canary's (`promote-full`), which doesn't scale across large fleets.

This is distinct from #4626/#4823: #4823 exempts the canary RS from this check during abort/dynamic-rollback-to-stable (so an aborting rollout isn't blocked by a broken canary), but did nothing for the inverse case — a broken **stable** RS blocking **forward** progression toward a healthy canary.

## Fix

`shouldDelayDestinationRuleUpdate()` now only requires availability from the ReplicaSet in the **direction of the switch**:
- Forward rollout progression requires the **canary** RS to be available.
- Abort / dynamic-rollback-to-stable requires the **stable** RS to be available.

This is the symmetric counterpart to the exemption #4823 already added for the canary-broken case, and matches the issue's stated expected behavior: *"The rollout should be able to promote a healthy canary even if the stable is not healthy anymore."* It requires no new timeout, config surface, or status field — the health of the RS being switched *to* is itself the bound, so a degraded source RS can no longer block a switch toward a healthy target indefinitely.

The original protection is preserved in both directions: forward progression still delays while the canary itself is unavailable, and abort-to-stable still delays while the stable itself is unavailable.

## Testing

Added regression coverage in `istio_test.go`:
- Healthy canary now proceeds (`UpdateHash` succeeds, DestinationRule updated) despite a degraded stable RS.
- `shouldDelayDestinationRuleUpdate` returns `false` for an unavailable stable RS during forward progression (previously `true`, reproducing the stuck condition).
- `shouldDelayDestinationRuleUpdate` still returns `true` for an unavailable stable RS during abort-to-stable (original protection retained).
- Existing "unavailable canary RS delays" case retained unchanged.

```
go build ./...                                    # pass
go test ./rollout/trafficrouting/istio/...         # ok
go vet ./rollout/trafficrouting/istio/...          # pass
```

Signed-off per DCO.