### PR TITLE
fix(trafficrouting): only gate Istio subset DestinationRule switch on relabeled ReplicaSets and honor replicaProgressThreshold. Fixes #4839

### DIFF
--- a/docs/features/traffic-management/istio.md
+++ b/docs/features/traffic-management/istio.md
@@ -249,6 +249,13 @@ During the lifecycle of a Rollout using Istio DestinationRule, Argo Rollouts wil
 * modify the DestinationRule `spec.subsets[].labels` to contain the `rollouts-pod-template-hash`
   label of the canary and stable ReplicaSets
 
+When a subset label is about to be switched to a different ReplicaSet (e.g. on the initial
+deployment, on a rollback, or when the stable subset is promoted), the switch is delayed until that
+ReplicaSet has at least one available replica and meets
+`spec.strategy.canary.replicaProgressThreshold` (all of its replicas available when no threshold is
+configured). A ReplicaSet that a subset already points at does not delay the update, since how much
+traffic it receives is governed by that same threshold through the canary step gates.
+
 ### Additional Subset DestinationRule's
 
 Argo Rollouts also allows users to add additional subset DestinationRule's.

--- a/rollout/trafficrouting/istio/istio.go
+++ b/rollout/trafficrouting/istio/istio.go
@@ -380,10 +380,18 @@ func (r *Reconciler) reconcileVirtualService(obj *unstructured.Unstructured, vsv
 }
 
 // shouldDelayDestinationRuleUpdate returns true if updating the DestinationRule should be
-// delayed because a traffic-receiving ReplicaSet is not yet fully available.
+// delayed because a ReplicaSet that is about to start receiving traffic through a relabeled
+// subset has not yet met its replica progress threshold (100% when none is configured).
+// Subsets of the live DestinationRule whose hash label is unchanged are not considered: they
+// already receive traffic and weight shifts to them are gated by AtDesiredReplicaCountsForCanary.
+// A nil DestinationRule treats both subsets as changing.
 // See: https://github.com/argoproj/argo-rollouts/issues/2507
