### PR TITLE
docs(notifications): replace ArgoCD .app.* variables with .rollout.* in generated service docs

### DIFF
--- a/docs/generated/notification-services/alertmanager.md
+++ b/docs/generated/notification-services/alertmanager.md
@@ -131,7 +131,7 @@ data:
 
 * `labels` - at least one label pair required, implement different notification strategies according to alertmanager routing
 * `annotations` - optional, specifies a set of information labels, which can be used to store longer additional information, but only for display
-* `generatorURL` - optional, default is '{{.app.spec.source.repoURL}}', backlink used to identify the entity that caused this alert in the client
+* `generatorURL` - optional, default is '{{.rollout.spec.source.repoURL}}', backlink used to identify the entity that caused this alert in the client
 
 the `label` or `annotations` or `generatorURL` values can be templated.
 
@@ -140,7 +140,7 @@ context: |
   argocdUrl: https://example.com/argocd
 
 template.app-deployed: |
-  message: Application {{.app.metadata.name}} has been healthy.
+  message: Application {{.rollout.metadata.name}} has been healthy.
   alertmanager:
     labels:
       fault_priority: "P5"
@@ -148,16 +148,16 @@ template.app-deployed: |
       event_status: "succeed"
       recipient: "{{.recipient}}"
     annotations:
-      application: '<a href="{{.context.argocdUrl}}/applications/{{.app.metadata.name}}">{{.app.metadata.name}}</a>'
-      author: "{{(call .repo.GetCommitMetadata .app.status.sync.revision).Author}}"
-      message: "{{(call .repo.GetCommitMetadata .app.status.sync.revision).Message}}"
+      application: '<a href="{{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}">{{.rollout.metadata.name}}</a>'
+      author: "{{(call .repo.GetCommitMetadata .rollout.status.sync.revision).Author}}"
+      message: "{{(call .repo.GetCommitMetadata .rollout.status.sync.revision).Message}}"
 ```
 
 You can do targeted push on [Alertmanager](https://github.com/prometheus/alertmanager) according to labels.
 
 ```yaml
 template.app-deployed: |
-  message: Application {{.app.metadata.name}} has been healthy.
+  message: Application {{.rollout.metadata.name}} has been healthy.
   alertmanager:
     labels:
       alertname: app-deployed

--- a/docs/generated/notification-services/email.md
+++ b/docs/generated/notification-services/email.md
@@ -69,8 +69,8 @@ metadata:
 data:
   template.app-sync-succeeded: |
     email:
-      subject: Application {{.app.metadata.name}} has been successfully synced.
+      subject: Application {{.rollout.metadata.name}} has been successfully synced.
     message: |
