### PR TITLE
fix(controller): honor scaling events while the rollout is paused by the user. Fixes #4261

### DIFF
--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -414,11 +414,21 @@ func (c *rolloutContext) syncRolloutStatusCanary() error {
 	return c.persistRolloutStatus(&newStatus)
 }
 
+// reconcileCanaryReplicaSets reconciles the stable, new and old ReplicaSets as part of a canary
+// update, unless progress has been halted (see haltProgress).
 func (c *rolloutContext) reconcileCanaryReplicaSets() (bool, error) {
 	if haltReason := c.haltProgress(); haltReason != "" {
 		c.log.Infof("Skipping canary/stable ReplicaSet reconciliation: %s", haltReason)
 		return false, nil
 	}
+	return c.scaleCanaryReplicaSets()
+}
+
+// scaleCanaryReplicaSets adjusts the replica counts of the stable, new and old ReplicaSets to
+// match spec.replicas and the current canary step. It does not consult haltProgress: a scaling
+// event (e.g. spec.replicas changed by a user or an HPA) does not advance the update, so it must
+// be applied even while the rollout is paused by the user or by an inconclusive analysis.
+func (c *rolloutContext) scaleCanaryReplicaSets() (bool, error) {
 	err := c.removeScaleDownDeadlines()
 	if err != nil {
 		return false, err

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -1811,6 +1811,106 @@ func TestCanaryRolloutScaleWhilePaused(t *testing.T) {
 	assert.JSONEq(t, expectedPatch, patch)
 }
 
+// TestCanaryRolloutScaleWhileUserPaused verifies that a scaling event in the middle of an update
+// is honored while the rollout is paused by the user (spec.paused), keeping the canary step ratio.
+func TestCanaryRolloutScaleWhileUserPaused(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{
+		{
+			SetWeight: ptr.To[int32](20),
+		},
+	}
+	r1 := newCanaryRollout("foo", 5, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(0))
+	r2 := bumpVersion(r1)
+
+	rs1 := newReplicaSetWithStatus(r1, 5, 5)
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	rs2 := newReplicaSetWithStatus(r2, 0, 0)
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+
+	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 5, 0, 5, true)
+	r2.Spec.Paused = true
+	r2.Spec.Replicas = ptr.To[int32](10)
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, rs2, "")
+	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
+
+	pausedCondition, _ := newPausedCondition(true)
+	conditions.SetRolloutCondition(&r2.Status, pausedCondition)
+
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2)
+
+	updatedIndex := f.expectUpdateReplicaSetAction(rs1)
+	patchIndex := f.expectPatchRolloutAction(r2)
+	f.run(getKey(r2, t))
+
+	updatedRS := f.getUpdatedReplicaSet(updatedIndex)
+	assert.Equal(t, int32(8), *updatedRS.Spec.Replicas)
+
+	patch := f.getPatchedRolloutWithoutConditions(patchIndex)
+	expectedPatch := `{
+		"status": {
+			"message": "manually paused",
+			"duration": {
+				"manualPauseStartedAt": "%s"
+			}
+		}
+	}`
+	now := timeutil.MetaNow().UTC().Format(time.RFC3339)
+	expectedPatch = fmt.Sprintf(expectedPatch, now)
+	assert.JSONEq(t, calculatePatch(r2, expectedPatch), patch)
+}
+
+// TestCanaryRolloutScaleFullyPromotedWhileUserPaused verifies that a fully promoted rollout that
+// is paused by the user (spec.paused) still scales its ReplicaSet when spec.replicas changes,
+// e.g. when an HPA scales it.
+func TestCanaryRolloutScaleFullyPromotedWhileUserPaused(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	steps := []v1alpha1.CanaryStep{
+		{
+			SetWeight: ptr.To[int32](20),
+		},
+	}
+	r1 := newCanaryRollout("foo", 5, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
+	rs1 := newReplicaSetWithStatus(r1, 5, 5)
+	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
+	f.kubeobjects = append(f.kubeobjects, rs1)
+	f.replicaSetLister = append(f.replicaSetLister, rs1)
+
+	r1.Spec.Paused = true
+	r1 = updateCanaryRolloutStatus(r1, rs1PodHash, 5, 5, 5, false)
+	r1.Spec.Replicas = ptr.To[int32](8)
+	pausedCondition, _ := newPausedCondition(true)
+	conditions.SetRolloutCondition(&r1.Status, pausedCondition)
+
+	f.rolloutLister = append(f.rolloutLister, r1)
+	f.objects = append(f.objects, r1)
+
+	updatedIndex := f.expectUpdateReplicaSetAction(rs1)
+	patchIndex := f.expectPatchRolloutAction(r1)
+	f.run(getKey(r1, t))
+
+	updatedRS := f.getUpdatedReplicaSet(updatedIndex)
+	assert.Equal(t, int32(8), *updatedRS.Spec.Replicas)
+
+	patch := f.getPatchedRolloutWithoutConditions(patchIndex)
+	expectedPatch := `{
+		"status": {
+			"duration": {
+				"manualPauseStartedAt": "%s"
+			}
+		}
+	}`
+	now := timeutil.MetaNow().UTC().Format(time.RFC3339)
+	expectedPatch = fmt.Sprintf(expectedPatch, now)
+	assert.JSONEq(t, calculatePatch(r1, expectedPatch), patch)
+}
+
 func TestResumeRolloutAfterPauseDuration(t *testing.T) {
 	f := newFixture(t)
 	defer f.Close()

--- a/rollout/canary_test.go
+++ b/rollout/canary_test.go
@@ -2,10 +2,14 @@ package rollout
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	core "k8s.io/client-go/testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -1811,57 +1815,73 @@ func TestCanaryRolloutScaleWhilePaused(t *testing.T) {
 	assert.JSONEq(t, expectedPatch, patch)
 }
 
+// newUserPausedRolloutMidUpdate returns a canary rollout in the middle of an update (5 stable
+// pods, 0 canary pods at a 20% step) that the user paused with spec.paused and then scaled
+// from 5 to 10 replicas, together with the stable ReplicaSet.
+func newUserPausedRolloutMidUpdate(f *fixture) (*v1alpha1.Rollout, *appsv1.ReplicaSet) {
+	steps := []v1alpha1.CanaryStep{{SetWeight: ptr.To[int32](20)}}
+	r1 := newCanaryRollout("foo", 5, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(0))
+	r2 := bumpVersion(r1)
+	rs1 := newReplicaSetWithStatus(r1, 5, 5)
+	rs2 := newReplicaSetWithStatus(r2, 0, 0)
+	f.kubeobjects = append(f.kubeobjects, rs1, rs2)
+	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
+
+	r2 = updateCanaryRolloutStatus(r2, rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey], 5, 0, 5, true)
+	r2.Spec.Paused = true
+	r2.Spec.Replicas = ptr.To[int32](10)
+	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, rs2, "")
+	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
+	pausedCondition, _ := newPausedCondition(true)
+	conditions.SetRolloutCondition(&r2.Status, pausedCondition)
+	f.rolloutLister = append(f.rolloutLister, r2)
+	f.objects = append(f.objects, r2)
+	return r2, rs1
+}
+
+// newUserPausedRolloutFullyPromoted returns a fully promoted canary rollout (5 replicas) that the
+// user paused with spec.paused and then scaled from 5 to 8 replicas, together with its ReplicaSet.
+func newUserPausedRolloutFullyPromoted(f *fixture) (*v1alpha1.Rollout, *appsv1.ReplicaSet) {
+	steps := []v1alpha1.CanaryStep{{SetWeight: ptr.To[int32](20)}}
+	r1 := newCanaryRollout("foo", 5, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
+	rs1 := newReplicaSetWithStatus(r1, 5, 5)
+	f.kubeobjects = append(f.kubeobjects, rs1)
+	f.replicaSetLister = append(f.replicaSetLister, rs1)
+
+	r1.Spec.Paused = true
+	r1 = updateCanaryRolloutStatus(r1, rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey], 5, 5, 5, false)
+	r1.Spec.Replicas = ptr.To[int32](8)
+	pausedCondition, _ := newPausedCondition(true)
+	conditions.SetRolloutCondition(&r1.Status, pausedCondition)
+	f.rolloutLister = append(f.rolloutLister, r1)
+	f.objects = append(f.objects, r1)
+	return r1, rs1
+}
+
+// manualPausePatch returns the status patch expected after reconciling a user-paused rollout:
+// the manual pause start time, plus the "manually paused" message when it was not set before.
+func manualPausePatch(r *v1alpha1.Rollout, withMessage bool) string {
+	now := timeutil.MetaNow().UTC().Format(time.RFC3339)
+	patch := `{"status": {"duration": {"manualPauseStartedAt": "%s"}}}`
+	if withMessage {
+		patch = `{"status": {"message": "manually paused", "duration": {"manualPauseStartedAt": "%s"}}}`
+	}
+	return calculatePatch(r, fmt.Sprintf(patch, now))
+}
+
 // TestCanaryRolloutScaleWhileUserPaused verifies that a scaling event in the middle of an update
 // is honored while the rollout is paused by the user (spec.paused), keeping the canary step ratio.
 func TestCanaryRolloutScaleWhileUserPaused(t *testing.T) {
 	f := newFixture(t)
 	defer f.Close()
+	r, rs := newUserPausedRolloutMidUpdate(f)
 
-	steps := []v1alpha1.CanaryStep{
-		{
-			SetWeight: ptr.To[int32](20),
-		},
-	}
-	r1 := newCanaryRollout("foo", 5, nil, steps, ptr.To[int32](0), intstr.FromInt(1), intstr.FromInt(0))
-	r2 := bumpVersion(r1)
+	updatedIndex := f.expectUpdateReplicaSetAction(rs)
+	patchIndex := f.expectPatchRolloutAction(r)
+	f.run(getKey(r, t))
 
-	rs1 := newReplicaSetWithStatus(r1, 5, 5)
-	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
-	rs2 := newReplicaSetWithStatus(r2, 0, 0)
-	f.kubeobjects = append(f.kubeobjects, rs1, rs2)
-	f.replicaSetLister = append(f.replicaSetLister, rs1, rs2)
-
-	r2 = updateCanaryRolloutStatus(r2, rs1PodHash, 5, 0, 5, true)
-	r2.Spec.Paused = true
-	r2.Spec.Replicas = ptr.To[int32](10)
-	progressingCondition, _ := newProgressingCondition(conditions.RolloutPausedReason, rs2, "")
-	conditions.SetRolloutCondition(&r2.Status, progressingCondition)
-
-	pausedCondition, _ := newPausedCondition(true)
-	conditions.SetRolloutCondition(&r2.Status, pausedCondition)
-
-	f.rolloutLister = append(f.rolloutLister, r2)
-	f.objects = append(f.objects, r2)
-
-	updatedIndex := f.expectUpdateReplicaSetAction(rs1)
-	patchIndex := f.expectPatchRolloutAction(r2)
-	f.run(getKey(r2, t))
-
-	updatedRS := f.getUpdatedReplicaSet(updatedIndex)
-	assert.Equal(t, int32(8), *updatedRS.Spec.Replicas)
-
-	patch := f.getPatchedRolloutWithoutConditions(patchIndex)
-	expectedPatch := `{
-		"status": {
-			"message": "manually paused",
-			"duration": {
-				"manualPauseStartedAt": "%s"
-			}
-		}
-	}`
-	now := timeutil.MetaNow().UTC().Format(time.RFC3339)
-	expectedPatch = fmt.Sprintf(expectedPatch, now)
-	assert.JSONEq(t, calculatePatch(r2, expectedPatch), patch)
+	assert.Equal(t, int32(8), *f.getUpdatedReplicaSet(updatedIndex).Spec.Replicas)
+	assert.JSONEq(t, manualPausePatch(r, true), f.getPatchedRolloutWithoutConditions(patchIndex))
 }
 
 // TestCanaryRolloutScaleFullyPromotedWhileUserPaused verifies that a fully promoted rollout that