-func (r *Reconciler) shouldDelayDestinationRuleUpdate(canaryHash, stableHash string) (bool, string) {
+func (r *Reconciler) shouldDelayDestinationRuleUpdate(dRule *DestinationRule, canaryHash, stableHash string) (bool, string) {
 	if r.rollout.Spec.Strategy.Canary.CanaryService != "" || r.rollout.Spec.Strategy.Canary.StableService != "" {
+		return false, ""
+	}
+	changingHashes := r.changingSubsetHashes(dRule, canaryHash, stableHash)
+	if len(changingHashes) == 0 {
 		return false, ""
 	}
 	abortOrDynamicRollbackToStable := rolloututil.AbortOrDynamicRollbackToStable(r.rollout, r.replicaSets, stableHash)
@@ -392,34 +400,86 @@ func (r *Reconciler) shouldDelayDestinationRuleUpdate(canaryHash, stableHash str
 			continue
 		}
 		rsHash := rs.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
-		if rsHash == "" || (rsHash != stableHash && rsHash != canaryHash) {
+		if rsHash == "" || !changingHashes[rsHash] {
 			continue
 		}
 		if abortOrDynamicRollbackToStable && rsHash == canaryHash {
 			continue
 		}
-		if !replicasetutil.IsReplicaSetAvailable(rs) {
+		if !r.readyForSubsetSwitch(rs) {
 			return true, rs.Name
 		}
 	}
 	return false, ""
 }
 
-func (r *Reconciler) UpdateHash(canaryHash, stableHash string, additionalDestinations ...v1alpha1.WeightDestination) error {
-	if shouldDelay, rsName := r.shouldDelayDestinationRuleUpdate(canaryHash, stableHash); shouldDelay {
-		r.log.Infof("delaying destination rule switch: ReplicaSet %s not fully available", rsName)
-		return fmt.Errorf("delaying destination rule switch: ReplicaSet %s not fully available", rsName)
+// readyForSubsetSwitch returns true if a subset may be relabeled onto rs: either all of its
+// replicas are available, or it meets the rollout's replicaProgressThreshold and has at least
+// one available replica. The latter floor keeps a zero-valued threshold from switching a subset
+// onto a ReplicaSet serving nothing.
+func (r *Reconciler) readyForSubsetSwitch(rs *appsv1.ReplicaSet) bool {
+	if replicasetutil.IsReplicaSetAvailable(rs) {
+		return true
 	}
+	// spec.replicas is the desired count for this ReplicaSet: the count the controller has already
+	// scaled it to for the current step. IsReplicaSetAvailable above covers the scale-down case,
+	// where available exceeds desired and ReplicaProgressThresholdMet's equality check would fail.
+	threshold := r.rollout.Spec.Strategy.Canary.ReplicaProgressThreshold
+	return rs.Status.AvailableReplicas > 0 && replicasetutil.ReplicaProgressThresholdMet(threshold, rs, *rs.Spec.Replicas)
+}
 
+// changingSubsetHashes returns the pod template hashes that the canary and stable subsets of the
+// given DestinationRule are about to be switched to.
+func (r *Reconciler) changingSubsetHashes(dRule *DestinationRule, canaryHash, stableHash string) map[string]bool {
+	canaryChanging := canaryHash != ""
+	stableChanging := stableHash != ""
+	dRuleSpec := r.rollout.Spec.Strategy.Canary.TrafficRouting.Istio.DestinationRule
+	if dRule != nil && dRuleSpec != nil {
+		for _, subset := range dRule.Spec.Subsets {
+			label := subset.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+			if subset.Name == dRuleSpec.CanarySubsetName && label == canaryHash {
+				canaryChanging = false
+			}
+			if subset.Name == dRuleSpec.StableSubsetName && label == stableHash {
+				stableChanging = false
+			}
+		}
+	}
+	changing := map[string]bool{}
+	if canaryChanging {
+		changing[canaryHash] = true
+	}
+	if stableChanging {
+		changing[stableHash] = true
+	}
+	return changing
+}
+
+func (r *Reconciler) delayDestinationRuleUpdateIfNeeded(dRule *DestinationRule, canaryHash, stableHash string) error {
+	shouldDelay, rsName := r.shouldDelayDestinationRuleUpdate(dRule, canaryHash, stableHash)
+	if !shouldDelay {
+		return nil
+	}
+	r.log.Infof("delaying destination rule switch: ReplicaSet %s has not met its replica progress threshold", rsName)
+	return fmt.Errorf("delaying destination rule switch: ReplicaSet %s has not met its replica progress threshold", rsName)
+}
+
+func (r *Reconciler) UpdateHash(canaryHash, stableHash string, additionalDestinations ...v1alpha1.WeightDestination) error {
 	dRuleSpec := r.rollout.Spec.Strategy.Canary.TrafficRouting.Istio.DestinationRule
 	if dRuleSpec == nil {
-		return nil
+		// No DestinationRule is configured (e.g. the ping-pong path), so there are no subsets to
+		// diff. Keep the pre-existing full-availability gate for this path rather than widening
+		// the change beyond subset routing.
+		return r.delayDestinationRuleUpdateIfNeeded(nil, canaryHash, stableHash)
 	}
 	ctx := context.TODO()
 	client := r.client.Resource(istioutil.GetIstioDestinationRuleGVR()).Namespace(r.rollout.Namespace)
 
 	origBytes, dRule, dRuleNew, err := r.getDestinationRule(dRuleSpec, client, ctx)
 	if err != nil {
+		return err
+	}
+	if err := r.delayDestinationRuleUpdateIfNeeded(dRule, canaryHash, stableHash); err != nil {
 		return err
 	}
 	if dRuleNew.Annotations == nil {

--- a/rollout/trafficrouting/istio/istio_test.go
+++ b/rollout/trafficrouting/istio/istio_test.go
@@ -3534,7 +3534,7 @@ func TestShouldDelayDestinationRuleUpdate(t *testing.T) {
 		otherRS := createUnavailableRS("other789", 1) // Unavailable but not a traffic target
 		r.replicaSets = []*appsv1.ReplicaSet{stableRS, canaryRS, otherRS}
 
-		shouldDelay, rsName := r.shouldDelayDestinationRuleUpdate("canary456", "stable123")
+		shouldDelay, rsName := r.shouldDelayDestinationRuleUpdate(destinationRuleWithSubsetLabels("", ""), "canary456", "stable123")
 		assert.False(t, shouldDelay, "unavailable RS with hash other789 should not delay; only canary and stable are targets")
 		assert.Empty(t, rsName)
 	})
@@ -3544,7 +3544,7 @@ func TestShouldDelayDestinationRuleUpdate(t *testing.T) {
 		canaryRS := createUnavailableRS("canary456", 1)
 		r.replicaSets = []*appsv1.ReplicaSet{stableRS, canaryRS}
 
-		shouldDelay, rsName := r.shouldDelayDestinationRuleUpdate("canary456", "stable123")
+		shouldDelay, rsName := r.shouldDelayDestinationRuleUpdate(destinationRuleWithSubsetLabels("", ""), "canary456", "stable123")
 		assert.True(t, shouldDelay)
 		assert.Equal(t, "rs-canary456", rsName)
 	})
@@ -3554,7 +3554,7 @@ func TestShouldDelayDestinationRuleUpdate(t *testing.T) {
 		canaryRS := createAvailableRS("canary456", 1)
 		r.replicaSets = []*appsv1.ReplicaSet{stableRS, canaryRS}
 
-		shouldDelay, rsName := r.shouldDelayDestinationRuleUpdate("canary456", "stable123")
+		shouldDelay, rsName := r.shouldDelayDestinationRuleUpdate(destinationRuleWithSubsetLabels("", ""), "canary456", "stable123")
 		assert.True(t, shouldDelay)
 		assert.Equal(t, "rs-stable123", rsName)
 	})
@@ -3568,7 +3568,7 @@ func TestShouldDelayDestinationRuleUpdate(t *testing.T) {
 		stableRS := createAvailableRS("stable123", 1)
 		rSvc.replicaSets = []*appsv1.ReplicaSet{stableRS, canaryRS}
 
-		shouldDelay, rsName := rSvc.shouldDelayDestinationRuleUpdate("canary456", "stable123")
+		shouldDelay, rsName := rSvc.shouldDelayDestinationRuleUpdate(destinationRuleWithSubsetLabels("", ""), "canary456", "stable123")
 		assert.False(t, shouldDelay, "delay check is skipped when canary/stable services are set")
 		assert.Empty(t, rsName)
 	})
@@ -3578,10 +3578,274 @@ func TestShouldDelayDestinationRuleUpdate(t *testing.T) {
 		canaryRS := createUnavailableRS("canary456", 0) // Scaled down; "unavailable" but should not block
 		r.replicaSets = []*appsv1.ReplicaSet{stableRS, canaryRS}
 
-		shouldDelay, rsName := r.shouldDelayDestinationRuleUpdate("canary456", "stable123")
+		shouldDelay, rsName := r.shouldDelayDestinationRuleUpdate(destinationRuleWithSubsetLabels("", ""), "canary456", "stable123")
 		assert.False(t, shouldDelay, "RS with 0 replicas should be skipped")
 		assert.Empty(t, rsName)
 	})
+}
+
+// destinationRuleWithSubsetLabels returns a DestinationRule whose canary and stable subsets carry
+// the given rollouts-pod-template-hash labels. An empty label leaves the subset unlabeled, as it is
+// before a rollout has relabeled it for the first time.
+func destinationRuleWithSubsetLabels(canaryLabel, stableLabel string) *DestinationRule {
+	labels := func(hash string) map[string]string {
+		if hash == "" {
+			return map[string]string{}
+		}
+		return map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: hash}
+	}
+	return &DestinationRule{Spec: DestinationRuleSpec{Subsets: []Subset{
+		{Name: "stable", Labels: labels(stableLabel)},
+		{Name: "canary", Labels: labels(canaryLabel)},
+	}}}
+}
+
+func destinationRuleUnstructuredWithSubsetLabels(canaryLabel, stableLabel string) *unstructured.Unstructured {
+	labels := func(hash string) string {
+		if hash == "" {
+			return "    labels: {}"
+		}
+		return "    labels:\n      rollouts-pod-template-hash: " + hash
+	}
+	return unstructuredutil.StrToUnstructuredUnsafe(`
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: istio-destrule
+  namespace: default
+  annotations:
+    argo-rollouts.argoproj.io/managed-by-rollouts: rollout
+spec:
+  host: ratings.prod.svc.cluster.local
+  subsets:
+  - name: stable
+` + labels(stableLabel) + `
+  - name: canary
+` + labels(canaryLabel) + `
+`)
+}
+
+// subsetGateRollout returns a subset-routed rollout with no canary/stable Services, which is the
+// only configuration where shouldDelayDestinationRuleUpdate applies.
+func subsetGateRollout(threshold *v1alpha1.ReplicaProgressThreshold) *v1alpha1.Rollout {
+	ro := rolloutWithDestinationRule(nil)
+	ro.Spec.Strategy.Canary.CanaryService = ""
+	ro.Spec.Strategy.Canary.StableService = ""
+	ro.Spec.Strategy.Canary.ReplicaProgressThreshold = threshold
+	return ro
+}
+
+func subsetGateRS(ro *v1alpha1.Rollout, hash string, replicas, available int32) *appsv1.ReplicaSet {
+	return &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rs-" + hash,
+			UID:       uuid.NewUUID(),
+			Namespace: metav1.NamespaceDefault,
+			Labels:    map[string]string{v1alpha1.DefaultRolloutUniqueLabelKey: hash},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: &replicas,
+			Template: ro.Spec.Template,
+		},
+		Status: appsv1.ReplicaSetStatus{Replicas: replicas, AvailableReplicas: available},
+	}
+}
+
+// TestShouldDelayDestinationRuleUpdateOnlyForChangingSubsets verifies that only ReplicaSets whose
+// hash is about to be written to a subset gate the update. A ReplicaSet a subset already points at
+// never delays it, even when it is not fully available: relabeling it is a no-op, and traffic
+// shifts to it are gated by AtDesiredReplicaCountsForCanary instead.
+func TestShouldDelayDestinationRuleUpdateOnlyForChangingSubsets(t *testing.T) {
+	ro := subsetGateRollout(nil)
+	reconcilerWith := func(rss ...*appsv1.ReplicaSet) *Reconciler {
+		return NewReconciler(ro, testutil.NewFakeDynamicClient(), record.NewFakeEventRecorder(), nil, nil, rss)
+	}
+
+	t.Run("subsets already point at canary and stable - partially available canary does not delay", func(t *testing.T) {
+		r := reconcilerWith(subsetGateRS(ro, "stable123", 10, 10), subsetGateRS(ro, "canary456", 10, 3))
+		shouldDelay, rsName := r.shouldDelayDestinationRuleUpdate(destinationRuleWithSubsetLabels("canary456", "stable123"), "canary456", "stable123")
+		assert.False(t, shouldDelay)
+		assert.Empty(t, rsName)
+	})
+
+	// Reproduces #4839: a degraded stable RS used to wedge the rollout forever, since the gate
+	// returned true on every reconcile even though the stable subset needed no change.
+	t.Run("subsets already point at canary and stable - degraded stable does not delay", func(t *testing.T) {
+		r := reconcilerWith(subsetGateRS(ro, "stable123", 10, 7), subsetGateRS(ro, "canary456", 10, 10))
+		shouldDelay, rsName := r.shouldDelayDestinationRuleUpdate(destinationRuleWithSubsetLabels("canary456", "stable123"), "canary456", "stable123")
+		assert.False(t, shouldDelay)
+		assert.Empty(t, rsName)
+	})
+
+	// The #2507 protection: a subset must not be pointed at a ReplicaSet that cannot serve it.
+	t.Run("canary subset switching to a not yet available RS delays", func(t *testing.T) {
+		r := reconcilerWith(subsetGateRS(ro, "stable123", 10, 10), subsetGateRS(ro, "canary456", 10, 3))
+		shouldDelay, rsName := r.shouldDelayDestinationRuleUpdate(destinationRuleWithSubsetLabels("old999", "stable123"), "canary456", "stable123")
+		assert.True(t, shouldDelay)
+		assert.Equal(t, "rs-canary456", rsName)
+	})
+
+	t.Run("canary subset switching while stable is degraded only checks canary", func(t *testing.T) {
+		r := reconcilerWith(subsetGateRS(ro, "stable123", 10, 7), subsetGateRS(ro, "canary456", 10, 10))
+		shouldDelay, rsName := r.shouldDelayDestinationRuleUpdate(destinationRuleWithSubsetLabels("old999", "stable123"), "canary456", "stable123")
+		assert.False(t, shouldDelay)
+		assert.Empty(t, rsName)
+	})
+
+	t.Run("stable subset switching on promotion delays until the new RS is available", func(t *testing.T) {
+		r := reconcilerWith(subsetGateRS(ro, "stable123", 10, 10), subsetGateRS(ro, "canary456", 10, 6))
+		shouldDelay, rsName := r.shouldDelayDestinationRuleUpdate(destinationRuleWithSubsetLabels("canary456", "stable123"), "canary456", "canary456")
+		assert.True(t, shouldDelay)
+		assert.Equal(t, "rs-canary456", rsName)
+
+		r = reconcilerWith(subsetGateRS(ro, "stable123", 10, 10), subsetGateRS(ro, "canary456", 10, 10))
+		shouldDelay, rsName = r.shouldDelayDestinationRuleUpdate(destinationRuleWithSubsetLabels("canary456", "stable123"), "canary456", "canary456")
+		assert.False(t, shouldDelay)
+		assert.Empty(t, rsName)
+	})
+
+	t.Run("unlabeled subsets are treated as changing", func(t *testing.T) {
+		r := reconcilerWith(subsetGateRS(ro, "stable123", 10, 10), subsetGateRS(ro, "canary456", 10, 3))
+		shouldDelay, rsName := r.shouldDelayDestinationRuleUpdate(destinationRuleWithSubsetLabels("", ""), "canary456", "stable123")
+		assert.True(t, shouldDelay)
+		assert.Equal(t, "rs-canary456", rsName)
+	})
+
+	t.Run("nil DestinationRule is treated as changing", func(t *testing.T) {
+		r := reconcilerWith(subsetGateRS(ro, "stable123", 10, 10), subsetGateRS(ro, "canary456", 10, 3))
+		shouldDelay, rsName := r.shouldDelayDestinationRuleUpdate(nil, "canary456", "stable123")
+		assert.True(t, shouldDelay)
+		assert.Equal(t, "rs-canary456", rsName)
+	})
+
+	// #4823/#4128: an abort must not be blocked by the broken canary it is aborting away from,
+	// even when the canary subset is the one being relabeled.
+	t.Run("aborting does not delay on an unavailable canary being relabeled", func(t *testing.T) {
+		abortingRO := subsetGateRollout(nil)
+		abortingRO.Status.Abort = true
+		r := NewReconciler(abortingRO, testutil.NewFakeDynamicClient(), record.NewFakeEventRecorder(), nil, nil, []*appsv1.ReplicaSet{
+			subsetGateRS(abortingRO, "stable123", 10, 10),
+			subsetGateRS(abortingRO, "canary456", 10, 0),
+		})
+		shouldDelay, rsName := r.shouldDelayDestinationRuleUpdate(destinationRuleWithSubsetLabels("old999", "stable123"), "canary456", "stable123")
+		assert.False(t, shouldDelay, "abort must not be blocked by the canary it is aborting away from")
+		assert.Empty(t, rsName)
+
+		// Control: the same state without the abort still delays, so the subtest above is
+		// exercising the abort skip and not some other exemption.
+		r.rollout.Status.Abort = false
+		shouldDelay, rsName = r.shouldDelayDestinationRuleUpdate(destinationRuleWithSubsetLabels("old999", "stable123"), "canary456", "stable123")
+		assert.True(t, shouldDelay)
+		assert.Equal(t, "rs-canary456", rsName)
+	})
+
+	t.Run("RS scaling down with more available than desired does not delay", func(t *testing.T) {
+		r := reconcilerWith(subsetGateRS(ro, "stable123", 5, 8), subsetGateRS(ro, "canary456", 10, 10))
+		shouldDelay, rsName := r.shouldDelayDestinationRuleUpdate(destinationRuleWithSubsetLabels("", ""), "canary456", "stable123")
+		assert.False(t, shouldDelay)
+		assert.Empty(t, rsName)
+	})
+}
+
+// TestShouldDelayDestinationRuleUpdateReplicaProgressThreshold verifies the subset switch honors
+// spec.strategy.canary.replicaProgressThreshold, as AtDesiredReplicaCountsForCanary,
+// checkReplicasAvailable and shouldFullPromote already do.
+func TestShouldDelayDestinationRuleUpdateReplicaProgressThreshold(t *testing.T) {
+	percent90 := &v1alpha1.ReplicaProgressThreshold{Type: v1alpha1.ProgressTypePercentage, Value: 90}
+	pods5 := &v1alpha1.ReplicaProgressThreshold{Type: v1alpha1.ProgressTypePods, Value: 5}
+	pods0 := &v1alpha1.ReplicaProgressThreshold{Type: v1alpha1.ProgressTypePods, Value: 0}
+	percent0 := &v1alpha1.ReplicaProgressThreshold{Type: v1alpha1.ProgressTypePercentage, Value: 0}
+
+	testCases := []struct {
+		name            string
+		threshold       *v1alpha1.ReplicaProgressThreshold
+		canaryAvailable int32
+		expectDelay     bool
+	}{
+		{"no threshold requires all replicas", nil, 9, true},
+		{"no threshold passes at all replicas", nil, 10, false},
+		{"percent threshold met", percent90, 9, false},
+		{"percent threshold not met", percent90, 8, true},
+		{"pods threshold met", pods5, 5, false},
+		{"pods threshold not met", pods5, 4, true},
+		// The CRD sets no minimum on the threshold value, so a zero threshold must not relabel a
+		// subset onto a ReplicaSet with nothing available - that is the #2507 downtime.
+		{"zero pods threshold still requires an available replica", pods0, 0, true},
+		{"zero pods threshold passes with one available replica", pods0, 1, false},
+		{"zero percent threshold still requires an available replica", percent0, 0, true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ro := subsetGateRollout(tc.threshold)
+			r := NewReconciler(ro, testutil.NewFakeDynamicClient(), record.NewFakeEventRecorder(), nil, nil, []*appsv1.ReplicaSet{
+				subsetGateRS(ro, "stable123", 10, 10),
+				subsetGateRS(ro, "canary456", 10, tc.canaryAvailable),
+			})
+
+			shouldDelay, rsName := r.shouldDelayDestinationRuleUpdate(destinationRuleWithSubsetLabels("", "stable123"), "canary456", "stable123")
+			assert.Equal(t, tc.expectDelay, shouldDelay)
+			if tc.expectDelay {
+				assert.Equal(t, "rs-canary456", rsName)
+			} else {
+				assert.Empty(t, rsName)
+			}
+		})
+	}
+}
+
+// TestUpdateHashUnchangedSubsetsWithPartiallyAvailableCanary verifies that once the DestinationRule
+// already points at the canary and stable ReplicaSets, UpdateHash no longer errors - and therefore
+// no longer blocks SetWeight - while the canary is scaling up between setWeight steps.
+func TestUpdateHashUnchangedSubsetsWithPartiallyAvailableCanary(t *testing.T) {
+	ro := subsetGateRollout(nil)
+	client := testutil.NewFakeDynamicClient(destinationRuleUnstructuredWithSubsetLabels("abc123", "def456"))
+	vsvcLister, druleLister := getIstioListers(client)
+	r := NewReconciler(ro, client, record.NewFakeEventRecorder(), vsvcLister, druleLister, []*appsv1.ReplicaSet{
+		subsetGateRS(ro, "def456", 10, 10),
+		subsetGateRS(ro, "abc123", 10, 2),
+	})
+	client.ClearActions()
+
+	err := r.UpdateHash("abc123", "def456")
+	assert.NoError(t, err)
+	assert.Len(t, client.Actions(), 0, "DestinationRule already has both hashes, so nothing should be written")
+}
+
+// TestUpdateHashThresholdMetSwitchesSubset verifies the canary subset is relabeled as soon as the
+// new ReplicaSet meets the configured threshold, rather than at 100% availability.
+func TestUpdateHashThresholdMetSwitchesSubset(t *testing.T) {
+	ro := subsetGateRollout(&v1alpha1.ReplicaProgressThreshold{Type: v1alpha1.ProgressTypePercentage, Value: 80})
+	client := testutil.NewFakeDynamicClient(destinationRuleUnstructuredWithSubsetLabels("old999", "def456"))
+	vsvcLister, druleLister := getIstioListers(client)
+	r := NewReconciler(ro, client, record.NewFakeEventRecorder(), vsvcLister, druleLister, []*appsv1.ReplicaSet{
+		subsetGateRS(ro, "def456", 10, 10),
+		subsetGateRS(ro, "abc123", 10, 8),
+	})
+	client.ClearActions()
+
+	err := r.UpdateHash("abc123", "def456")
+	assert.NoError(t, err)
+	actions := client.Actions()
+	assert.Len(t, actions, 1)
+	assert.Equal(t, "update", actions[0].GetVerb())
+}
+
+// TestUpdateHashNoDestinationRuleKeepsAvailabilityGate verifies the gate is unchanged for rollouts
+// with no DestinationRule and no canary/stable Services (e.g. ping-pong), where there are no
+// subsets to diff.
+func TestUpdateHashNoDestinationRuleKeepsAvailabilityGate(t *testing.T) {
+	ro := subsetGateRollout(nil)
+	ro.Spec.Strategy.Canary.TrafficRouting.Istio.DestinationRule = nil
+	client := testutil.NewFakeDynamicClient()
+
+	r := NewReconciler(ro, client, record.NewFakeEventRecorder(), nil, nil, []*appsv1.ReplicaSet{subsetGateRS(ro, "def456", 10, 10), subsetGateRS(ro, "abc123", 10, 2)})
+	err := r.UpdateHash("abc123", "def456")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "delaying destination rule switch")
+
+	r = NewReconciler(ro, client, record.NewFakeEventRecorder(), nil, nil, []*appsv1.ReplicaSet{subsetGateRS(ro, "def456", 10, 10), subsetGateRS(ro, "abc123", 10, 10)})
+	assert.NoError(t, r.UpdateHash("abc123", "def456"))
+	assert.Len(t, client.Actions(), 0)
 }
 
 func TestUpdateHashInvalidDestinationRule(t *testing.T) {

--- a/rollout/trafficrouting_test.go
+++ b/rollout/trafficrouting_test.go
@@ -2294,3 +2294,185 @@ func TestDynamicStableScaleNewCanarySupersedeShouldNotOverloadStable(t *testing.
 			"checkReplicasAvailable should return early. Calls observed: %v", setWeightCalls)
 	f.fakeTrafficRouting.AssertNotCalled(t, "UpdateHash", mock.Anything, mock.Anything, mock.Anything)
 }