-      {{if eq .serviceType "slack"}}:white_check_mark:{{end}} Application {{.app.metadata.name}} has been successfully synced at {{.app.status.operationState.finishedAt}}.
-      Sync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .
+      {{if eq .serviceType "slack"}}:white_check_mark:{{end}} Application {{.rollout.metadata.name}} has been successfully synced at {{.rollout.status.operationState.finishedAt}}.
+      Sync operation details are available at: {{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}?operation=true .
 ```

--- a/docs/generated/notification-services/github.md
+++ b/docs/generated/notification-services/github.md
@@ -67,41 +67,41 @@ metadata:
 ```yaml
 template.app-deployed: |
   message: |
-    Application {{.app.metadata.name}} is now running new version of deployments manifests.
+    Application {{.rollout.metadata.name}} is now running new version of deployments manifests.
   github:
-    repoURLPath: "{{.app.spec.source.repoURL}}"
-    revisionPath: "{{.app.status.operationState.syncResult.revision}}"
+    repoURLPath: "{{.rollout.spec.source.repoURL}}"
+    revisionPath: "{{.rollout.status.operationState.syncResult.revision}}"
     status:
       state: success
-      label: "continuous-delivery/{{.app.metadata.name}}"
-      targetURL: "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"
+      label: "continuous-delivery/{{.rollout.metadata.name}}"
+      targetURL: "{{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}?operation=true"
     deployment:
       state: success
       environment: production
-      environmentURL: "https://{{.app.metadata.name}}.example.com"
-      logURL: "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"
+      environmentURL: "https://{{.rollout.metadata.name}}.example.com"
+      logURL: "{{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}?operation=true"
       requiredContexts: []
       autoMerge: true
       transientEnvironment: false
       reference: v1.0.0
     pullRequestComment:
       content: |
-        Application {{.app.metadata.name}} is now running new version of deployments manifests.
-        See more here: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true
-      commentTag: "continuous-delivery/{{.app.metadata.name}}"
+        Application {{.rollout.metadata.name}} is now running new version of deployments manifests.
+        See more here: {{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}?operation=true
+      commentTag: "continuous-delivery/{{.rollout.metadata.name}}"
     checkRun:
-      name: "continuous-delivery/{{.app.metadata.name}}"
-      details_url: "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"
+      name: "continuous-delivery/{{.rollout.metadata.name}}"
+      details_url: "{{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}?operation=true"
       status: completed
       conclusion: success
       started_at: "YYYY-MM-DDTHH:MM:SSZ"
       completed_at: "YYYY-MM-DDTHH:MM:SSZ"
       output:
-        title: "Deployment of {{.app.metadata.name}} on ArgoCD"
-        summary: "Application {{.app.metadata.name}} is now running new version of deployments manifests."
+        title: "Deployment of {{.rollout.metadata.name}} on ArgoCD"
+        summary: "Application {{.rollout.metadata.name}} is now running new version of deployments manifests."
         text: |
-          Application {{.app.metadata.name}} is now running new version of deployments manifests.
-          See more here: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true
+          Application {{.rollout.metadata.name}} is now running new version of deployments manifests.
+          See more here: {{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}?operation=true
 ```
 
 **Notes**:

--- a/docs/generated/notification-services/googlechat.md
+++ b/docs/generated/notification-services/googlechat.md
@@ -51,7 +51,7 @@ You can send [simple text](https://developers.google.com/chat/reference/message-
 
 ```yaml
 template.app-sync-succeeded: |
-  message: The app {{ .app.metadata.name }} has successfully synced!
+  message: The app {{ .rollout.metadata.name }} has successfully synced!
 ```
 
 A card message can be defined as follows:
@@ -65,17 +65,17 @@ template.app-sync-succeeded: |
         sections:
           - widgets:
               - decoratedText:
-                  text: The app {{ .app.metadata.name }} has successfully synced!
+                  text: The app {{ .rollout.metadata.name }} has successfully synced!
           - widgets:
               - decoratedText:
                   topLabel: Repository
-                  text: {{ call .repo.RepoURLToHTTPS .app.spec.source.repoURL }}
+                  text: {{ call .repo.RepoURLToHTTPS .rollout.spec.source.repoURL }}
               - decoratedText:
                   topLabel: Revision
-                  text: {{ .app.spec.source.targetRevision }}
+                  text: {{ .rollout.spec.source.targetRevision }}
               - decoratedText:
                   topLabel: Author
-                  text: {{ (call .repo.GetCommitMetadata .app.status.sync.revision).Author }}
+                  text: {{ (call .repo.GetCommitMetadata .rollout.status.sync.revision).Author }}
 ```
 All [Card fields](https://developers.google.com/chat/api/reference/rest/v1/cards#Card_1) are supported and can be used
 in notifications. It is also possible to use the previous (now deprecated) `cards` key to use the legacy card fields,
@@ -89,7 +89,7 @@ It is possible send both simple text and card messages in a chat thread by speci
 
 ```yaml
 template.app-sync-succeeded: |
-  message: The app {{ .app.metadata.name }} has successfully synced!
+  message: The app {{ .rollout.metadata.name }} has successfully synced!
   googlechat:
-    threadKey: {{ .app.metadata.name }}
+    threadKey: {{ .rollout.metadata.name }}
 ```

--- a/docs/generated/notification-services/grafana.md
+++ b/docs/generated/notification-services/grafana.md
@@ -53,7 +53,7 @@ metadata:
 data:
   templates:
     template.app-deployed: |
-      message: Application {{.app.metadata.name}} is now running new version of deployments manifests.
+      message: Application {{.rollout.metadata.name}} is now running new version of deployments manifests.
 ```
 
 8. Create subscription for your Grafana integration

--- a/docs/generated/notification-services/mattermost.md
+++ b/docs/generated/notification-services/mattermost.md
@@ -62,20 +62,20 @@ Mattermost is compatible with attachments of Slack. See [Mattermost Integration 
 ```yaml
 template.app-deployed: |
   message: |
-    Application {{.app.metadata.name}} is now running new version of deployments manifests.
+    Application {{.rollout.metadata.name}} is now running new version of deployments manifests.
   mattermost:
     attachments: |
       [{
-        "title": "{{.app.metadata.name}}",
-        "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+        "title": "{{.rollout.metadata.name}}",
+        "title_link": "{{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}",
         "color": "#18be52",
         "fields": [{
           "title": "Sync Status",
-          "value": "{{.app.status.sync.status}}",
+          "value": "{{.rollout.status.sync.status}}",
           "short": true
         }, {
           "title": "Repository",
-          "value": "{{.app.spec.source.repoURL}}",
+          "value": "{{.rollout.spec.source.repoURL}}",
           "short": true
         }]
       }]

--- a/docs/generated/notification-services/newrelic.md
+++ b/docs/generated/notification-services/newrelic.md
@@ -48,20 +48,20 @@ metadata:
 ## Templates
 
 - `revision` - **optional**, The revision being deployed. Can contain a custom template to extract the revision from your specific application status structure.
-  - Defaults to `{{.app.status.operationState.syncResult.revision}}`
+  - Defaults to `{{.rollout.status.operationState.syncResult.revision}}`
 - `description` - **optional**, high-level description of this deployment, visible in the [Summary](https://docs.newrelic.com/docs/apm/applications-menu/monitoring/apm-overview-page) page and on the [Deployments](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page) page when you select an individual deployment.
   - Defaults to `message`
 - `changelog` - **optional**, A summary of what changed in this deployment, visible in the [Deployments](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page) page when you select (selected deployment) > Change log.
-  - Defaults to `{{(call .repo.GetCommitMetadata .app.status.sync.revision).Message}}`
+  - Defaults to `{{(call .repo.GetCommitMetadata .rollout.status.sync.revision).Message}}`
 - `user` - **optional**, A username to associate with the deployment, visible in the [Summary](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page) and on the [Deployments](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page).
-  - Defaults to `{{(call .repo.GetCommitMetadata .app.status.sync.revision).Author}}`
+  - Defaults to `{{(call .repo.GetCommitMetadata .rollout.status.sync.revision).Author}}`
 
 ```yaml
 context: |
   argocdUrl: https://example.com/argocd
 
 template.app-deployed: |
-  message: Application {{.app.metadata.name}} has successfully deployed.
+  message: Application {{.rollout.metadata.name}} has successfully deployed.
   newrelic:
-    description: Application {{.app.metadata.name}} has successfully deployed
+    description: Application {{.rollout.metadata.name}} has successfully deployed
 ```

--- a/docs/generated/notification-services/opsgenie.md
+++ b/docs/generated/notification-services/opsgenie.md
@@ -43,15 +43,15 @@ data:
       <your-team>: <integration-api-key>
   template.opsgenie: |
     message: |
-      [Argo CD] Application {{.app.metadata.name}} has a problem.
+      [Argo CD] Application {{.rollout.metadata.name}} has a problem.
     opsgenie:
       description: |
-        Application: {{.app.metadata.name}}
-        Health Status: {{.app.status.health.status}}
-        Operation State Phase: {{.app.status.operationState.phase}}
-        Sync Status: {{.app.status.sync.status}}
+        Application: {{.rollout.metadata.name}}
+        Health Status: {{.rollout.status.health.status}}
+        Operation State Phase: {{.rollout.status.operationState.phase}}
+        Sync Status: {{.rollout.status.sync.status}}
       priority: P1
-      alias: {{.app.metadata.name}}
+      alias: {{.rollout.metadata.name}}
       note: Error from Argo CD!
       actions:
         - Restart
@@ -60,11 +60,11 @@ data:
         - OverwriteQuietHours
         - Critical
       visibleTo:
-        - Id: "{{.app.metadata.responderId}}"
+        - Id: "{{.rollout.metadata.responderId}}"
           Type: "team"
         - Name: "rocket_team"
           Type: "team"
-        - Id: "{{.app.metadata.responderUserId}}"
+        - Id: "{{.rollout.metadata.responderUserId}}"
           Type: "user"
         - Username: "trinity@opsgenie.com"
           Type: "user"
@@ -77,7 +77,7 @@ data:
     - description: Application has a problem.
       send:
       - opsgenie
-      when: app.status.health.status == 'Degraded' or app.status.operationState.phase in ['Error', 'Failed'] or app.status.sync.status == 'Unknown'
+      when: rollout.status.health.status == 'Degraded' or rollout.status.operationState.phase in ['Error', 'Failed'] or rollout.status.sync.status == 'Unknown'
 ```
 
 16. Add annotation in the application YAML file to enable notifications for a specific Argo CD app.

--- a/docs/generated/notification-services/rocketchat.md
+++ b/docs/generated/notification-services/rocketchat.md
@@ -75,21 +75,21 @@ The message attachments can be specified in `attachments` string fields under `r
 ```yaml
 template.app-sync-status: |
   message: |
-    Application {{.app.metadata.name}} sync is {{.app.status.sync.status}}.
-    Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
+    Application {{.rollout.metadata.name}} sync is {{.rollout.status.sync.status}}.
+    Application details: {{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}.
   rocketchat:
     attachments: |
       [{
-        "title": "{{.app.metadata.name}}",
-        "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+        "title": "{{.rollout.metadata.name}}",
+        "title_link": "{{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}",
         "color": "#18be52",
         "fields": [{
           "title": "Sync Status",
-          "value": "{{.app.status.sync.status}}",
+          "value": "{{.rollout.status.sync.status}}",
           "short": true
         }, {
           "title": "Repository",
-          "value": "{{.app.spec.source.repoURL}}",
+          "value": "{{.rollout.spec.source.repoURL}}",
           "short": true
         }]
       }]

--- a/docs/generated/notification-services/slack.md
+++ b/docs/generated/notification-services/slack.md
@@ -102,21 +102,21 @@ The message blocks and attachments can be specified in `blocks` and `attachments
 ```yaml
 template.app-sync-status: |
   message: |
-    Application {{.app.metadata.name}} sync is {{.app.status.sync.status}}.
-    Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
+    Application {{.rollout.metadata.name}} sync is {{.rollout.status.sync.status}}.
+    Application details: {{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}.
   slack:
     attachments: |
       [{
-        "title": "{{.app.metadata.name}}",
-        "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+        "title": "{{.rollout.metadata.name}}",
+        "title_link": "{{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}",
         "color": "#18be52",
         "fields": [{
           "title": "Sync Status",
-          "value": "{{.app.status.sync.status}}",
+          "value": "{{.rollout.status.sync.status}}",
           "short": true
         }, {
           "title": "Repository",
-          "value": "{{.app.spec.source.repoURL}}",
+          "value": "{{.rollout.spec.source.repoURL}}",
           "short": true
         }]
       }]
@@ -129,23 +129,23 @@ If you set `username` and `icon` in template, the values set in template will be
 ```yaml
 template.app-sync-status: |
   message: |
-    Application {{.app.metadata.name}} sync is {{.app.status.sync.status}}.
-    Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
+    Application {{.rollout.metadata.name}} sync is {{.rollout.status.sync.status}}.
+    Application details: {{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}.
   slack:
     username: "testbot"
     icon: https://example.com/image.png
     attachments: |
       [{
-        "title": "{{.app.metadata.name}}",
-        "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+        "title": "{{.rollout.metadata.name}}",
+        "title_link": "{{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}",
         "color": "#18be52",
         "fields": [{
           "title": "Sync Status",
-          "value": "{{.app.status.sync.status}}",
+          "value": "{{.rollout.status.sync.status}}",
           "short": true
         }, {
           "title": "Repository",
-          "value": "{{.app.spec.source.repoURL}}",
+          "value": "{{.rollout.spec.source.repoURL}}",
           "short": true
         }]
       }]
@@ -159,49 +159,49 @@ Furthermore, the messages can be broadcast to the channel at the specific templa
 ```yaml
 template.app-sync-status: |
   message: |
-    Application {{.app.metadata.name}} sync is {{.app.status.sync.status}}.
-    Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
+    Application {{.rollout.metadata.name}} sync is {{.rollout.status.sync.status}}.
+    Application details: {{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}.
   slack:
     attachments: |
       [{
-        "title": "{{.app.metadata.name}}",
-        "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+        "title": "{{.rollout.metadata.name}}",
+        "title_link": "{{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}",
         "color": "#18be52",
         "fields": [{
           "title": "Sync Status",
-          "value": "{{.app.status.sync.status}}",
+          "value": "{{.rollout.status.sync.status}}",
           "short": true
         }, {
           "title": "Repository",
-          "value": "{{.app.spec.source.repoURL}}",
+          "value": "{{.rollout.spec.source.repoURL}}",
           "short": true
         }]
       }]
     # Aggregate the messages to the thread by git commit hash
-    groupingKey: "{{.app.status.sync.revision}}"
+    groupingKey: "{{.rollout.status.sync.revision}}"
     notifyBroadcast: false
 template.app-sync-failed: |
   message: |
-    Application {{.app.metadata.name}} sync is {{.app.status.sync.status}}.
-    Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
+    Application {{.rollout.metadata.name}} sync is {{.rollout.status.sync.status}}.
+    Application details: {{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}.
   slack:
     attachments: |
       [{
-        "title": "{{.app.metadata.name}}",
-        "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+        "title": "{{.rollout.metadata.name}}",
+        "title_link": "{{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}",
         "color": "#ff0000",
         "fields": [{
           "title": "Sync Status",
-          "value": "{{.app.status.sync.status}}",
+          "value": "{{.rollout.status.sync.status}}",
           "short": true
         }, {
           "title": "Repository",
-          "value": "{{.app.spec.source.repoURL}}",
+          "value": "{{.rollout.spec.source.repoURL}}",
           "short": true
         }]
       }]
     # Aggregate the messages to the thread by git commit hash
-    groupingKey: "{{.app.status.sync.revision}}"
+    groupingKey: "{{.rollout.status.sync.revision}}"
     notifyBroadcast: true
 ```
 

--- a/docs/generated/notification-services/teams-workflows.md
+++ b/docs/generated/notification-services/teams-workflows.md
@@ -84,27 +84,27 @@ template.app-sync-succeeded: |
     # ThemeColor supports Adaptive Card semantic colors: "Good", "Warning", "Attention", "Accent"
     # or hex colors like "#000080"
     themeColor: "Good"
-    title: Application {{.app.metadata.name}} has been successfully synced
-    text: Application {{.app.metadata.name}} has been successfully synced at {{.app.status.operationState.finishedAt}}.
-    summary: "{{.app.metadata.name}} sync succeeded"
+    title: Application {{.rollout.metadata.name}} has been successfully synced
+    text: Application {{.rollout.metadata.name}} has been successfully synced at {{.rollout.status.operationState.finishedAt}}.
+    summary: "{{.rollout.metadata.name}} sync succeeded"
     facts: |
       [{
         "name": "Sync Status",
-        "value": "{{.app.status.sync.status}}"
+        "value": "{{.rollout.status.sync.status}}"
       }, {
         "name": "Repository",
-        "value": "{{.app.spec.source.repoURL}}"
+        "value": "{{.rollout.spec.source.repoURL}}"
       }]
     sections: |
       [{
         "facts": [
           {
             "name": "Namespace",
-            "value": "{{.app.metadata.namespace}}"
+            "value": "{{.rollout.metadata.namespace}}"
           },
           {
             "name": "Cluster",
-            "value": "{{.app.spec.destination.server}}"
+            "value": "{{.rollout.spec.destination.server}}"
           }
         ]
       }]
@@ -114,7 +114,7 @@ template.app-sync-succeeded: |
         "name": "View in Argo CD",
         "targets": [{
           "os": "default",
-          "uri": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}"
+          "uri": "{{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}"
         }]
       }]
 ```
@@ -141,14 +141,14 @@ template.app-sync-succeeded: |
         "body": [
           {
             "type": "TextBlock",
-            "text": "Application {{.app.metadata.name}} synced successfully",
+            "text": "Application {{.rollout.metadata.name}} synced successfully",
             "size": "Large",
             "weight": "Bolder",
             "color": "Good"
           },
           {
             "type": "TextBlock",
-            "text": "Application {{.app.metadata.name}} has been successfully synced at {{.app.status.operationState.finishedAt}}.",
+            "text": "Application {{.rollout.metadata.name}} has been successfully synced at {{.rollout.status.operationState.finishedAt}}.",
             "wrap": true
           },
           {
@@ -156,11 +156,11 @@ template.app-sync-succeeded: |
             "facts": [
               {
                 "title": "Sync Status",
-                "value": "{{.app.status.sync.status}}"
+                "value": "{{.rollout.status.sync.status}}"
               },
               {
                 "title": "Repository",
-                "value": "{{.app.spec.source.repoURL}}"
+                "value": "{{.rollout.spec.source.repoURL}}"
               }
             ]
           }
@@ -169,7 +169,7 @@ template.app-sync-succeeded: |
           {
             "type": "Action.OpenUrl",
             "title": "View in Argo CD",
-            "url": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}"
+            "url": "{{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}"
           }
         ]
       }
@@ -196,7 +196,7 @@ The Teams Workflows service supports the following template fields, which are au
   facts: |
     [{
       "name": "Status",
-      "value": "{{.app.status.sync.status}}"
+      "value": "{{.rollout.status.sync.status}}"
     }]
   ```
 - `sections` - JSON array of sections containing facts (facts are extracted and converted to FactSet)
@@ -205,7 +205,7 @@ The Teams Workflows service supports the following template fields, which are au
     [{
       "facts": [{
         "name": "Namespace",
-        "value": "{{.app.metadata.namespace}}"
+        "value": "{{.rollout.metadata.namespace}}"
       }]
     }]
   ```
@@ -217,7 +217,7 @@ The Teams Workflows service supports the following template fields, which are au
       "name": "View Details",
       "targets": [{
         "os": "default",
-        "uri": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}"
+        "uri": "{{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}"
       }]
     }]
   ```
@@ -329,7 +329,7 @@ template.app-sync-succeeded-advanced: |
                     "items": [
                       {
                         "type": "TextBlock",
-                        "text": "Application {{.app.metadata.name}}",
+                        "text": "Application {{.rollout.metadata.name}}",
                         "weight": "Bolder",
                         "size": "Large"
                       },
@@ -348,11 +348,11 @@ template.app-sync-succeeded-advanced: |
                 "facts": [
                   {
                     "title": "Status",
-                    "value": "{{.app.status.sync.status}}"
+                    "value": "{{.rollout.status.sync.status}}"
                   },
                   {
                     "title": "Repository",
-                    "value": "{{.app.spec.source.repoURL}}"
+                    "value": "{{.rollout.spec.source.repoURL}}"
                   }
                 ]
               }
@@ -363,7 +363,7 @@ template.app-sync-succeeded-advanced: |
           {
             "type": "Action.OpenUrl",
             "title": "View in Argo CD",
-            "url": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}"
+            "url": "{{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}"
           }
         ]
       }

