### PR TITLE
fix: skip externally-mutated RS in FindNewReplicaSet fallback

### DIFF
--- a/utils/replicaset/replicaset.go
+++ b/utils/replicaset/replicaset.go
@@ -66,8 +66,24 @@ func FindNewReplicaSet(rollout *v1alpha1.Rollout, rsList []*appsv1.ReplicaSet) *
 
 		desired := rollout.Spec.Template.DeepCopy()
 		if PodTemplateEqualIgnoreHash(live, desired) {
+			// Guard against a false positive caused by an external mutation of the RS pod
+			// template (e.g. an in-place container restart updating the image field). The
+			// intent of this fallback is only to survive a change in the hash *function*
+			// itself (e.g. a k8s library upgrade). In that case the RS label still encodes
+			// the hash of the original template using the old algorithm, so recomputing the
+			// hash of the *live* RS template with the new algorithm should yield the same
+			// value as the label — confirming it is the function that changed, not the
+			// template. If the recomputed hash differs from the label, the RS template was
+			// genuinely mutated and we must not reuse this RS.
+			liveHash := hash.ComputePodTemplateHash(&rs.Spec.Template, rollout.Status.CollisionCount)
+			rsLabelHash := rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+			if liveHash != rsLabelHash {
+				logCtx := logutil.WithRollout(rollout)
+				logCtx.Infof("Skipping RS '%s': pod template matches desired but live hash (%s) differs from RS label (%s), indicating an external mutation", rs.Name, liveHash, rsLabelHash)
+				continue
+			}
 			logCtx := logutil.WithRollout(rollout)
-			logCtx.Infof("ComputePodTemplateHash hash changed (expected: %s, actual: %s)", podHash, rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey])
+			logCtx.Infof("ComputePodTemplateHash hash changed (expected: %s, actual: %s)", podHash, rsLabelHash)
 			return rs
 		}
 	}

--- a/utils/replicaset/replicaset_test.go
+++ b/utils/replicaset/replicaset_test.go
@@ -99,6 +99,32 @@ func TestFindNewReplicaSet(t *testing.T) {
 	})
 }
 
+// TestFindNewReplicaSetExternalMutation verifies that FindNewReplicaSet returns nil (and does not
+// reuse an existing RS) when the RS pod template was externally mutated to match the desired spec
+// but the RS label still carries the old hash. This is the scenario described in
+// https://github.com/argoproj/argo-rollouts/issues/4976 where a BlueGreen rollout gets stuck
+// after an in-place container restart updates the image field inside the live RS without triggering
+// a proper RS replacement.
+func TestFindNewReplicaSetExternalMutation(t *testing.T) {
+	// roOld represents the rollout as it was when the RS was first created (image "v1").
+	roOld := generateRollout("v1")
+	// The RS was created from roOld — its label encodes the hash of the "v1" template.
+	rs := generateRS(roOld)
+	*(rs.Spec.Replicas) = 1
+
+	// roNew represents the rollout after an image-only update (image "v2").
+	roNew := generateRollout("v2")
+	// Simulate an external mutation: the live RS pod template now shows "v2" (e.g., the pod was
+	// OOMKilled and restarted in-place, updating the image field inside the RS spec), but its
+	// rollouts-pod-template-hash label still holds the old "v1" hash.
+	rs.Spec.Template.Spec.Containers[0].Image = "v2"
+
+	// FindNewReplicaSet must not return this RS: the RS label hash was computed from the old
+	// template, not the mutated one, so the third fallback should skip it.
+	actual := FindNewReplicaSet(&roNew, []*appsv1.ReplicaSet{&rs})
+	assert.Nil(t, actual, "expected nil because the RS was externally mutated — a new RS should be created")
+}
+
 func TestFindOldReplicaSets(t *testing.T) {
 	now := metav1.Now()
 	before := metav1.Time{Time: now.Add(-time.Minute)}


### PR DESCRIPTION
## What this PR does / why we need it

Fixes a bug where a BlueGreen rollout becomes permanently stuck reporting `Healthy`
against the _old_ ReplicaSet after an image-only update, never creating a new RS and
never updating `status.currentPodHash`.

Fixes #4976

## Root cause

`FindNewReplicaSet` has three resolution paths when looking for the RS matching the desired pod template:

1. Hash match using `ComputePodTemplateHash` (current algorithm)
2. Hash match using the deprecated `controller.ComputeHash`
3. **Deep-equality fallback** — iterates all RSes and calls `PodTemplateEqualIgnoreHash(live, desired)`, intended to survive a change in the hash _function_ (e.g. a k8s library upgrade)

The bug is in path 3. When a container is **OOMKilled and restarted in-place**, Kubernetes can
mutate the RS pod template so that it now matches the new desired spec — without updating the
`rollouts-pod-template-hash` label. Path 3 then returns the old RS as `c.newRS`,
`CheckPodSpecChange` sees no diff, and no new RS is ever created. The controller logs the hash
mismatch on every reconcile but takes no action:

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] My builds are green. Try syncing with master if they are not. 
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [ ] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [ ] I understand what the code does and WHY/HOW it works in several scenarios
* [ ] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).