+
+// istioSubsetFixtures returns a VirtualService and a DestinationRule for subset-level Istio
+// routing, with the DestinationRule subsets already labeled with the given hashes.
+func istioSubsetFixtures(canaryHash, stableHash string, canaryWeight, stableWeight int32) (*unstructured.Unstructured, *unstructured.Unstructured) {
+	vsvc := unstructuredutil.StrToUnstructuredUnsafe(fmt.Sprintf(`
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: foo-vsvc
+  namespace: default
+spec:
+  hosts:
+  - foo
+  http:
+  - route:
+    - destination:
+        host: foo
+        subset: stable
+      weight: %d
+    - destination:
+        host: foo
+        subset: canary
+      weight: %d
+`, stableWeight, canaryWeight))
+	dRule := unstructuredutil.StrToUnstructuredUnsafe(fmt.Sprintf(`
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: foo-dr
+  namespace: default
+  annotations:
+    %s: foo
+spec:
+  host: foo
+  subsets:
+  - name: stable
+    labels:
+      %s: %s
+  - name: canary
+    labels:
+      %s: %s
+`, v1alpha1.ManagedByRolloutsKey,
+		v1alpha1.DefaultRolloutUniqueLabelKey, stableHash,
+		v1alpha1.DefaultRolloutUniqueLabelKey, canaryHash))
+	return vsvc, dRule
+}
+
+// withIstioSubsetRouting configures ro for subset-level Istio routing with no canary/stable
+// Services, which is the only configuration where the DestinationRule subset gate applies.
+func withIstioSubsetRouting(ro *v1alpha1.Rollout) {
+	ro.Spec.Strategy.Canary.CanaryService = ""
+	ro.Spec.Strategy.Canary.StableService = ""
+	ro.Spec.Strategy.Canary.TrafficRouting = &v1alpha1.RolloutTrafficRouting{
+		Istio: &v1alpha1.IstioTrafficRouting{
+			VirtualService: &v1alpha1.IstioVirtualService{Name: "foo-vsvc"},
+			DestinationRule: &v1alpha1.IstioDestinationRule{
+				Name:             "foo-dr",
+				CanarySubsetName: "canary",
+				StableSubsetName: "stable",
+			},
+		},
+	}
+}
+
+// TestSetWeightProceedsWhenStableIsDegraded reproduces #4839 through the controller: with Istio
+// DestinationRule subset routing and no canary/stable Services, a degraded stable ReplicaSet used
+// to block every setWeight step, because UpdateHash required both the canary and stable
+// ReplicaSets to be 100% available and its error aborted the reconcile before SetWeight and before
+// the status was persisted. The stable subset is already labeled here, so no relabel is pending and
+// nothing about the stable ReplicaSet should gate the step. No replicaProgressThreshold is
+// configured, so only the changed subset scoping can make this pass.
+func TestSetWeightProceedsWhenStableIsDegraded(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+	f.fakeTrafficRouting = nil // use the real Istio reconciler so the subset gate runs
+
+	steps := []v1alpha1.CanaryStep{
+		{SetWeight: ptr.To[int32](10)},
+		{Pause: &v1alpha1.RolloutPause{}},
+		{SetWeight: ptr.To[int32](50)},
+	}
+	r1 := newCanaryRollout("foo", 10, nil, steps, ptr.To[int32](2), intstr.FromInt(1), intstr.FromInt(0))
+	r2 := bumpVersion(r1)
+	withIstioSubsetRouting(r2)
+
+	rs1 := newReplicaSetWithStatus(r1, 10, 7) // degraded stable: 3 pods crashlooping
+	rs2 := newReplicaSetWithStatus(r2, 5, 5)  // healthy canary
+	stableHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	canaryHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+
+	r2 = updateCanaryRolloutStatus(r2, stableHash, 12, 5, 15, false)
+	r2.Status.CurrentPodHash = canaryHash
+	r2.Status.Canary.Weights = &v1alpha1.TrafficWeights{
+		Canary: v1alpha1.WeightDestination{Weight: 10, PodTemplateHash: canaryHash},
+		Stable: v1alpha1.WeightDestination{Weight: 90, PodTemplateHash: stableHash},
+	}
+
+	fooVsvc, fooDR := istioSubsetFixtures(canaryHash, stableHash, 10, 90)
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2)
+	f.dynamicOnlyObjects = append(f.dynamicOnlyObjects, fooVsvc, fooDR)
+	f.virtualServiceLister = append(f.virtualServiceLister, fooVsvc)
+
+	f.expectPatchRolloutAction(r2)
+
+	prevLog := log.StandardLogger().Out
+	defer log.SetOutput(prevLog)
+	logBuf := bytes.NewBuffer(nil)
+	log.SetOutput(logBuf)
+
+	f.run(getKey(r2, t))
+
+	logOut := logBuf.String()
+	assert.False(t, strings.Contains(logOut, "delaying destination rule switch"),
+		"a degraded stable ReplicaSet must not delay a step that relabels no subset; log: %s", logOut)
+	assert.True(t, strings.Contains(logOut, "desiredWeight '50'"),
+		"expected setWeight step to proceed to 50; log: %s", logOut)
+	assert.True(t, strings.Contains(strings.Join(f.events, " "), conditions.RolloutStepCompletedReason),
+		"expected setWeight step to complete; events: %v", f.events)
+}
+
+// TestSetWeightHonorsReplicaProgressThresholdAtScale is the large-replica-count case this gate
+// matters most for: with 190 replicas and replicaProgressThreshold 95%, a setWeight step must
+// advance once 91 of the canary's 95 desired pods are available (95.8%), instead of waiting for
+// the last few stragglers as every other canary gate already allows.
+func TestSetWeightHonorsReplicaProgressThresholdAtScale(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+	f.fakeTrafficRouting = nil // use the real Istio reconciler so the subset gate runs
+
+	steps := []v1alpha1.CanaryStep{
+		{SetWeight: ptr.To[int32](10)},
+		{Pause: &v1alpha1.RolloutPause{}},
+		{SetWeight: ptr.To[int32](50)},
+	}
+	r1 := newCanaryRollout("foo", 190, nil, steps, ptr.To[int32](2), intstr.FromInt(1), intstr.FromInt(0))
+	r2 := bumpVersion(r1)
+	withIstioSubsetRouting(r2)
+	r2.Spec.Strategy.Canary.ReplicaProgressThreshold = &v1alpha1.ReplicaProgressThreshold{
+		Type:  v1alpha1.ProgressTypePercentage,
+		Value: 95,
+	}
+
+	rs1 := newReplicaSetWithStatus(r1, 190, 190)
+	rs2 := newReplicaSetWithStatus(r2, 95, 91) // 4 stragglers out of 95: 95.8% >= 95%
+	stableHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	canaryHash := rs2.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+
+	r2 = updateCanaryRolloutStatus(r2, stableHash, 281, 95, 285, false)
+	r2.Status.CurrentPodHash = canaryHash
+	r2.Status.Canary.Weights = &v1alpha1.TrafficWeights{
+		Canary: v1alpha1.WeightDestination{Weight: 10, PodTemplateHash: canaryHash},
+		Stable: v1alpha1.WeightDestination{Weight: 90, PodTemplateHash: stableHash},
+	}
+
+	fooVsvc, fooDR := istioSubsetFixtures(canaryHash, stableHash, 10, 90)
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2)
+	f.dynamicOnlyObjects = append(f.dynamicOnlyObjects, fooVsvc, fooDR)
+	f.virtualServiceLister = append(f.virtualServiceLister, fooVsvc)
+
+	f.expectPatchRolloutAction(r2)
+
+	prevLog := log.StandardLogger().Out
+	defer log.SetOutput(prevLog)
+	logBuf := bytes.NewBuffer(nil)
+	log.SetOutput(logBuf)
+
+	f.run(getKey(r2, t))
+
+	logOut := logBuf.String()
+	assert.False(t, strings.Contains(logOut, "delaying destination rule switch"),
+		"a canary meeting replicaProgressThreshold must not delay the setWeight step; log: %s", logOut)
+	assert.True(t, strings.Contains(logOut, "desiredWeight '50'"),
+		"expected setWeight step to proceed to 50 at 91/95 available; log: %s", logOut)
+	assert.True(t, strings.Contains(strings.Join(f.events, " "), conditions.RolloutStepCompletedReason),
+		"expected setWeight step to complete; events: %v", f.events)
+}


