### PR TITLE
fix(analysis): don't report Successful for a terminated bounded metric that never succeeded. Fixes #4479

### DIFF
--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -647,8 +647,18 @@ func assessMetricStatus(metric v1alpha1.Metric, result v1alpha1.MetricResult, te
 		logger.Infof("Metric Assessment Result - %s: Count (%s) Reached", v1alpha1.AnalysisPhaseSuccessful, effectiveCount.String())
 		return v1alpha1.AnalysisPhaseSuccessful
 	}
-	// if we get here, this metric runs indefinitely
+	// if we get here, this metric runs indefinitely (or is a bounded metric whose count
+	// was not yet reached)
 	if terminating {
+		// A bounded metric (effectiveCount != nil) that is terminated before reaching its
+		// target count must not be reported Successful if it never once produced a successful
+		// measurement. Falling through to AnalysisPhaseSuccessful here would mask a metric
+		// whose every measurement Failed or Errored (see #4479).
+		if effectiveCount != nil && result.Successful == 0 && (result.Failed > 0 || result.Error > 0) {
+			phase := lastMeasurement.Phase
+			logger.Infof("Metric Assessment Result - %s: Run Terminated", phase)
+			return phase
+		}
 		logger.Infof(SuccessfulAssessmentRunTerminatedResult)
 		return v1alpha1.AnalysisPhaseSuccessful
 	}

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -864,6 +864,58 @@ func TestAssessMetricStatusCountReached(t *testing.T) {
 	assert.Equal(t, v1alpha1.AnalysisPhaseInconclusive, assessMetricStatus(metric, result, false))
 }
 
+// TestAssessMetricStatusTerminatedBeforeCountReachedNeverSucceeded reproduces
+// https://github.com/argoproj/argo-rollouts/issues/4479: a bounded metric (Count
+// specified) that is terminated early, before reaching its target count, must not be
+// reported Successful when every measurement taken so far was Errored or Failed and
+// none succeeded. Previously this fell through to a hardcoded AnalysisPhaseSuccessful.
+func TestAssessMetricStatusTerminatedBeforeCountReachedNeverSucceeded(t *testing.T) {
+	count := intstr.FromInt(5)
+	failureLimit := intstr.FromInt(2)
+	metric := v1alpha1.Metric{
+		Name:         "dd-analysis2",
+		Count:        &count,
+		FailureLimit: &failureLimit,
+		Interval:     "10s",
+	}
+	result := v1alpha1.MetricResult{
+		Count:            1,
+		Failed:           1,
+		Error:            3,
+		ConsecutiveError: 0,
+		Measurements: []v1alpha1.Measurement{
+			newMeasurement(v1alpha1.AnalysisPhaseError),
+			newMeasurement(v1alpha1.AnalysisPhaseError),
+			newMeasurement(v1alpha1.AnalysisPhaseError),
+			newMeasurement(v1alpha1.AnalysisPhaseFailed),
+		},
+	}
+	// Not yet terminating: run keeps measuring toward its target count.
+	assert.Equal(t, v1alpha1.AnalysisPhaseRunning, assessMetricStatus(metric, result, false))
+	// Terminated early: must reflect the real last-known outcome (Failed, matching the
+	// last measurement), not a blind Successful.
+	assert.Equal(t, v1alpha1.AnalysisPhaseFailed, assessMetricStatus(metric, result, true))
+
+	// Same scenario, but every measurement (including the last) was an Error: should
+	// report Error rather than Successful.
+	result.Failed = 0
+	result.Error = 4
+	result.Measurements = []v1alpha1.Measurement{
+		newMeasurement(v1alpha1.AnalysisPhaseError),
+		newMeasurement(v1alpha1.AnalysisPhaseError),
+		newMeasurement(v1alpha1.AnalysisPhaseError),
+		newMeasurement(v1alpha1.AnalysisPhaseError),
+	}
+	assert.Equal(t, v1alpha1.AnalysisPhaseError, assessMetricStatus(metric, result, true))
+
+	// A bounded metric terminated early that DID succeed at least once should
+	// keep the pre-existing behavior of reporting Successful.
+	result.Successful = 1
+	result.Failed = 1
+	result.Error = 3
+	assert.Equal(t, v1alpha1.AnalysisPhaseSuccessful, assessMetricStatus(metric, result, true))
+}
+
 func TestCalculateNextReconcileTimeInterval(t *testing.T) {
 	now := metav1.Now()
 	nowMinus30 := metav1.NewTime(now.Add(time.Second * -30))


### PR DESCRIPTION
## Summary
Fixes #4479. When an AnalysisRun is terminated before a bounded metric
(Count specified) reaches its target count, `assessMetricStatus()` fell
through to a hardcoded `AnalysisPhaseSuccessful` as long as the
failure/inconclusive/consecutive-error limits hadn't been exceeded yet.

This is wrong when the metric never recorded a single successful
measurement: a metric whose every measurement Errored or Failed (as in the
issue's `dd-analysis2` example — 3 Errors + 1 Failed, count target of 5
never reached) was still reported `Successful`, silently masking a real
failure and letting a canary rollout proceed on bad data.

## Fix
If the run is terminating, the metric is bounded (`effectiveCount != nil`),
it has never succeeded (`Successful == 0`), and it has at least one
Failed or Error measurement, report the phase of the *last* measurement
instead of blindly returning `Successful`. Metrics that succeeded at least
once, or are genuinely indefinite (no count specified), keep the existing
behavior unchanged — verified against all pre-existing unit tests.

## Test plan
- [x] Added `TestAssessMetricStatusTerminatedBeforeCountReachedNeverSucceeded`,
      reproducing the exact issue scenario (Count=5, FailureLimit=2, 3
      Errors + 1 Failed) plus an Error-only variant and a "succeeded once"
      variant that confirms the pre-existing behavior is preserved.
- [x] `go test ./analysis/...` passes (all existing tests unmodified and green).
- [x] `go build ./...` passes.

Checklist:
- [x] This is a bug fix.
- [x] Conventional commit title, suffixed with the issue number.
- [x] Commit signed with DCO.
- [x] Builds are green.
- [x] Added unit tests for the change.
- [x] Ran all tests locally, they pass.
- [x] Used AI/Agent tooling for this PR; I am responsible for all code in it.
- [ ] My organization is added to USERS.md. (N/A — personal contribution)