@@ -1870,45 +1890,29 @@ func TestCanaryRolloutScaleWhileUserPaused(t *testing.T) {
 func TestCanaryRolloutScaleFullyPromotedWhileUserPaused(t *testing.T) {
 	f := newFixture(t)
 	defer f.Close()
+	r, rs := newUserPausedRolloutFullyPromoted(f)
 
-	steps := []v1alpha1.CanaryStep{
-		{
-			SetWeight: ptr.To[int32](20),
-		},
-	}
-	r1 := newCanaryRollout("foo", 5, nil, steps, ptr.To[int32](1), intstr.FromInt(1), intstr.FromInt(0))
-	rs1 := newReplicaSetWithStatus(r1, 5, 5)
-	rs1PodHash := rs1.Labels[v1alpha1.DefaultRolloutUniqueLabelKey]
-	f.kubeobjects = append(f.kubeobjects, rs1)
-	f.replicaSetLister = append(f.replicaSetLister, rs1)
+	updatedIndex := f.expectUpdateReplicaSetAction(rs)
+	patchIndex := f.expectPatchRolloutAction(r)
+	f.run(getKey(r, t))
 
-	r1.Spec.Paused = true
-	r1 = updateCanaryRolloutStatus(r1, rs1PodHash, 5, 5, 5, false)
-	r1.Spec.Replicas = ptr.To[int32](8)
-	pausedCondition, _ := newPausedCondition(true)
-	conditions.SetRolloutCondition(&r1.Status, pausedCondition)
+	assert.Equal(t, int32(8), *f.getUpdatedReplicaSet(updatedIndex).Spec.Replicas)
+	assert.JSONEq(t, manualPausePatch(r, false), f.getPatchedRolloutWithoutConditions(patchIndex))
+}
 
-	f.rolloutLister = append(f.rolloutLister, r1)
-	f.objects = append(f.objects, r1)
+// TestCanaryRolloutScaleWhileUserPausedReturnsScalingError verifies that a failure to scale
+// during a scaling event on a user-paused rollout is surfaced so the rollout is requeued.
+func TestCanaryRolloutScaleWhileUserPausedReturnsScalingError(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+	r, rs := newUserPausedRolloutFullyPromoted(f)
 
-	updatedIndex := f.expectUpdateReplicaSetAction(rs1)
-	patchIndex := f.expectPatchRolloutAction(r1)
-	f.run(getKey(r1, t))
-
-	updatedRS := f.getUpdatedReplicaSet(updatedIndex)
-	assert.Equal(t, int32(8), *updatedRS.Spec.Replicas)
-
-	patch := f.getPatchedRolloutWithoutConditions(patchIndex)
-	expectedPatch := `{
-		"status": {
-			"duration": {
-				"manualPauseStartedAt": "%s"
-			}
-		}
-	}`
-	now := timeutil.MetaNow().UTC().Format(time.RFC3339)
-	expectedPatch = fmt.Sprintf(expectedPatch, now)
-	assert.JSONEq(t, calculatePatch(r1, expectedPatch), patch)
+	c, i, k8sI := f.newController(noResyncPeriodFunc)
+	f.kubeclient.PrependReactor("update", "replicasets", func(action core.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("replicaset update failed")
+	})
+	f.expectUpdateReplicaSetAction(rs)
+	f.runController(getKey(r, t), true, true, c, i, k8sI)
 }
 
 func TestResumeRolloutAfterPauseDuration(t *testing.T) {

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -300,13 +300,14 @@ func (c *rolloutContext) syncReplicasOnly() error {
 			newStatus.AvailableReplicas = replicasetutil.GetAvailableReplicaCountForReplicaSets(c.allRSs)
 		}
 	}
-	// The controller wants to use the rolloutCanary method to reconcile the rollout if the rollout is not paused.
-	// If there are no scaling events, the rollout should only sync its status
+	// Scale the ReplicaSets directly, bypassing the haltProgress check in reconcileCanaryReplicaSets:
+	// a scaling event must be honored even while the rollout is paused by the user (spec.paused),
+	// otherwise the rollout never reaches the new spec.replicas until it is resumed.
 	if c.rollout.Spec.Strategy.Canary != nil {
-		if _, err := c.reconcileCanaryReplicaSets(); err != nil {
+		if _, err := c.scaleCanaryReplicaSets(); err != nil {
 			// If we get an error while trying to scale, the rollout will be requeued
 			// so we can abort this resync
-			return fmt.Errorf("failed to reconcileCanaryReplicaSets in syncReplicasOnly: %w", err)
+			return fmt.Errorf("failed to scaleCanaryReplicaSets in syncReplicasOnly: %w", err)
 		}
 		newStatus.AvailableReplicas = replicasetutil.GetAvailableReplicaCountForReplicaSets(c.allRSs)
 		newStatus.HPAReplicas = replicasetutil.GetActualReplicaCountForReplicaSets(c.allRSs)

--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -116,6 +116,31 @@ func (s *CanarySuite) TestRolloutScalingWhenPaused() {
 		ExpectCanaryStablePodCount(1, 3)
 }
 
+// TestRolloutScalingWhenUserPaused verifies that a rollout paused by the user (spec.paused) still
+// honors changes to spec.replicas, for example from an HPA
+func (s *CanarySuite) TestRolloutScalingWhenUserPaused() {
+	s.Given().
+		RolloutObjects(`@functional/rollout-basic.yaml`).
+		When().
+		ApplyManifests().
+		WaitForRolloutStatus("Healthy").
+		PatchSpec(`
+spec:
+  paused: true`).
+		WaitForRolloutStatus("Paused").
+		ScaleRollout(4).
+		WaitForRolloutAvailableReplicas(4).
+		Then().
+		ExpectRevisionPodCount("1", 4).
+		ExpectRolloutStatus("Paused").
+		When().
+		ScaleRollout(2).
+		WaitForRolloutAvailableReplicas(2).
+		Then().
+		ExpectRevisionPodCount("1", 2).
+		ExpectRolloutStatus("Paused")
+}
+
 // TestRolloutWithMaxSurgeScalingDuringUpdate verifies behavior when scaling a rollout up/down in middle of update and with maxSurge 100%
 func (s *CanarySuite) TestRolloutWithMaxSurgeScalingDuringUpdate() {
 	s.Given().


### PR DESCRIPTION
## Summary

- honor `spec.replicas` changes (manual or from an HPA) while a canary rollout is paused with `spec.paused: true`
- split the ReplicaSet scaling out of `reconcileCanaryReplicaSets()` into `scaleCanaryReplicaSets()`, which does not consult `haltProgress()`, and call it from `syncReplicasOnly()`
- add two unit tests (mid-update and fully promoted) and one e2e test that scale a user-paused rollout up and down

Fixes #4261

## Problem

With `spec.paused: true`, editing `spec.replicas` on a canary rollout does nothing until the rollout is resumed. The controller logs show the scaling event being detected and then skipped:

```
msg="Syncing replicas only due to scaling event"
msg="Skipping canary/stable ReplicaSet reconciliation: user paused"
```

The same applies to an HPA targeting the rollout, which contradicts the HPA support documented for paused rollouts. Blue-green rollouts are not affected.

## Root cause

`reconcile()` short-circuits to `syncReplicasOnly()` when `isScalingEvent()` is true. For canary, `syncReplicasOnly()` called `reconcileCanaryReplicaSets()`, whose first statement is the `haltProgress()` gate (`spec.paused` or inconclusive analysis), so nothing was scaled. `reconcileBlueGreenReplicaSets()` has no such gate, which is why blue-green scales while paused.

The gate was introduced inside `reconcileCanaryReplicaSets()` by #1699 while refactoring `syncReplicasOnly()`. Before that change the scaling path did not check `spec.paused`.

## Fix

`scaleCanaryReplicaSets()` now holds the scaling logic and is used by both callers. `reconcileCanaryReplicaSets()` keeps the gate for the normal `rolloutCanary()` path, so a paused rollout still does not progress through its steps. A scaling event only adjusts replica counts to `spec.replicas` at the current step ratio, so applying it while paused does not advance the update.

## Testing

- `TestCanaryRolloutScaleWhileUserPaused` and `TestCanaryRolloutScaleFullyPromotedWhileUserPaused` fail on master (the expected ReplicaSet update never happens) and pass with this change. `TestCanaryRolloutScaleWhileUserPausedReturnsScalingError` covers the error path of the new call in `syncReplicasOnly()`. The `rollout` package passes in full.
- `TestRolloutScalingWhenUserPaused` (e2e) on a kind cluster: with a controller built from master it times out waiting for `status.availableReplicas=4` and the controller log shows the skip message above. With this change it passes, together with `TestRolloutScalingWhenPaused`, `TestCanaryWithPausedRollout` and `TestRolloutScalingDuringUpdate`.
- `go test ./...` passes in full with Go 1.26.1 (the version in `go.mod`). `golangci-lint run ./rollout/...` reports no issues.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] My builds are green. Try syncing with master if they are not. 
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] I have run all tests locally (including the flaky ones) and they pass on my workstation
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY/HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).