### PR DESCRIPTION
## Problem

`spec.strategy.canary.replicaProgressThreshold` is not honored when Istio **DestinationRule subset** routing is used without `canaryService`/`stableService`.

`AtDesiredReplicaCountsForCanary`, `checkReplicasAvailable` and `shouldFullPromote` all consult the threshold. `shouldDelayDestinationRuleUpdate` (added in #3602 for #2507, made blocking in #4612) does not — it requires 100% availability of every ReplicaSet carrying the canary or stable hash. Since `reconcileTrafficRouting` runs `UpdateHash` before `SetWeight` on every reconcile, and its error aborts the reconcile before the weight is applied and before the status is persisted, that gate overrides the threshold on every `setWeight` step — including steps where the subsets already carry both hashes and the update would be a no-op.

Result: a single slow or unschedulable pod stalls every weight step (a ~190-replica rollout takes 13–17 min instead of a few), and a degraded **stable** ReplicaSet wedges the rollout indefinitely (#4839) even though its subset needs no change.

## Fix

The gate protects a subset **relabel**, which can only happen when a subset's label actually changes. So pass the live `*DestinationRule` (already fetched in `UpdateHash`) to the gate, check only the hashes a subset is about to switch **to**, and let those pass at `replicaProgressThreshold` rather than at 100% availability — with a floor of one available replica, since the CRD sets no minimum on the threshold and a zero value would otherwise relabel a subset onto a ReplicaSet serving nothing (#2507).

A subset already carrying its target hash is skipped: relabeling it is a no-op, and traffic shifts to it are gated by `AtDesiredReplicaCountsForCanary`. Every relabel is still gated, so #4612's DestinationRule-before-SetWeight ordering holds on rollback (`TestRollbackDestinationRuleBeforeSetWeight` passes unchanged). Rollouts with no `destinationRule` (e.g. ping-pong) have no subsets to diff and keep their existing gate.

**Scope of the #4839 fix:** the reported scenario (stable degrades mid-rollout, subset already labeled) is fixed. On a first-ever rollout both subsets are unlabeled, so a degraded stable still gates the initial relabel — intentionally, since narrowing an unlabeled subset onto zero available pods is the #2507 outage. It now clears at the configured threshold instead of requiring 100%.

## Tests

* `istio_test.go`: changing-subset semantics (partially available canary / degraded stable with unchanged labels → no delay; relabel onto an unavailable RS → delay; promotion; unlabeled and `nil` DestinationRule; scale-down; abort not blocked by the canary it is aborting away from), a `replicaProgressThreshold` matrix including the zero-threshold cases, and `UpdateHash` end-to-end.
* `trafficrouting_test.go`, one controller-level test per half of the fix: `TestSetWeightProceedsWhenStableIsDegraded` (#4839, no threshold configured, so only the changed-subset scoping can make it pass) and `TestSetWeightHonorsReplicaProgressThresholdAtScale` (190 replicas, `Percent: 95`, canary at 91/95). **Both fail on master and pass with this change.**

Each behavior above was mutation-checked: neutralizing the changed-subset scoping, the `> 0` floor, the `IsReplicaSetAvailable` branch or the abort skip individually makes the suite fail.

Docs: one paragraph in `docs/features/traffic-management/istio.md` on when the subset switch is delayed.

Fixes #4839 · Supersedes #4990 · Related: #2507, #3602, #4612, #4775, #4823

## Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green. Try syncing with master if they are not.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
