### PR TITLE
chore: sync OWNERS for membership Sep 2026

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,15 +4,16 @@ owners:
 - zachaller
 
 approvers:
+- agaudreault
 - alexmt
-- huikang
 - jessesuen
-- khhirani
+- kostis-codefresh
 - leoluz
+- zachaller
 
 reviewers:
+- Hariharasuthan99
 - agrawroh
-- dthomson25
-- harikrongali
-- kostis-codefresh
-- perenesenko
+- jmeridth
+- mkilchhofer
+- yu-croco


### PR DESCRIPTION
Sync `OWNERS` with the Sep 2026 membership round.

- https://github.com/argoproj/argoproj/pull/471
- https://github.com/argoproj/argoproj/blob/main/MAINTAINERS.md

Adds `agaudreault` and `kostis-codefresh` as approvers, `Hariharasuthan99` as reviewer, and removes alumni/inactive entries.

Made with [Cursor](https://cursor.com)