### PR TITLE
docs: clarify plugin status as beta instead of alpha

### DIFF
--- a/docs/analysis/plugins.md
+++ b/docs/analysis/plugins.md
@@ -1,8 +1,8 @@
 # Metric Plugins
 
-!!! warning "Alpha Feature (Since 1.5.0)"
+!!! warning "Beta Feature (Since 1.5.0)"
 
-    This is an experimental, [alpha-quality](https://github.com/argoproj/argoproj/blob/main/community/feature-status.md#alpha)
+    This is a [beta-quality](https://github.com/argoproj/argoproj/blob/main/community/feature-status.md#beta)
     feature that allows you to support metric providers that are not natively supported.
 
 Argo Rollouts supports getting analysis metrics via 3rd party [plugin system](../plugins.md). This allows users to extend the capabilities of Rollouts

--- a/docs/features/traffic-management/plugins.md
+++ b/docs/features/traffic-management/plugins.md
@@ -1,9 +1,13 @@
 # Traffic Router Plugins
 
-!!! warning "Alpha Feature (Since 1.5.0)"
+!!! warning "Beta Feature (Since 1.5.0)"
 
-    This is an experimental, [alpha-quality](https://github.com/argoproj/argoproj/blob/main/community/feature-status.md#alpha)
-    feature that allows you to supporttraffic router that are not natively supported.
+    This is a [beta-quality](https://github.com/argoproj/argoproj/blob/main/community/feature-status.md#beta)
+    feature that allows you to support traffic routers that are not natively supported.
+
+    Although this feature is Beta, the plugin interface itself is stable: there is no intention to remove or break
+    it in the future. Any change to the API's semantics would only happen as part of a new major version of Argo
+    Rollouts, and future changes are expected to enhance the interface rather than break it.
 
 Argo Rollouts supports getting traffic router via 3rd party [plugin system](../../plugins.md). This allows users to extend the capabilities of Rollouts
 to support traffic router that are not natively supported. Rollout's uses a plugin library called


### PR DESCRIPTION
Move traffic and analysis plugins to "beta" 

Should solve https://github.com/argoproj/argo-rollouts/discussions/4717#discussioncomment-18231298

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [ ] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [ ] I understand what the code does and WHY/HOW it works in several scenarios
* [ ] I know if my code is just adding new functionality or changing old functionality for existing users
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).