### PR TITLE
fix(metricprovider): resolve measurement on Terminate instead of leaving it Running forever. Fixes #4815

### DIFF
--- a/metricproviders/kayenta/kayenta.go
+++ b/metricproviders/kayenta/kayenta.go
@@ -307,9 +307,18 @@ func scopeToScopeRequest(scope v1alpha1.KayentaScope) (ScopeRequest, error) {
 	}, nil
 }
 
-// Terminate should not be used the kayenta provider since all the work should occur in the Run method
+// Terminate marks an in-progress measurement Inconclusive when its AnalysisRun is terminated
+// early. The kayenta provider has no API integration to cancel an in-progress canary judgment,
+// so unlike Run/Resume it cannot produce a real result here. Previously this returned the
+// measurement unchanged, which left its Phase as Running forever: analysis.go only treats a
+// measurement as complete once its Phase reports Completed(), so a terminated-but-unresolved
+// measurement caused Terminate to be invoked again on every subsequent reconcile - an infinite
+// loop and resource leak (see #4815).
 func (p *Provider) Terminate(run *v1alpha1.AnalysisRun, metric v1alpha1.Metric, measurement v1alpha1.Measurement) v1alpha1.Measurement {
-	p.logCtx.Warn("kayenta provider should not execute the Terminate method")
+	p.logCtx.Warn("kayenta provider cannot cancel an in-progress canary judgment; marking measurement Inconclusive on terminate")
+	now := timeutil.MetaNow()
+	measurement.FinishedAt = &now
+	measurement.Phase = v1alpha1.AnalysisPhaseInconclusive
 	return measurement
 }
 

--- a/metricproviders/kayenta/kayenta_test.go
+++ b/metricproviders/kayenta/kayenta_test.go
@@ -12,6 +12,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 )
@@ -227,7 +228,8 @@ func TestRunSuccessfully(t *testing.T) {
 	assert.Equal(t, nil, p.GarbageCollect(run, metric, 0))
 
 	measurement2 := p.Terminate(run, metric, measurement)
-	assert.Equal(t, measurement, measurement2)
+	assert.Equal(t, v1alpha1.AnalysisPhaseInconclusive, measurement2.Phase)
+	assert.NotNil(t, measurement2.FinishedAt)
 }
 
 func TestRunBadJobResponse(t *testing.T) {
@@ -863,6 +865,31 @@ func TestRunStartAndEndMismatched(t *testing.T) {
 
 	assert.Equal(t, v1alpha1.AnalysisPhaseError, measurement4.Phase)
 	assert.Contains(t, measurement4.Message, "controlScope.end and experimentScope.end must both be set or be empty")
+}
+
+// TestTerminate reproduces https://github.com/argoproj/argo-rollouts/issues/4815: Terminate
+// must resolve a still-Running measurement to a completed phase. Previously it returned the
+// measurement unchanged, which left Phase as Running forever - analysis.go only stops calling
+// Terminate once the measurement's Phase reports Completed(), so this caused Terminate to be
+// invoked again on every subsequent reconcile.
+func TestTerminate(t *testing.T) {
+	e := *log.NewEntry(log.New())
+	c := NewTestClient(func(req *http.Request) *http.Response {
+		t.Fatal("Terminate should not make any HTTP calls")
+		return nil
+	})
+
+	p := NewKayentaProvider(e, c)
+
+	measurement := v1alpha1.Measurement{
+		Phase: v1alpha1.AnalysisPhaseRunning,
+	}
+
+	result := p.Terminate(newAnalysisRun(), buildMetric(), measurement)
+
+	assert.True(t, result.Phase.Completed(), "Terminate must resolve the measurement to a completed phase")
+	assert.Equal(t, v1alpha1.AnalysisPhaseInconclusive, result.Phase)
+	require.NotNil(t, result.FinishedAt)
 }
 
 // RoundTripFunc .


### PR DESCRIPTION
## Summary
Fixes #4815. The kayenta provider is the only provider that legitimately
returns `AnalysisPhaseRunning` from `Run`/`Resume` (it polls an external
Kayenta canary judgment job). Its `Terminate` implementation, however, was
a no-op that returned the measurement unchanged, still `Phase: Running`.

`analysis.go` only considers a measurement complete once its `Phase`
reports `Completed()`; a `Running` measurement returned from `Terminate`
never satisfies that, so on the next reconcile `generateMetricTasks` finds
the measurement still in-progress and terminating, and calls `Terminate()`
again — an infinite reconcile loop for any Kayenta `AnalysisRun`
terminated while a measurement was in flight.

## Fix
Kayenta has no API integration in this provider to cancel an in-progress
canary judgment (no cancellation endpoint is called anywhere in this
file), so `Terminate` can't produce a real result. This resolves the
measurement to `AnalysisPhaseInconclusive` and sets `FinishedAt`,
mirroring how the job provider's `Terminate` resolves a force-stopped Job.

## Test plan
- [x] The existing `TestRunSuccessfully` asserted `Terminate` returned the
      measurement byte-for-byte unchanged — i.e. it encoded the exact bug
      being fixed here. Updated that assertion to check the corrected
      behavior.
- [x] Added `TestTerminate`, which fails against the old code (verified
      locally by reverting the fix) and passes with the fix.
- [x] `go test ./metricproviders/...` passes.
- [x] `go build ./...` passes, `gofmt` clean.

Checklist:
- [x] This is a bug fix.
- [x] Conventional commit title, suffixed with the issue number.
- [x] Commit signed with DCO.
- [x] Builds are green.
- [x] Added unit tests for the change.
- [x] Ran all tests locally, they pass.
- [x] Used AI/Agent tooling for this PR; I am responsible for all code in it.