--- a/docs/generated/notification-services/teams.md
+++ b/docs/generated/notification-services/teams.md
@@ -105,11 +105,11 @@ template.app-sync-succeeded: |
         "facts": [
           {
             "name": "Sync Status",
-            "value": "{{.app.status.sync.status}}"
+            "value": "{{.rollout.status.sync.status}}"
           },
           {
             "name": "Repository",
-            "value": "{{.app.spec.source.repoURL}}"
+            "value": "{{.rollout.spec.source.repoURL}}"
           }
         ]
       }]
@@ -119,12 +119,12 @@ template.app-sync-succeeded: |
         "name":"Operation Details",
         "targets":[{
           "os":"default",
-          "uri":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"
+          "uri":"{{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}?operation=true"
         }]
       }]
-    title: Application {{.app.metadata.name}} has been successfully synced
-    text: Application {{.app.metadata.name}} has been successfully synced at {{.app.status.operationState.finishedAt}}.
-    summary: "{{.app.metadata.name}} sync succeeded"
+    title: Application {{.rollout.metadata.name}} has been successfully synced
+    text: Application {{.rollout.metadata.name}} has been successfully synced at {{.rollout.status.operationState.finishedAt}}.
+    summary: "{{.rollout.metadata.name}} sync succeeded"
 ```
 
 ### facts field
@@ -137,11 +137,11 @@ template.app-sync-succeeded: |
     facts: |
       [{
         "name": "Sync Status",
-        "value": "{{.app.status.sync.status}}"
+        "value": "{{.rollout.status.sync.status}}"
       },
       {
         "name": "Repository",
-        "value": "{{.app.spec.source.repoURL}}"
+        "value": "{{.rollout.spec.source.repoURL}}"
       }]
 ```
 

