### PR TITLE
fix(metricprovider): respect --logformat json for metric plugin process logger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
+	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.8.0
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
 	github.com/juju/ansiterm v1.0.0
@@ -125,7 +126,6 @@ require (
 	github.com/gregdel/pushover v1.3.1 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect

--- a/metricproviders/plugin/client/client.go
+++ b/metricproviders/plugin/client/client.go
@@ -2,10 +2,13 @@ package client
 
 import (
 	"fmt"
+	"io"
 	"os/exec"
 	"sync"
 
+	"github.com/hashicorp/go-hclog"
 	goPlugin "github.com/hashicorp/go-plugin"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/argoproj/argo-rollouts/metricproviders/plugin/rpc"
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
@@ -68,6 +71,7 @@ func (m *metricPlugin) startPluginSystem(metric v1alpha1.Metric) (rpc.MetricProv
 				Plugins:         pluginMap,
 				Cmd:             exec.Command(pluginPath, args...),
 				Managed:         true,
+				Logger:          newPluginLogger(),
 			})
 
 			rpcClient, err := m.pluginClient[pluginName].Client()
@@ -107,4 +111,28 @@ func (m *metricPlugin) startPluginSystem(metric v1alpha1.Metric) (rpc.MetricProv
 	}
 
 	return nil, fmt.Errorf("no plugin found")
+}
+
+// newPluginLogger builds the hclog.Logger used for the go-plugin client's own log output
+// (handshake/lifecycle logs, and the plugin process's stderr relay). By default go-plugin
+// falls back to its own unstructured text logger whenever ClientConfig.Logger is nil, which
+// is inconsistent with the controller's own logs when the controller is run with
+// `--logformat json`: every other component's logs are JSON, but metric plugin logs remain
+// plain text. When the controller's standard logger is configured for JSON output, mirror
+// that here so the plugin logger's output is JSON too. Returns nil (go-plugin's own default
+// logger) in every other case, preserving prior behavior exactly.
+func newPluginLogger() hclog.Logger {
+	return newPluginLoggerWithOutput(hclog.DefaultOutput)
+}
+
+func newPluginLoggerWithOutput(w io.Writer) hclog.Logger {
+	if _, ok := log.StandardLogger().Formatter.(*log.JSONFormatter); !ok {
+		return nil
+	}
+	return hclog.New(&hclog.LoggerOptions{
+		Output:     w,
+		Level:      hclog.Trace,
+		Name:       "plugin",
+		JSONFormat: true,
+	})
 }

--- a/metricproviders/plugin/client/client_test.go
+++ b/metricproviders/plugin/client/client_test.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNewPluginLoggerRespectsControllerLogFormat verifies that the go-plugin client's own
+// logger mirrors the controller's configured log format. Before this fix, the plugin
+// client's Logger field was always left unset, so go-plugin always fell back to its
+// unstructured, hardcoded-text default logger regardless of the controller's own
+// `--logformat json` setting.
+func TestNewPluginLoggerRespectsControllerLogFormat(t *testing.T) {
+	origFormatter := log.StandardLogger().Formatter
+	defer log.StandardLogger().SetFormatter(origFormatter)
+
+	t.Run("default text logformat leaves go-plugin's own default logger untouched", func(t *testing.T) {
+		log.StandardLogger().SetFormatter(&log.TextFormatter{})
+		logger := newPluginLogger()
+		assert.Nil(t, logger, "expected nil so go-plugin falls back to its own default logger")
+	})
+
+	t.Run("json logformat produces a JSON plugin logger", func(t *testing.T) {
+		log.StandardLogger().SetFormatter(&log.JSONFormatter{})
+
+		var buf bytes.Buffer
+		logger := newPluginLoggerWithOutput(&buf)
+		assert.NotNil(t, logger)
+
+		logger.Info("plugin log line", "plugin", "my-plugin")
+
+		var parsed map[string]any
+		err := json.Unmarshal(buf.Bytes(), &parsed)
+		assert.NoError(t, err, "expected the plugin logger to emit a single JSON object, got: %s", buf.String())
+		assert.Equal(t, "plugin log line", parsed["@message"])
+	})
+}


### PR DESCRIPTION
## Problem

Fixes #4408.

The metric provider plugin client (`metricproviders/plugin/client/client.go`) builds its `go-plugin` `ClientConfig` without ever setting `Logger`:

```go
m.pluginClient[pluginName] = goPlugin.NewClient(&goPlugin.ClientConfig{
    HandshakeConfig: handshakeConfig,
    Plugins:         pluginMap,
    Cmd:             exec.Command(pluginPath, args...),
    Managed:         true,
})
```

`hashicorp/go-plugin`'s own `Start()` explicitly falls back to its own hardcoded, unstructured `hclog` logger whenever `Logger` is `nil`:

```go
// hashicorp/go-plugin client.go
if config.Logger == nil {
    config.Logger = hclog.New(&hclog.LoggerOptions{
        Output: hclog.DefaultOutput,
        Level:  hclog.Trace,
        Name:   "plugin",
    })
}
```

This means every log line related to the metric plugin's handshake/lifecycle, and the relayed stderr of the plugin subprocess itself, is always emitted in `go-plugin`'s own fixed text format (`argo-rollouts 2025-08-18T09:53:56.003Z [DEBUG] plugin.my-plugin: ...`) — regardless of the controller's own `--logformat json` flag. Every other controller log line respects `--logformat`; this is the one place that doesn't, which breaks structured-log parsing/ingestion pipelines built around the controller's JSON output.

## Verification the bug is real and current

Confirmed directly against current `master` (`4e6a27986`, 2026-08-25):

- `metricproviders/plugin/client/client.go`'s `ClientConfig` literal has no `Logger` field, exactly as described in the issue.
- `go-plugin` (`v1.8.0`, this repo's current pinned version) still has the `if config.Logger == nil { ... }` fallback quoted above (`hashicorp/go-plugin@v1.8.0/client.go:417`).
- No prior PR or commit touches this file to address logger configuration (`git log -- metricproviders/plugin/client/client.go` shows no related change).
- The same pattern (no `Logger` set) also exists in `rollout/trafficrouting/plugin/client/client.go` and `rollout/steps/plugin/client/client.go`, which are out of scope for this PR — it's scoped narrowly to the metric provider plugin client, matching the issue title/report. Happy to open follow-up PRs for the other two plugin types if maintainers want the same treatment there.

## Fix

Added `newPluginLogger()` (and a testable `newPluginLoggerWithOutput()` helper) in `metricproviders/plugin/client/client.go`:

- If the controller's standard `logrus` logger is configured with `logrus.JSONFormatter` (i.e. the controller was started with `--logformat json`, which `cmd/rollouts-controller/main.go` applies via `log.SetFormatter(...)` on the same package-level `logrus` standard logger), build an `hclog.Logger` with `JSONFormat: true`, keeping every other option (`Trace` level, `"plugin"` name, `hclog.DefaultOutput`) identical to `go-plugin`'s own default so nothing else about the logger's behavior changes.
- Otherwise, return `nil`, which is exactly what was passed implicitly before this change — `go-plugin` falls back to its own default (unstructured) logger, so behavior for the default/text-format case (the overwhelming majority of current deployments) is completely unchanged.

This is a minimal, additive, non-breaking change: it only changes plugin logger *output format*, never plugin behavior, and only takes effect when the operator has already opted into `--logformat json`.

## Test

Added `metricproviders/plugin/client/client_test.go` (this package had no test file at all before this PR):

- `newPluginLogger()` returns `nil` when the controller's logger is the default `logrus.TextFormatter` — preserving `go-plugin`'s own default logger.
- `newPluginLoggerWithOutput()` (used to capture output without writing to the real `hclog.DefaultOutput`/stderr in the test) returns a non-nil logger that emits a single valid JSON object per log line when the controller's logger is `logrus.JSONFormatter`, verified by unmarshaling the captured output and asserting the `@message` field.

**Revert-and-reconfirm proof:** reverted `metricproviders/plugin/client/client.go` alone (kept the new test file and `go.mod`) and re-ran the test:

```
metricproviders/plugin/client/client_test.go:23:13: undefined: newPluginLogger
metricproviders/plugin/client/client_test.go:31:13: undefined: newPluginLoggerWithOutput
FAIL	github.com/argoproj/argo-rollouts/metricproviders/plugin/client [build failed]
```

Restored the fix and confirmed:

```
--- PASS: TestNewPluginLoggerRespectsControllerLogFormat (0.00s)
    --- PASS: .../default_text_logformat_leaves_go-plugin's_own_default_logger_untouched (0.00s)
    --- PASS: .../json_logformat_produces_a_JSON_plugin_logger (0.00s)
PASS
ok  	github.com/argoproj/argo-rollouts/metricproviders/plugin/client	0.65s
```

Full verification before submission:

- `go build ./...` — clean.
- `go vet ./...` — clean.
- `go test ./metricproviders/...` — all packages pass except a **pre-existing, unrelated** failure in `metricproviders/datadog` (`TestRunSuite`/`TestRunSuiteV2`), which I confirmed also fails identically on unmodified `upstream/master` before this change (JSON error-message field-casing mismatch, apparently due to a newer Go toolchain's stdlib `encoding/json` error text in my local environment — unrelated to this PR's package).
- `gofmt -l metricproviders/plugin/client/` — no output (clean).

## Scope note

`go.mod` moves `github.com/hashicorp/go-hclog` from an indirect to a direct requirement (it was already present transitively via `go-plugin`, version unchanged at `v1.6.3`) since this PR now imports it directly. No other dependency changes.