--- a/docs/generated/notification-services/webhook.md
+++ b/docs/generated/notification-services/webhook.md
@@ -136,16 +136,16 @@ data:
     webhook:
       github:
         method: POST
-        path: /repos/{{call .repo.FullNameByRepoURL .app.spec.source.repoURL}}/statuses/{{.app.status.operationState.operation.sync.revision}}
+        path: /repos/{{call .repo.FullNameByRepoURL .rollout.spec.source.repoURL}}/statuses/{{.rollout.status.operationState.operation.sync.revision}}
         body: |
           {
-            {{if eq .app.status.operationState.phase "Running"}} "state": "pending"{{end}}
-            {{if eq .app.status.operationState.phase "Succeeded"}} "state": "success"{{end}}
-            {{if eq .app.status.operationState.phase "Error"}} "state": "error"{{end}}
-            {{if eq .app.status.operationState.phase "Failed"}} "state": "error"{{end}},
+            {{if eq .rollout.status.operationState.phase "Running"}} "state": "pending"{{end}}
+            {{if eq .rollout.status.operationState.phase "Succeeded"}} "state": "success"{{end}}
+            {{if eq .rollout.status.operationState.phase "Error"}} "state": "error"{{end}}
+            {{if eq .rollout.status.operationState.phase "Failed"}} "state": "error"{{end}},
             "description": "ArgoCD",
-            "target_url": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
-            "context": "continuous-delivery/{{.app.metadata.name}}"
+            "target_url": "{{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}",
+            "context": "continuous-delivery/{{.rollout.metadata.name}}"
           }
 ```
 
@@ -208,16 +208,16 @@ data:
         body: |
           {
             "attachments": [{
-              "title": "{{.app.metadata.name}}",
-              "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+              "title": "{{.rollout.metadata.name}}",
+              "title_link": "{{.context.argocdUrl}}/applications/{{.rollout.metadata.name}}",
               "color": "#18be52",
               "fields": [{
                 "title": "Sync Status",
-                "value": "{{.app.status.sync.status}}",
+                "value": "{{.rollout.status.sync.status}}",
                 "short": true
               }, {
                 "title": "Repository",
-                "value": "{{.app.spec.source.repoURL}}",
+                "value": "{{.rollout.spec.source.repoURL}}",
                 "short": true
               }]
             }]

--- a/hack/gen-docs/main.go
+++ b/hack/gen-docs/main.go
@@ -48,6 +48,24 @@ func generateNotificationsDocs() {
 		if e := strReplaceDocFiles("../catalog.md#triggers", "../../features/notifications.md#custom-triggers", files); e != nil {
 			log.Fatal(e)
 		}
+		// Argo Rollouts notifications only have access to Rollout resources, not Argo CD Application
+		// resources. Replace the ArgoCD-sourced .app.* template variables with their Rollout equivalents.
+		if e := strReplaceDocFiles(".app.metadata.name", ".rollout.metadata.name", files); e != nil {
+			log.Fatal(e)
+		}
+		if e := strReplaceDocFiles(".app.metadata.", ".rollout.metadata.", files); e != nil {
+			log.Fatal(e)
+		}
+		if e := strReplaceDocFiles(".app.spec.", ".rollout.spec.", files); e != nil {
+			log.Fatal(e)
+		}
+		if e := strReplaceDocFiles(".app.status.", ".rollout.status.", files); e != nil {
+			log.Fatal(e)
+		}
+		// Also fix bare `app.status.` (no leading dot) used in trigger `when` expressions
+		if e := strReplaceDocFiles(" app.status.", " rollout.status.", files); e != nil {
+			log.Fatal(e)
+		}
 	}
 }
 


### PR DESCRIPTION
**Fixes #3998**

## What changed?

The generated notification-service docs were copied verbatim from the `notifications-engine` project, which is ArgoCD-centric. Example templates throughout the docs used ArgoCD Application variables (`.app.metadata.name`, `.app.spec.*`, `.app.status.*`) that don't exist in an Argo Rollouts context — Rollouts notifications only have access to Rollout resources.

This caused confusion for users who tried to use the documented templates and got errors (see discussion in #3990).

## How was it fixed?

Added string-replacement passes to `hack/gen-docs/main.go` so the generator rewrites ArgoCD variables to their Rollout equivalents whenever the docs are regenerated:

| Before | After |
|--------|-------|
| `{{.app.metadata.name}}` | `{{.rollout.metadata.name}}` |
| `{{.app.spec.*}}` | `{{.rollout.spec.*}}` |
| `{{.app.status.*}}` | `{{.rollout.status.*}}` |

The same replacements are applied to the currently-committed generated files in `docs/generated/notification-services/` so the docs are immediately correct without needing a generator run.

## Files changed

- `hack/gen-docs/main.go` — 5 new `strReplaceDocFiles` calls in `generateNotificationsDocs()`
- `docs/generated/notification-services/*.md` — 14 files updated (email, slack, webhook, rocketchat, github, grafana, newrelic, opsgenie, teams-workflows, and others)